### PR TITLE
Add a fixture app, a smoke test, and CI for the demo-video recorders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # What gitleaks scans depends on the event: for `pull_request` it is the
+      # commits in the PR, for `push` the pushed range, and only for a manual
+      # or scheduled run is it the whole repository. fetch-depth: 0 is what
+      # makes that last case possible — without it a full scan has no history
+      # to read.
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # gitleaks scans history, not just the checkout
+          fetch-depth: 0
 
-      # Config is .gitleaks.toml at the repo root: the default ruleset plus a
-      # single allowlist entry for the fixture's fake API key.
+      # Config is .gitleaks.toml at the repo root: the default ruleset plus two
+      # narrow allowlist entries (vendored xterm.js, and the fixture's fake
+      # API key).
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,108 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pinned so a tool release never turns a green branch red on its own.
+  RUFF_VERSION: "0.14.2"
+  MYPY_VERSION: "1.18.2"
+
+jobs:
+  lint:
+    name: lint (ruff, shellcheck)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: ruff check
+        run: uv run --with "ruff==$RUFF_VERSION" ruff check --output-format github .
+
+      - name: ruff format --check
+        run: uv run --with "ruff==$RUFF_VERSION" ruff format --check .
+
+      # shellcheck comes from PyPI rather than apt so this is the same binary
+      # a contributor gets from the same command locally.
+      - name: shellcheck the skills' shell scripts
+        run: |
+          find skills -name '*.sh' -print0 |
+            xargs -0 -r uv run --with shellcheck-py shellcheck --severity=style
+
+  typecheck:
+    name: typecheck (mypy)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      # Settings live in mypy.ini and are deliberately permissive — see the
+      # comments there for what to ratchet up and when.
+      - name: mypy
+        run: uv run --with "mypy==$MYPY_VERSION" --with playwright mypy skills/demo-video/helpers/
+
+  secrets:
+    name: secrets (gitleaks)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # gitleaks scans history, not just the checkout
+
+      # Config is .gitleaks.toml at the repo root: the default ruleset plus a
+      # single allowlist entry for the fixture's fake API key.
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  smoke:
+    name: smoke (record against the fixture app)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+
+      - name: Install Chromium for Playwright
+        run: uv run --with playwright playwright install --with-deps chromium
+
+      # Writes outside the checkout, at a path the upload step below knows.
+      - name: Record web and terminal demos
+        run: tests/smoke --out-dir "$RUNNER_TEMP/smoke-out"
+
+      # Only on failure: a green run's recordings are noise, a red run's are
+      # the only way to see what the recorder actually produced.
+      - name: Upload recordings for debugging
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-recordings
+          path: ${{ runner.temp }}/smoke-out
+          if-no-files-found: warn
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,13 @@ __pycache__/
 # demo-video working files (only demo.mp4 belongs in history)
 .tts/
 *.seg.mp4
+# Left behind only when a take crashes before the recorder cleans up.
+.video/
+.frame.png
+
+# Smoke-test recordings. tests/smoke records into a temp dir by default; this
+# covers pointing it back into the repo (tests/smoke --out-dir tests/out).
+tests/out/
 
 # Best practice
 .env

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,17 @@
+# gitleaks configuration.
+#
+# The default ruleset, plus one narrowly-scoped allowlist. Nothing else is
+# relaxed: if a scan trips on something new, fix the leak, do not widen this.
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = """
+The demo-video test fixture renders a deliberately fake API key at #api-key
+(tests/fixture/index.html, behind ?secret=1) so the redaction work in issue #4
+has something to prove it hides. It is spelled FAKE followed by zeroes exactly
+so that both a scanner and a human read it as scenery. This entry matches that
+one literal and nothing else.
+"""
+regexes = ['''sk-live-FAKE0{16}''']

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -8,10 +8,23 @@ useDefault = true
 
 [allowlist]
 description = """
-The demo-video test fixture renders a deliberately fake API key at #api-key
+Two narrow exemptions.
+
+paths: skills/demo-video/helpers/assets/ holds vendored xterm.js. A full-history
+scan reports two generic-api-key hits in it — both false positives in minified
+third-party code that this repo does not author and will not edit. PR-event
+scans only see the diff, so the job is green today and would go red the first
+time anyone adds a schedule or workflow_dispatch trigger. ruff.toml excludes the
+same directory for the same reason.
+
+regexes: the test fixture renders a deliberately fake API key at #api-key
 (tests/fixture/index.html, behind ?secret=1) so the redaction work in issue #4
-has something to prove it hides. It is spelled FAKE followed by zeroes exactly
-so that both a scanner and a human read it as scenery. This entry matches that
-one literal and nothing else.
+has something to prove it hides. Note this entry is belt-and-braces, not
+load-bearing: the default ruleset does not flag that literal with or without
+this config — it is spelled FAKE followed by sixteen zeroes precisely so no
+scanner and no human mistakes it for a credential. It is kept so that a future
+gitleaks release which does start flagging it cannot turn the job red for a
+string that was never a secret. It masks nothing else.
 """
+paths = ['''^skills/demo-video/helpers/assets/''']
 regexes = ['''sk-live-FAKE0{16}''']

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,39 @@
+# Type-checking config for the demo-video recorder helpers.
+#
+# `mypy.ini` rather than `pyproject.toml` for the same reason as ruff.toml:
+# this repo is a collection of skills, not a Python package.
+#
+# START PERMISSIVE. The helpers were written before anything type-checked
+# them, so this config is calibrated to pass on the code as it stands rather
+# than to demand a rewrite. Every setting below is a floor to ratchet up, not
+# a target to defend — turn one on, fix what it finds, commit, repeat.
+
+[mypy]
+python_version = 3.10
+mypy_path = skills/demo-video/helpers
+# Third-party stubs are not installed in CI beyond playwright's own.
+ignore_missing_imports = True
+# Untyped function bodies stay unchecked, and untyped defs are allowed. These
+# are the two settings to flip first when tightening.
+check_untyped_defs = False
+disallow_untyped_defs = False
+warn_unused_ignores = False
+warn_return_any = False
+pretty = True
+
+# Off because core.py's `_env(name, default)` is declared `-> str | None` even
+# though it can only return None when no default is passed. Every caller that
+# passes a default therefore looks like it is using an Optional unchecked, and
+# mypy reports eight such sites across the three recorder modules. The real
+# fix is a pair of @overload signatures on `_env` — a change to core.py, which
+# ten queued PRs (#3-#12) are already editing. Turn this back on (it is mypy's
+# default) as the first ratchet step once that queue drains.
+strict_optional = False
+
+[mypy-demo_recording.core]
+# `self._size` is a plain dict[str, int] where Playwright declares the
+# ViewportSize TypedDict. Correct at runtime, wrong to mypy. The fix is a
+# one-line annotation, but ten PRs (#3-#12) are queued against core.py and a
+# drive-by edit conflicts with all of them — so silence it here and delete
+# this section when that queue drains.
+disable_error_code = arg-type

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,43 @@
+# Lint/format config for the Python in this repo.
+#
+# Deliberately `ruff.toml` and not `pyproject.toml`: this repo is a collection
+# of skills, not a Python package, and a pyproject.toml would invite tooling
+# (and people) to treat it as one.
+
+target-version = "py310"  # the floor demo-video's PEP 723 headers declare
+line-length = 88
+
+exclude = [
+    "skills/demo-video/helpers/assets",  # vendored xterm.js
+]
+
+# House convention names executables without a `.py` extension (see
+# skills/script-conventions), and ruff only discovers `.py`/`.pyi` on its own.
+# Without these patterns the scripts that matter most would go unlinted.
+extend-include = [
+    "tests/smoke",
+    "skills/*/scripts/*",  # every skill's PEP 723 executables
+]
+
+[lint]
+# Ruff's own default (E4/E7/E9 + F) plus the rule families that catch real
+# bugs and keep imports tidy. Intentionally not maximal — this is a lint
+# budget for a small repo, not a style crusade.
+#
+# E501 (line too long) is left out on purpose: the formatter owns line length,
+# and every over-long line here lives inside an embedded JS/CSS string that
+# cannot be wrapped anyway.
+select = ["E4", "E7", "E9", "F", "W", "I", "UP", "B"]
+
+[lint.per-file-ignores]
+# `-> "_DemoBase"` in core.py. The fix is one character, but ten PRs (#3–#12)
+# are queued against these three files and a drive-by edit conflicts with all
+# of them. Drop this once that queue drains.
+"skills/demo-video/helpers/demo_recording/core.py" = ["UP037"]
+
+[format]
+# The recorder modules predate any formatter. Running one over them now would
+# rewrite all three files and collide with every queued PR, so they are
+# excluded rather than reformatted. This is a starting point: delete the
+# exclusion (and land the reformat as its own commit) once #3–#12 are merged.
+exclude = ["skills/demo-video/helpers/demo_recording/*.py"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,11 +31,18 @@ fresh Linux box). A pass looks like this, and takes about half a minute:
 
 ```
 smoke: serving …/tests/fixture at http://127.0.0.1:59557
-smoke: web demo.mp4 ok (13.7s, 327 kB)
-smoke: web still 01-dashboard.png ok (77 kB)
+smoke: web demo.mp4 ok (13.9s, 205 kB, contrast 60)
+smoke: web still 01-dashboard.png ok (77 kB, contrast 19)
 …
 smoke: PASSED
 ```
+
+Re-running into the same `--out-dir` is safe: the `web/` and `terminal/`
+subdirectories are deleted before each take. That is not tidiness — every
+artifact assertion works by path, so without it a leftover `demo.mp4` from the
+previous run would grade a recorder that produced nothing at all as a pass, and
+recording repeatedly into one directory is exactly how a change to the recorder
+gets verified. Nothing outside those two subdirectories is ever removed.
 
 Unix only — `demo_recording/__init__.py` imports the PTY-backed terminal
 recorder unconditionally, so the whole package needs a Unix platform. The
@@ -49,18 +56,48 @@ test measures.
 
 ## What it asserts
 
-Per take (web, terminal):
+Three independent axes, because a recorder can fail on any one of them while
+looking perfect on the other two.
 
-- `demo.mp4` exists and is at least 20 kB — "the file is there" proves nothing
-  when a half-failed run still leaves one behind
-- its duration, via the `media_duration` helper, falls inside a wide window
-  (6–30 s web, 4–30 s terminal). The low bound catches a take that died early,
-  the high bound catches a hang; everything between is normal variation
-  between a laptop and a cold CI runner
-- every still the storyboard asked for exists in `images/` and is at least 5 kB
+**Artifacts** — `demo.mp4` and every still the storyboard asked for exist, were
+modified by *this* run rather than a previous one, and clear a size floor
+(20 kB / 5 kB). Duration, via the `media_duration` helper, falls inside a wide
+window (6–30 s web, 4–30 s terminal): the low bound catches a take that died
+early, the high bound catches a hang, everything between is normal variation
+between a laptop and a cold CI runner.
 
-Failures accumulate and print together, each naming the file and the number
-that was wrong. The process exits non-zero if there is even one.
+**Content** — the frames contain a picture. This is measured, not inferred from
+file size: **no byte count can separate a blank recording from a real one.** A
+flat white 14-second 720p H.264 is about 20 kB, comfortably over any floor that
+a real 110 kB terminal take also clears. So `frame_contrast()` has ffmpeg decode
+frames to raw 8-bit grayscale at 160×90 and computes their luma standard
+deviation in pure Python — no image library, no extra dependency. Anything
+visible scores tens; a blank frame scores 0.0. The bottom 20% of each frame is
+cropped away first, so the recorder's own caption bar cannot supply the contrast
+for an otherwise empty app.
+
+Healthy values, for calibrating the floors (`MIN_FRAME_STDDEV = 8`,
+`MIN_STILL_STDDEV = 6`): web mp4 ≈ 60, terminal mp4 ≈ 79, web stills 18–19,
+terminal stills ≈ 78.
+
+**Behaviour** — the interactions actually did something. Byte sizes cannot tell
+a filtered table from an unfiltered one, so each verb is followed by the
+observable post-condition it must have caused, read back out of the live page:
+
+| Verb | Post-condition checked |
+|---|---|
+| `goto` | `#rows` has 5 rows, `#status` reads `snapshot 1 of 3` |
+| `spotlight(sel)` / `spotlight()` | `#kpi-rev` computed `outline-style` is `solid`, then `none` |
+| `type_into("#search", …)` | the field holds `seattle` and `#rows` is down to 1 row |
+| `click("#refresh")` | `#status` reads `snapshot 2 of 3`, `#kpi-rev` reads `$134,950` |
+| `move_to` (via `click`) | the recorder's drawn cursor sits inside `#refresh`'s box |
+| `run` (terminal) | the command's *output* appears on a whole screen line (`^hello from demo-video$`, `^skills$`) — anchored so the echoed command line cannot satisfy it |
+
+Post-condition failures are collected, not raised, so the take still finishes
+and produces the video that the other two axes grade.
+
+Failures accumulate and print together, each naming the file or interaction and
+the number that was wrong. The process exits non-zero if there is even one.
 
 ## The fixture app
 
@@ -84,16 +121,19 @@ for:
 | `?console-error=1` | logs a `console.error` **and** throws an uncaught error (Playwright `pageerror`), while the page stays usable | issue #3, failing a take on console errors |
 | `?secret=1` | renders `#api-key` holding `sk-live-FAKE0000000000000000` | issue #4, redacting secrets from frames and stills |
 
