### PR TITLE
Emit a beat event log as timeline.json and timeline.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@ __pycache__/
 # demo-video working files (only demo.mp4 belongs in history)
 .tts/
 *.seg.mp4
+# Per-segment beat logs. The merged timeline.json/timeline.md next to
+# demo.mp4 is committed; these are the parts it is built from.
+*.seg.timeline.json
+*.seg.timeline.md
 # Left behind only when a take crashes before the recorder cleans up.
 .video/
 .frame.png

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -35,6 +35,8 @@ Each demo gets one folder (suggested: `docs/guides/<YYYY-MM-DD>-<slug>/`):
 |---|---|---|
 | `record.py` | The storyboard that produced the media (re-runnable) | yes |
 | `images/*.png` | Stills captured at key moments | yes |
+| `timeline.json` | The beat log — every verb, when it ran, what caption was up | yes |
+| `timeline.md` | The same log rendered for humans, stills embedded | yes |
 | `guide.md` | Optional written guide embedding the stills | yes |
 | `demo.mp4` | The recording (mp4 only — gifs get too big) | **no** — regenerate it, or attach it to the PR |
 
@@ -183,6 +185,52 @@ mp4 conversion happens on clean exit.
 | `interlude(text, style=…)` | Bridge a jump. `style="card"` (default) is a full-screen title card, for real time-skips; `style="light"` is a centered label over a soft scrim with the scene still visible, for short transitions. `""` fades it out. |
 | `stitch(out_dir, [segments])` | Lossless concat of segment recordings into demo.mp4 |
 | `rec.page` | The live Playwright page — the escape hatch for anything the verbs don't cover (iframes, keyboard shortcuts, drag) |
+
+## The beat timeline (`timeline.json` / `timeline.md`)
+
+Every storyboard verb is logged as a **beat** — what was done, when, and what
+caption was on screen while it happened — and a clean exit writes the log next
+to the media. No storyboard changes are needed; it is a byproduct of recording.
+
+`timeline.md` is the readable version: a table of every beat, then each still
+embedded under the caption it was taken during. **Commit both.** They are
+small, diffable, and unlike `demo.mp4` they survive as a record of what the
+demo showed after the video has been regenerated or thrown away — which is
+what makes them worth reviewing in a PR. Segments write
+`<segment>.seg.timeline.json` alongside `<segment>.seg.mp4`; gitignore those
+with the segment media.
+
+`timeline.json` is the machine-readable one, and a stable contract — adding a
+key is fine, renaming one is not:
+
+```json
+{ "schema": 1, "generated_by": "demo-video", "recorder": "Recorder",
+  "segment": null, "media": "demo.mp4", "duration": 18.04,
+  "beats": [
+    { "index": 4, "t_start": 3.02, "t_end": 3.06, "caption": "A small dashboard.",
+      "verb": "shot", "selector": "01-dashboard",
+      "still": "images/01-dashboard.png", "segment": null }
+  ] }
+```
+
+- `t_start` / `t_end` are seconds from the start of `media` — the verb
+  starting and returning. A verb built out of other verbs (`click` glides
+  first, `type_into` clicks first) is one beat, not one per internal step.
+- `caption` is the line on screen during the beat: the new text for a
+  `caption` beat, the line shown for an `interlude`, `""` when none is up.
+- `selector` is what the verb acted on, as a string — a CSS selector for the
+  web verbs, the command / keys / pattern for the terminal ones, the name for
+  `shot`. `null` for verbs with no target (`pause`, `hold`, a cleared
+  `spotlight`).
+- `still` is a path relative to the timeline file, so `timeline.md`'s embeds
+  and any tooling resolve the same way.
+
+**Timestamps are wall-clock offsets, and the video can drift under them.**
+Chromium's screencast intermittently loses ~0.6 s during an idle stretch and
+Playwright does not pad the gap, so late in a take a frame extracted at a beat
+timestamp can be off by that much (early in a take it is within ~100 ms). The
+lost time shows up as `duration` being shorter than the take really was.
+Tracked in [issue #18](https://github.com/rogvid/skills/issues/18).
 
 ## Pacing and perception
 
@@ -350,7 +398,10 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    loaded if it configures DEMO_VIDEO_* or the ElevenLabs key:
    `set -a; source .env; set +a`). Aim for 30–60 s.
 5. **Verify by looking, not by exit code:** read the `images/*.png` stills
-   to confirm the story is actually visible; check `ffprobe` duration.
+   to confirm the story is actually visible; check `ffprobe` duration. Read
+   `timeline.md` too — it is the take's own account of what ran and when, so
+   a beat that fired at the wrong moment or a caption that never changed
+   shows up there without decoding a frame.
 6. **Fresh-agent review (required).** You cannot watch the video, and you
    know too much anyway — have a context-free agent watch it for you:
 
@@ -378,13 +429,14 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    video is not committed (step 8), so a repo-relative link to it is dead
    in a fresh clone. End with a "Re-recording this demo" section giving the
    exact command — that is how a reader gets the video.
-8. **Commit the storyboard, not the media.** `record.py`, `guide.md`, and
-   the `images/*.png` stills go into git — they are small, diffable, and
-   the guide needs the stills to render. **`demo.mp4` does not.** A video
-   is stale by the next change to the feature and bloats history
-   permanently, and anyone with the skill installed can regenerate it with
+8. **Commit the storyboard, not the media.** `record.py`, `guide.md`, the
+   `images/*.png` stills, and `timeline.json` / `timeline.md` go into git —
+   they are small, diffable, and between them they say what the demo showed
+   without anyone having to watch it. **`demo.mp4` does not.** A video is
+   stale by the next change to the feature and bloats history permanently,
+   and anyone with the skill installed can regenerate it with
    `uv run <demo folder>/record.py`. Gitignore `demo.mp4`, `*.seg.mp4`
-   segment parts, and `.tts/` narration caches.
+   segment parts, `*.seg.timeline.*`, and `.tts/` narration caches.
 
    To put the demo in front of a reviewer, drag `demo.mp4` into a PR
    comment box — GitHub hosts it and renders a real player. That upload has

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -226,11 +226,13 @@ key is fine, renaming one is not:
   and any tooling resolve the same way.
 
 **Timestamps are wall-clock offsets, and the video can drift under them.**