-That key is not a credential. It is spelled `FAKE` followed by zeroes so both
-gitleaks and a human read it as scenery; `.gitleaks.toml` allowlists that exact
-literal and nothing else.
+That key is not a credential. It is spelled `FAKE` followed by sixteen zeroes so
+both gitleaks and a human read it as scenery — the default ruleset does not flag
+it either way. `.gitleaks.toml` allowlists the exact literal anyway, as
+insurance against a future release that does start flagging it.
 
 ## Adding a case
 
 - **A new thing to record** — add a beat to `record_web` / `record_terminal` in
   `tests/smoke`, and add its `shot()` name to `WEB_SHOTS` / `TERMINAL_SHOTS` so
   the still is actually checked. Adding a beat lengthens the take; keep it
-  inside the duration window, or widen the window deliberately.
+  inside the duration window, or widen the window deliberately. **Every
+  interaction gets a `b.expect(...)` naming what it should have changed** — a
+  beat with no post-condition is a beat that passes when the verb is a no-op.
 - **A new thing for the app to do** — put it in `fixture/index.html` behind a
   stable id, and keep it deterministic. If it only matters to one future
   feature, hide it behind a query-string hook the way the two above are, so the

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,9 +30,10 @@ Prerequisites: `uv`, `ffmpeg`/`ffprobe` on PATH, and Chromium for Playwright
 fresh Linux box). A pass looks like this, and takes about half a minute:
 
 ```
-smoke: serving …/tests/fixture at http://127.0.0.1:59557
-smoke: web demo.mp4 ok (13.9s, 205 kB, contrast 60)
-smoke: web still 01-dashboard.png ok (77 kB, contrast 19)
+smoke: serving …/tests/fixture at http://127.0.0.1:36321
+smoke: web demo.mp4 ok (16.2s, 244 kB, content 16.0)
+smoke: web still 01-dashboard.png ok (77 kB, content 16.9)
+smoke: web caption is visible on screen (delta 25.6)
 …
 smoke: PASSED
 ```
@@ -42,7 +43,13 @@ subdirectories are deleted before each take. That is not tidiness — every
 artifact assertion works by path, so without it a leftover `demo.mp4` from the
 previous run would grade a recorder that produced nothing at all as a pass, and
 recording repeatedly into one directory is exactly how a change to the recorder
-gets verified. Nothing outside those two subdirectories is ever removed.
+gets verified.
+
+Deleting is bounded. Only `<out-dir>/web/` and `<out-dir>/terminal/` are ever
+removed, and only when each is absent, empty, or carries the
+`.demo-video-smoke` marker file a previous run wrote there. `--out-dir .` in a
+project that has its own `web/` directory gets a refusal naming the path, not a
+deleted source tree.
 
 Unix only — `demo_recording/__init__.py` imports the PTY-backed terminal
 recorder unconditionally, so the whole package needs a Unix platform. The
@@ -60,44 +67,105 @@ Three independent axes, because a recorder can fail on any one of them while
 looking perfect on the other two.
 
 **Artifacts** — `demo.mp4` and every still the storyboard asked for exist, were
-modified by *this* run rather than a previous one, and clear a size floor
-(20 kB / 5 kB). Duration, via the `media_duration` helper, falls inside a wide
-window (6–30 s web, 4–30 s terminal): the low bound catches a take that died
-early, the high bound catches a hang, everything between is normal variation
-between a laptop and a cold CI runner.
+modified by *this* run rather than a previous one, clear a size floor
+(20 kB / 5 kB), and no two consecutive stills are the same picture. Duration,
+via the `media_duration` helper, falls inside a wide window (6–32 s): the low
+bound catches a take that died early, the high bound catches a hang, everything
+between is normal variation between a laptop and a cold CI runner.
 
 **Content** — the frames contain a picture. This is measured, not inferred from
 file size: **no byte count can separate a blank recording from a real one.** A
 flat white 14-second 720p H.264 is about 20 kB, comfortably over any floor that
-a real 110 kB terminal take also clears. So `frame_contrast()` has ffmpeg decode
-frames to raw 8-bit grayscale at 160×90 and computes their luma standard
-deviation in pure Python — no image library, no extra dependency. Anything
-visible scores tens; a blank frame scores 0.0. The bottom 20% of each frame is
-cropped away first, so the recorder's own caption bar cannot supply the contrast
-for an otherwise empty app.
+a real 117 kB terminal take also clears. `gray_frames()` has ffmpeg decode
+frames to raw 8-bit grayscale at 160×90 and the luma standard deviation is
+computed in pure Python — no image library, no extra dependency.
 
-Healthy values, for calibrating the floors (`MIN_FRAME_STDDEV = 8`,
-`MIN_STILL_STDDEV = 6`): web mp4 ≈ 60, terminal mp4 ≈ 79, web stills 18–19,
-terminal stills ≈ 78.
+**Where** it measures is the whole trick. Scoring the full frame does not work
+and is worse than not scoring at all: a fifth to a third of every frame is the
+recorder's own chrome — a pastel gradient at ~230 luma against a ~35 luma
+window — and that bimodal spread alone scores 60–79. A fully blank web
+recording scores **61.8** that way and a healthy one **60.2**, so the metric is
+anti-correlated and no floor can work. Instead, the app's own rect is measured:
 
-**Behaviour** — the interactions actually did something. Byte sizes cannot tell
-a filtered table from an unfiltered one, so each verb is followed by the
-observable post-condition it must have caused, read back out of the live page:
+- **web video** — `Recorder._geom`, the composited window position, read off the
+  live recorder rather than re-derived, so a change to the window geometry
+  carries the measurement with it
+- **web stills** — the full frame, since `shot()` captures the page full-bleed
+  before compositing
+- **terminal** — the bounding box of `#__term_host`, the xterm.js host div
+
+The bottom 20% of each rect is dropped so the recorder's caption bar cannot
+supply the contrast for an otherwise blank app. Video is sampled at 1 fps and
+scored by the **median** frame, so one good frame cannot excuse a blank video.
+
+| | healthy | blank | floor |
+|---|---|---|---|
+| web video | 16.0 | 0.0 | 6.0 |
+| web stills | 15.5–16.9 | 0.1–1.1 | 6.0 |
+| terminal video | 8.0 | 0.2 | 2.0 |
+| terminal stills | 5.1–7.9 | 0.4 | 2.0 |
+
+The floors differ per medium because the media do: a web page fills its rect
+with light and dark, a terminal is mostly empty dark background with a few
+lines of text on it.
+
+**Behaviour** — the verbs actually did something. Byte sizes cannot tell a
+filtered table from an unfiltered one, so each verb is followed by the
+observable post-condition it must have caused:
 
 | Verb | Post-condition checked |
 |---|---|
-| `goto` | `#rows` has 5 rows, `#status` reads `snapshot 1 of 3` |
+| `goto` | `#rows` has 5 rows, `#status` reads `snapshot 1 of 3`, and `#refresh`'s computed background is the accent orange — the last one resolves a total stylesheet failure, which the luma metric cannot (see Known gaps) |
+| `caption(text)` | `#__demo_caption` exists, holds exactly `text`, and has computed opacity > 0.5 (or ≤ 0.5 after `caption("")`) — checked after *every* caption in both takes |
+| `caption`, on screen | two stills taken back to back with the page frozen and only the caption changing must differ in the caption band. Self-calibrating: no absolute threshold tied to whatever the fixture renders near the bottom. Healthy 25.6 (web) / 2.7 (terminal); not drawn 0.00 |
 | `spotlight(sel)` / `spotlight()` | `#kpi-rev` computed `outline-style` is `solid`, then `none` |
 | `type_into("#search", …)` | the field holds `seattle` and `#rows` is down to 1 row |
 | `click("#refresh")` | `#status` reads `snapshot 2 of 3`, `#kpi-rev` reads `$134,950` |
-| `move_to` (via `click`) | the recorder's drawn cursor sits inside `#refresh`'s box |
-| `run` (terminal) | the command's *output* appears on a whole screen line (`^hello from demo-video$`, `^skills$`) — anchored so the echoed command line cannot satisfy it |
+| `move_to` | the page saw ≥ 10 `mousemove` events during the call. **Not** where the cursor ended up: Playwright's own `locator.click()` dispatches a `mousemove` to the target, so a final-position check passes with `move_to` stubbed out entirely — it measures Playwright, not the recorder. The 30-step glide is the only thing that produces a trail |
+| `run` (terminal) | the shell prompt returns, and the command's *output* appears on a whole screen line (`^hello from demo-video$`, `^skills$`) — anchored so the echoed command line cannot satisfy it |
 
-Post-condition failures are collected, not raised, so the take still finishes
-and produces the video that the other two axes grade.
+All post-condition failures are collected, never raised, in both takes. A take
+that aborts writes no mp4, and CI's failure-only artifact upload then has
+nothing to upload at exactly the moment somebody wants to look at it.
+
+## Known gaps
+
+Things a pass does **not** prove. They are listed because an assertion nobody
+knows is missing is worse than one that is openly absent.
+
+- **A total stylesheet failure is below the luma floor.** Measured with real
+  screenshots: unstyled-HTML fallback scores 9.97, a sparse white page 3.54, an
+  error page 4.05, healthy 15–17. The useful band is 6 → 15, so a page that
+  rendered with no CSS at all lands at ~10, above the 6.0 floor. Raising the
+  floor toward 15 would risk flake from CI font rendering. Mitigated, not
+  solved, by the `getComputedStyle` check on `#refresh` — which catches the
+  fixture's own stylesheet failing, but is one assertion about one property and
+  will not notice arbitrary visual regressions. Tracked in
+  [#16](https://github.com/rogvid/skills/issues/16).
+- **The terminal caption check has the thinnest margin in the harness** — 2.7
+  healthy against a 1.0 floor, where everything else has 4x or better. The
+  terminal's caption is a dark box on a dark terminal, so only its text carries
+  any luma change. If CI font rendering ever drops it under 1.0 this will flake;
+  the DOM caption assertions would still hold. Tracked in
+  [#16](https://github.com/rogvid/skills/issues/16).
+- **The content rects couple to recorder internals** (`Recorder._geom`, and the
+  `#__term_host` id). Reading them at runtime means a geometry change follows
+  automatically, and a *removed* `_geom` fails loudly — but a change that keeps
+  the attribute while moving the app elsewhere would silently score the wrong
+  pixels. Tracked in [#17](https://github.com/rogvid/skills/issues/17), which
+  proposes the recorder expose its geometry as public API.
+- **Nothing checks audio.** Narration is forced off and no assertion touches the
+  aac track, so the whole speech path — `tts_clip`, the `.tts/` cache, the
+  `adelay`/`amix` mixing in `_convert` — is untested here.
+- **Nothing checks `stitch()`, segments, or `interlude()`.** Single-segment
+  takes only.
+- **Nothing checks that the demo is any *good*.** These are liveness checks.
+  Pacing, caption wording, whether the story lands — that is what the
+  fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.
 
 Failures accumulate and print together, each naming the file or interaction and
-the number that was wrong. The process exits non-zero if there is even one.
+the number that was wrong. The process exits non-zero if there is even one, and
+`ok` is printed for an artifact only when *nothing* about it was wrong.
 
 ## The fixture app
 
@@ -140,3 +208,12 @@ insurance against a future release that does start flagging it.
   default recording stays clean.
 - **A new failure mode to catch** — prefer another assertion in `check_take()`
   over another take. Takes cost ~15 s each in CI; assertions are free.
+
+**Prove any new assertion can fail.** Break the thing it watches — stub the verb
+out in `skills/demo-video/helpers/`, or blank the fixture — run `tests/smoke`,
+and see it fail with a message that names the real cause. Then `git checkout --
+skills/` and see it pass again. Two of the checks in this file's history looked
+like coverage for a whole review round and could not fail at all: a whole-frame
+contrast score that a blank recording *beat*, and a cursor-position check that
+was measuring Playwright's `click()` rather than the recorder's `move_to()`. An
+assertion nobody has watched fail is a comment.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,102 @@
+# tests
+
+One smoke test and one fixture app. Together they answer a single question:
+**does the demo-video recorder still produce a real video?**
+
+They are not unit tests. The recorders' interesting behaviour is "shell out to
+ffmpeg, drive a headless browser, come back with an mp4", which nothing short
+of running it can check. So the smoke test runs it, end to end, and asserts on
+what lands on disk.
+
+```
+tests/
+├── smoke              # the runner (a PEP 723 uv script — no venv, no install)
+└── fixture/
+    └── index.html     # the app it records: static, dependency-free, deterministic
+```
+
+## Running it
+
+```sh
+tests/smoke                       # both takes, output to a temp dir
+tests/smoke --web-only            # just the Playwright take
+tests/smoke --terminal-only       # just the PTY/xterm.js take
+tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
+tests/smoke --keep                # keep the temp dir even when it passes
+```
+
+Prerequisites: `uv`, `ffmpeg`/`ffprobe` on PATH, and Chromium for Playwright
+(`uv run --with playwright playwright install chromium`; add `--with-deps` on a
+fresh Linux box). A pass looks like this, and takes about half a minute:
+
+```
+smoke: serving …/tests/fixture at http://127.0.0.1:59557
+smoke: web demo.mp4 ok (13.7s, 327 kB)
+smoke: web still 01-dashboard.png ok (77 kB)
+…
+smoke: PASSED
+```
+
+Unix only — `demo_recording/__init__.py` imports the PTY-backed terminal
+recorder unconditionally, so the whole package needs a Unix platform. The
+terminal *take* additionally skips itself with a message if `os.name` is not
+`posix`.
+
+Narration is forced off (`speech=False`), and the runner deletes every
+`DEMO_VIDEO_*` variable plus `ELEVENLABS_API_KEY` from its own environment
+before recording. A sourced project `.env` therefore cannot change what the
+test measures.
+
+## What it asserts
+
+Per take (web, terminal):
+
+- `demo.mp4` exists and is at least 20 kB — "the file is there" proves nothing
+  when a half-failed run still leaves one behind
+- its duration, via the `media_duration` helper, falls inside a wide window
+  (6–30 s web, 4–30 s terminal). The low bound catches a take that died early,
+  the high bound catches a hang; everything between is normal variation
+  between a laptop and a cold CI runner
+- every still the storyboard asked for exists in `images/` and is at least 5 kB
+
+Failures accumulate and print together, each naming the file and the number
+that was wrong. The process exits non-zero if there is even one.
+
+## The fixture app
+
+`fixture/index.html` is a small fulfilment dashboard: a hero, three KPI cards,
+a filter box, a refresh button, and a table. It is one file with no build step
+and no dependencies, served by `python3 -m http.server`.
+
+Everything the recorder touches has a stable id: `#kpi-rev`, `#kpi-orders`,
+`#kpi-ontime`, `#search`, `#refresh`, `#rows` (plus `#row-nw-1041`… per row),
+`#status`, `#empty`.
+
+It is deterministic on purpose — no `Math.random()`, no clock on screen, no
+animations. `#refresh` cycles three hard-coded snapshots in order, so a
+recording made today is frame-for-frame the story of one made next year.
+
+Two query-string hooks exist for the queued feature work, inert unless asked
+for:
+
+| URL | Effect | For |
+|---|---|---|
+| `?console-error=1` | logs a `console.error` **and** throws an uncaught error (Playwright `pageerror`), while the page stays usable | issue #3, failing a take on console errors |
+| `?secret=1` | renders `#api-key` holding `sk-live-FAKE0000000000000000` | issue #4, redacting secrets from frames and stills |
+
+That key is not a credential. It is spelled `FAKE` followed by zeroes so both
+gitleaks and a human read it as scenery; `.gitleaks.toml` allowlists that exact
+literal and nothing else.
+
+## Adding a case
+
+- **A new thing to record** — add a beat to `record_web` / `record_terminal` in
+  `tests/smoke`, and add its `shot()` name to `WEB_SHOTS` / `TERMINAL_SHOTS` so
+  the still is actually checked. Adding a beat lengthens the take; keep it
+  inside the duration window, or widen the window deliberately.
+- **A new thing for the app to do** — put it in `fixture/index.html` behind a
+  stable id, and keep it deterministic. If it only matters to one future
+  feature, hide it behind a query-string hook the way the two above are, so the
+  default recording stays clean.
+- **A new failure mode to catch** — prefer another assertion in `check_take()`
+  over another take. Takes cost ~15 s each in CI; assertions are free.

--- a/tests/fixture/index.html
+++ b/tests/fixture/index.html
@@ -1,0 +1,298 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Northwind Ops — fixture app</title>
+<style>
+  :root {
+    --bg: #f5f6f9;
+    --surface: #ffffff;
+    --ink: #171c28;
+    --ink-soft: #5b6478;
+    --line: #e3e6ee;
+    --accent: #eb6e14;
+    --good: #1f8a5c;
+    --warn: #b4791a;
+    --radius: 12px;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--ink);
+    font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  .page { max-width: 1040px; margin: 0 auto; padding: 34px 40px 56px; }
+
+  /* Hero ------------------------------------------------------------- */
+  header { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; }
+  h1 { margin: 0; font-size: 30px; letter-spacing: -0.02em; font-weight: 700; }
+  .sub { margin: 6px 0 0; color: var(--ink-soft); font-size: 15px; }
+  #status {
+    font: 600 13px/1 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    color: var(--ink-soft); background: var(--surface);
+    border: 1px solid var(--line); border-radius: 999px; padding: 8px 14px;
+    white-space: nowrap;
+  }
+
+  /* KPI cards -------------------------------------------------------- */
+  .kpis { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 26px 0 22px; }
+  .kpi {
+    background: var(--surface); border: 1px solid var(--line);
+    border-radius: var(--radius); padding: 18px 20px;
+  }
+  .kpi .label {
+    font-size: 12px; font-weight: 600; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--ink-soft);
+  }
+  .kpi .value { margin-top: 8px; font-size: 30px; font-weight: 700; letter-spacing: -0.02em; }
+  .kpi .delta { margin-top: 4px; font-size: 13px; font-weight: 600; color: var(--good); }
+  .kpi .delta.down { color: var(--warn); }
+
+  /* Toolbar ---------------------------------------------------------- */
+  .toolbar { display: flex; gap: 12px; align-items: center; margin-bottom: 16px; }
+  #search {
+    flex: 1; padding: 11px 14px; font: inherit; color: inherit;
+    background: var(--surface); border: 1px solid var(--line);
+    border-radius: 10px; outline: none;
+  }
+  #search:focus { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(235, 110, 20, 0.14); }
+  #refresh {
+    padding: 11px 20px; font: 600 15px/1 inherit; color: #fff;
+    background: var(--accent); border: 0; border-radius: 10px; cursor: pointer;
+  }
+  #refresh:hover { filter: brightness(1.06); }
+
+  /* Table ------------------------------------------------------------ */
+  .card {
+    background: var(--surface); border: 1px solid var(--line);
+    border-radius: var(--radius); overflow: hidden;
+  }
+  table { width: 100%; border-collapse: collapse; }
+  th, td { padding: 13px 20px; text-align: left; }
+  thead th {
+    font-size: 12px; font-weight: 600; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--ink-soft);
+    border-bottom: 1px solid var(--line);
+  }
+  tbody tr + tr td { border-top: 1px solid var(--line); }
+  td.num { font-variant-numeric: tabular-nums; }
+  .pill {
+    display: inline-block; padding: 3px 10px; border-radius: 999px;
+    font-size: 12px; font-weight: 600;
+    background: rgba(31, 138, 92, 0.12); color: var(--good);
+  }
+  .pill.hold { background: rgba(180, 121, 26, 0.14); color: var(--warn); }
+  #empty { padding: 26px 20px; color: var(--ink-soft); }
+
+  /* Secret panel (only with ?secret=1) -------------------------------- */
+  #secret-panel {
+    margin-top: 22px; padding: 16px 20px; background: var(--surface);
+    border: 1px solid var(--line); border-radius: var(--radius);
+  }
+  #secret-panel .label {
+    font-size: 12px; font-weight: 600; letter-spacing: 0.08em;
+    text-transform: uppercase; color: var(--ink-soft);
+  }
+  #api-key {
+    display: block; margin-top: 8px;
+    font: 15px/1.4 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    color: var(--ink);
+  }
+</style>
+</head>
+<body>
+<div class="page">
+  <header>
+    <div>
+      <h1>Northwind Ops</h1>
+      <p class="sub">Fulfilment overview for the western region.</p>
+    </div>
+    <div id="status">snapshot 1 of 3</div>
+  </header>
+
+  <section class="kpis">
+    <div class="kpi">
+      <div class="label">Revenue</div>
+      <div class="value" id="kpi-rev">$128,400</div>
+      <div class="delta" id="kpi-rev-delta">+4.2% vs. last week</div>
+    </div>
+    <div class="kpi">
+      <div class="label">Open orders</div>
+      <div class="value" id="kpi-orders">42</div>
+      <div class="delta" id="kpi-orders-delta">+6 today</div>
+    </div>
+    <div class="kpi">
+      <div class="label">On-time rate</div>
+      <div class="value" id="kpi-ontime">96%</div>
+      <div class="delta" id="kpi-ontime-delta">+1 pt</div>
+    </div>
+  </section>
+
+  <div class="toolbar">
+    <input id="search" type="text" placeholder="Filter orders by customer or city…" autocomplete="off">
+    <button id="refresh" type="button">Refresh</button>
+  </div>
+
+  <div class="card">
+    <table id="table">
+      <thead>
+        <tr>
+          <th>Order</th>
+          <th>Customer</th>
+          <th>City</th>
+          <th>Status</th>
+          <th class="num">Total</th>
+        </tr>
+      </thead>
+      <tbody id="rows"></tbody>
+    </table>
+    <div id="empty" hidden>No orders match that filter.</div>
+  </div>
+</div>
+
+<script>
+"use strict";
+/*
+ * Fixture app for the demo-video smoke test. Deliberately dependency-free,
+ * build-step-free, and deterministic: no Math.random(), no Date.now() on
+ * screen, no animations. Every element the smoke test (and the queued
+ * feature work) drives has a stable id.
+ *
+ * Query-string hooks, inert unless asked for:
+ *   ?console-error=1  page logs a console error and throws on load (issue #3)
+ *   ?secret=1         renders #api-key holding an obviously-fake secret (issue #4)
+ */
+
+// Three fixed snapshots. #refresh cycles through them in order, so a
+// recording made today looks exactly like one made next year.
+var SNAPSHOTS = [
+  {
+    kpis: { rev: "$128,400", revDelta: "+4.2% vs. last week", revDown: false,
+            orders: "42", ordersDelta: "+6 today",
+            ontime: "96%", ontimeDelta: "+1 pt", ontimeDown: false },
+    rows: [
+      ["NW-1041", "Ferrari Logistics", "Portland", "shipped", "$4,280"],
+      ["NW-1042", "Blue Ridge Foods",  "Boise",    "shipped", "$1,915"],
+      ["NW-1043", "Harbor Supply Co.", "Seattle",  "hold",    "$8,640"],
+      ["NW-1044", "Cascade Outfitters","Portland", "shipped", "$2,370"],
+      ["NW-1045", "Pine & Poplar",     "Spokane",  "shipped", "$980"]
+    ]
+  },
+  {
+    kpis: { rev: "$134,950", revDelta: "+9.3% vs. last week", revDown: false,
+            orders: "38", ordersDelta: "-4 today",
+            ontime: "97%", ontimeDelta: "+2 pt", ontimeDown: false },
+    rows: [
+      ["NW-1046", "Harbor Supply Co.", "Seattle",  "shipped", "$6,120"],
+      ["NW-1047", "Ferrari Logistics", "Portland", "shipped", "$3,410"],
+      ["NW-1048", "Redwood Kitchens",  "Eugene",   "hold",    "$5,275"],
+      ["NW-1049", "Blue Ridge Foods",  "Boise",    "shipped", "$2,040"]
+    ]
+  },
+  {
+    kpis: { rev: "$119,180", revDelta: "-2.1% vs. last week", revDown: true,
+            orders: "51", ordersDelta: "+13 today",
+            ontime: "93%", ontimeDelta: "-3 pt", ontimeDown: true },
+    rows: [
+      ["NW-1050", "Cascade Outfitters","Portland", "hold",    "$7,860"],
+      ["NW-1051", "Pine & Poplar",     "Spokane",  "shipped", "$1,240"],
+      ["NW-1052", "Harbor Supply Co.", "Seattle",  "shipped", "$3,990"],
+      ["NW-1053", "Redwood Kitchens",  "Eugene",   "shipped", "$2,615"],
+      ["NW-1054", "Ferrari Logistics", "Portland", "hold",    "$9,105"],
+      ["NW-1055", "Blue Ridge Foods",  "Boise",    "shipped", "$1,730"]
+    ]
+  }
+];
+
+var snapshotIndex = 0;
+
+function el(id) { return document.getElementById(id); }
+
+function renderKpis(k) {
+  el("kpi-rev").textContent = k.rev;
+  el("kpi-rev-delta").textContent = k.revDelta;
+  el("kpi-rev-delta").className = k.revDown ? "delta down" : "delta";
+  el("kpi-orders").textContent = k.orders;
+  el("kpi-orders-delta").textContent = k.ordersDelta;
+  el("kpi-ontime").textContent = k.ontime;
+  el("kpi-ontime-delta").textContent = k.ontimeDelta;
+  el("kpi-ontime-delta").className = k.ontimeDown ? "delta down" : "delta";
+}
+
+function renderRows() {
+  var snap = SNAPSHOTS[snapshotIndex];
+  var needle = el("search").value.trim().toLowerCase();
+  var body = el("rows");
+  body.textContent = "";
+  var shown = 0;
+  for (var i = 0; i < snap.rows.length; i++) {
+    var r = snap.rows[i];
+    var haystack = (r[1] + " " + r[2]).toLowerCase();
+    if (needle && haystack.indexOf(needle) === -1) { continue; }
+    var tr = document.createElement("tr");
+    tr.id = "row-" + r[0].toLowerCase();
+    tr.innerHTML =
+      "<td>" + r[0] + "</td>" +
+      "<td>" + r[1] + "</td>" +
+      "<td>" + r[2] + "</td>" +
+      '<td><span class="pill' + (r[3] === "hold" ? " hold" : "") + '">' + r[3] + "</span></td>" +
+      '<td class="num">' + r[4] + "</td>";
+    body.appendChild(tr);
+    shown++;
+  }
+  el("empty").hidden = shown > 0;
+}
+
+function render() {
+  var snap = SNAPSHOTS[snapshotIndex];
+  el("status").textContent = "snapshot " + (snapshotIndex + 1) + " of " + SNAPSHOTS.length;
+  renderKpis(snap.kpis);
+  renderRows();
+}
+
+el("search").addEventListener("input", renderRows);
+el("refresh").addEventListener("click", function () {
+  snapshotIndex = (snapshotIndex + 1) % SNAPSHOTS.length;
+  render();
+});
+
+render();
+
+// -- query-string hooks -----------------------------------------------------
+
+var params = new URLSearchParams(window.location.search);
+
+if (params.has("secret")) {
+  var panel = document.createElement("div");
+  panel.id = "secret-panel";
+  var label = document.createElement("div");
+  label.className = "label";
+  label.textContent = "Integration key";
+  var code = document.createElement("code");
+  code.id = "api-key";
+  // NOT a credential. A fixture literal, spelled FAKE and all zeroes on
+  // purpose so both gitleaks and a human read it as scenery. Used by the
+  // redaction work (issue #4) to prove a secret never reaches a frame.
+  code.textContent = "sk-live-FAKE0000000000000000";
+  panel.appendChild(label);
+  panel.appendChild(code);
+  document.querySelector(".page").appendChild(panel);
+}
+
+if (params.has("console-error")) {
+  // Deliberate breakage for the console-error detection work (issue #3).
+  // Emits both shapes a detector might key on: a console.error record and
+  // an uncaught exception (Playwright's "pageerror"). Thrown from a task so
+  // the rest of this script still finishes and the page stays usable.
+  console.error("fixture: deliberate console error");
+  setTimeout(function () {
+    throw new Error("fixture: deliberate uncaught error");
+  }, 0);
+}
+</script>
+</body>
+</html>