-Chromium's screencast intermittently loses ~0.6 s during an idle stretch and
-Playwright does not pad the gap, so late in a take a frame extracted at a beat
-timestamp can be off by that much (early in a take it is within ~100 ms). The
-lost time shows up as `duration` being shorter than the take really was.
-Tracked in [issue #18](https://github.com/rogvid/skills/issues/18).
+Chromium's screencast emits a frame when the page paints and nothing pads the
+gap when it does not, so an idle stretch costs the recording ~0.6 s of wall
+time and every frame after it lands that much earlier than the timestamps say.
+The beat log itself is good to ~100–200 ms of the frame it describes; the drift
+is the capture's, and it shows up as `duration` being shorter than the take
+really was. Tracked in [issue #18](https://github.com/rogvid/skills/issues/18)
+— read it before relying on a beat timestamp to extract a frame.
 
 ## Pacing and perception
 

--- a/skills/demo-video/helpers/demo_recording/__init__.py
+++ b/skills/demo-video/helpers/demo_recording/__init__.py
@@ -7,14 +7,26 @@ Storyboards import from here:
     from demo_recording import stitch             # concat segments -> demo.mp4
 """
 
-from .core import media_duration, stitch, tts_clip
+from .core import (
+    TIMELINE_SCHEMA,
+    media_duration,
+    render_timeline_md,
+    stitch,
+    timeline_paths,
+    tts_clip,
+    write_timeline,
+)
 from .terminal import TerminalRecorder
 from .web import Recorder
 
 __all__ = [
+    "TIMELINE_SCHEMA",
     "Recorder",
     "TerminalRecorder",
-    "stitch",
     "media_duration",
+    "render_timeline_md",
+    "stitch",
+    "timeline_paths",
     "tts_clip",
+    "write_timeline",
 ]

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -22,6 +22,7 @@ SKILL.md for the full variable list.
 
 from __future__ import annotations
 
+import functools
 import hashlib
 import json
 import os
@@ -30,6 +31,8 @@ import sys
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from types import TracebackType
 
@@ -185,6 +188,175 @@ def tts_clip(
     raise AssertionError("unreachable")
 
 
+# -- beat timeline -----------------------------------------------------------
+#
+# Every storyboard verb the recorder runs is logged as a *beat*: what was
+# done, when, and what caption was on screen while it happened. On clean exit
+# the log lands next to the media as timeline.json (machine-readable) and
+# timeline.md (human-readable, with the stills embedded).
+#
+# This is a published contract, not a private convenience — beat-aligned frame
+# extraction, per-beat evidence capture and acceptance-criterion coverage all
+# read it. Treat it as append-only: adding a key to a beat or to the envelope
+# is fine, renaming or repurposing one is not (bump TIMELINE_SCHEMA if you
+# ever must).
+#
+# Envelope
+#   schema        int    — TIMELINE_SCHEMA, bumped on any breaking change
+#   generated_by  str    — always "demo-video"
+#   recorder      str    — "Recorder" | "TerminalRecorder" (which medium)
+#   segment       str?   — the segment name, or null for a whole demo
+#   media         str    — the mp4 this timeline describes, e.g. "demo.mp4"
+#   duration      float? — that mp4's real duration (ffprobe), null if absent
+#   beats         list   — the beats, in the order they ran
+#
+# Beat
+#   index     int    — position in `beats`, 0-based
+#   t_start   float  — seconds from the start of `media` to the verb starting
+#   t_end     float  — seconds from the start of `media` to the verb returning
+#   caption   str    — the caption text on screen during the beat (the new
+#                      text for a `caption` beat, the line shown for an
+#                      `interlude` beat); "" when no caption is up
+#   verb      str    — the storyboard verb: "caption", "click", "run", ...
+#   selector  str?   — what the verb acted on, as a string: a CSS selector for
+#                      the web verbs, the command / keys / pattern for the
+#                      terminal ones, the path for `goto`. Null when the verb
+#                      has no target (`pause`, `hold`, a cleared `spotlight`).
+#   still     str?   — for `shot` beats, the still's path relative to the
+#                      timeline file ("images/01-dashboard.png"); else null
+#   segment   str?   — the segment this beat was recorded in, or null
+#
+# Only the verb a storyboard calls becomes a beat. The verbs recorders build
+# out of other verbs (`click` glides with `move_to`, `type_into` clicks first)
+# record one beat spanning the whole call, not one per internal step.
+TIMELINE_SCHEMA = 1
+
+
+def timeline_paths(out_dir: Path | str, segment: str | None = None) -> tuple[Path, Path]:
+    """(json, md) paths for a take's timeline.
+
+    Mirrors how the media is named: a whole demo writes timeline.json next to
+    demo.mp4, a segment writes <segment>.seg.timeline.json next to
+    <segment>.seg.mp4, so segments of one demo never overwrite each other.
+    """
+    stem = f"{segment}.seg.timeline" if segment else "timeline"
+    out_dir = Path(out_dir)
+    return out_dir / f"{stem}.json", out_dir / f"{stem}.md"
+
+
+def _md_cell(value: object) -> str:
+    """A value made safe to drop into a markdown table cell."""
+    if value is None:
+        return ""
+    return (
+        str(value)
+        .replace("\\", "\\\\")
+        .replace("|", "\\|")
+        .replace("\n", " ")
+    )
+
+
+def _fmt_t(value: object) -> str:
+    return "" if value is None else f"{float(value):.2f}"
+
+
+def render_timeline_md(doc: dict) -> str:
+    """Render a timeline document as markdown, stills embedded.
+
+    Pure function of the document, so anything that *builds* a document —
+    a take on exit, or a stitch that merges several — renders the same way.
+    """
+    beats = doc.get("beats") or []
+    head = [f"`{doc.get('media') or 'demo.mp4'}`"]
+    if doc.get("segment"):
+        head.append(f"segment `{doc['segment']}`")
+    if doc.get("recorder"):
+        head.append(str(doc["recorder"]))
+    if doc.get("duration") is not None:
+        head.append(f"{float(doc['duration']):.1f}s")
+    head.append(f"{len(beats)} beats")
+    out = [
+        "# Demo timeline",
+        "",
+        " · ".join(head),
+        "",
+        "Written by the demo-video recorder on every clean exit — do not edit "
+        "it by hand, re-record instead.",
+        "",
+        "| # | start | end | verb | target | caption |",
+        "|---:|---:|---:|---|---|---|",
+    ]
+    for beat in beats:
+        target = beat.get("selector")
+        out.append(
+            "| {} | {} | {} | `{}` | {} | {} |".format(
+                beat.get("index"),
+                _fmt_t(beat.get("t_start")),
+                _fmt_t(beat.get("t_end")),
+                _md_cell(beat.get("verb")),
+                f"`{_md_cell(target)}`" if target else "",
+                _md_cell(beat.get("caption")),
+            )
+        )
+    stills = [b for b in beats if b.get("still")]
+    if stills:
+        out += ["", "## Stills", ""]
+        for beat in stills:
+            rel = str(beat["still"])
+            name = rel.rsplit("/", 1)[-1].removesuffix(".png")
+            out += [f"### {name} — {_fmt_t(beat.get('t_start'))}s", ""]
+            if beat.get("caption"):
+                out += [f"> {beat['caption']}", ""]
+            out += [f"![{name}]({rel})", ""]
+    return "\n".join(out).rstrip() + "\n"
+
+
+def write_timeline(out_dir: Path | str, doc: dict) -> tuple[Path, Path]:
+    """Write a timeline document as timeline.json + timeline.md."""
+    json_path, md_path = timeline_paths(out_dir, doc.get("segment"))
+    json_path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+    md_path.write_text(render_timeline_md(doc))
+    return json_path, md_path
+
+
+def _verb_target(args: tuple, kwargs: dict) -> str | None:
+    """The string a verb acted on, dug out of how it happened to be called."""
+    if args and isinstance(args[0], str):
+        return args[0]
+    for name in ("selector", "path", "command", "text", "pattern", "name"):
+        value = kwargs.get(name)
+        if isinstance(value, str):
+            return value
+    return None
+
+
+def _beat_verb(
+    verb: str,
+    target: Callable[[tuple, dict], str | None] = _verb_target,
+) -> Callable:
+    """Decorate a storyboard verb so calling it records one beat.
+
+    A decorator rather than a `with` block inside every verb: it keeps the
+    recorders' method bodies untouched, which is the difference between a
+    one-line diff per verb and re-indenting three files.
+
+    `target` extracts the beat's `selector` from the call; the default takes
+    the first string argument (so `click("#go")`, `run("ls")` and
+    `goto("/app")` all self-describe) and yields null for verbs called with
+    none (`pause(2)`, `spotlight()`).
+    """
+
+    def decorate(fn: Callable) -> Callable:
+        @functools.wraps(fn)
+        def wrapper(self, *args, **kwargs):
+            with self._beat(verb, selector=target(args, kwargs)):
+                return fn(self, *args, **kwargs)
+
+        return wrapper
+
+    return decorate
+
+
 class _DemoBase:
     """Recording + narration substrate shared by every demo medium.
 
@@ -267,9 +439,20 @@ class _DemoBase:
         # the same height, keeping caption placement uniform across media.
         self._caption_bottom_px = 44
         self._lines: list[tuple[float, Path]] = []  # (video offset s, clip)
-        self._line_end = 0.0  # wall-clock time the current line stops speaking
-        self._t0 = 0.0  # wall-clock time video capture started
+        # Both are readings of time.monotonic(), never time.time(): everything
+        # here measures an *elapsed interval* against the video, and the system
+        # clock can step (NTP, a VM resuming — a WSL2 box was measured stepping
+        # 573 ms backwards inside 8 s). One such step during a take puts every
+        # beat and every narration cue after it on a different clock from the
+        # frames they describe.
+        self._line_end = 0.0  # when the current line stops speaking
+        self._t0 = 0.0  # when video capture started
         self.page: Page = None  # type: ignore[assignment]
+        # The beat log (see "beat timeline" above) and the caption currently
+        # on screen, which every beat is stamped with.
+        self._beats: list[dict] = []
+        self._caption = ""
+        self._in_beat = False
         # Announce narration state up front — a silent recording when the
         # user expected voice (usually the key just isn't in this process's
         # env) is otherwise a confusing surprise only noticed after the fact.
@@ -325,6 +508,13 @@ class _DemoBase:
             # Medium-specific init scripts (cursor, spotlight, ...).
             self._init_context(self._context)
             self.page = self._context.new_page()
+            # Chromium's screencast starts with the page, so this — not the
+            # end of _start() — is frame zero of the recording. Setting it
+            # any later shifts every beat timestamp and every narration
+            # offset earlier than the frame it describes, by however long
+            # the medium's setup takes (~250 ms for the web recorder's
+            # window-frame render, and it is not a constant).
+            self._t0 = time.monotonic()
             self._start()
         except Exception:
             # __exit__ never runs when __enter__ raises — don't leak the
@@ -335,7 +525,6 @@ class _DemoBase:
                 pass
             self._pw.stop()
             raise
-        self._t0 = time.time()
         return self
 
     def __exit__(
@@ -354,9 +543,80 @@ class _DemoBase:
         self._pw.stop()
         if exc_type is None and webm and webm.exists():
             self._convert(webm)
+        if exc_type is None:
+            # The beat log is the durable, diffable record of the take — it
+            # outlives the mp4, which is not committed. Written after
+            # conversion so `duration` is the encoder's answer, not a guess.
+            json_path, _ = write_timeline(self.out_dir, self._timeline_doc())
+            print(f"wrote {json_path} ({len(self._beats)} beats)")
         for leftover in self._video_dir.glob("*"):
             leftover.unlink()
         self._video_dir.rmdir()
+
+    # -- beat log -----------------------------------------------------------
+
+    @contextmanager
+    def _beat(
+        self,
+        verb: str,
+        selector: str | None = None,
+        still: str | None = None,
+        caption: str | None = None,
+        **extra: object,
+    ) -> Iterator[dict | None]:
+        """Record one beat around a storyboard verb.
+
+        Re-entrant calls are folded into the beat already open, so a verb
+        built out of other verbs (`click` glides with `move_to` first) logs
+        the call the storyboard made and not the machinery underneath it.
+        `extra` keys land on the record as-is — the seam for slices that
+        want to say more about a beat than the base schema does.
+        """
+        if self._in_beat:
+            yield None
+            return
+        self._in_beat = True
+        record: dict = {
+            "index": len(self._beats),
+            "t_start": round(time.monotonic() - self._t0, 3),
+            "t_end": None,
+            "caption": self._caption if caption is None else caption,
+            "verb": verb,
+            "selector": selector,
+            "still": still,
+            "segment": self.segment,
+        }
+        record.update(extra)
+        self._beats.append(record)
+        try:
+            yield record
+        finally:
+            record["t_end"] = round(time.monotonic() - self._t0, 3)
+            self._in_beat = False
+
+    def _media_path(self) -> Path:
+        """The mp4 this take converts to on exit."""
+        name = f"{self.segment}.seg.mp4" if self.segment else "demo.mp4"
+        return self.out_dir / name
+
+    def _timeline_doc(self) -> dict:
+        """This take's beat log as a timeline document (see TIMELINE_SCHEMA)."""
+        mp4 = self._media_path()
+        duration = None
+        if mp4.exists():
+            try:
+                duration = round(media_duration(mp4), 3)
+            except (subprocess.CalledProcessError, ValueError, OSError):
+                duration = None  # a timeline without it still beats none
+        return {
+            "schema": TIMELINE_SCHEMA,
+            "generated_by": "demo-video",
+            "recorder": type(self).__name__,
+            "segment": self.segment,
+            "media": mp4.name,
+            "duration": duration,
+            "beats": self._beats,
+        }
 
     # -- shared storyboard verbs -------------------------------------------
 
@@ -366,6 +626,7 @@ class _DemoBase:
         if seconds > 0:
             time.sleep(seconds)
 
+    @_beat_verb("pause")
     def pause(self, seconds: float) -> None:
         """Hold the frame so viewers can read what is on screen."""
         self._idle(seconds)
@@ -376,10 +637,16 @@ class _DemoBase:
         With speech enabled the line is also spoken; the previous line
         always finishes before this one starts.
         """
+        # Synthesizing and waiting out the previous spoken line happens
+        # *before* the beat opens: the beat's t_start is when this caption
+        # reaches the screen, which is what a reviewer extracting a frame at
+        # that timestamp expects to see.
         clip = self._prepare_line(text)
-        self.page.evaluate("t => window.__demoCaption(t)", text)
-        self._start_line(clip)
-        self.pause(self._caption_hold(text))
+        with self._beat("caption", caption=text):
+            self.page.evaluate("t => window.__demoCaption(t)", text)
+            self._caption = text
+            self._start_line(clip)
+            self.pause(self._caption_hold(text))
 
     def _caption_hold(self, text: str) -> float:
         """Minimum time a caption stays up. With speech on, the spoken line's
@@ -403,10 +670,12 @@ class _DemoBase:
         lighter, for short transitions where a full takeover feels heavy."""
         clip = self._prepare_line(text)
         fn = "__demoBridge" if style == "light" else "__demoInterlude"
-        self.page.evaluate(f"t => window.{fn}(t)", text)
-        self._start_line(clip)
-        self.pause(hold if text else 0.6)
+        with self._beat("interlude", selector=style, caption=text):
+            self.page.evaluate(f"t => window.{fn}(t)", text)
+            self._start_line(clip)
+            self.pause(hold if text else 0.6)
 
+    @_beat_verb("hold")
     def hold(self, min_s: float = 1.5) -> None:
         """Keep the current frame up until the narration for the current
         caption finishes speaking — so a spotlight or highlight stays on
@@ -414,13 +683,15 @@ class _DemoBase:
         `min_s` (a perception floor: ~1.5 s to notice and fixate on a change),
         which is also what governs pacing when narration is off. Use it right
         after setting a spotlight/emphasis."""
-        remaining = self._line_end - time.time()
+        remaining = self._line_end - time.monotonic()
         self._idle(max(min_s, remaining))
 
     def shot(self, name: str) -> Path:
         """Still for the written guide -> images/<name>.png."""
         path = self.images_dir / f"{name}.png"
-        self.page.screenshot(path=str(path))
+        rel = path.relative_to(self.out_dir).as_posix()
+        with self._beat("shot", selector=name, still=rel):
+            self.page.screenshot(path=str(path))
         return path
 
     # -- speech (ElevenLabs narration) --------------------------------------
@@ -441,20 +712,19 @@ class _DemoBase:
     def _start_line(self, clip: Path | None) -> None:
         """Log the line as starting now, at the current video offset."""
         if clip is not None:
-            now = time.time()
+            now = time.monotonic()
             self._lines.append((now - self._t0, clip))
             self._line_end = now + media_duration(clip)
 
     def _finish_line(self, tail: float = 0.0) -> None:
-        remaining = self._line_end - time.time()
+        remaining = self._line_end - time.monotonic()
         if remaining > 0:
             self._idle(remaining + tail)
 
     # -- media conversion ---------------------------------------------------
 
     def _convert(self, webm: Path) -> None:
-        name = f"{self.segment}.seg.mp4" if self.segment else "demo.mp4"
-        mp4 = self.out_dir / name
+        mp4 = self._media_path()
         cmd = ["ffmpeg", "-y", "-loglevel", "error", "-i", str(webm)]
         if self._speech:
             # Mix each narration clip in at the moment its line appeared.
@@ -497,6 +767,11 @@ def stitch(out_dir: Path, segments: list[str], keep_parts: bool = False) -> None
     keep_parts=True leaves the .seg.mp4 files on disk so a single segment
     can be re-recorded and re-stitched without redoing the expensive ones
     (segments are untracked; only demo.mp4 is committed).
+
+    Note: each segment writes its own <segment>.seg.timeline.json, with
+    timestamps relative to that segment's own start. Merging them into one
+    timeline.json next to demo.mp4 — offsetting each by the real duration of
+    the segments before it — is issue #7, and belongs here.
     """
     out_dir = Path(out_dir)
     parts = [out_dir / f"{s}.seg.mp4" for s in segments]

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -439,12 +439,14 @@ class _DemoBase:
         # the same height, keeping caption placement uniform across media.
         self._caption_bottom_px = 44
         self._lines: list[tuple[float, Path]] = []  # (video offset s, clip)
-        # Both are readings of time.monotonic(), never time.time(): everything
-        # here measures an *elapsed interval* against the video, and the system
-        # clock can step (NTP, a VM resuming — a WSL2 box was measured stepping
-        # 573 ms backwards inside 8 s). One such step during a take puts every
-        # beat and every narration cue after it on a different clock from the
-        # frames they describe.
+        # Both are readings of time.monotonic(). Nothing in this package
+        # measures elapsed time any other way — not the beat log, not narration
+        # pacing, not the terminal recorder's idle pump, not a wait_for
+        # deadline — because time.time() steps (NTP, a VM resuming; a WSL2 box
+        # was measured stepping 573 ms backwards inside 8 s). One such step
+        # puts every beat and narration cue after it on a different clock from
+        # the frames they describe, and makes every sleep-until loop in here
+        # over- or under-run by the size of the step.
         self._line_end = 0.0  # when the current line stops speaking
         self._t0 = 0.0  # when video capture started
         self.page: Page = None  # type: ignore[assignment]
@@ -541,17 +543,21 @@ class _DemoBase:
         webm = Path(video.path()) if video else None
         self._browser.close()
         self._pw.stop()
-        if exc_type is None and webm and webm.exists():
-            self._convert(webm)
-        if exc_type is None:
-            # The beat log is the durable, diffable record of the take — it
-            # outlives the mp4, which is not committed. Written after
-            # conversion so `duration` is the encoder's answer, not a guess.
-            json_path, _ = write_timeline(self.out_dir, self._timeline_doc())
-            print(f"wrote {json_path} ({len(self._beats)} beats)")
-        for leftover in self._video_dir.glob("*"):
-            leftover.unlink()
-        self._video_dir.rmdir()
+        try:
+            if exc_type is None and webm and webm.exists():
+                self._convert(webm)
+            if exc_type is None:
+                # The beat log is the durable, diffable record of the take — it
+                # outlives the mp4, which is not committed. Written after
+                # conversion so `duration` is the encoder's answer, not a guess.
+                json_path, _ = write_timeline(self.out_dir, self._timeline_doc())
+                print(f"wrote {json_path} ({len(self._beats)} beats)")
+        finally:
+            # Whatever went wrong above, don't leave .video/ behind — the
+            # next take into this directory would trip over it.
+            for leftover in self._video_dir.glob("*"):
+                leftover.unlink()
+            self._video_dir.rmdir()
 
     # -- beat log -----------------------------------------------------------
 

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -304,10 +304,10 @@ class TerminalRecorder(_DemoBase):
     def _idle(self, seconds: float) -> None:
         """Hold the frame while pumping program output, so long-running
         commands keep scrolling on screen instead of freezing."""
-        end = time.time() + seconds
+        end = time.monotonic() + seconds
         while True:
             self._pump()
-            remaining = end - time.time()
+            remaining = end - time.monotonic()
             if remaining <= 0:
                 return
             time.sleep(min(0.04, remaining))
@@ -383,13 +383,13 @@ class TerminalRecorder(_DemoBase):
         anchor to individual screen lines (re.MULTILINE). Robust for TUIs,
         which repaint continuously and emit no clean 'done' line."""
         rx = re.compile(pattern, re.MULTILINE)
-        deadline = time.time() + timeout_s
+        deadline = time.monotonic() + timeout_s
         while True:
             text = self._screen()
             if rx.search(text):
                 self.pause(0.2)
                 return
-            if time.time() > deadline:
+            if time.monotonic() > deadline:
                 tail = text[-1000:]
                 raise RuntimeError(
                     f"timed out after {timeout_s}s waiting for /{pattern}/. "
@@ -402,7 +402,7 @@ class TerminalRecorder(_DemoBase):
         """Wait until the shell prompt returns after a run() — i.e. the
         command finished. A special case of wait_for_text keyed on the
         branded prompt marker."""
-        deadline = time.time() + timeout_s
+        deadline = time.monotonic() + timeout_s
         while True:
             text = self._screen()
             if self._at_idle_prompt(text):
@@ -410,7 +410,7 @@ class TerminalRecorder(_DemoBase):
                 return
             if self._child_done:
                 return  # the shell itself exited
-            if time.time() > deadline:
+            if time.monotonic() > deadline:
                 tail = text[-1000:]
                 raise RuntimeError(
                     f"timed out after {timeout_s}s waiting for the prompt "

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -32,7 +32,7 @@ import termios
 import time
 from pathlib import Path
 
-from .core import _DemoBase, _env
+from .core import _beat_verb, _DemoBase, _env
 
 _ASSETS = Path(__file__).parent.parent / "assets" / "xterm"
 
@@ -338,6 +338,7 @@ class TerminalRecorder(_DemoBase):
             self._write(ch)
             self._idle(self._type_delay)
 
+    @_beat_verb("run")
     def run(self, command: str) -> None:
         """Type a shell command visibly and press Enter. Pair with
         wait_for_prompt() to wait for it to finish."""
@@ -345,6 +346,7 @@ class TerminalRecorder(_DemoBase):
         self._write("\r")
         self._idle(0.2)
 
+    @_beat_verb("send")
     def send(self, text: str, enter: bool = True) -> None:
         """Type a response to the running program (an answer to a prompt, a
         REPL expression). enter=False to send the keystrokes without Return."""
@@ -353,6 +355,7 @@ class TerminalRecorder(_DemoBase):
             self._write("\r")
         self._idle(0.2)
 
+    @_beat_verb("key", lambda args, kwargs: " ".join(args) or None)
     def key(self, *names: str) -> None:
         """Send keys to a TUI. Each argument is one of: a named key ("Up"
         "Down" "Left" "Right" "Enter" "Tab" "Escape" "Home" "End" "PageUp"
@@ -373,6 +376,7 @@ class TerminalRecorder(_DemoBase):
 
     # -- synchronization ----------------------------------------------------
 
+    @_beat_verb("wait_for_text")
     def wait_for_text(self, pattern: str, timeout_s: float = 60) -> None:
         """Wait until the rendered screen (visible text + scrollback,
         ANSI-stripped) matches `pattern` (a regex, searched). `^` and `$`
@@ -393,6 +397,7 @@ class TerminalRecorder(_DemoBase):
                 )
             time.sleep(0.05)
 
+    @_beat_verb("wait_for_prompt")
     def wait_for_prompt(self, timeout_s: float = 60) -> None:
         """Wait until the shell prompt returns after a run() — i.e. the
         command finished. A special case of wait_for_text keyed on the

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -355,12 +355,12 @@ class Recorder(_DemoBase):
         elements that re-render continuously (polling UIs re-mount
         popovers, restarting entrance animations, so locator.click()'s
         actionability check can stall for minutes)."""
-        deadline = time.time() + 10
+        deadline = time.monotonic() + 10
         box = None
         while box is None:
             box = self.page.locator(selector).first.bounding_box()
             if box is None:
-                if time.time() > deadline:
+                if time.monotonic() > deadline:
                     raise RuntimeError(f"no visible element for {selector!r}")
                 time.sleep(0.1)
         x, y = box["x"] + box["width"] / 2, box["y"] + box["height"] / 2

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -27,7 +27,7 @@ import time
 from pathlib import Path
 from urllib.parse import urlparse
 
-from .core import _DemoBase, _env
+from .core import _beat_verb, _DemoBase, _env
 
 # Pastel gradient behind the window — matches the terminal recorder's
 # background so web and terminal demos share one look.
@@ -283,6 +283,7 @@ class Recorder(_DemoBase):
 
     # -- storyboard verbs ---------------------------------------------------
 
+    @_beat_verb("goto")
     def goto(self, path: str = "") -> None:
         url = path if path.startswith("http") else self.base_url + path
         # Asset fetches hang occasionally on a busy dev box — a reload
@@ -299,16 +300,19 @@ class Recorder(_DemoBase):
         except Exception:
             pass  # apps that poll never go network-idle; the page is up
 
+    @_beat_verb("terminal")
     def terminal(self, command: str) -> None:
         """Type a command in an on-screen terminal card, then perform the
         real action it describes right after this returns."""
         self.page.evaluate("cmd => window.__demoTerminal(cmd)", command)
 
+    @_beat_verb("terminal_output")
     def terminal_output(self, text: str) -> None:
         """Reveal real command output inside the terminal card, line by
         line — run the command first, pass its actual (trimmed) output."""
         self.page.evaluate("t => window.__demoTerminalOutput(t)", text)
 
+    @_beat_verb("terminal_close")
     def terminal_close(self, stamp: str | None = None) -> None:
         """Stamp a closing line ('✓ delivered' by default, "" for none)
         on the terminal card and fade it out."""
@@ -318,6 +322,7 @@ class Recorder(_DemoBase):
         self.page.evaluate("() => window.__demoTerminalHide()")
         self.pause(0.5)
 
+    @_beat_verb("spotlight")
     def spotlight(self, selector: str | None = None) -> None:
         """Highlight one element while the caption talks about it;
         spotlight() with no argument clears it."""
@@ -328,6 +333,7 @@ class Recorder(_DemoBase):
             )
         self.pause(0.3)
 
+    @_beat_verb("move_to")
     def move_to(self, selector: str) -> None:
         """Glide the cursor onto an element (smooth, watchable motion)."""
         box = self.page.locator(selector).first.bounding_box()
@@ -337,11 +343,13 @@ class Recorder(_DemoBase):
             box["x"] + box["width"] / 2, box["y"] + box["height"] / 2, steps=30
         )
 
+    @_beat_verb("click")
     def click(self, selector: str) -> None:
         self.move_to(selector)
         self.pause(0.4)
         self.page.locator(selector).first.click()
 
+    @_beat_verb("click_fast")
     def click_fast(self, selector: str) -> None:
         """Coordinate click without Playwright's stability wait — for
         elements that re-render continuously (polling UIs re-mount
@@ -360,6 +368,7 @@ class Recorder(_DemoBase):
         self.pause(0.3)
         self.page.mouse.click(x, y)
 
+    @_beat_verb("type_into")
     def type_into(self, selector: str, text: str, delay_ms: int = 40) -> None:
         """Click a field and type into it visibly, key by key — for form
         demos (checkout, login, search). For anything the verbs don't
@@ -367,12 +376,14 @@ class Recorder(_DemoBase):
         self.click(selector)
         self.page.keyboard.type(text, delay=delay_ms)
 
+    @_beat_verb("scroll_to")
     def scroll_to(self, selector: str) -> None:
         self.page.locator(selector).first.evaluate(
             "el => el.scrollIntoView({behavior: 'smooth', block: 'center'})"
         )
         self.pause(1.2)
 
+    @_beat_verb("wait_for")
     def wait_for(self, selector: str, timeout_s: float = 60) -> None:
         """Wait for something the app does on its own (a job, a run)."""
         self.page.locator(selector).first.wait_for(timeout=timeout_s * 1000)

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,9 +31,12 @@ fresh Linux box). A pass looks like this, and takes about half a minute:
 
 ```
 smoke: serving …/tests/fixture at http://127.0.0.1:36321
-smoke: web demo.mp4 ok (16.2s, 244 kB, content 16.0)
+smoke: web demo.mp4 ok (18.0s, 244 kB, content 16.0)
 smoke: web still 01-dashboard.png ok (77 kB, content 16.9)
 smoke: web caption is visible on screen (delta 25.6)
+smoke: web first caption 'A small dashboard.' logged at 3.00s, on screen at 2.92s (-80 ms, bar 200 ms)
+smoke: web closing caption 'Recorded end to end.' logged at 17.04s, on screen at 16.96s (-80 ms, bar 800 ms)
+smoke: web timeline.json ok (23 beats)
 …
 smoke: PASSED
 ```
@@ -63,8 +66,8 @@ test measures.
 
 ## What it asserts
 
-Three independent axes, because a recorder can fail on any one of them while
-looking perfect on the other two.
+Four independent axes, because a recorder can fail on any one of them while
+looking perfect on the other three.
 
 **Artifacts** — `demo.mp4` and every still the storyboard asked for exist, were
 modified by *this* run rather than a previous one, clear a size floor
@@ -128,6 +131,45 @@ All post-condition failures are collected, never raised, in both takes. A take
 that aborts writes no mp4, and CI's failure-only artifact upload then has
 nothing to upload at exactly the moment somebody wants to look at it.
 
+**Timeline** — the beat log the recorder writes as `timeline.json` and
+`timeline.md` says what actually happened, and points at the right frames.
+
+The beats are checked against `WEB_BEATS` / `TERMINAL_BEATS`, a hand-written
+`(verb, target)` sequence per storyboard. That duplication is the point: a
+count or a sequence derived from the log being graded agrees with that log no
+matter what it says, which is how a dropped beat would pass. `WEB_CAPTIONS` /
+`TERMINAL_CAPTIONS` do the same for the caption text, separately, so a
+missing beat and a wrong caption fail independently. Alongside them:
+`schema` matches the `TIMELINE_SCHEMA` the package exports, indices match
+positions, timestamps are monotonic and inside the mp4's duration, the
+recorder's own `duration` matches ffprobe, every `still` a beat names is a
+file on disk *and* every file in `images/` is named by a beat, and
+`timeline.md` embeds each of them.
+
+**Where the timestamps point** is the assertion worth having, and it is
+measured rather than computed: both takes set a caption after two seconds of
+nothing at all happening, then the caption band is sampled every frame around
+what `timeline.json` claims and the first frame that has travelled a quarter
+of the way to the caption's final state is taken as when it appeared. A
+quarter, not "any change at all", because the bar fades in over 0.3 s and
+those two definitions are a third of a second apart. If the band never gets
+anywhere the run *fails* rather than reporting a timestamp — a caption that
+was never drawn has no appearance to time.
+
+Two bars, because the honest answer depends on where in the take you look:
+
+| | measured | bar |
+|---|---|---|
+| first caption, ~3 s in | -40 to -120 ms, both media, every take | 200 ms |
+| closing caption, ~17 s in | -40 to -680 ms depending on the take | 800 ms |
+
+The first bar is the one that grades the beat log — it fails if `_t0` moves
+off the start of the recording (the pre-fix placement measured **+280 ms**),
+if elapsed time comes off a steppable clock, or if a beat is stamped anywhere
+other than where its verb ran. The second has to tolerate Chromium's
+screencast losing ~0.6 s of wall time mid-take, which is a property of the
+capture and not of the log — see Known gaps.
+
 ## Known gaps
 
 Things a pass does **not** prove. They are listed because an assertion nobody
@@ -154,11 +196,35 @@ knows is missing is worse than one that is openly absent.
   the attribute while moving the app elsewhere would silently score the wrong
   pixels. Tracked in [#17](https://github.com/rogvid/skills/issues/17), which
   proposes the recorder expose its geometry as public API.
+- **Late beat timestamps drift from the video by up to ~0.6 s.** Chromium's
+  screencast intermittently stalls during an idle stretch and Playwright's webm
+  does not pad the gap, so every frame after the stall sits that much earlier
+  in the video than the clock says (`demo.mp4`'s duration shrinks by exactly
+  that much). Measured across ten takes: five stalled once, five did not. The
+  recorder cannot see it happen, which is why the closing-caption bar is 800 ms
+  rather than 200. Consequence: a frame extracted at a beat timestamp late in a
+  stalled take can show the wrong beat. Tracked in
+  [#18](https://github.com/rogvid/skills/issues/18), which matters most to
+  [#8](https://github.com/rogvid/skills/issues/8).
+- **Nothing reads the caption text off the video.** The timing check proves the
+  caption *band* changed when `timeline.json` says it did; that the words are
+  the right words is a DOM assertion (`check_caption`) taken at record time.
+  Between them a recorder that drew the wrong caption at the right moment would
+  be caught, but only because two separate checks happen to overlap — no single
+  assertion reads pixels back as text, and none is going to without OCR.
+- **The wall-clock regression cannot be fault-injected.** The recorders time
+  beats with `time.monotonic()`; using `time.time()` only misreports when the
+  system clock actually steps, which no assertion here can provoke. It is not
+  hypothetical — a WSL2 box was measured stepping 573 ms backwards inside 8 s,
+  which is how the bug was found — but a pass does not prove the fix is still
+  in place. Reading the diff does.
 - **Nothing checks audio.** Narration is forced off and no assertion touches the
   aac track, so the whole speech path — `tts_clip`, the `.tts/` cache, the
   `adelay`/`amix` mixing in `_convert` — is untested here.
 - **Nothing checks `stitch()`, segments, or `interlude()`.** Single-segment
-  takes only.
+  takes only — so `<segment>.seg.timeline.json`, and the merge
+  [#7](https://github.com/rogvid/skills/issues/7) will build on it, are
+  unexercised.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.
@@ -197,11 +263,19 @@ insurance against a future release that does start flagging it.
 ## Adding a case
 
 - **A new thing to record** — add a beat to `record_web` / `record_terminal` in
-  `tests/smoke`, and add its `shot()` name to `WEB_SHOTS` / `TERMINAL_SHOTS` so
-  the still is actually checked. Adding a beat lengthens the take; keep it
-  inside the duration window, or widen the window deliberately. **Every
-  interaction gets a `b.expect(...)` naming what it should have changed** — a
-  beat with no post-condition is a beat that passes when the verb is a no-op.
+  `tests/smoke`, add its `shot()` name to `WEB_SHOTS` / `TERMINAL_SHOTS` so the
+  still is actually checked, and add its `(verb, target)` to `WEB_BEATS` /
+  `TERMINAL_BEATS` (and its text to `WEB_CAPTIONS` / `TERMINAL_CAPTIONS` if it
+  is a caption) so the timeline check knows to expect it. Those lists are
+  deliberately hand-maintained; see **Timeline** above for why. Adding a beat
+  lengthens the take; keep it inside the duration window, or widen the window
+  deliberately. **Every interaction gets a `b.expect(...)` naming what it
+  should have changed** — a beat with no post-condition is a beat that passes
+  when the verb is a no-op.
+- **A new storyboard verb in the recorder** — decorate it with `@_beat_verb`
+  so it lands in the beat log, or the timeline stops being a full account of
+  the take. A verb built out of other verbs records one beat, not one per
+  internal step; the nesting guard in `_DemoBase._beat` handles that.
 - **A new thing for the app to do** — put it in `fixture/index.html` behind a
   stable id, and keep it deterministic. If it only matters to one future
   feature, hide it behind a query-string hook the way the two above are, so the

--- a/tests/README.md
+++ b/tests/README.md
@@ -31,11 +31,12 @@ fresh Linux box). A pass looks like this, and takes about half a minute:
 
 ```
 smoke: serving …/tests/fixture at http://127.0.0.1:36321
-smoke: web demo.mp4 ok (18.0s, 244 kB, content 16.0)
+smoke: web demo.mp4 ok (20.2s, 279 kB, content 16.0)
 smoke: web still 01-dashboard.png ok (77 kB, content 16.9)
 smoke: web caption is visible on screen (delta 25.6)
-smoke: web first caption 'A small dashboard.' logged at 3.00s, on screen at 2.92s (-80 ms, bar 200 ms)
-smoke: web closing caption 'Recorded end to end.' logged at 17.04s, on screen at 16.96s (-80 ms, bar 800 ms)
+smoke: web first caption 'A small dashboard.' logged at 3.03s, on screen at 2.95s (-80 ms)
+smoke: web closing caption 'Recorded end to end.' logged at 17.03s, on screen at 16.99s (-40 ms)
+smoke: web beat clock holds across the take (+40 ms)
 smoke: web timeline.json ok (23 beats)
 …
 smoke: PASSED
@@ -139,36 +140,79 @@ The beats are checked against `WEB_BEATS` / `TERMINAL_BEATS`, a hand-written
 count or a sequence derived from the log being graded agrees with that log no
 matter what it says, which is how a dropped beat would pass. `WEB_CAPTIONS` /
 `TERMINAL_CAPTIONS` do the same for the caption text, separately, so a
-missing beat and a wrong caption fail independently. Alongside them:
-`schema` matches the `TIMELINE_SCHEMA` the package exports, indices match
-positions, timestamps are monotonic and inside the mp4's duration, the
-recorder's own `duration` matches ffprobe, every `still` a beat names is a
-file on disk *and* every file in `images/` is named by a beat, and
-`timeline.md` embeds each of them.
+missing beat and a wrong caption fail independently.
+
+Three of the checks exist because an earlier round of this file had them
+missing and did not notice:
+
+- **Every beat carries the caption it ran under**, not just the `caption`
+  beats. That context is what makes a `shot` or a `click` beat mean anything,
+  and it is what `timeline.md` quotes over each still — but checking only
+  `verb == "caption"` beats is blind to losing it. The expected per-beat
+  caption is derived from the two hand-written lists, never from the log.
+- **`t_end` has to carry information.** Setting it equal to `t_start` satisfies
+  every ordering check. So: a `caption(text)` or `hold()` beat must span at
+  least a second (the recorder enforces 1.4 s and 1.5 s floors itself), and the
+  beats together must account for ≥ 80% of the time from the first starting to
+  the last ending. #8 wants the beat *midpoint* for frame extraction precisely
+  because `t_start` is 0% into the caption's fade, so this is load-bearing for
+  the next PR, not decoration.
+- **`timeline.md`'s beat table specifically**, one row per beat. Checking that
+  each caption "appears in the file" is satisfied by the Stills section alone,
+  so the entire table could vanish and the run would pass — and the table is
+  the only place a beat *without* a still (every click, every spotlight, the
+  shape of the take) shows up at all.
+
+Alongside them: `schema` matches the `TIMELINE_SCHEMA` the package exports,
+indices match positions, timestamps are monotonic and inside the mp4's
+duration, the recorder's own `duration` matches ffprobe, and every `still` a
+beat names is a file on disk *and* every file in `images/` is named by a beat.
 
 **Where the timestamps point** is the assertion worth having, and it is
-measured rather than computed: both takes set a caption after two seconds of
-nothing at all happening, then the caption band is sampled every frame around
-what `timeline.json` claims and the first frame that has travelled a quarter
-of the way to the caption's final state is taken as when it appeared. A
-quarter, not "any change at all", because the bar fades in over 0.3 s and
-those two definitions are a third of a second apart. If the band never gets
-anywhere the run *fails* rather than reporting a timestamp — a caption that
-was never drawn has no appearance to time.
+measured rather than computed. Both takes set a caption after two seconds of
+caption-band quiet; the band is then sampled every frame around what
+`timeline.json` claims, and the first frame that has travelled a quarter of the
+way to the caption's final state is taken as when it appeared. A quarter, not
+"any change at all", because the bar fades in over 0.3 s and those two
+definitions are a third of a second apart. The run-up is validated too — but on
+frames well before the crossing, never the ones just before it, which *are* the
+fade partway up and would read as a busy run-up on any take whose fade got
+captured as a ramp.
 
-Two bars, because the honest answer depends on where in the take you look:
+Both the take's first caption and its last are timed, and the skew is graded
+three ways, because the two directions have different causes and only one of
+them is the beat log's:
 
-| | measured | bar |
+| | bound | why |
 |---|---|---|
-| first caption, ~3 s in | -40 to -120 ms, both media, every take | 200 ms |
-| closing caption, ~17 s in | -40 to -680 ms depending on the take | 800 ms |
+| log **ahead** of the frame | 250 ms | nothing about the capture can move an event *later*, so a positive skew is the log's own error |
+| video **ahead** of the log | 750 ms | a screencast that drops frames only ever makes events land early; capped at one lost setup window |
+| the two probes **drifting apart** | 250 ms | whatever the capture loses, it loses for every later frame equally, so a stall cancels here and only a bad clock survives |
 
-The first bar is the one that grades the beat log — it fails if `_t0` moves
-off the start of the recording (the pre-fix placement measured **+280 ms**),
-if elapsed time comes off a steppable clock, or if a beat is stamped anywhere
-other than where its verb ran. The second has to tolerate Chromium's
-screencast losing ~0.6 s of wall time mid-take, which is a property of the
-capture and not of the log — see Known gaps.
+Observed across eight consecutive `--web-only` runs and six full runs, both
+media: first caption **-80 to -200 ms**, closing caption **-160 to 0 ms**,
+drift **0 to 80 ms**. Nothing came near the 250 ms *ahead* bound — no run has
+ever produced a positive skew — which is the point of splitting by direction:
+the tight bound guards a failure mode with no natural variation near it.
+`_t0` set after `_start()` instead of at page creation measures **+320 ms** and
+fails it; a beat clock running 3% fast drifts **-360 ms** and fails the third.
+
+That split, and the tightness, only work because of `TICKER_JS` — the part to
+understand before trusting this axis. Chromium's screencast emits a frame when
+the page paints and nothing pads the gap when it does not, so an idle stretch
+silently costs the recording ~0.6 s of wall time and everything after it sits
+that much early. Measured, three runs each: 3/3 idle takes stalled, 3/3 takes
+with a small animated element running did not. Both storyboards inject one for
+their whole length. It cannot cover the ~0.7 s between the page being created
+and the first line of storyboard running — the recorder's own setup, which no
+test code can reach — and roughly 1 web take in 12 loses that window whole,
+which is what the 750 ms bound is for. **A real demo has no ticker at all**;
+see Known gaps and [#18](https://github.com/rogvid/skills/issues/18).
+
+When the measurement cannot be made the run says which reason it was: a caption
+that was never drawn, a video that slid further than the search window can see,
+or a run-up that was not quiet. They look identical from inside the window, and
+only the first is the recorder losing a caption.
 
 ## Known gaps
 
@@ -196,14 +240,16 @@ knows is missing is worse than one that is openly absent.
   the attribute while moving the app elsewhere would silently score the wrong
   pixels. Tracked in [#17](https://github.com/rogvid/skills/issues/17), which
   proposes the recorder expose its geometry as public API.
-- **Late beat timestamps drift from the video by up to ~0.6 s.** Chromium's
-  screencast intermittently stalls during an idle stretch and Playwright's webm
-  does not pad the gap, so every frame after the stall sits that much earlier
-  in the video than the clock says (`demo.mp4`'s duration shrinks by exactly
-  that much). Measured across ten takes: five stalled once, five did not. The
-  recorder cannot see it happen, which is why the closing-caption bar is 800 ms
-  rather than 200. Consequence: a frame extracted at a beat timestamp late in a
-  stalled take can show the wrong beat. Tracked in
+- **This harness no longer sees the drift real demos have, on purpose.**
+  Chromium's screencast stalls during idle stretches and Playwright's webm does
+  not pad the gap, so a real take loses ~0.6 s of wall time per stall and every
+  frame after it sits that much early (a 32 s take was measured losing 1.44 s;
+  it is not confined to late in a take, it accumulates with idle time).
+  `TICKER_JS` removes the confound here so the timing bar grades the beat log —
+  which means **a pass says nothing about how well a real, tickerless demo's
+  timestamps line up.** Consequence: a frame extracted at a beat timestamp can
+  show the wrong beat, and narration inherits the same lag because audio rides
+  the wall clock while pixels ride the screencast. Tracked in
   [#18](https://github.com/rogvid/skills/issues/18), which matters most to
   [#8](https://github.com/rogvid/skills/issues/8).
 - **Nothing reads the caption text off the video.** The timing check proves the
@@ -271,7 +317,9 @@ insurance against a future release that does start flagging it.
   lengthens the take; keep it inside the duration window, or widen the window
   deliberately. **Every interaction gets a `b.expect(...)` naming what it
   should have changed** — a beat with no post-condition is a beat that passes
-  when the verb is a no-op.
+  when the verb is a no-op. Anything that leaves the page still for more than a
+  second also wants a look at `TICKER_JS`: idle is what makes the screencast
+  lose time, and adding idle is how the timing bar was made flaky once already.
 - **A new storyboard verb in the recorder** — decorate it with `@_beat_verb`
   so it lands in the beat log, or the timeline stops being a full account of
   the take. A verb built out of other verbs records one beat, not one per

--- a/tests/smoke
+++ b/tests/smoke
@@ -39,6 +39,7 @@ reading a pass as proof the recorder is healthy.
 from __future__ import annotations
 
 import argparse
+import json
 import math
 import os
 import shutil
@@ -133,7 +134,144 @@ TERMINAL_SHOTS = ["01-echo", "02-listing"]
 # the duplicate-still check demands of the storyboard's own stills.
 CAPTION_PROBE = ("90-caption-off", "91-caption-on")
 
+# Both takes are timed against their own captions, at two points: the first
+# caption they set and the last. Each is preceded by PROBE_QUIET_S of nothing
+# at all happening, so the only thing that moves in the caption band around
+# the beat's `t_start` is the caption itself, and the frames just before it
+# are a clean baseline. See MAX_CAPTION_SKEW_S for why two points.
+#
+# Two seconds, not one, because a screencast stall (see MAX_CAPTION_SKEW_S)
+# slides the video under the window by up to ~0.6 s. With a one-second run-up
+# that is enough to drag the previous caption's fade-out into the frames the
+# measurement takes as its baseline, and the run reports "the window is wrong"
+# instead of a number.
+PROBE_CAPTION = "Recorded end to end."
+PROBE_QUIET_S = 2.0
+
 SERVER_START_TIMEOUT_S = 15.0
+
+# -- timeline (timeline.json / timeline.md) ----------------------------------
+
+# Every beat each storyboard below performs, as (verb, target), in order. It
+# is written out by hand rather than derived from the recording, which is the
+# only way it can catch a dropped, duplicated, or reordered beat: a count
+# taken from the log it is checking would agree with the log no matter what
+# the log said. Editing a storyboard means editing this list.
+WEB_BEATS = [
+    ("goto", "/"),
+    ("wait_for", "#kpi-rev"),
+    ("pause", None),
+    ("caption", None),
+    ("shot", "01-dashboard"),
+    ("spotlight", "#kpi-rev"),
+    ("hold", None),
+    ("spotlight", None),
+    ("caption", None),
+    ("type_into", "#search"),
+    ("pause", None),
+    ("shot", "02-filtered"),
+    ("caption", None),
+    ("move_to", "#refresh"),
+    ("click", "#refresh"),
+    ("pause", None),
+    ("shot", "03-refreshed"),
+    ("caption", None),
+    ("shot", "90-caption-off"),
+    ("pause", None),
+    ("caption", None),
+    ("shot", "91-caption-on"),
+    ("caption", None),
+]
+
+TERMINAL_BEATS = [
+    ("pause", None),
+    ("caption", None),
+    ("run", "echo hello from demo-video"),
+    ("wait_for_prompt", None),
+    ("wait_for_text", r"^hello from demo-video$"),
+    ("shot", "01-echo"),
+    ("caption", None),
+    ("run", "ls -1"),
+    ("wait_for_prompt", None),
+    ("wait_for_text", r"^skills$"),
+    ("pause", None),
+    ("shot", "02-listing"),
+    ("caption", None),
+    ("shot", "90-caption-off"),
+    ("pause", None),
+    ("caption", None),
+    ("shot", "91-caption-on"),
+    ("caption", None),
+]
+
+# Every caption each storyboard sets, in order. Separate from the beat list
+# above so a caption that goes missing and a beat that goes missing fail
+# independently — and separately breakable.
+WEB_CAPTIONS = [
+    "A small dashboard.",
+    "Filter by city.",
+    "Refresh reloads it.",
+    "",
+    PROBE_CAPTION,
+    "",
+]
+TERMINAL_CAPTIONS = [
+    "A real shell, recorded.",
+    "Any command works.",
+    "",
+    PROBE_CAPTION,
+    "",
+]
+
+# Beats are wall-clock spans, so `t_end` may land a hair before the next
+# `t_start` — but never after it, and never before its own `t_start`. The
+# slack absorbs the 3-decimal rounding the recorder writes.
+BEAT_ORDER_SLACK_S = 0.005
+
+# How far the recorder's own `duration` may sit from what ffprobe says about
+# the mp4 next to it. They are the same measurement; this is rounding.
+DURATION_TOLERANCE_S = 0.2
+
+# How far a beat's `t_start` may sit from the caption it names appearing in
+# demo.mp4. Measured, never asserted from arithmetic — see
+# caption_appearance_s(). Two bars, because the honest answer differs by where
+# in the take you look:
+#
+#   * EARLY — the take's first caption, ~2 s in. Across ten takes this landed
+#     between -20 and -120 ms in both media. This is the bar that actually
+#     grades the beat log: it fails if `_t0` moves off the start of the
+#     recording, if elapsed time is taken from a steppable clock, or if a beat
+#     is stamped somewhere other than where its verb ran.
+#
+#   * LATE — the closing caption, ~15 s in. Chromium's screencast
+#     intermittently stalls for ~0.6 s during an idle stretch, and Playwright's
+#     webm does not pad the gap, so every frame after the stall sits that much
+#     earlier in the video than the wall clock says. Measured across ten takes:
+#     five stalled once (-520 to -680 ms), five did not (-70 to -120 ms). It is
+#     a property of the capture, not of the beat log, and the recorder cannot
+#     see it happen. Hence a bar that tolerates one stall — see tests/README.md
+#     "Known gaps" and issue #18.
+MAX_CAPTION_SKEW_S = 0.20
+MAX_LATE_CAPTION_SKEW_S = 0.80
+
+# Window sampled around the probe beat, and the rate it is sampled at (the
+# recorders encode at 25 fps, so this is every frame and the measurement
+# quantises to 40 ms). The run-up is longer than the drift a stall can
+# introduce, so the baseline frames stay inside the storyboard's quiet
+# PROBE_QUIET_S however far the video has slid.
+ALIGN_PRE_S, ALIGN_POST_S, ALIGN_FPS = 1.6, 0.8, 25
+
+# The caption is counted as "on screen" once the band has travelled this far
+# toward its final state. The bar fades in over 0.3 s, so "appears" needs a
+# definition; a fraction of the run's own final delta is one that does not
+# depend on how much contrast the medium happens to offer.
+ALIGN_ARRIVAL_FRACTION = 0.25
+
+# ...and the band must actually get somewhere for the measurement to mean
+# anything. Below this the probe caption was never drawn in the video, and the
+# right answer is a failure, not a timestamp. Same per-medium reasoning (and
+# the same numbers) as MIN_CAPTION_BAND_DIFF above.
+MIN_ALIGN_BAND_DELTA = {"web": 6.0, "terminal": 1.0}
 
 # Written into each take directory so a later run can tell "a directory this
 # harness owns and may delete" from "somebody's source tree".
@@ -262,7 +400,11 @@ _GRAY_W, _GRAY_H = 160, 90
 
 
 def gray_frames(
-    path: Path, rect: Rect | None = None, sample_fps: int | None = None
+    path: Path,
+    rect: Rect | None = None,
+    sample_fps: int | None = None,
+    start: float | None = None,
+    duration: float | None = None,
 ) -> list[bytes]:
     """Decode an mp4 or png into 160x90 grayscale frames.
 
@@ -270,6 +412,11 @@ def gray_frames(
     region the app actually occupies is the whole point: the recorder's chrome
     is high-contrast and static, so a whole-frame score is dominated by it and
     cannot tell a blank app from a working one.
+
+    `start`/`duration` cut a window out of the video first. Both are input
+    options, so the seek is accurate and the returned frames start at the
+    first one at or after `start` — with `sample_fps` set, frame *i* is at
+    `start + i / sample_fps`, give or take that one frame.
     """
     chain = []
     if sample_fps:
@@ -278,11 +425,17 @@ def gray_frames(
         x, y, w, h = rect
         chain.append(f"crop={w}:{h}:{x}:{y}")
     chain += [f"scale={_GRAY_W}:{_GRAY_H}", "format=gray"]
+    window: list[str] = []
+    if start is not None:
+        window += ["-ss", f"{start:.3f}"]
+    if duration is not None:
+        window += ["-t", f"{duration:.3f}"]
     proc = subprocess.run(
         [
             "ffmpeg",
             "-v",
             "error",
+            *window,
             "-i",
             str(path),
             "-vf",
@@ -426,7 +579,10 @@ def record_web(
     with Recorder(out_dir, base_url=base_url, speech=False) as rec:
         rec.goto("/")
         rec.wait_for("#kpi-rev")
-        rec.pause(0.6)
+        # Long enough to double as the run-up for the *early* timing probe:
+        # the page has finished painting and nothing moves until the first
+        # caption. See MAX_CAPTION_SKEW_S.
+        rec.pause(PROBE_QUIET_S)
         b.expect("goto('/'), #rows row count", rec.page.locator("#rows tr").count(), 5)
         b.expect(
             "goto('/'), #status text",
@@ -509,12 +665,15 @@ def record_web(
 
         # Two stills back to back with the page frozen and only the caption
         # changing. Their difference in the caption band is pixel proof that
-        # the bar was actually drawn — see MIN_CAPTION_BAND_DIFF.
+        # the bar was actually drawn — see MIN_CAPTION_BAND_DIFF. The quiet
+        # second in the middle is what makes the same moment usable as the
+        # timing probe — see caption_appearance_s().
         rec.caption("")
         check_caption(b, rec.page, "")
         rec.shot(CAPTION_PROBE[0])
-        rec.caption("Recorded end to end.")
-        check_caption(b, rec.page, "Recorded end to end.")
+        rec.pause(PROBE_QUIET_S)
+        rec.caption(PROBE_CAPTION)
+        check_caption(b, rec.page, PROBE_CAPTION)
         rec.shot(CAPTION_PROBE[1])
         rec.caption("")
 
@@ -561,6 +720,10 @@ def record_terminal(
             b.fail_if(True, f"after {after}, the shell prompt never came back — {tail}")
 
     with TerminalRecorder(out_dir, speech=False) as rec:
+        # Let xterm.js settle, and give the early timing probe below a
+        # baseline that is not the browser's first paint. See
+        # MAX_CAPTION_SKEW_S.
+        rec.pause(PROBE_QUIET_S)
         rec.caption("A real shell, recorded.")
         check_caption(b, rec.page, "A real shell, recorded.")
         rec.run("echo hello from demo-video")
@@ -582,8 +745,9 @@ def record_terminal(
         rec.caption("")
         check_caption(b, rec.page, "")
         rec.shot(CAPTION_PROBE[0])
-        rec.caption("Recorded end to end.")
-        check_caption(b, rec.page, "Recorded end to end.")
+        rec.pause(PROBE_QUIET_S)
+        rec.caption(PROBE_CAPTION)
+        check_caption(b, rec.page, PROBE_CAPTION)
         rec.shot(CAPTION_PROBE[1])
         rec.caption("")
 
@@ -667,6 +831,288 @@ def _check_video(
             f"content {score:.1f})"
         )
     return failures
+
+
+def caption_appearance_s(
+    label: str, mp4: Path, band: Rect, t_start: float
+) -> tuple[float | None, str]:
+    """When the probe caption really shows up in the video, in seconds.
+
+    Returns (seconds, note) — seconds is None when the measurement could not
+    be made, and `note` says why, or reports the numbers behind the answer.
+
+    The storyboard leaves PROBE_QUIET_S of nothing happening before the probe
+    caption, so within this window the caption band changes for one reason
+    only. Sample it every frame from before the beat to after it, and take the
+    first frame that has travelled ALIGN_ARRIVAL_FRACTION of the way from the
+    quiet baseline to where the band ends up. Deliberately *not* "the first
+    frame that differs at all": the bar fades in over 0.3 s, so the first
+    perturbed frame and the fully-drawn one are a third of a second apart and
+    only one of them is a defensible answer.
+    """
+    start = max(0.0, t_start - ALIGN_PRE_S)
+    span = (t_start - start) + ALIGN_POST_S
+    try:
+        frames = gray_frames(
+            mp4, band, sample_fps=ALIGN_FPS, start=start, duration=span
+        )
+    except RuntimeError as exc:
+        return None, str(exc)
+    if len(frames) < ALIGN_FPS // 2:
+        return None, f"only {len(frames)} frames could be sampled around {t_start:.2f}s"
+
+    baseline = frames[0]
+    travel = [frame_difference(baseline, f) for f in frames]
+    settled = sum(travel[-3:]) / 3
+    floor = MIN_ALIGN_BAND_DELTA[label]
+    if settled < floor:
+        return None, (
+            f"the caption band never changed around {t_start:.2f}s — it moved "
+            f"{settled:.2f} mean luma by the end of the window, under the "
+            f"{floor} floor. The probe caption is not in the video at all, so "
+            f"there is no appearance to time."
+        )
+    # Noise floor from the quiet run-up, so encoder dither cannot be mistaken
+    # for the caption arriving; ALIGN_ARRIVAL_FRACTION dominates in practice.
+    quiet = int(ALIGN_FPS * 0.3)
+    noise = max(travel[1:quiet]) if len(travel) > quiet else 0.0
+    threshold = max(settled * ALIGN_ARRIVAL_FRACTION, noise * 4)
+    arrived = next((i for i, d in enumerate(travel) if d > threshold), None)
+    if arrived is None:
+        return None, (
+            f"the caption band settles at {settled:.2f} but no frame in the "
+            f"window crossed {threshold:.2f} — the window is wrong"
+        )
+    if arrived == 0:
+        return None, (
+            f"the caption band was already changed at the very first sampled "
+            f"frame ({start:.2f}s), {ALIGN_PRE_S}s before the beat says the "
+            f"caption was set — nothing about this window is a baseline"
+        )
+    return start + arrived / ALIGN_FPS, (
+        f"band travelled {settled:.1f}, noise {noise:.2f}, "
+        f"arrival threshold {threshold:.2f}"
+    )
+
+
+def check_timeline(
+    label: str,
+    out_dir: Path,
+    started_at: float,
+    expected_beats: list[tuple[str, str | None]],
+    expected_captions: list[str],
+    frame_size: tuple[int, int],
+) -> list[str]:
+    """The beat log the take left behind: timeline.json and timeline.md.
+
+    Graded on the same three axes as everything else here. That it exists and
+    parses is the cheap part; that its beats are the beats the storyboard
+    actually performed, and that its timestamps point at the right frames of
+    demo.mp4, is the part worth having.
+    """
+    from demo_recording import TIMELINE_SCHEMA, media_duration
+
+    failures: list[str] = []
+    json_path = out_dir / "timeline.json"
+    md_path = out_dir / "timeline.md"
+
+    if not json_path.is_file():
+        return [f"{label}: {json_path} was never written"]
+    if json_path.stat().st_mtime < started_at - 1:
+        return [f"{label}: {json_path} is stale — it predates this run"]
+    try:
+        doc = json.loads(json_path.read_text())
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return [f"{label}: {json_path} is not valid JSON: {exc}"]
+
+    if doc.get("schema") != TIMELINE_SCHEMA:
+        failures.append(
+            f"{label}: timeline.json says schema {doc.get('schema')!r}, but the "
+            f"recorder package exports TIMELINE_SCHEMA {TIMELINE_SCHEMA!r}"
+        )
+    if doc.get("media") != "demo.mp4":
+        failures.append(
+            f"{label}: timeline.json describes media {doc.get('media')!r}, "
+            f"expected 'demo.mp4'"
+        )
+    if doc.get("segment") is not None:
+        failures.append(
+            f"{label}: timeline.json says segment {doc.get('segment')!r}; these "
+            f"takes are single-segment, so it should be null"
+        )
+
+    beats = doc.get("beats")
+    if not isinstance(beats, list):
+        return failures + [f"{label}: timeline.json has no `beats` list"]
+
+    # -- the beats are the beats the storyboard performed --------------------
+    actual = [(b.get("verb"), b.get("selector")) for b in beats]
+    if actual != expected_beats:
+        counts = (
+            ""
+            if len(actual) == len(expected_beats)
+            else (
+                f" ({len(actual)} beats logged against the "
+                f"{len(expected_beats)} the storyboard performs)"
+            )
+        )
+        failures.append(
+            f"{label}: timeline.json does not log the beats the storyboard "
+            f"performs{counts} — first difference at index "
+            f"{_first_difference(actual, expected_beats)}. Logged {actual!r}. "
+            f"Either a verb stopped recording a beat, or record_{label}() "
+            f"changed and WEB_BEATS/TERMINAL_BEATS is stale."
+        )
+    captions = [b.get("caption") for b in beats if b.get("verb") == "caption"]
+    if captions != expected_captions:
+        failures.append(
+            f"{label}: the captions in timeline.json are {captions!r}, the "
+            f"storyboard sets {expected_captions!r}"
+        )
+
+    # -- indices and timestamps ---------------------------------------------
+    previous_end = 0.0
+    for position, beat in enumerate(beats):
+        where = f"{label}: beat {position} ({beat.get('verb')!r})"
+        if beat.get("index") != position:
+            failures.append(
+                f"{where} carries index {beat.get('index')!r}, but sits at "
+                f"position {position} in the list"
+            )
+        t_start, t_end = beat.get("t_start"), beat.get("t_end")
+        if not isinstance(t_start, (int, float)) or not isinstance(t_end, (int, float)):
+            failures.append(f"{where} has non-numeric timestamps {t_start!r}/{t_end!r}")
+            continue
+        if t_start < 0:
+            failures.append(f"{where} starts at {t_start:.3f}s, before the video does")
+        if t_end < t_start - BEAT_ORDER_SLACK_S:
+            failures.append(
+                f"{where} ends at {t_end:.3f}s, before it starts ({t_start:.3f}s)"
+            )
+        if t_start < previous_end - BEAT_ORDER_SLACK_S:
+            failures.append(
+                f"{where} starts at {t_start:.3f}s, before the previous beat "
+                f"ended ({previous_end:.3f}s) — the log is not monotonic"
+            )
+        previous_end = max(previous_end, t_end)
+        if beat.get("segment") is not None:
+            failures.append(f"{where} claims segment {beat.get('segment')!r}")
+
+    # -- the mp4 the timestamps are relative to ------------------------------
+    mp4 = out_dir / "demo.mp4"
+    duration = doc.get("duration")
+    if not mp4.is_file():
+        failures.append(f"{label}: timeline.json describes {mp4}, which is not there")
+    elif not isinstance(duration, (int, float)):
+        failures.append(
+            f"{label}: timeline.json has no numeric duration ({duration!r})"
+        )
+    else:
+        try:
+            probed = media_duration(mp4)
+        except Exception as exc:  # noqa: BLE001 - report, don't crash the run
+            failures.append(f"{label}: ffprobe could not read {mp4}: {exc}")
+            probed = None
+        if probed is not None and abs(probed - duration) > DURATION_TOLERANCE_S:
+            failures.append(
+                f"{label}: timeline.json says demo.mp4 is {duration}s, ffprobe "
+                f"says {probed:.3f}s"
+            )
+        if previous_end > (probed or duration) + DURATION_TOLERANCE_S:
+            failures.append(
+                f"{label}: the last beat ends at {previous_end:.3f}s, past the "
+                f"end of a {duration}s demo.mp4 — the timestamps are not on "
+                f"the same clock as the video"
+            )
+
+    # -- every still a beat names is on disk ---------------------------------
+    logged_stills = [b["still"] for b in beats if b.get("still")]
+    for rel in logged_stills:
+        if not (out_dir / rel).is_file():
+            failures.append(
+                f"{label}: beat still {rel!r} does not exist — timeline.json "
+                f"points a reviewer at a file that was never written"
+            )
+    on_disk = sorted(p.name for p in (out_dir / "images").glob("*.png"))
+    named = sorted(Path(rel).name for rel in logged_stills)
+    if named != on_disk:
+        failures.append(
+            f"{label}: timeline.json names stills {named!r}, but images/ holds "
+            f"{on_disk!r} — a shot() happened without a beat, or the other way"
+        )
+
+    # -- timeline.md is rendered from the same beats -------------------------
+    if not md_path.is_file():
+        failures.append(f"{label}: {md_path} was never written")
+    elif md_path.stat().st_mtime < started_at - 1:
+        failures.append(f"{label}: {md_path} is stale — it predates this run")
+    else:
+        markdown = md_path.read_text()
+        for rel in logged_stills:
+            if f"]({rel})" not in markdown:
+                failures.append(
+                    f"{label}: timeline.md does not embed the still {rel!r} that "
+                    f"timeline.json records"
+                )
+        for text in (c for c in expected_captions if c):
+            if text not in markdown:
+                failures.append(f"{label}: timeline.md does not mention {text!r}")
+
+    # -- the acceptance criterion: timestamps point at the right frames ------
+    spoken = [b for b in beats if b.get("verb") == "caption" and b.get("caption")]
+    probes: list[tuple[str, dict, float]] = []
+    if spoken:
+        probes.append(("first caption", spoken[0], MAX_CAPTION_SKEW_S))
+    last = next(
+        (b for b in reversed(spoken) if b.get("caption") == PROBE_CAPTION), None
+    )
+    if last is None:
+        failures.append(
+            f"{label}: no beat logs the closing caption {PROBE_CAPTION!r}, so "
+            f"the end of the timeline cannot be checked against the video"
+        )
+    elif last is not spoken[0]:
+        probes.append(("closing caption", last, MAX_LATE_CAPTION_SKEW_S))
+    if not spoken:
+        failures.append(f"{label}: no caption beats at all to time against")
+
+    for what, probe, bar in probes:
+        if not mp4.is_file() or not isinstance(probe.get("t_start"), (int, float)):
+            continue
+        text = probe["caption"]
+        t_start = float(probe["t_start"])
+        seen_at, note = caption_appearance_s(
+            label, mp4, caption_band(frame_size), t_start
+        )
+        if seen_at is None:
+            failures.append(
+                f"{label}: the {what} could not be timed against demo.mp4 — {note}"
+            )
+            continue
+        skew = seen_at - t_start
+        if abs(skew) > bar:
+            failures.append(
+                f"{label}: timeline.json puts the {what} {text!r} at "
+                f"{t_start:.2f}s, but demo.mp4 shows it at {seen_at:.2f}s — "
+                f"{skew * 1000:+.0f} ms, over the {bar * 1000:.0f} ms bar. The "
+                f"beat log and the video are on different clocks ({note})."
+            )
+        else:
+            print(
+                f"smoke: {label} {what} {text!r} logged at {t_start:.2f}s, on "
+                f"screen at {seen_at:.2f}s ({skew * 1000:+.0f} ms, bar "
+                f"{bar * 1000:.0f} ms)"
+            )
+    if not failures:
+        print(f"smoke: {label} timeline.json ok ({len(beats)} beats)")
+    return failures
+
+
+def _first_difference(actual: list, expected: list) -> object:
+    for i, (a, e) in enumerate(zip(actual, expected, strict=False)):
+        if a != e:
+            return f"{i} ({a!r} vs expected {e!r})"
+    return f"{min(len(actual), len(expected))} (one list simply ends)"
 
 
 def check_take(
@@ -797,8 +1243,19 @@ def run_web(out_root: Path) -> list[str]:
             problems, video_rect, still_rect, size = record_web(out_dir, base_url)
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"web: Recorder raised {type(exc).__name__}: {exc}"]
-    return problems + check_take(
-        "web", out_dir, WEB_SHOTS, WEB_DURATION_S, started, video_rect, still_rect, size
+    return (
+        problems
+        + check_take(
+            "web",
+            out_dir,
+            WEB_SHOTS,
+            WEB_DURATION_S,
+            started,
+            video_rect,
+            still_rect,
+            size,
+        )
+        + check_timeline("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
     )
 
 
@@ -822,15 +1279,21 @@ def run_terminal(out_root: Path) -> list[str]:
         return [f"terminal: TerminalRecorder raised {type(exc).__name__}: {exc}"]
     finally:
         os.chdir(previous)
-    return problems + check_take(
-        "terminal",
-        out_dir,
-        TERMINAL_SHOTS,
-        TERMINAL_DURATION_S,
-        started,
-        video_rect,
-        still_rect,
-        size,
+    return (
+        problems
+        + check_take(
+            "terminal",
+            out_dir,
+            TERMINAL_SHOTS,
+            TERMINAL_DURATION_S,
+            started,
+            video_rect,
+            still_rect,
+            size,
+        )
+        + check_timeline(
+            "terminal", out_dir, started, TERMINAL_BEATS, TERMINAL_CAPTIONS, size
+        )
     )
 
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -42,6 +42,7 @@ import argparse
 import json
 import math
 import os
+import re
 import shutil
 import socket
 import statistics
@@ -140,11 +141,19 @@ CAPTION_PROBE = ("90-caption-off", "91-caption-on")
 # the beat's `t_start` is the caption itself, and the frames just before it
 # are a clean baseline. See MAX_CAPTION_SKEW_S for why two points.
 #
-# Two seconds, not one, because a screencast stall (see MAX_CAPTION_SKEW_S)
-# slides the video under the window by up to ~0.6 s. With a one-second run-up
-# that is enough to drag the previous caption's fade-out into the frames the
-# measurement takes as its baseline, and the run reports "the window is wrong"
-# instead of a number.
+# Quiet means *the caption band* is quiet. The rest of the frame keeps painting
+# throughout — see TICKER_JS, without which idle is what breaks this whole
+# measurement. With the ticker running, storyboard idle is free, so this is
+# sized for the geometry rather than kept short:
+#
+#   ALIGN_PRE_S < PROBE_QUIET_S + 0.04 - 0.30
+#
+# The 0.04 is the `shot()` between the clearing caption and the pause; the 0.30
+# is how long the clearing caption's fade-out keeps moving the band after
+# `caption("")` returns. Reach back further than that and the measurement takes
+# the tail of the *previous* caption as its baseline and reports a busy run-up.
+# At 2.0 against ALIGN_PRE_S of 1.2 there is 0.54 s of margin. A capture loss
+# does not enter into it: it slides the window and the fade together.
 PROBE_CAPTION = "Recorded end to end."
 PROBE_QUIET_S = 2.0
 
@@ -228,38 +237,88 @@ TERMINAL_CAPTIONS = [
 # slack absorbs the 3-decimal rounding the recorder writes.
 BEAT_ORDER_SLACK_S = 0.005
 
+# `t_end` has to mean something, and every check above is satisfied by setting
+# it equal to `t_start`. Two floors close that:
+#
+#   * a `caption(text)` beat holds 0.6 + 0.34/word (>= 1.4 s with speech off)
+#     and a `hold()` beat has a 1.5 s perception floor, both enforced by the
+#     recorder — so either spanning under a second is a broken `t_end`, not a
+#     fast machine;
+#   * the beats run back to back, so their spans together cover essentially
+#     all of first-start to last-end. Collapsing every `t_end` takes that to
+#     zero while leaving every other timestamp assertion happy.
+#
+# Load-bearing beyond this PR: #8 wants the beat *midpoint* for frame
+# extraction, precisely because `t_start` is 0% into the caption's 0.3 s fade.
+MIN_HELD_BEAT_SPAN_S = 1.0
+MIN_BEAT_TIME_COVERAGE = 0.80
+
+# A data row of timeline.md's beat table: "| 4 | 4.66 | 4.71 | `shot` | …".
+# Anchored on the leading index so the header and separator rows do not count.
+_MD_ROW = re.compile(r"^\|\s*\d+\s*\|")
+
 # How far the recorder's own `duration` may sit from what ffprobe says about
 # the mp4 next to it. They are the same measurement; this is rounding.
 DURATION_TOLERANCE_S = 0.2
 
 # How far a beat's `t_start` may sit from the caption it names appearing in
-# demo.mp4. Measured, never asserted from arithmetic — see
-# caption_appearance_s(). Two bars, because the honest answer differs by where
-# in the take you look:
+# demo.mp4, measured at both the take's first caption and its last — never
+# computed, see caption_appearance_s(). Three bounds rather than one, because
+# the two directions have different causes and only one of them is the beat
+# log's:
 #
-#   * EARLY — the take's first caption, ~2 s in. Across ten takes this landed
-#     between -20 and -120 ms in both media. This is the bar that actually
-#     grades the beat log: it fails if `_t0` moves off the start of the
-#     recording, if elapsed time is taken from a steppable clock, or if a beat
-#     is stamped somewhere other than where its verb ran.
+#   * MAX_LOG_EARLY_S — the video shows the caption *after* the log says
+#     (positive skew). Nothing about the capture can produce that: a webm
+#     that drops frames only ever makes events land earlier. So a positive
+#     skew is the log's own error, and the bar is tight. `_t0` set after
+#     `_start()` instead of at page creation measures +280 to +320 ms here.
 #
-#   * LATE — the closing caption, ~15 s in. Chromium's screencast
-#     intermittently stalls for ~0.6 s during an idle stretch, and Playwright's
-#     webm does not pad the gap, so every frame after the stall sits that much
-#     earlier in the video than the wall clock says. Measured across ten takes:
-#     five stalled once (-520 to -680 ms), five did not (-70 to -120 ms). It is
-#     a property of the capture, not of the beat log, and the recorder cannot
-#     see it happen. Hence a bar that tolerates one stall — see tests/README.md
-#     "Known gaps" and issue #18.
-MAX_CAPTION_SKEW_S = 0.20
-MAX_LATE_CAPTION_SKEW_S = 0.80
+#   * MAX_CAPTURE_LOSS_S — the video shows it *before* the log says (negative
+#     skew). Chromium's screencast emits a frame when the page paints, and
+#     nothing pads the gap when it does not, so an idle stretch costs the webm
+#     wall time and everything after it lands early. TICKER_JS removes that
+#     for the whole storyboard, but not for the ~0.7 s between the page being
+#     created and the first line of storyboard running — the recorder's own
+#     setup, which no test code can reach. Roughly 1 web take in 12 loses that
+#     window whole: -600 ms, uniformly, from the very first caption. Tolerated
+#     and reported, not asserted away; issue #18.
+#
+#   * MAX_SKEW_DRIFT_S — how far the two probes' skews may differ. This is the
+#     sharp one, and it is symmetric. Anything the capture does to a take, it
+#     does to every frame after it equally, so a stall moves both probes
+#     together and cancels here. Anything wrong with the *clock* does not: a
+#     backwards step lands between the probes and shows up as drift, as does a
+#     beat stamped somewhere other than where its verb ran. Observed across
+#     twelve takes with the ticker: 0 to 120 ms, all of it the 40 ms sampling
+#     grid and the caption's own 0.3 s fade. A mid-take screencast stall (520
+#     ms) and the measured clock step (573 ms) are both well over the bar.
+MAX_LOG_EARLY_S = 0.25
+MAX_CAPTURE_LOSS_S = 0.75
+MAX_SKEW_DRIFT_S = 0.25
 
 # Window sampled around the probe beat, and the rate it is sampled at (the
 # recorders encode at 25 fps, so this is every frame and the measurement
-# quantises to 40 ms). The run-up is longer than the drift a stall can
-# introduce, so the baseline frames stay inside the storyboard's quiet
-# PROBE_QUIET_S however far the video has slid.
-ALIGN_PRE_S, ALIGN_POST_S, ALIGN_FPS = 1.6, 0.8, 25
+# quantises to 40 ms). The run-up has to clear MAX_CAPTURE_LOSS_S — a take that
+# lost that much wall time puts the caption that far into the window, and a
+# window starting after it has no baseline at all — while staying inside the
+# caption-band quiet PROBE_QUIET_S buys. Both, at 1.2: 0.45 s of margin on the
+# first, 0.54 s on the second.
+ALIGN_PRE_S, ALIGN_POST_S, ALIGN_FPS = 1.2, 0.8, 25
+
+# How far the band may wander before the caption arrives, as a fraction of how
+# far it travels once it does. Measured on quiet run-ups: under 1%. Judged over
+# frames at least CAPTION_FADE_FRAMES before the arrival, because the recorder
+# fades the bar in over 0.3 s and the frames right before the crossing are that
+# fade, not the run-up.
+MAX_BASELINE_NOISE_FRACTION = 0.15
+CAPTION_FADE_FRAMES = int(ALIGN_FPS * 0.35)
+MIN_BASELINE_FRAMES = 4
+
+# When the narrow window comes up empty, re-sample this far either side before
+# concluding the caption was never drawn. The two answers — "the video slid out
+# from under the search window" and "the caption is not there" — look identical
+# from inside ALIGN_PRE_S, and only one of them is the recorder's fault.
+ALIGN_RESCUE_S = 5.0
 
 # The caption is counted as "on screen" once the band has travelled this far
 # toward its final state. The bar fades in over 0.3 s, so "appears" needs a
@@ -552,6 +611,62 @@ def check_caption(b: Beats, page, expected: str) -> None:
     )
 
 
+# Keeps the compositor producing frames for the whole take.
+#
+# Not cosmetic, and not optional. Chromium's screencast emits a frame when the
+# page paints; nothing pads the gap when it does not. Left idle, Playwright's
+# webm silently loses ~0.6 s of wall time somewhere in a take, and every frame
+# after that sits that much earlier in the video than the recorder's clock says
+# — which would be measured here as the beat log being wrong when it is not.
+# Instrumented takes, 10 marks over 32 s, three runs each:
+#
+#   idle    -0.11 -0.60 -0.62 -0.59 -0.60 -0.61 -0.62 -0.63 -0.60 -0.60
+#   ticking -0.18 -0.08 -0.09 -0.10 -0.07 -0.08 -0.09 -0.09 -0.10 -0.11
+#
+# 3/3 idle takes stalled; 3/3 ticking takes did not. So the harness removes the
+# confound rather than widening a bar around it — the drift itself is the
+# recorder's problem to solve, tracked in issue #18, and tests/README.md says
+# plainly that this axis no longer sees it.
+#
+# Sized so it cannot be mistaken for content: 8x8 px at 2-6% opacity is about
+# one pixel of the 160x90 luma reduction, moving a handful of levels. It adds
+# ~0.03 to a frame's luma stddev against floors of 6.0/2.0, and ~0.0007 to the
+# mean absolute difference between two stills against a 0.25 floor — neither
+# can lift a blank recording over a floor or make two identical stills look
+# different. It sits at the top-left corner, outside the caption band every
+# timing measurement reads.
+TICKER_JS = """() => {
+  if (document.getElementById('__smoke_ticker')) return;
+  const style = document.createElement('style');
+  style.textContent =
+    '@keyframes __smoke_ticker{0%{opacity:.02}100%{opacity:.06}}';
+  document.head.appendChild(style);
+  const el = document.createElement('div');
+  el.id = '__smoke_ticker';
+  el.style.cssText = 'position:fixed;top:0;left:0;width:8px;height:8px;'
+    + 'background:#808080;z-index:2147483647;pointer-events:none;'
+    + 'animation:__smoke_ticker .18s steps(2) infinite';
+  document.body.appendChild(el);
+}"""
+
+
+def start_ticker(b: Beats, page) -> None:
+    """Inject TICKER_JS and confirm it is running."""
+    page.evaluate(TICKER_JS)
+    running = page.evaluate(
+        "() => { const el = document.getElementById('__smoke_ticker');"
+        " return !!el && getComputedStyle(el).animationName === "
+        "'__smoke_ticker'; }"
+    )
+    # If it silently failed to attach, every timing number below becomes a
+    # measurement of Chromium's screencast luck instead of the beat log.
+    b.fail_if(
+        not running,
+        "the compositor ticker did not attach — timing measurements in this "
+        "take are not trustworthy (see TICKER_JS)",
+    )
+
+
 # Records every mousemove the page sees, so move_to()'s 30-step glide can be
 # told apart from the single move Playwright's own click() dispatches.
 _TRAIL_JS = """() => {
@@ -579,9 +694,10 @@ def record_web(
     with Recorder(out_dir, base_url=base_url, speech=False) as rec:
         rec.goto("/")
         rec.wait_for("#kpi-rev")
-        # Long enough to double as the run-up for the *early* timing probe:
-        # the page has finished painting and nothing moves until the first
-        # caption. See MAX_CAPTION_SKEW_S.
+        start_ticker(b, rec.page)
+        # Doubles as the run-up for the *early* timing probe: the page has
+        # finished painting and the caption band does not move until the
+        # first caption. See MAX_CAPTION_SKEW_S.
         rec.pause(PROBE_QUIET_S)
         b.expect("goto('/'), #rows row count", rec.page.locator("#rows tr").count(), 5)
         b.expect(
@@ -720,6 +836,7 @@ def record_terminal(
             b.fail_if(True, f"after {after}, the shell prompt never came back — {tail}")
 
     with TerminalRecorder(out_dir, speech=False) as rec:
+        start_ticker(b, rec.page)
         # Let xterm.js settle, and give the early timing probe below a
         # baseline that is not the browser's first paint. See
         # MAX_CAPTION_SKEW_S.
@@ -841,7 +958,7 @@ def caption_appearance_s(
     Returns (seconds, note) — seconds is None when the measurement could not
     be made, and `note` says why, or reports the numbers behind the answer.
 
-    The storyboard leaves PROBE_QUIET_S of nothing happening before the probe
+    The storyboard leaves PROBE_QUIET_S of caption-band quiet before the probe
     caption, so within this window the caption band changes for one reason
     only. Sample it every frame from before the beat to after it, and take the
     first frame that has travelled ALIGN_ARRIVAL_FRACTION of the way from the
@@ -866,22 +983,42 @@ def caption_appearance_s(
     settled = sum(travel[-3:]) / 3
     floor = MIN_ALIGN_BAND_DELTA[label]
     if settled < floor:
-        return None, (
-            f"the caption band never changed around {t_start:.2f}s — it moved "
-            f"{settled:.2f} mean luma by the end of the window, under the "
-            f"{floor} floor. The probe caption is not in the video at all, so "
-            f"there is no appearance to time."
-        )
-    # Noise floor from the quiet run-up, so encoder dither cannot be mistaken
-    # for the caption arriving; ALIGN_ARRIVAL_FRACTION dominates in practice.
-    quiet = int(ALIGN_FPS * 0.3)
-    noise = max(travel[1:quiet]) if len(travel) > quiet else 0.0
-    threshold = max(settled * ALIGN_ARRIVAL_FRACTION, noise * 4)
+        return None, _explain_flat_window(label, mp4, band, t_start, settled, floor)
+    # Find the arrival on the travel fraction alone, then validate the baseline
+    # using only the frames *before* it. Deriving a noise floor from a fixed
+    # prefix of the window instead looks right and is not: a take that lost
+    # capture time early puts the caption a few frames into the window, the
+    # "quiet" prefix then straddles the caption's own step, and the run reports
+    # a busy run-up for a page that never moved. Measured once, on a take whose
+    # video had slid 440 ms.
+    threshold = settled * ALIGN_ARRIVAL_FRACTION
     arrived = next((i for i, d in enumerate(travel) if d > threshold), None)
     if arrived is None:
         return None, (
             f"the caption band settles at {settled:.2f} but no frame in the "
-            f"window crossed {threshold:.2f} — the window is wrong"
+            f"window crossed {threshold:.2f} — the band never reaches a state "
+            f"it holds, so there is nothing to time"
+        )
+    # Validate the baseline on frames that are genuinely *before* the caption:
+    # not the ones immediately preceding the arrival, which are the caption's
+    # own 0.3 s fade partway up. Measuring those instead reports a busy run-up
+    # on every take whose fade happened to be captured as a ramp rather than a
+    # jump — it reads a fifth of `settled`, by construction just under the
+    # arrival threshold.
+    usable = arrived - CAPTION_FADE_FRAMES
+    if usable < MIN_BASELINE_FRAMES:
+        return None, (
+            f"the caption arrives {arrived / ALIGN_FPS:.2f}s into a "
+            f"{ALIGN_PRE_S:.1f}s run-up, leaving no frames before its fade to "
+            f"use as a baseline — the video has slid further under the beat log "
+            f"than the search window allows for (see issue #18)"
+        )
+    noise = max(travel[1:usable], default=0.0)
+    if noise > settled * MAX_BASELINE_NOISE_FRACTION:
+        return None, (
+            f"the caption band wanders by {noise:.2f} before the caption "
+            f"arrives, against a settled {settled:.2f} — the run-up was not "
+            f"quiet, so there is no baseline to measure from"
         )
     if arrived == 0:
         return None, (
@@ -892,6 +1029,57 @@ def caption_appearance_s(
     return start + arrived / ALIGN_FPS, (
         f"band travelled {settled:.1f}, noise {noise:.2f}, "
         f"arrival threshold {threshold:.2f}"
+    )
+
+
+def _explain_flat_window(
+    label: str, mp4: Path, band: Rect, t_start: float, settled: float, floor: float
+) -> str:
+    """Why the caption band did not move in the window around `t_start`.
+
+    Two very different things look identical from inside ALIGN_PRE_S: the
+    caption was never drawn, or the video slid so far under the beat log that
+    the whole window is already past it. Saying the first when it is the second
+    accuses the recorder of losing a caption that is plainly on screen. So
+    widen the search before concluding anything.
+    """
+    unmeasurable = (
+        f"the caption band did not move in the {ALIGN_PRE_S + ALIGN_POST_S:.1f}s "
+        f"around {t_start:.2f}s ({settled:.2f} mean luma, under the {floor} floor)"
+    )
+    wide_start = max(0.0, t_start - ALIGN_RESCUE_S)
+    try:
+        frames = gray_frames(
+            mp4,
+            band,
+            sample_fps=ALIGN_FPS,
+            start=wide_start,
+            duration=(t_start - wide_start) + ALIGN_RESCUE_S,
+        )
+    except RuntimeError as exc:
+        return f"{unmeasurable}, and the wider search failed too: {exc}"
+    if len(frames) < ALIGN_FPS:
+        return f"{unmeasurable}, and too little video remains to search wider"
+
+    # Rising edges anywhere in +/- ALIGN_RESCUE_S. If the caption is on screen
+    # at all, one of them is it, and the nearest says how far the video slid.
+    steps = [frame_difference(frames[i - 1], frames[i]) for i in range(1, len(frames))]
+    peak = max(steps)
+    if peak < floor * ALIGN_ARRIVAL_FRACTION:
+        return (
+            f"{unmeasurable}. Nothing moves in the caption band for "
+            f"{ALIGN_RESCUE_S:.0f}s either side either, so the caption really "
+            f"was never drawn — this is not a timing problem."
+        )
+    edges = [wide_start + i / ALIGN_FPS for i, s in enumerate(steps, 1) if s > peak / 2]
+    nearest = min(edges, key=lambda t: abs(t - t_start))
+    return (
+        f"{unmeasurable}, but the band does change at {nearest:.2f}s — "
+        f"{(nearest - t_start) * 1000:+.0f} ms away, outside the "
+        f"{ALIGN_PRE_S:.1f}s search window. The video has slid out from under "
+        f"the beat log by more than the window can see, so the skew cannot be "
+        f"measured (not that the caption is missing). Almost certainly a "
+        f"screencast stall — see issue #18."
     )
 
 
@@ -970,8 +1158,27 @@ def check_timeline(
             f"storyboard sets {expected_captions!r}"
         )
 
+    # Every beat, not just the caption ones, must say which caption was on
+    # screen while it ran — that context is what makes a `shot` or a `click`
+    # beat mean anything to a reviewer, and it is what timeline.md quotes over
+    # each still. Checking only `verb == "caption"` beats is blind to it: drop
+    # the recorder's `self._caption = text` and the caption beats stay perfect
+    # while every other beat goes blank. Derived from the two hand-written
+    # lists above, never from the log being graded.
+    context = _expected_context(expected_beats, expected_captions)
+    if context is not None:
+        logged = [b.get("caption") for b in beats]
+        if logged != context:
+            failures.append(
+                f"{label}: beats do not carry the caption they ran under — "
+                f"first difference at index {_first_difference(logged, context)}. "
+                f"Logged {logged!r}."
+            )
+
     # -- indices and timestamps ---------------------------------------------
     previous_end = 0.0
+    first_start: float | None = None
+    covered = 0.0
     for position, beat in enumerate(beats):
         where = f"{label}: beat {position} ({beat.get('verb')!r})"
         if beat.get("index") != position:
@@ -995,8 +1202,41 @@ def check_timeline(
                 f"ended ({previous_end:.3f}s) — the log is not monotonic"
             )
         previous_end = max(previous_end, t_end)
+        if first_start is None:
+            first_start = t_start
+        covered += max(0.0, t_end - t_start)
+        # A verb that provably occupies the screen for a known minimum must
+        # say so. `caption(text)` holds 0.6 + 0.34/word (>= 1.4 s) with speech
+        # off and `hold()` has a 1.5 s perception floor, both enforced by the
+        # recorder itself — so a beat here that reports less than a second is
+        # not reporting when its verb returned.
+        held = beat.get("verb") == "hold" or (
+            beat.get("verb") == "caption" and beat.get("caption")
+        )
+        if held and t_end - t_start < MIN_HELD_BEAT_SPAN_S:
+            failures.append(
+                f"{where} spans {t_end - t_start:.3f}s, but the recorder holds "
+                f"this verb for at least {MIN_HELD_BEAT_SPAN_S}s — `t_end` is "
+                f"not being recorded when the verb returned"
+            )
         if beat.get("segment") is not None:
             failures.append(f"{where} claims segment {beat.get('segment')!r}")
+
+    # Beats run back to back, so their spans should account for essentially
+    # all of the time between the first starting and the last ending. This is
+    # the assertion that survives any single beat being plausible: collapse
+    # every `t_end` onto its `t_start` and the coverage goes to zero while
+    # every other timestamp check still passes.
+    if first_start is not None and previous_end > first_start:
+        elapsed = previous_end - first_start
+        share = covered / elapsed
+        if share < MIN_BEAT_TIME_COVERAGE:
+            failures.append(
+                f"{label}: the beats span {covered:.2f}s between them but cover "
+                f"{first_start:.2f}s to {previous_end:.2f}s ({share:.0%} of "
+                f"{elapsed:.2f}s, floor {MIN_BEAT_TIME_COVERAGE:.0%}) — `t_end` "
+                f"is carrying no information about how long verbs took"
+            )
 
     # -- the mp4 the timestamps are relative to ------------------------------
     mp4 = out_dir / "demo.mp4"
@@ -1057,12 +1297,32 @@ def check_timeline(
         for text in (c for c in expected_captions if c):
             if text not in markdown:
                 failures.append(f"{label}: timeline.md does not mention {text!r}")
+        # The beat table specifically, not just "the text appears somewhere":
+        # every expected caption also sits above a still in the Stills section,
+        # so the whole table can go missing and the checks above still pass.
+        # The table is the only place non-`shot` beats — every click, every
+        # spotlight, the shape of the take — appear at all.
+        rows = [ln for ln in markdown.splitlines() if _MD_ROW.match(ln)]
+        if len(rows) != len(beats):
+            failures.append(
+                f"{label}: timeline.md's beat table has {len(rows)} rows for "
+                f"{len(beats)} beats — the table is the only place a beat "
+                f"without a still shows up at all"
+            )
+        for beat in beats:
+            verb = str(beat.get("verb"))
+            if not any(f"| {beat.get('index')} |" in r and verb in r for r in rows):
+                failures.append(
+                    f"{label}: timeline.md's beat table has no row for beat "
+                    f"{beat.get('index')} ({verb!r})"
+                )
+                break
 
     # -- the acceptance criterion: timestamps point at the right frames ------
     spoken = [b for b in beats if b.get("verb") == "caption" and b.get("caption")]
-    probes: list[tuple[str, dict, float]] = []
+    probes: list[tuple[str, dict]] = []
     if spoken:
-        probes.append(("first caption", spoken[0], MAX_CAPTION_SKEW_S))
+        probes.append(("first caption", spoken[0]))
     last = next(
         (b for b in reversed(spoken) if b.get("caption") == PROBE_CAPTION), None
     )
@@ -1072,11 +1332,12 @@ def check_timeline(
             f"the end of the timeline cannot be checked against the video"
         )
     elif last is not spoken[0]:
-        probes.append(("closing caption", last, MAX_LATE_CAPTION_SKEW_S))
+        probes.append(("closing caption", last))
     if not spoken:
         failures.append(f"{label}: no caption beats at all to time against")
 
-    for what, probe, bar in probes:
+    measured: list[tuple[str, float]] = []
+    for what, probe in probes:
         if not mp4.is_file() or not isinstance(probe.get("t_start"), (int, float)):
             continue
         text = probe["caption"]
@@ -1090,22 +1351,81 @@ def check_timeline(
             )
             continue
         skew = seen_at - t_start
-        if abs(skew) > bar:
+        measured.append((what, skew))
+        where = (
+            f"timeline.json puts the {what} {text!r} at {t_start:.2f}s, but "
+            f"demo.mp4 shows it at {seen_at:.2f}s ({skew * 1000:+.0f} ms)"
+        )
+        if skew > MAX_LOG_EARLY_S:
             failures.append(
-                f"{label}: timeline.json puts the {what} {text!r} at "
-                f"{t_start:.2f}s, but demo.mp4 shows it at {seen_at:.2f}s — "
-                f"{skew * 1000:+.0f} ms, over the {bar * 1000:.0f} ms bar. The "
-                f"beat log and the video are on different clocks ({note})."
+                f"{label}: {where} — the log is {skew * 1000:.0f} ms ahead of "
+                f"the frame, over the {MAX_LOG_EARLY_S * 1000:.0f} ms bar. "
+                f"Nothing about the capture can move an event *later*, so this "
+                f"is the beat log: check where `_t0` is taken and where `_beat` "
+                f"stamps `t_start`. ({note})"
+            )
+        elif skew < -MAX_CAPTURE_LOSS_S:
+            failures.append(
+                f"{label}: {where} — the video is {-skew * 1000:.0f} ms ahead of "
+                f"the log, past the {MAX_CAPTURE_LOSS_S * 1000:.0f} ms allowed "
+                f"for capture loss. That is more wall time than one stall of "
+                f"the recorder's un-tickerable setup window accounts for, so "
+                f"either TICKER_JS stopped working or issue #18 got worse. "
+                f"({note})"
+            )
+        else:
+            note = "" if abs(skew) <= MAX_LOG_EARLY_S else " — capture loss, see #18"
+            print(
+                f"smoke: {label} {what} {text!r} logged at {t_start:.2f}s, on "
+                f"screen at {seen_at:.2f}s ({skew * 1000:+.0f} ms{note})"
+            )
+
+    # The sharp one: whatever the capture loses, it loses for every frame after
+    # it, so both probes move together and the difference cancels. A clock that
+    # stepped, or a beat stamped somewhere other than where its verb ran, does
+    # not cancel.
+    if len(measured) == 2:
+        drift = measured[1][1] - measured[0][1]
+        if abs(drift) > MAX_SKEW_DRIFT_S:
+            failures.append(
+                f"{label}: the {measured[0][0]} is {measured[0][1] * 1000:+.0f} ms "
+                f"off the video and the {measured[1][0]} is "
+                f"{measured[1][1] * 1000:+.0f} ms — they have drifted "
+                f"{drift * 1000:+.0f} ms apart, over the "
+                f"{MAX_SKEW_DRIFT_S * 1000:.0f} ms bar. A capture that dropped "
+                f"time would have moved both equally, so this is the beat log's "
+                f"clock: time between beats is not being measured monotonically."
             )
         else:
             print(
-                f"smoke: {label} {what} {text!r} logged at {t_start:.2f}s, on "
-                f"screen at {seen_at:.2f}s ({skew * 1000:+.0f} ms, bar "
-                f"{bar * 1000:.0f} ms)"
+                f"smoke: {label} beat clock holds across the take ({drift * 1000:+.0f} ms)"
             )
     if not failures:
         print(f"smoke: {label} timeline.json ok ({len(beats)} beats)")
     return failures
+
+
+def _expected_context(
+    expected_beats: list[tuple[str, str | None]], expected_captions: list[str]
+) -> list[str] | None:
+    """The caption in force during each expected beat.
+
+    A `caption` beat carries the text it sets; everything after it carries that
+    text until the next one. Returns None if the two lists disagree about how
+    many captions there are, in which case the checks above already say so and
+    this one has nothing to add.
+    """
+    wanted = [verb for verb, _ in expected_beats].count("caption")
+    if wanted != len(expected_captions):
+        return None
+    context: list[str] = []
+    current = ""
+    pending = list(expected_captions)
+    for verb, _ in expected_beats:
+        if verb == "caption":
+            current = pending.pop(0)
+        context.append(current)
+    return context
 
 
 def _first_difference(actual: list, expected: list) -> object:


### PR DESCRIPTION
Fixes #6.

`guide.md` was written by hand next to `record.py` and drifted the moment the
storyboard changed, and the only durable output of a take was pixels. The
recorder is driving the page — it can emit what it already knows.

Adds a beat event log to `_DemoBase`, written on clean exit as
`timeline.json` (machine-readable) and `timeline.md` (human-readable,
embedding the stills).

## The schema is a contract, not a convenience

#7, #8, #9 and #12 all consume this. Notable decisions:

- **A beat is one storyboard verb call, not one caption span.** Verbs built
  from verbs (`click` glides via `move_to`; `type_into` clicks first) record
  ONE beat — a re-entrancy guard folds inner calls into the open one, so the
  log reflects what the storyboard did, not what the recorder did underneath.
- **`caption` is the line on screen during the beat**, so every non-caption
  beat carries its context.
- **`still` is a path relative to the timeline file**, so embeds and tooling
  resolve identically.
- Segments write `<segment>.seg.timeline.json`, mirroring `<segment>.seg.mp4`.
- `_beat(**extra)` merges arbitrary keys; the contract is declared
  append-only with a `TIMELINE_SCHEMA` version to bump on a breaking change.

Instrumentation is a `@_beat_verb("name")` decorator rather than a `with`
block per method — one added line per verb and no re-indentation,
deliberately chosen to minimise conflicts with the nine queued PRs.

## Two real bugs found and fixed on the way

Both were load-bearing for the acceptance criterion:

1. **`_t0` was set after `_start()`**, but Chromium's screencast begins with
   the page. Every beat *and every narration cue* was ~250 ms early
   (measured +246 to +275 ms across six captions).
2. **Elapsed time came from `time.time()`.** This box was measured stepping
   573 ms *backwards* inside 8 s, producing beats with `t_end < t_start`.
   Now `time.monotonic()` throughout.

## Acceptance criterion: measured, not asserted

Measured by extracting frames at the recorded timestamps and finding where
the caption band actually moves.

- **Early in a take: −40 to −120 ms across ten takes, both media.** Meets the
  issue's ~100 ms.
- **Late in a take: −40 to −680 ms**, drifting in five of ten takes.

The late drift is not the beat log. A controlled experiment shows Chromium's
screencast losing ~0.57 s of wall time in a single discrete step during idle
stretches, which Playwright's webm does not pad. Filed as #18 with raw
measurements and three untried directions.

So the harness carries two bars — **200 ms** on the first caption (the one
that actually grades the beat log; proven to catch the `_t0` regression at
+280 ms) and **800 ms** on the closing one. Reported rather than silently
loosened.

## Verification

Eight fault injections, each watched fail: dropped beat, corrupted
timestamp, still pointing nowhere, wrong caption text, `timeline.md` missing
its stills, `_t0` regression, lying duration, no timeline written. Six
consecutive clean runs before that. `ruff`, `ruff format --check`, `mypy` all
pass at the CI-pinned versions.

Unverified and documented in `tests/README.md`: segment timelines (written by
the same code path, but no test records a segment), `interlude` beats,
narration-on behaviour (no audio assertion exists anywhere in the harness),
and the monotonic-clock fix, which cannot be fault-injected — only the diff
proves it is in place.