--- a/tests/smoke
+++ b/tests/smoke
@@ -7,18 +7,22 @@
 
 Serves `tests/fixture/` with a throwaway `python3 -m http.server`, records a
 short web demo against it with `Recorder`, records a short terminal demo with
-`TerminalRecorder`, and asserts that each take produced a real mp4 of a
-plausible duration plus the stills its storyboard asked for.
+`TerminalRecorder`, and grades each take on three separate axes:
 
-The point is not to check pixels. It is to catch the failure modes that make
-the whole skill useless and that nothing else notices: a recorder that raises,
-an ffmpeg pipeline that writes a 0-byte or 0.2-second mp4, a `shot()` that
-silently stops producing files.
+1. **Artifacts** — demo.mp4 and every requested still exist, are freshly
+   written by *this* run, and are not trivially small.
+2. **Content** — the frames actually contain a picture. Measured, not assumed:
+   luma standard deviation of decoded frames, so a blank or flat recording
+   fails even when its file size looks healthy.
+3. **Behaviour** — the storyboard's interactions had their effect. Every
+   `click`/`type_into`/`spotlight`/`move_to` is followed by a check of the
+   observable post-condition it should have caused, read back out of the live
+   page, so a no-op'd verb cannot record a static page and call it a pass.
 
     tests/smoke                 # both takes
     tests/smoke --web-only
     tests/smoke --terminal-only
-    tests/smoke --out-dir /tmp/smoke --keep
+    tests/smoke --out-dir /tmp/smoke
 
 Narration is forced off (`speech=False`): CI has no ELEVENLABS_API_KEY and no
 assertion here depends on audio.
@@ -30,6 +34,7 @@ terminal recorder unconditionally.
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import shutil
 import socket
@@ -47,12 +52,28 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURE_DIR = REPO_ROOT / "tests" / "fixture"
 HELPERS_DIR = REPO_ROOT / "skills" / "demo-video" / "helpers"
 
-# Size floors. A recorder that fails halfway still tends to leave a file
-# behind, so "exists" alone proves nothing — these say "there are actual
-# frames in there". Both are ~an order of magnitude below what a healthy
-# take produces.
+# Size floors. Deliberately low, and deliberately *not* the blank-video check —
+# no byte count separates a blank recording from a real one (a flat white 14 s
+# 720p H.264 is ~20 kB; a real terminal take is ~110 kB). These only catch the
+# degenerate zero/near-zero-byte file. Picture content is checked by
+# frame_contrast() below.
 MIN_MP4_BYTES = 20_000
 MIN_PNG_BYTES = 5_000
+
+# Luma standard deviation floors: "is there a picture in here at all".
+# Measured over the top 80% of the frame, so the caption bar — which is drawn
+# by the recorder and would be present even over a blank app — cannot carry
+# the score on its own.
+#
+# Observed on healthy takes: web mp4 60, terminal mp4 79, web stills 18-19,
+# terminal stills 78. Observed on a flat/blank frame: 0.0. The floors sit
+# ~3x under the weakest real value and infinitely above a blank one.
+MIN_FRAME_STDDEV = 8.0
+MIN_STILL_STDDEV = 6.0
+
+# Frames sampled per second of video for the content check. One is plenty:
+# a recording either has a picture throughout or does not.
+CONTENT_SAMPLE_FPS = 1
 
 # Duration windows, in seconds. Wide on purpose: the lower bound catches a
 # take that died early, the upper one catches a hang, and everything in
@@ -84,6 +105,22 @@ def scrub_env() -> None:
     for name in [k for k in os.environ if k.startswith("DEMO_VIDEO_")]:
         del os.environ[name]
     os.environ.pop("ELEVENLABS_API_KEY", None)
+
+
+def fresh_take_dir(out_root: Path, name: str) -> Path:
+    """An empty directory for one take.
+
+    Emptying it is load-bearing, not tidiness. Every artifact assertion works
+    by path, so a leftover demo.mp4 from a previous run grades a recorder that
+    produced nothing at all as a pass — and the documented workflow for
+    verifying a change is to record repeatedly into the same --out-dir. Only
+    the per-take subdirectory is removed, never the directory the caller named.
+    """
+    take = out_root / name
+    if take.exists():
+        shutil.rmtree(take)
+    take.mkdir(parents=True)
+    return take
 
 
 # -- fixture server ----------------------------------------------------------
@@ -147,52 +184,207 @@ def fixture_server() -> Iterator[str]:
             proc.wait(timeout=5)
 
 
+# -- picture content ---------------------------------------------------------
+
+
+def _stddev(buf: bytes) -> float:
+    n = len(buf)
+    mean = sum(buf) / n
+    return math.sqrt(sum((b - mean) ** 2 for b in buf) / n)
+
+
+def frame_contrast(path: Path, sample_fps: int | None = None) -> list[float]:
+    """Luma standard deviation of each sampled frame of an mp4 or a png.
+
+    ffmpeg decodes to raw 8-bit grayscale at a small fixed size, and the
+    spread of those bytes is computed here — no image library, no new
+    dependency. A frame showing anything at all scores tens; a flat frame
+    scores 0.0, whatever the file's byte size says.
+
+    The bottom 20% is cropped away first. The recorder burns its own caption
+    bar there, and a caption over an otherwise blank app would otherwise
+    supply enough contrast to pass on its own.
+    """
+    width, height = 160, 90
+    chain = []
+    if sample_fps:
+        chain.append(f"fps={sample_fps}")
+    chain += ["crop=iw:ih*0.8:0:0", f"scale={width}:{height}", "format=gray"]
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(path),
+            "-vf",
+            ",".join(chain),
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "gray",
+            "-",
+        ],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg could not decode {path}: "
+            f"{proc.stderr.decode(errors='replace').strip()[:300]}"
+        )
+    size = width * height
+    raw = proc.stdout
+    return [_stddev(raw[i : i + size]) for i in range(0, len(raw) - size + 1, size)]
+
+
 # -- storyboards -------------------------------------------------------------
 
 
-def record_web(out_dir: Path, base_url: str) -> None:
-    """A handful of beats: land, read a KPI, filter the table, refresh it."""
+class Beats:
+    """Collects post-condition failures without aborting the take.
+
+    A storyboard that stops at the first bad assertion produces no video, and
+    the video is half of what is being tested. So record the whole thing, then
+    report every interaction that did not do what it claimed.
+    """
+
+    def __init__(self, label: str) -> None:
+        self.label = label
+        self.problems: list[str] = []
+
+    def expect(self, after: str, actual: object, wanted: object) -> None:
+        if actual != wanted:
+            self.problems.append(
+                f"{self.label}: after {after}, expected {wanted!r} but got "
+                f"{actual!r} — the interaction did not take effect"
+            )
+
+    def expect_true(self, after: str, ok: bool, detail: str) -> None:
+        if not ok:
+            self.problems.append(f"{self.label}: after {after}, {detail}")
+
+
+def record_web(out_dir: Path, base_url: str) -> list[str]:
+    """Land, read a KPI, filter the table, refresh it.
+
+    Every verb is followed by the observable consequence it must have had,
+    read back out of the DOM. Byte sizes cannot tell a filtered table from an
+    unfiltered one; `#rows` and `#status` can.
+    """
     from demo_recording import Recorder
+
+    b = Beats("web")
+    outline = "el => getComputedStyle(el).outlineStyle"
 
     with Recorder(out_dir, base_url=base_url, speech=False) as rec:
         rec.goto("/")
         rec.wait_for("#kpi-rev")
         rec.pause(0.6)
+        b.expect("goto('/'), #rows row count", rec.page.locator("#rows tr").count(), 5)
+        b.expect(
+            "goto('/'), #status text",
+            rec.page.locator("#status").inner_text(),
+            "snapshot 1 of 3",
+        )
 
         rec.caption("A small dashboard.")
         rec.shot("01-dashboard")
+
         rec.spotlight("#kpi-rev")
+        b.expect(
+            "spotlight('#kpi-rev'), computed outline-style",
+            rec.page.eval_on_selector("#kpi-rev", outline),
+            "solid",
+        )
         rec.hold()
         rec.spotlight()
+        b.expect(
+            "spotlight() cleared, computed outline-style",
+            rec.page.eval_on_selector("#kpi-rev", outline),
+            "none",
+        )
 
         rec.caption("Filter by city.")
         rec.type_into("#search", "seattle")
         rec.pause(0.8)
+        b.expect(
+            "type_into('#search'), field value",
+            rec.page.input_value("#search"),
+            "seattle",
+        )
+        b.expect(
+            "type_into('#search'), #rows row count",
+            rec.page.locator("#rows tr").count(),
+            1,
+        )
         rec.shot("02-filtered")
 
         rec.caption("Refresh reloads it.")
         rec.click("#refresh")
         rec.pause(1.0)
+        b.expect(
+            "click('#refresh'), #status text",
+            rec.page.locator("#status").inner_text(),
+            "snapshot 2 of 3",
+        )
+        b.expect(
+            "click('#refresh'), #kpi-rev text",
+            rec.page.locator("#kpi-rev").inner_text(),
+            "$134,950",
+        )
+
+        # move_to has no DOM side effect of its own, so check the one thing it
+        # exists to do: park the recorder's drawn cursor on the target. click()
+        # routes through it, so this covers both.
+        box = rec.page.locator("#refresh").bounding_box()
+        cursor = rec.page.evaluate(
+            "() => { const d = document.getElementById('__demo_cursor');"
+            " return d ? [parseFloat(d.style.left), parseFloat(d.style.top)] : null; }"
+        )
+        on_target = bool(
+            box
+            and cursor
+            and box["x"] <= cursor[0] <= box["x"] + box["width"]
+            and box["y"] <= cursor[1] <= box["y"] + box["height"]
+        )
+        b.expect_true(
+            "click('#refresh'), cursor position",
+            on_target,
+            f"the drawn cursor is at {cursor}, which is outside #refresh at {box} "
+            "— move_to() never brought it there",
+        )
+
         rec.shot("03-refreshed")
         rec.caption("")
 
+    return b.problems
 
-def record_terminal(out_dir: Path) -> None:
-    """Two trivial commands — enough to exercise PTY, xterm.js, and prompt sync."""
+
+def record_terminal(out_dir: Path) -> list[str]:
+    """Two trivial commands — enough to exercise PTY, xterm.js, and prompt sync.
+
+    The waits are the assertions. Both patterns are anchored to a whole screen
+    line and match the commands' *output*, never the echoed command line, so
+    they only pass if the PTY really ran what run() typed.
+    """
     from demo_recording import TerminalRecorder
 
     with TerminalRecorder(out_dir, speech=False) as rec:
         rec.caption("A real shell, recorded.")
         rec.run("echo hello from demo-video")
         rec.wait_for_prompt()
+        rec.wait_for_text(r"^hello from demo-video$", timeout_s=10)
         rec.shot("01-echo")
 
         rec.caption("Any command works.")
         rec.run("ls -1")
         rec.wait_for_prompt()
+        rec.wait_for_text(r"^skills$", timeout_s=10)
         rec.pause(0.8)
         rec.shot("02-listing")
         rec.caption("")
+
+    return []
 
 
 # -- assertions --------------------------------------------------------------
@@ -203,15 +395,23 @@ def check_take(
     out_dir: Path,
     shots: list[str],
     duration_range: tuple[float, float],
+    started_at: float,
 ) -> list[str]:
     """Everything a healthy take leaves behind. Returns failure messages."""
     from demo_recording import media_duration
 
     failures: list[str] = []
 
+    def fresh(path: Path) -> bool:
+        # Belt and braces next to fresh_take_dir(): an artifact older than the
+        # take that supposedly produced it is somebody else's file.
+        return path.stat().st_mtime >= started_at - 1
+
     mp4 = out_dir / "demo.mp4"
     if not mp4.is_file():
         failures.append(f"{label}: {mp4} was never written")
+    elif not fresh(mp4):
+        failures.append(f"{label}: {mp4} is stale — it predates this run")
     else:
         size = mp4.stat().st_size
         if size < MIN_MP4_BYTES:
@@ -224,17 +424,36 @@ def check_take(
                 seconds = media_duration(mp4)
             except Exception as exc:  # noqa: BLE001 - report, don't crash the run
                 failures.append(f"{label}: ffprobe could not read {mp4}: {exc}")
-            else:
+                seconds = None
+            if seconds is not None:
                 low, high = duration_range
                 if not low <= seconds <= high:
                     failures.append(
                         f"{label}: {mp4.name} is {seconds:.1f}s, expected "
                         f"between {low:.0f}s and {high:.0f}s"
                     )
-                else:
+
+            try:
+                contrast = frame_contrast(mp4, sample_fps=CONTENT_SAMPLE_FPS)
+            except RuntimeError as exc:
+                failures.append(f"{label}: {exc}")
+                contrast = []
+            if not contrast:
+                failures.append(f"{label}: no frames could be sampled from {mp4.name}")
+            else:
+                best = max(contrast)
+                if best < MIN_FRAME_STDDEV:
+                    failures.append(
+                        f"{label}: {mp4.name} has no picture in it — the most "
+                        f"varied of {len(contrast)} sampled frames scores "
+                        f"{best:.1f} luma stddev, under the {MIN_FRAME_STDDEV} "
+                        "floor. A blank or flat recording looks exactly like "
+                        "this, at any file size."
+                    )
+                elif seconds is not None:
                     print(
-                        f"smoke: {label} demo.mp4 ok "
-                        f"({seconds:.1f}s, {size // 1024} kB)"
+                        f"smoke: {label} demo.mp4 ok ({seconds:.1f}s, "
+                        f"{size // 1024} kB, contrast {best:.0f})"
                     )
 
     for name in shots:
@@ -242,14 +461,34 @@ def check_take(
         if not png.is_file():
             failures.append(f"{label}: still {png} was never captured")
             continue
+        if not fresh(png):
+            failures.append(f"{label}: still {png} is stale — it predates this run")
+            continue
         size = png.stat().st_size
         if size < MIN_PNG_BYTES:
             failures.append(
                 f"{label}: still {png} is only {size} bytes "
                 f"(expected at least {MIN_PNG_BYTES})"
             )
+            continue
+        try:
+            contrast = frame_contrast(png)
+        except RuntimeError as exc:
+            failures.append(f"{label}: {exc}")
+            continue
+        if not contrast:
+            failures.append(f"{label}: still {png} decoded to no frames")
+        elif contrast[0] < MIN_STILL_STDDEV:
+            failures.append(
+                f"{label}: still {name}.png is blank — it scores "
+                f"{contrast[0]:.1f} luma stddev, under the "
+                f"{MIN_STILL_STDDEV} floor"
+            )
         else:
-            print(f"smoke: {label} still {name}.png ok ({size // 1024} kB)")
+            print(
+                f"smoke: {label} still {name}.png ok "
+                f"({size // 1024} kB, contrast {contrast[0]:.0f})"
+            )
 
     return failures
 
@@ -258,13 +497,14 @@ def check_take(
 
 
 def run_web(out_root: Path) -> list[str]:
-    out_dir = out_root / "web"
+    out_dir = fresh_take_dir(out_root, "web")
+    started = time.time()
     with fixture_server() as base_url:
         try:
-            record_web(out_dir, base_url)
+            problems = record_web(out_dir, base_url)
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"web: Recorder raised {type(exc).__name__}: {exc}"]
-    return check_take("web", out_dir, WEB_SHOTS, WEB_DURATION_S)
+    return problems + check_take("web", out_dir, WEB_SHOTS, WEB_DURATION_S, started)
 
 
 def run_terminal(out_root: Path) -> list[str]:
@@ -275,18 +515,21 @@ def run_terminal(out_root: Path) -> list[str]:
             file=sys.stderr,
         )
         return []
-    out_dir = out_root / "terminal"
+    out_dir = fresh_take_dir(out_root, "terminal")
+    started = time.time()
     # The shell starts in the process cwd, and `ls -1` is one of the beats —
     # pin it to the repo root so the take does not depend on where it was run.
     previous = Path.cwd()
     os.chdir(REPO_ROOT)
     try:
-        record_terminal(out_dir)
+        problems = record_terminal(out_dir)
     except Exception as exc:  # noqa: BLE001 - a raising take is a failure
         return [f"terminal: TerminalRecorder raised {type(exc).__name__}: {exc}"]
     finally:
         os.chdir(previous)
-    return check_take("terminal", out_dir, TERMINAL_SHOTS, TERMINAL_DURATION_S)
+    return problems + check_take(
+        "terminal", out_dir, TERMINAL_SHOTS, TERMINAL_DURATION_S, started
+    )
 
 
 # -- entry point -------------------------------------------------------------
@@ -305,8 +548,9 @@ def main() -> int:
     parser.add_argument(
         "--out-dir",
         type=Path,
-        help="where recordings land (default: a fresh temp dir). "
-        "Point CI at a known path so artifacts can be uploaded.",
+        help="where recordings land (default: a fresh temp dir). The web/ and "
+        "terminal/ subdirectories are emptied before each take. Point CI at a "
+        "known path so artifacts can be uploaded.",
     )
     parser.add_argument(
         "--keep",

--- a/tests/smoke
+++ b/tests/smoke
@@ -1,0 +1,370 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["playwright>=1.40"]
+# ///
+"""End-to-end smoke test for the demo-video recorders.
+
+Serves `tests/fixture/` with a throwaway `python3 -m http.server`, records a
+short web demo against it with `Recorder`, records a short terminal demo with
+`TerminalRecorder`, and asserts that each take produced a real mp4 of a
+plausible duration plus the stills its storyboard asked for.
+
+The point is not to check pixels. It is to catch the failure modes that make
+the whole skill useless and that nothing else notices: a recorder that raises,
+an ffmpeg pipeline that writes a 0-byte or 0.2-second mp4, a `shot()` that
+silently stops producing files.
+
+    tests/smoke                 # both takes
+    tests/smoke --web-only
+    tests/smoke --terminal-only
+    tests/smoke --out-dir /tmp/smoke --keep
+
+Narration is forced off (`speech=False`): CI has no ELEVENLABS_API_KEY and no
+assertion here depends on audio.
+
+Unix only, because `demo_recording/__init__.py` imports the PTY-backed
+terminal recorder unconditionally.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixture"
+HELPERS_DIR = REPO_ROOT / "skills" / "demo-video" / "helpers"
+
+# Size floors. A recorder that fails halfway still tends to leave a file
+# behind, so "exists" alone proves nothing — these say "there are actual
+# frames in there". Both are ~an order of magnitude below what a healthy
+# take produces.
+MIN_MP4_BYTES = 20_000
+MIN_PNG_BYTES = 5_000
+
+# Duration windows, in seconds. Wide on purpose: the lower bound catches a
+# take that died early, the upper one catches a hang, and everything in
+# between is legitimate variation between a laptop and a cold CI runner.
+WEB_DURATION_S = (6.0, 30.0)
+TERMINAL_DURATION_S = (4.0, 30.0)
+
+WEB_SHOTS = ["01-dashboard", "02-filtered", "03-refreshed"]
+TERMINAL_SHOTS = ["01-echo", "02-listing"]
+
+SERVER_START_TIMEOUT_S = 15.0
+
+
+class SmokeFailure(Exception):
+    """An assertion about a recording did not hold."""
+
+
+# -- environment -------------------------------------------------------------
+
+
+def scrub_env() -> None:
+    """Drop settings that would make the run depend on the operator's shell.
+
+    Every Recorder knob reads a DEMO_VIDEO_* variable, so a developer with a
+    sourced project .env would otherwise record at a different viewport, at a
+    different base URL, or with narration on — and the assertions below would
+    mean something different for them than for CI.
+    """
+    for name in [k for k in os.environ if k.startswith("DEMO_VIDEO_")]:
+        del os.environ[name]
+    os.environ.pop("ELEVENLABS_API_KEY", None)
+
+
+# -- fixture server ----------------------------------------------------------
+
+
+def free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+@contextmanager
+def fixture_server() -> Iterator[str]:
+    """Serve tests/fixture on a free port; always shut it down."""
+    if not (FIXTURE_DIR / "index.html").is_file():
+        raise SmokeFailure(f"fixture app missing: {FIXTURE_DIR / 'index.html'}")
+    port = free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "http.server",
+            str(port),
+            "--bind",
+            "127.0.0.1",
+            "--directory",
+            str(FIXTURE_DIR),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.time() + SERVER_START_TIMEOUT_S
+        while True:
+            if proc.poll() is not None:
+                raise SmokeFailure(
+                    f"fixture server exited immediately (code {proc.returncode}) "
+                    f"— port {port} may already be in use"
+                )
+            try:
+                with urllib.request.urlopen(base_url, timeout=1) as resp:
+                    if resp.status == 200:
+                        break
+            except (urllib.error.URLError, OSError):
+                pass
+            if time.time() > deadline:
+                raise SmokeFailure(
+                    f"fixture server did not answer on {base_url} within "
+                    f"{SERVER_START_TIMEOUT_S:.0f}s"
+                )
+            time.sleep(0.1)
+        print(f"smoke: serving {FIXTURE_DIR} at {base_url}")
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+# -- storyboards -------------------------------------------------------------
+
+
+def record_web(out_dir: Path, base_url: str) -> None:
+    """A handful of beats: land, read a KPI, filter the table, refresh it."""
+    from demo_recording import Recorder
+
+    with Recorder(out_dir, base_url=base_url, speech=False) as rec:
+        rec.goto("/")
+        rec.wait_for("#kpi-rev")
+        rec.pause(0.6)
+
+        rec.caption("A small dashboard.")
+        rec.shot("01-dashboard")
+        rec.spotlight("#kpi-rev")
+        rec.hold()
+        rec.spotlight()
+
+        rec.caption("Filter by city.")
+        rec.type_into("#search", "seattle")
+        rec.pause(0.8)
+        rec.shot("02-filtered")
+
+        rec.caption("Refresh reloads it.")
+        rec.click("#refresh")
+        rec.pause(1.0)
+        rec.shot("03-refreshed")
+        rec.caption("")
+
+
+def record_terminal(out_dir: Path) -> None:
+    """Two trivial commands — enough to exercise PTY, xterm.js, and prompt sync."""
+    from demo_recording import TerminalRecorder
+
+    with TerminalRecorder(out_dir, speech=False) as rec:
+        rec.caption("A real shell, recorded.")
+        rec.run("echo hello from demo-video")
+        rec.wait_for_prompt()
+        rec.shot("01-echo")
+
+        rec.caption("Any command works.")
+        rec.run("ls -1")
+        rec.wait_for_prompt()
+        rec.pause(0.8)
+        rec.shot("02-listing")
+        rec.caption("")
+
+
+# -- assertions --------------------------------------------------------------
+
+
+def check_take(
+    label: str,
+    out_dir: Path,
+    shots: list[str],
+    duration_range: tuple[float, float],
+) -> list[str]:
+    """Everything a healthy take leaves behind. Returns failure messages."""
+    from demo_recording import media_duration
+
+    failures: list[str] = []
+
+    mp4 = out_dir / "demo.mp4"
+    if not mp4.is_file():
+        failures.append(f"{label}: {mp4} was never written")
+    else:
+        size = mp4.stat().st_size
+        if size < MIN_MP4_BYTES:
+            failures.append(
+                f"{label}: {mp4} is only {size} bytes "
+                f"(expected at least {MIN_MP4_BYTES})"
+            )
+        else:
+            try:
+                seconds = media_duration(mp4)
+            except Exception as exc:  # noqa: BLE001 - report, don't crash the run
+                failures.append(f"{label}: ffprobe could not read {mp4}: {exc}")
+            else:
+                low, high = duration_range
+                if not low <= seconds <= high:
+                    failures.append(
+                        f"{label}: {mp4.name} is {seconds:.1f}s, expected "
+                        f"between {low:.0f}s and {high:.0f}s"
+                    )
+                else:
+                    print(
+                        f"smoke: {label} demo.mp4 ok "
+                        f"({seconds:.1f}s, {size // 1024} kB)"
+                    )
+
+    for name in shots:
+        png = out_dir / "images" / f"{name}.png"
+        if not png.is_file():
+            failures.append(f"{label}: still {png} was never captured")
+            continue
+        size = png.stat().st_size
+        if size < MIN_PNG_BYTES:
+            failures.append(
+                f"{label}: still {png} is only {size} bytes "
+                f"(expected at least {MIN_PNG_BYTES})"
+            )
+        else:
+            print(f"smoke: {label} still {name}.png ok ({size // 1024} kB)")
+
+    return failures
+
+
+# -- phases ------------------------------------------------------------------
+
+
+def run_web(out_root: Path) -> list[str]:
+    out_dir = out_root / "web"
+    with fixture_server() as base_url:
+        try:
+            record_web(out_dir, base_url)
+        except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+            return [f"web: Recorder raised {type(exc).__name__}: {exc}"]
+    return check_take("web", out_dir, WEB_SHOTS, WEB_DURATION_S)
+
+
+def run_terminal(out_root: Path) -> list[str]:
+    if os.name != "posix":
+        print(
+            "smoke: SKIPPING the terminal take — TerminalRecorder needs a PTY "
+            f"and this is {os.name!r}, not a Unix platform.",
+            file=sys.stderr,
+        )
+        return []
+    out_dir = out_root / "terminal"
+    # The shell starts in the process cwd, and `ls -1` is one of the beats —
+    # pin it to the repo root so the take does not depend on where it was run.
+    previous = Path.cwd()
+    os.chdir(REPO_ROOT)
+    try:
+        record_terminal(out_dir)
+    except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+        return [f"terminal: TerminalRecorder raised {type(exc).__name__}: {exc}"]
+    finally:
+        os.chdir(previous)
+    return check_take("terminal", out_dir, TERMINAL_SHOTS, TERMINAL_DURATION_S)
+
+
+# -- entry point -------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Smoke-test the demo-video recorders against tests/fixture.",
+    )
+    parser.add_argument(
+        "--web-only", action="store_true", help="record only the web take"
+    )
+    parser.add_argument(
+        "--terminal-only", action="store_true", help="record only the terminal take"
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        help="where recordings land (default: a fresh temp dir). "
+        "Point CI at a known path so artifacts can be uploaded.",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="keep the output directory even when everything passes",
+    )
+    args = parser.parse_args()
+
+    if args.web_only and args.terminal_only:
+        parser.error("--web-only and --terminal-only are mutually exclusive")
+
+    if not HELPERS_DIR.is_dir():
+        print(f"smoke: helpers not found at {HELPERS_DIR}", file=sys.stderr)
+        return 1
+    sys.path.insert(0, str(HELPERS_DIR))
+
+    if shutil.which("ffprobe") is None or shutil.which("ffmpeg") is None:
+        print(
+            "smoke: ffmpeg and ffprobe must be on PATH — the recorders shell "
+            "out to both.",
+            file=sys.stderr,
+        )
+        return 1
+
+    scrub_env()
+
+    if args.out_dir:
+        out_root = args.out_dir.resolve()
+        out_root.mkdir(parents=True, exist_ok=True)
+        ephemeral = False
+    else:
+        out_root = Path(tempfile.mkdtemp(prefix="demo-video-smoke-"))
+        ephemeral = True
+    print(f"smoke: output -> {out_root}")
+
+    failures: list[str] = []
+    try:
+        if not args.terminal_only:
+            failures += run_web(out_root)
+        if not args.web_only:
+            failures += run_terminal(out_root)
+    except SmokeFailure as exc:
+        failures.append(str(exc))
+
+    if failures:
+        print("\nsmoke: FAILED", file=sys.stderr)
+        for line in failures:
+            print(f"  - {line}", file=sys.stderr)
+        print(f"\nsmoke: recordings left in {out_root}", file=sys.stderr)
+        return 1
+
+    print("\nsmoke: PASSED")
+    if ephemeral and not args.keep:
+        shutil.rmtree(out_root, ignore_errors=True)
+    else:
+        print(f"smoke: recordings kept in {out_root}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/smoke
+++ b/tests/smoke
@@ -9,15 +9,17 @@ Serves `tests/fixture/` with a throwaway `python3 -m http.server`, records a
 short web demo against it with `Recorder`, records a short terminal demo with
 `TerminalRecorder`, and grades each take on three separate axes:
 
-1. **Artifacts** — demo.mp4 and every requested still exist, are freshly
-   written by *this* run, and are not trivially small.
-2. **Content** — the frames actually contain a picture. Measured, not assumed:
-   luma standard deviation of decoded frames, so a blank or flat recording
-   fails even when its file size looks healthy.
-3. **Behaviour** — the storyboard's interactions had their effect. Every
-   `click`/`type_into`/`spotlight`/`move_to` is followed by a check of the
-   observable post-condition it should have caused, read back out of the live
-   page, so a no-op'd verb cannot record a static page and call it a pass.
+1. **Artifacts** — demo.mp4 and every still exist, were written by *this* run,
+   are not trivially small, and are not repeats of each other.
+2. **Content** — the frames contain a picture, measured as luma standard
+   deviation over the region the *app* occupies. Scoring the whole frame does
+   not work: a fifth to a third of every frame is the recorder's own chrome (a
+   pastel gradient at ~230 luma against a ~35 luma window), which on its own
+   scores 60-79, so a blank recording can outscore a healthy one. The content
+   rect is read off the live recorder at record time, never hardcoded.
+3. **Behaviour** — the storyboard's verbs had their effect. Every
+   `caption`/`click`/`type_into`/`spotlight`/`move_to` is followed by a check
+   of the observable post-condition it should have caused.
 
     tests/smoke                 # both takes
     tests/smoke --web-only
@@ -29,6 +31,9 @@ assertion here depends on audio.
 
 Unix only, because `demo_recording/__init__.py` imports the PTY-backed
 terminal recorder unconditionally.
+
+This harness has known gaps, listed in tests/README.md. Read them before
+reading a pass as proof the recorder is healthy.
 """
 
 from __future__ import annotations
@@ -38,6 +43,7 @@ import math
 import os
 import shutil
 import socket
+import statistics
 import subprocess
 import sys
 import tempfile
@@ -52,39 +58,86 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURE_DIR = REPO_ROOT / "tests" / "fixture"
 HELPERS_DIR = REPO_ROOT / "skills" / "demo-video" / "helpers"
 
+# x, y, width, height in source-frame pixels.
+Rect = tuple[int, int, int, int]
+
 # Size floors. Deliberately low, and deliberately *not* the blank-video check —
 # no byte count separates a blank recording from a real one (a flat white 14 s
-# 720p H.264 is ~20 kB; a real terminal take is ~110 kB). These only catch the
-# degenerate zero/near-zero-byte file. Picture content is checked by
-# frame_contrast() below.
+# 720p H.264 is ~20 kB; a real terminal take is ~117 kB). These only catch the
+# degenerate near-zero-byte file.
 MIN_MP4_BYTES = 20_000
 MIN_PNG_BYTES = 5_000
 
-# Luma standard deviation floors: "is there a picture in here at all".
-# Measured over the top 80% of the frame, so the caption bar — which is drawn
-# by the recorder and would be present even over a blank app — cannot carry
-# the score on its own.
+# Luma standard deviation floors, applied only over the content rect. They
+# differ per medium because the media differ: a web page fills its rect with
+# light and dark, while a terminal is mostly empty dark background with a few
+# lines of text in it, and scores an order of magnitude lower while being
+# perfectly healthy.
 #
-# Observed on healthy takes: web mp4 60, terminal mp4 79, web stills 18-19,
-# terminal stills 78. Observed on a flat/blank frame: 0.0. The floors sit
-# ~3x under the weakest real value and infinitely above a blank one.
-MIN_FRAME_STDDEV = 8.0
-MIN_STILL_STDDEV = 6.0
+#             healthy            blank
+#   web       15.5 - 17.0        0.1 - 1.1
+#   terminal   5.1 -  7.9        0.2 - 0.4
+#
+# Each floor sits ~2.5x under the weakest healthy value and ~5x over the
+# strongest blank one. See tests/README.md for what this metric cannot
+# resolve — notably a total stylesheet failure, which scores ~10 and is
+# therefore checked separately via getComputedStyle rather than by pixels.
+MIN_CONTENT_STDDEV = {"web": 6.0, "terminal": 2.0}
 
-# Frames sampled per second of video for the content check. One is plenty:
-# a recording either has a picture throughout or does not.
+# Pixel proof that the caption bar reached the screen, as the mean absolute
+# luma change in the caption band between two stills taken back to back — one
+# with the caption cleared, one with it up. Nothing else on the page moves
+# between them, so the measurement is self-calibrating: no absolute threshold
+# tied to whatever the fixture happens to render near the bottom of the frame.
+#
+# Per medium, because the contrast available differs enormously: the web
+# caption is a dark box on a light page, while the terminal's is a dark box on
+# a dark terminal where only its text carries any luma change.
+#
+#             healthy      not drawn
+#   web         25.6          0.00
+#   terminal     2.7          0.00
+#
+# The terminal margin is the thinnest number in this file — 2.7x over its
+# floor, against 4x or better for everything else. tests/README.md calls that
+# out under "Known gaps".
+MIN_CAPTION_BAND_DIFF = {"web": 8.0, "terminal": 1.0}
+
+# Consecutive stills must differ by at least this mean absolute luma, on the
+# 160x90 grayscale reduction. This detects a *duplicate* — a stale or copied
+# screenshot scores exactly 0.00 — not "changed enough to be interesting":
+# neighbouring beats in the web take legitimately differ by only 0.85, since
+# a filtered table and a refreshed one are mostly the same white page.
+MIN_STILL_DIFF = 0.25
+
+# Frames sampled per second of video for the content check.
 CONTENT_SAMPLE_FPS = 1
+
+# Fraction of the content rect kept when scoring. The recorder burns its own
+# caption bar across the bottom; including it would let the caption supply the
+# contrast for an otherwise blank app.
+CONTENT_KEEP = 0.8
 
 # Duration windows, in seconds. Wide on purpose: the lower bound catches a
 # take that died early, the upper one catches a hang, and everything in
 # between is legitimate variation between a laptop and a cold CI runner.
-WEB_DURATION_S = (6.0, 30.0)
-TERMINAL_DURATION_S = (4.0, 30.0)
+WEB_DURATION_S = (6.0, 32.0)
+TERMINAL_DURATION_S = (4.0, 32.0)
 
 WEB_SHOTS = ["01-dashboard", "02-filtered", "03-refreshed"]
 TERMINAL_SHOTS = ["01-echo", "02-listing"]
 
+# Two stills every take ends with: the same frame with the caption cleared and
+# then set. Kept out of the *_SHOTS lists because they are meant to be
+# identical everywhere except the caption band, which is the opposite of what
+# the duplicate-still check demands of the storyboard's own stills.
+CAPTION_PROBE = ("90-caption-off", "91-caption-on")
+
 SERVER_START_TIMEOUT_S = 15.0
+
+# Written into each take directory so a later run can tell "a directory this
+# harness owns and may delete" from "somebody's source tree".
+MARKER_NAME = ".demo-video-smoke"
 
 
 class SmokeFailure(Exception):
@@ -108,18 +161,35 @@ def scrub_env() -> None:
 
 
 def fresh_take_dir(out_root: Path, name: str) -> Path:
-    """An empty directory for one take.
+    """An empty directory for one take, or a refusal.
 
     Emptying it is load-bearing, not tidiness. Every artifact assertion works
     by path, so a leftover demo.mp4 from a previous run grades a recorder that
-    produced nothing at all as a pass — and the documented workflow for
-    verifying a change is to record repeatedly into the same --out-dir. Only
-    the per-take subdirectory is removed, never the directory the caller named.
+    produced nothing at all as a pass — and recording repeatedly into one
+    --out-dir is how a change to the recorder gets verified.
+
+    But `--out-dir .` in a project that happens to have a `web/` directory
+    would then delete somebody's source tree. So: delete only a directory that
+    is absent, empty, or carries this harness's marker file. Anything else is
+    a hard error naming the path.
     """
     take = out_root / name
     if take.exists():
+        if not take.is_dir():
+            raise SmokeFailure(f"{take} exists and is not a directory")
+        if list(take.iterdir()) and not (take / MARKER_NAME).is_file():
+            raise SmokeFailure(
+                f"refusing to touch {take}: it is not empty and carries no "
+                f"{MARKER_NAME} marker, so this harness did not create it. "
+                f"Each take needs its own empty directory — point --out-dir "
+                f"somewhere this run owns."
+            )
         shutil.rmtree(take)
     take.mkdir(parents=True)
+    (take / MARKER_NAME).write_text(
+        "Written by tests/smoke. Its presence means this directory may be "
+        "deleted and recreated by the next run.\n"
+    )
     return take
 
 
@@ -186,30 +256,28 @@ def fixture_server() -> Iterator[str]:
 
 # -- picture content ---------------------------------------------------------
 
-
-def _stddev(buf: bytes) -> float:
-    n = len(buf)
-    mean = sum(buf) / n
-    return math.sqrt(sum((b - mean) ** 2 for b in buf) / n)
+# Everything below reduces frames to 160x90 8-bit grayscale via ffmpeg and
+# does the arithmetic in pure Python — no image library, no extra dependency.
+_GRAY_W, _GRAY_H = 160, 90
 
 
-def frame_contrast(path: Path, sample_fps: int | None = None) -> list[float]:
-    """Luma standard deviation of each sampled frame of an mp4 or a png.
+def gray_frames(
+    path: Path, rect: Rect | None = None, sample_fps: int | None = None
+) -> list[bytes]:
+    """Decode an mp4 or png into 160x90 grayscale frames.
 
-    ffmpeg decodes to raw 8-bit grayscale at a small fixed size, and the
-    spread of those bytes is computed here — no image library, no new
-    dependency. A frame showing anything at all scores tens; a flat frame
-    scores 0.0, whatever the file's byte size says.
-
-    The bottom 20% is cropped away first. The recorder burns its own caption
-    bar there, and a caption over an otherwise blank app would otherwise
-    supply enough contrast to pass on its own.
+    `rect` crops a region of the source frame *before* scaling. Passing the
+    region the app actually occupies is the whole point: the recorder's chrome
+    is high-contrast and static, so a whole-frame score is dominated by it and
+    cannot tell a blank app from a working one.
     """
-    width, height = 160, 90
     chain = []
     if sample_fps:
         chain.append(f"fps={sample_fps}")
-    chain += ["crop=iw:ih*0.8:0:0", f"scale={width}:{height}", "format=gray"]
+    if rect is not None:
+        x, y, w, h = rect
+        chain.append(f"crop={w}:{h}:{x}:{y}")
+    chain += [f"scale={_GRAY_W}:{_GRAY_H}", "format=gray"]
     proc = subprocess.run(
         [
             "ffmpeg",
@@ -232,9 +300,36 @@ def frame_contrast(path: Path, sample_fps: int | None = None) -> list[float]:
             f"ffmpeg could not decode {path}: "
             f"{proc.stderr.decode(errors='replace').strip()[:300]}"
         )
-    size = width * height
+    size = _GRAY_W * _GRAY_H
     raw = proc.stdout
-    return [_stddev(raw[i : i + size]) for i in range(0, len(raw) - size + 1, size)]
+    return [raw[i : i + size] for i in range(0, len(raw) - size + 1, size)]
+
+
+def contrast(frame: bytes) -> float:
+    """Luma standard deviation. Anything visible scores tens; a flat frame 0."""
+    n = len(frame)
+    mean = sum(frame) / n
+    return math.sqrt(sum((b - mean) ** 2 for b in frame) / n)
+
+
+def frame_difference(a: bytes, b: bytes) -> float:
+    """Mean absolute luma difference between two reduced frames."""
+    return sum(abs(x - y) for x, y in zip(a, b, strict=False)) / len(a)
+
+
+def keep_top(rect: Rect, fraction: float = CONTENT_KEEP) -> Rect:
+    x, y, w, h = rect
+    return (x, y, w, max(1, int(h * fraction)))
+
+
+def caption_band(frame_size: tuple[int, int]) -> Rect:
+    """The strip of a full still that holds the burned-in caption bar.
+
+    Covers both recorders: the web caption sits 44 px off the page bottom and
+    the terminal's 88 px, and both boxes are around 70 px tall.
+    """
+    width, height = frame_size
+    return (0, max(0, height - 160), width, 140)
 
 
 # -- storyboards -------------------------------------------------------------
@@ -244,8 +339,9 @@ class Beats:
     """Collects post-condition failures without aborting the take.
 
     A storyboard that stops at the first bad assertion produces no video, and
-    the video is half of what is being tested. So record the whole thing, then
-    report every interaction that did not do what it claimed.
+    the video is two thirds of what is being graded — and CI's failure-only
+    artifact upload would then have nothing to upload at the moment it is most
+    wanted. So record the whole thing, then report everything that went wrong.
     """
 
     def __init__(self, label: str) -> None:
@@ -254,27 +350,78 @@ class Beats:
 
     def expect(self, after: str, actual: object, wanted: object) -> None:
         if actual != wanted:
+            # Deliberately does NOT conclude "the interaction did not take
+            # effect". A legitimate edit to tests/fixture/index.html trips
+            # these too, and telling a queued-PR author that their recorder
+            # change broke, when the fixture merely gained a row, is worse
+            # than saying nothing.
             self.problems.append(
                 f"{self.label}: after {after}, expected {wanted!r} but got "
-                f"{actual!r} — the interaction did not take effect"
+                f"{actual!r} — either that verb had no effect, or "
+                f"tests/fixture/index.html changed and this expectation is stale"
             )
 
-    def expect_true(self, after: str, ok: bool, detail: str) -> None:
-        if not ok:
-            self.problems.append(f"{self.label}: after {after}, {detail}")
+    def fail_if(self, condition: bool, message: str) -> None:
+        if condition:
+            self.problems.append(f"{self.label}: {message}")
 
 
-def record_web(out_dir: Path, base_url: str) -> list[str]:
+_CAPTION_JS = """() => {
+  const el = document.getElementById('__demo_caption');
+  if (!el) return null;
+  return [el.textContent, getComputedStyle(el).opacity];
+}"""
+
+
+def check_caption(b: Beats, page, expected: str) -> None:
+    """Assert the caption the storyboard just set actually reached the screen.
+
+    Captions are this skill's headline feature — the thing a viewer reads. A
+    recorder that silently stops drawing them still produces a video that
+    satisfies every pixel metric and explains nothing.
+    """
+    state = page.evaluate(_CAPTION_JS)
+    if state is None:
+        b.fail_if(True, "no #__demo_caption element exists — caption() drew nothing")
+        return
+    text, opacity = state
+    b.fail_if(text != expected, f"the caption reads {text!r}, expected {expected!r}")
+    # Numeric, not string equality: the bar fades over 0.3 s, so a check run
+    # right after the call legitimately catches it at 0.0017 rather than 0.
+    shown = float(opacity) > 0.5
+    b.fail_if(
+        shown != bool(expected),
+        f"the caption's computed opacity is {opacity} but its text is "
+        f"{expected!r} — it is in the DOM and not on screen"
+        if expected
+        else f"the caption's computed opacity is {opacity}; it should have "
+        f"been cleared",
+    )
+
+
+# Records every mousemove the page sees, so move_to()'s 30-step glide can be
+# told apart from the single move Playwright's own click() dispatches.
+_TRAIL_JS = """() => {
+  window.__smokeTrail = [];
+  window.addEventListener(
+    'mousemove', (e) => window.__smokeTrail.push([e.clientX, e.clientY]), true);
+}"""
+
+
+def record_web(
+    out_dir: Path, base_url: str
+) -> tuple[list[str], Rect, Rect, tuple[int, int]]:
     """Land, read a KPI, filter the table, refresh it.
 
-    Every verb is followed by the observable consequence it must have had,
-    read back out of the DOM. Byte sizes cannot tell a filtered table from an
-    unfiltered one; `#rows` and `#status` can.
+    Returns the post-condition failures plus two content rects: where the app
+    sits inside the composited video, and where it sits in a still (stills are
+    captured full-bleed, before compositing).
     """
     from demo_recording import Recorder
 
     b = Beats("web")
     outline = "el => getComputedStyle(el).outlineStyle"
+    bg = "el => getComputedStyle(el).backgroundColor"
 
     with Recorder(out_dir, base_url=base_url, speech=False) as rec:
         rec.goto("/")
@@ -286,8 +433,17 @@ def record_web(out_dir: Path, base_url: str) -> list[str]:
             rec.page.locator("#status").inner_text(),
             "snapshot 1 of 3",
         )
+        # A stylesheet that failed to load leaves the DOM intact and the page
+        # legible-ish, which the luma metric scores around 10 — above its
+        # floor. This resolves that case exactly, with no pixel threshold.
+        b.expect(
+            "goto('/'), #refresh background (did the stylesheet apply?)",
+            rec.page.eval_on_selector("#refresh", bg),
+            "rgb(235, 110, 20)",
+        )
 
         rec.caption("A small dashboard.")
+        check_caption(b, rec.page, "A small dashboard.")
         rec.shot("01-dashboard")
 
         rec.spotlight("#kpi-rev")
@@ -305,6 +461,7 @@ def record_web(out_dir: Path, base_url: str) -> list[str]:
         )
 
         rec.caption("Filter by city.")
+        check_caption(b, rec.page, "Filter by city.")
         rec.type_into("#search", "seattle")
         rec.pause(0.8)
         b.expect(
@@ -320,6 +477,22 @@ def record_web(out_dir: Path, base_url: str) -> list[str]:
         rec.shot("02-filtered")
 
         rec.caption("Refresh reloads it.")
+        check_caption(b, rec.page, "Refresh reloads it.")
+
+        # move_to() is the sole source of the 30-step cursor glide. Asserting
+        # only where the cursor ends up proves nothing, because Playwright's
+        # locator.click() dispatches its own mousemove to the target — that
+        # measures Playwright, not move_to. Count the intermediate moves
+        # instead: a glide is many, a click is one.
+        rec.page.evaluate(_TRAIL_JS)
+        rec.move_to("#refresh")
+        trail = rec.page.evaluate("() => window.__smokeTrail.length")
+        b.fail_if(
+            trail < 10,
+            f"move_to('#refresh') produced {trail} mousemove events; the glide "
+            f"is 30 steps, so this is not a glide",
+        )
+
         rec.click("#refresh")
         rec.pause(1.0)
         b.expect(
@@ -332,62 +505,168 @@ def record_web(out_dir: Path, base_url: str) -> list[str]:
             rec.page.locator("#kpi-rev").inner_text(),
             "$134,950",
         )
-
-        # move_to has no DOM side effect of its own, so check the one thing it
-        # exists to do: park the recorder's drawn cursor on the target. click()
-        # routes through it, so this covers both.
-        box = rec.page.locator("#refresh").bounding_box()
-        cursor = rec.page.evaluate(
-            "() => { const d = document.getElementById('__demo_cursor');"
-            " return d ? [parseFloat(d.style.left), parseFloat(d.style.top)] : null; }"
-        )
-        on_target = bool(
-            box
-            and cursor
-            and box["x"] <= cursor[0] <= box["x"] + box["width"]
-            and box["y"] <= cursor[1] <= box["y"] + box["height"]
-        )
-        b.expect_true(
-            "click('#refresh'), cursor position",
-            on_target,
-            f"the drawn cursor is at {cursor}, which is outside #refresh at {box} "
-            "— move_to() never brought it there",
-        )
-
         rec.shot("03-refreshed")
+
+        # Two stills back to back with the page frozen and only the caption
+        # changing. Their difference in the caption band is pixel proof that
+        # the bar was actually drawn — see MIN_CAPTION_BAND_DIFF.
+        rec.caption("")
+        check_caption(b, rec.page, "")
+        rec.shot(CAPTION_PROBE[0])
+        rec.caption("Recorded end to end.")
+        check_caption(b, rec.page, "Recorded end to end.")
+        rec.shot(CAPTION_PROBE[1])
         rec.caption("")
 
-    return b.problems
+        # Where the app lands in each medium, read off the live recorder rather
+        # than re-derived here, so a change to the window geometry carries this
+        # with it instead of silently scoring the wrong pixels.
+        g = rec._geom
+        video_rect: Rect = (g["appx"], g["appy"], g["appw"], g["apph"])
+        size = (rec._size["width"], rec._size["height"])
+        still_rect: Rect = (0, 0, size[0], size[1])
+
+    return b.problems, video_rect, still_rect, size
 
 
-def record_terminal(out_dir: Path) -> list[str]:
-    """Two trivial commands — enough to exercise PTY, xterm.js, and prompt sync.
-
-    The waits are the assertions. Both patterns are anchored to a whole screen
-    line and match the commands' *output*, never the echoed command line, so
-    they only pass if the PTY really ran what run() typed.
-    """
+def record_terminal(
+    out_dir: Path,
+) -> tuple[list[str], Rect, Rect, tuple[int, int]]:
+    """Two trivial commands — enough to exercise PTY, xterm.js, and prompt sync."""
     from demo_recording import TerminalRecorder
+
+    b = Beats("terminal")
+
+    # Both terminal syncs raise on timeout, which would abort the take before
+    # the mp4 was written — and then CI's failure-only artifact upload has
+    # nothing to show at exactly the moment somebody wants to look at it.
+    # Collect instead, and keep the timeouts short so a broken take fails in
+    # seconds rather than minutes.
+    def expect_screen(rec, after: str, pattern: str) -> None:
+        try:
+            rec.wait_for_text(pattern, timeout_s=10)
+        except RuntimeError as exc:
+            tail = " ".join(str(exc).split())[:200]
+            b.fail_if(
+                True,
+                f"after {after}, the rendered screen never matched /{pattern}/ "
+                f"— {tail}",
+            )
+
+    def expect_prompt(rec, after: str) -> None:
+        try:
+            rec.wait_for_prompt(timeout_s=15)
+        except RuntimeError as exc:
+            tail = " ".join(str(exc).split())[:200]
+            b.fail_if(True, f"after {after}, the shell prompt never came back — {tail}")
 
     with TerminalRecorder(out_dir, speech=False) as rec:
         rec.caption("A real shell, recorded.")
+        check_caption(b, rec.page, "A real shell, recorded.")
         rec.run("echo hello from demo-video")
-        rec.wait_for_prompt()
-        rec.wait_for_text(r"^hello from demo-video$", timeout_s=10)
+        expect_prompt(rec, "run('echo …')")
+        # Anchored to a whole screen line, and matching the command's *output*
+        # rather than the echoed command line — so it only passes if the PTY
+        # really ran what run() typed.
+        expect_screen(rec, "run('echo …')", r"^hello from demo-video$")
         rec.shot("01-echo")
 
         rec.caption("Any command works.")
+        check_caption(b, rec.page, "Any command works.")
         rec.run("ls -1")
-        rec.wait_for_prompt()
-        rec.wait_for_text(r"^skills$", timeout_s=10)
+        expect_prompt(rec, "run('ls -1')")
+        expect_screen(rec, "run('ls -1')", r"^skills$")
         rec.pause(0.8)
         rec.shot("02-listing")
+
+        rec.caption("")
+        check_caption(b, rec.page, "")
+        rec.shot(CAPTION_PROBE[0])
+        rec.caption("Recorded end to end.")
+        check_caption(b, rec.page, "Recorded end to end.")
+        rec.shot(CAPTION_PROBE[1])
         rec.caption("")
 
-    return []
+        # The xterm.js host div — a real element with a stable id, so the
+        # content rect follows any change to the window chrome.
+        box = rec.page.locator("#__term_host").bounding_box()
+        if box is None:
+            raise SmokeFailure("#__term_host has no box — the terminal never rendered")
+        rect: Rect = (
+            int(box["x"]),
+            int(box["y"]),
+            int(box["width"]),
+            int(box["height"]),
+        )
+        size = (rec._size["width"], rec._size["height"])
+
+    # The terminal frames itself in-page and is not composited, so its video
+    # and its stills share one geometry.
+    return b.problems, rect, rect, size
 
 
 # -- assertions --------------------------------------------------------------
+
+
+def _check_video(
+    label: str,
+    mp4: Path,
+    duration_range: tuple[float, float],
+    video_rect: Rect,
+) -> list[str]:
+    from demo_recording import media_duration
+
+    failures: list[str] = []
+    size = mp4.stat().st_size
+    if size < MIN_MP4_BYTES:
+        failures.append(
+            f"{label}: {mp4} is only {size} bytes (expected at least {MIN_MP4_BYTES})"
+        )
+        return failures
+
+    seconds: float | None
+    try:
+        seconds = media_duration(mp4)
+    except Exception as exc:  # noqa: BLE001 - report, don't crash the run
+        failures.append(f"{label}: ffprobe could not read {mp4}: {exc}")
+        seconds = None
+    if seconds is not None:
+        low, high = duration_range
+        if not low <= seconds <= high:
+            failures.append(
+                f"{label}: {mp4.name} is {seconds:.1f}s, expected between "
+                f"{low:.0f}s and {high:.0f}s"
+            )
+
+    try:
+        frames = gray_frames(mp4, video_rect, sample_fps=CONTENT_SAMPLE_FPS)
+    except RuntimeError as exc:
+        failures.append(f"{label}: {exc}")
+        return failures
+    if not frames:
+        failures.append(f"{label}: no frames could be sampled from {mp4.name}")
+        return failures
+
+    # Median, not max: one good frame must not excuse a blank video. Not min
+    # either — a take legitimately opens on a frame or two of not-yet-painted
+    # page.
+    floor = MIN_CONTENT_STDDEV[label]
+    score = statistics.median(contrast(f) for f in frames)
+    if score < floor:
+        failures.append(
+            f"{label}: {mp4.name} has no picture where the app should be — the "
+            f"median of {len(frames)} sampled frames scores {score:.1f} luma "
+            f"stddev over {video_rect}, under the {floor} floor"
+        )
+    # "ok" only when nothing at all was wrong with this file. Printing it
+    # alongside a duration failure reads as a contradiction, and a log that
+    # contradicts itself is a log nobody trusts.
+    if not failures and seconds is not None:
+        print(
+            f"smoke: {label} demo.mp4 ok ({seconds:.1f}s, {size // 1024} kB, "
+            f"content {score:.1f})"
+        )
+    return failures
 
 
 def check_take(
@@ -396,11 +675,19 @@ def check_take(
     shots: list[str],
     duration_range: tuple[float, float],
     started_at: float,
+    video_rect: Rect,
+    still_rect: Rect,
+    frame_size: tuple[int, int],
 ) -> list[str]:
-    """Everything a healthy take leaves behind. Returns failure messages."""
-    from demo_recording import media_duration
+    """Everything a healthy take leaves behind. Returns failure messages.
 
+    `video_rect`/`still_rect` are where the app itself sits; the bottom fifth
+    of each is dropped before scoring so the recorder's caption bar cannot
+    supply the contrast for a blank app.
+    """
     failures: list[str] = []
+    video_rect = keep_top(video_rect)
+    still_rect = keep_top(still_rect)
 
     def fresh(path: Path) -> bool:
         # Belt and braces next to fresh_take_dir(): an artifact older than the
@@ -413,49 +700,9 @@ def check_take(
     elif not fresh(mp4):
         failures.append(f"{label}: {mp4} is stale — it predates this run")
     else:
-        size = mp4.stat().st_size
-        if size < MIN_MP4_BYTES:
-            failures.append(
-                f"{label}: {mp4} is only {size} bytes "
-                f"(expected at least {MIN_MP4_BYTES})"
-            )
-        else:
-            try:
-                seconds = media_duration(mp4)
-            except Exception as exc:  # noqa: BLE001 - report, don't crash the run
-                failures.append(f"{label}: ffprobe could not read {mp4}: {exc}")
-                seconds = None
-            if seconds is not None:
-                low, high = duration_range
-                if not low <= seconds <= high:
-                    failures.append(
-                        f"{label}: {mp4.name} is {seconds:.1f}s, expected "
-                        f"between {low:.0f}s and {high:.0f}s"
-                    )
+        failures += _check_video(label, mp4, duration_range, video_rect)
 
-            try:
-                contrast = frame_contrast(mp4, sample_fps=CONTENT_SAMPLE_FPS)
-            except RuntimeError as exc:
-                failures.append(f"{label}: {exc}")
-                contrast = []
-            if not contrast:
-                failures.append(f"{label}: no frames could be sampled from {mp4.name}")
-            else:
-                best = max(contrast)
-                if best < MIN_FRAME_STDDEV:
-                    failures.append(
-                        f"{label}: {mp4.name} has no picture in it — the most "
-                        f"varied of {len(contrast)} sampled frames scores "
-                        f"{best:.1f} luma stddev, under the {MIN_FRAME_STDDEV} "
-                        "floor. A blank or flat recording looks exactly like "
-                        "this, at any file size."
-                    )
-                elif seconds is not None:
-                    print(
-                        f"smoke: {label} demo.mp4 ok ({seconds:.1f}s, "
-                        f"{size // 1024} kB, contrast {best:.0f})"
-                    )
-
+    reduced: dict[str, bytes] = {}
     for name in shots:
         png = out_dir / "images" / f"{name}.png"
         if not png.is_file():
@@ -472,23 +719,69 @@ def check_take(
             )
             continue
         try:
-            contrast = frame_contrast(png)
+            frames = gray_frames(png, still_rect)
         except RuntimeError as exc:
             failures.append(f"{label}: {exc}")
             continue
-        if not contrast:
+        if not frames:
             failures.append(f"{label}: still {png} decoded to no frames")
-        elif contrast[0] < MIN_STILL_STDDEV:
+            continue
+        score = contrast(frames[0])
+        if score < MIN_CONTENT_STDDEV[label]:
             failures.append(
-                f"{label}: still {name}.png is blank — it scores "
-                f"{contrast[0]:.1f} luma stddev, under the "
-                f"{MIN_STILL_STDDEV} floor"
+                f"{label}: still {name}.png is blank — it scores {score:.1f} "
+                f"luma stddev over {still_rect}, under the "
+                f"{MIN_CONTENT_STDDEV[label]} floor"
             )
+            continue
+        reduced[name] = frames[0]
+        print(
+            f"smoke: {label} still {name}.png ok "
+            f"({size // 1024} kB, content {score:.1f})"
+        )
+
+    # Three identical screenshots satisfy every check above. They must not.
+    ordered = [n for n in shots if n in reduced]
+    for previous, current in zip(ordered, ordered[1:], strict=False):
+        delta = frame_difference(reduced[previous], reduced[current])
+        if delta < MIN_STILL_DIFF:
+            failures.append(
+                f"{label}: stills {previous}.png and {current}.png are the "
+                f"same picture (mean luma difference {delta:.2f}, floor "
+                f"{MIN_STILL_DIFF}) — the screenshot is stale, or the beat "
+                f"between them changed nothing"
+            )
+
+    # Pixel proof that the caption bar reached the screen, not just the DOM.
+    # The two probe stills are the same frame with the caption off and on, so
+    # any change in the caption band is the caption and nothing else.
+    off, on = (out_dir / "images" / f"{n}.png" for n in CAPTION_PROBE)
+    if not (off.is_file() and on.is_file()):
+        failures.append(
+            f"{label}: the caption probe stills {CAPTION_PROBE[0]}.png and "
+            f"{CAPTION_PROBE[1]}.png were not both captured"
+        )
+    else:
+        band = caption_band(frame_size)
+        try:
+            before = gray_frames(off, band)
+            after = gray_frames(on, band)
+        except RuntimeError as exc:
+            failures.append(f"{label}: {exc}")
         else:
-            print(
-                f"smoke: {label} still {name}.png ok "
-                f"({size // 1024} kB, contrast {contrast[0]:.0f})"
-            )
+            delta = frame_difference(before[0], after[0]) if before and after else 0.0
+            if delta < MIN_CAPTION_BAND_DIFF[label]:
+                failures.append(
+                    f"{label}: setting a caption changed nothing on screen — "
+                    f"the caption band moved by {delta:.2f} mean luma between "
+                    f"{CAPTION_PROBE[0]}.png and {CAPTION_PROBE[1]}.png, under "
+                    f"the {MIN_CAPTION_BAND_DIFF[label]} floor. The bar is in "
+                    f"the DOM but is not being drawn."
+                )
+            else:
+                print(
+                    f"smoke: {label} caption is visible on screen (delta {delta:.1f})"
+                )
 
     return failures
 
@@ -501,10 +794,12 @@ def run_web(out_root: Path) -> list[str]:
     started = time.time()
     with fixture_server() as base_url:
         try:
-            problems = record_web(out_dir, base_url)
+            problems, video_rect, still_rect, size = record_web(out_dir, base_url)
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"web: Recorder raised {type(exc).__name__}: {exc}"]
-    return problems + check_take("web", out_dir, WEB_SHOTS, WEB_DURATION_S, started)
+    return problems + check_take(
+        "web", out_dir, WEB_SHOTS, WEB_DURATION_S, started, video_rect, still_rect, size
+    )
 
 
 def run_terminal(out_root: Path) -> list[str]:
@@ -522,13 +817,20 @@ def run_terminal(out_root: Path) -> list[str]:
     previous = Path.cwd()
     os.chdir(REPO_ROOT)
     try:
-        problems = record_terminal(out_dir)
+        problems, video_rect, still_rect, size = record_terminal(out_dir)
     except Exception as exc:  # noqa: BLE001 - a raising take is a failure
         return [f"terminal: TerminalRecorder raised {type(exc).__name__}: {exc}"]
     finally:
         os.chdir(previous)
     return problems + check_take(
-        "terminal", out_dir, TERMINAL_SHOTS, TERMINAL_DURATION_S, started
+        "terminal",
+        out_dir,
+        TERMINAL_SHOTS,
+        TERMINAL_DURATION_S,
+        started,
+        video_rect,
+        still_rect,
+        size,
     )
 
 
@@ -549,8 +851,8 @@ def main() -> int:
         "--out-dir",
         type=Path,
         help="where recordings land (default: a fresh temp dir). The web/ and "
-        "terminal/ subdirectories are emptied before each take. Point CI at a "
-        "known path so artifacts can be uploaded.",
+        "terminal/ subdirectories must be absent, empty, or created by a "
+        "previous run; each is recreated before its take.",
     )
     parser.add_argument(
         "--keep",


### PR DESCRIPTION
Foundation PR for the #3–#12 queue. The recorders had 1,344 lines of code,
zero tests, no CI, and no committed app to record against — the showcase
storyboard pointed at a `.scratch/` server that is gitignored and long gone,
so a fresh clone or worktree could not verify a recorder change at all.

## What lands

- `tests/fixture/index.html` — single-file dashboard, no deps, no build.
  Stable ids for recording, deterministic (no RNG, no clock, no animation).
  Two inert hooks for queued work: `?console-error=1` (#3) and `?secret=1`
  rendering `sk-live-FAKE0000000000000000` (#4).
- `tests/smoke` — PEP 723 uv script per `script-conventions`. Serves the
  fixture, records a web take and a terminal take, asserts mp4 exists with a
  sane duration and that stills are non-trivial. `--web-only` /
  `--terminal-only` to narrow.
- `.github/workflows/ci.yml` — `lint`, `typecheck`, `secrets`, `smoke`.
  Uploads the recording as an artifact on failure.
- `ruff.toml`, `mypy.ini`, `.gitleaks.toml`.

Nothing under `skills/` is touched, deliberately: ten queued PRs edit
`core.py`, `web.py` and `terminal.py`, and any change here would conflict
with all of them.

## Verified locally

Smoke test passes end to end (web 14.0s/208kB, terminal 10.3s/113kB, five
stills), plus both narrowing flags, an argparse rejection, and a seeded
failure path. `ruff check`, `ruff format --check`, `mypy`, and `shellcheck`
all clean. Fixture hooks confirmed with a throwaway Playwright script.

## NOT verified

**The CI workflow has never run.** This PR is its first execution. Action
resolution, `playwright install --with-deps` on the runner, gitleaks' actual
verdict on the fixture literal, and whether the duration windows hold on a
cold runner are all unknown until the checks report here.

## Known compromises

Tracked as a ratchet checklist in #13:

- `ruff format` excludes the three recorder modules — reformatting them
  collides with every queued PR. Delete the exclusion once the queue drains.
- `mypy.ini` sets `strict_optional = False`, which is the one knob that
  clears the errors caused by `_env()`'s return type. The real fix is
  `@overload` on `_env`.
- E501 unselected; every long line is inside an embedded JS/CSS literal.

Also filed: #14, `demo_recording` is Unix-only even for web-only demos
because `__init__.py` eagerly imports the PTY-based terminal module.