### PR TITLE
Fail the take on console errors, failed requests, and non-zero exit codes

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -256,25 +256,45 @@ app itself and writes what it saw into `timeline.json` as `issues`:
 | `http_error` | a response with status ≥ 400 (3xx redirects are normal) | no |
 | `nonzero_exit` | a `TerminalRecorder` `run()` whose command failed | yes |
 
-Every issue is **attributed to the beat that was running when it fired** —
+Each issue is **attributed to the beat that was running when it fired** —
 `beat` (an index into `beats`), plus the beat's `verb` and `caption` copied
 alongside so the list reads on its own. "The take broke" is not a bug report;
 "the take broke during `click('#refresh')`, under the caption *Refresh reloads
 it*" is. `timeline.md` gets an **Issues** section saying the same thing in
 prose, so a reviewer reading the PR sees it without opening the JSON.
 
+**`beat` is `null` when no beat can honestly claim the problem**, and that is a
+real answer rather than a gap. Playwright hands the recorder page events only
+while it is being called, so the naive reading — blame the most recently
+started beat — invents attributions in both directions: an error thrown during
+a three-second `hold()` would be blamed on the beat *after* the hold and quoted
+under a caption that had not appeared yet. Holds therefore pump events as they
+wait, and anything still ambiguous — a problem surfacing between two verbs,
+or after a long stretch where nothing reached Playwright — records `beat: null`
+instead of a confident guess. Trust `beat`; `t` is when the problem was
+*observed*, which can lag when it happened.
+
 Nothing has to be asked for: **a summary prints on stderr at the end of every
 take**, listing each problem and its beat, or saying plainly that there were
 none.
 
-`TerminalRecorder.run()` additionally records `exit_code` on its beat. The
-shell reports it through an invisible escape sequence in its own prompt, which
-the recorder strips before the terminal ever renders it — so the status is
-known without typing `echo $?` into the demo. It arrives when the prompt comes
-back, which is normally during the `wait_for_prompt()` that follows; a `run()`
-that is never waited on can end the take with `exit_code: null`. Non-bash
-shells that do not expand `$?` in their prompt also leave it null, rather than
-wrong.
+`TerminalRecorder.run()` additionally records `exit_code` on its beat, and
+`timeline.md` gets an `exit` column when any beat has one. The shell reports
+the status through an invisible escape in its own prompt, carrying `$?` and
+bash's command number, which the recorder strips before the terminal ever
+renders it — so the status is known without typing `echo $?` into the demo.
+
+The command number is what makes it trustworthy. The shell prints a prompt at
+startup before any command, and reprints one for an empty Enter or a Ctrl-C, and
+each of those reports a status belonging to no command; the number is what tells
+them apart. Two `run()`s with no wait between them queue, and each status
+reaches the beat that typed it, because the shell still runs them in order.
+
+An `exit_code` is either right or `null`, never wrong. It is `null` when the
+status never arrived: a `run()` the storyboard never waited on and the take
+ended, a program still running at the end, or a shell that does not expand `$?`
+in its prompt (zsh needs `PROMPT_SUBST`; only bash is exercised). Pair every
+`run()` with `wait_for_prompt()` and it is always there.
 
 ### `strict=True`
 

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -123,6 +123,7 @@ clean:
 | `DEMO_VIDEO_TERMINAL_FONT_SIZE` | `TerminalRecorder` font px | `15` |
 | `DEMO_VIDEO_VIEWPORT` | recording size, `"1280x720"` | 1280×720 |
 | `DEMO_VIDEO_SPEECH` | force narration on/off (`1`/`0`) | auto by API key |
+| `DEMO_VIDEO_STRICT` | fail the take on console errors / non-zero exits (`1`/`0`) | off |
 | `DEMO_VIDEO_VOICE_ID` | ElevenLabs voice | Sarah (premade) |
 | `DEMO_VIDEO_SPEECH_MODEL` | ElevenLabs model | `eleven_multilingual_v2` |
 | `DEMO_VIDEO_SKILL_DIR` | where storyboards find this skill | the constant baked into each storyboard |
@@ -168,8 +169,10 @@ needed; captions are the narration script.
 
 ## Recorder API (storyboard verbs)
 
-`Recorder(out_dir, base_url=..., segment=None, ...)` as a context manager;
-mp4 conversion happens on clean exit.
+`Recorder(out_dir, base_url=..., segment=None, strict=False, ...)` as a context
+manager; mp4 conversion happens on clean exit. `strict=True` refuses a take
+that recorded a console error, an uncaught exception, or a non-zero exit — see
+**Failing the take on a broken app**.
 
 | Verb | Use |
 |---|---|
@@ -206,10 +209,16 @@ key is fine, renaming one is not:
 ```json
 { "schema": 1, "generated_by": "demo-video", "recorder": "Recorder",
   "segment": null, "media": "demo.mp4", "duration": 18.04,
+  "strict": false, "issue_count": 1,
   "beats": [
     { "index": 4, "t_start": 3.02, "t_end": 3.06, "caption": "A small dashboard.",
       "verb": "shot", "selector": "01-dashboard",
       "still": "images/01-dashboard.png", "segment": null }
+  ],
+  "issues": [
+    { "kind": "console_error", "t": 0.47, "beat": 0, "verb": "goto",
+      "caption": "", "message": "Cannot read properties of undefined",
+      "url": "http://localhost:3000/app.js", "line": 412 }
   ] }
 ```
 
@@ -224,6 +233,71 @@ key is fine, renaming one is not:
   `spotlight`).
 - `still` is a path relative to the timeline file, so `timeline.md`'s embeds
   and any tooling resolve the same way.
+- `exit_code` appears on `TerminalRecorder` `run` beats — see **Failing the
+  take** below.
+- `issues` is what the recorder saw *behind* the pixels; `issue_count` is how
+  many it saw, and is larger than `len(issues)` only when a take blew past the
+  200-issue cap.
+
+## Failing the take on a broken app
+
+**A demo that looks perfect while the app throws `TypeError` on every render
+passes any review that only watches pixels.** This is the failure mode with no
+visual signature at all: the captions are right, the stills are pretty, the
+video is convincing, and the feature is broken. So every take also watches the
+app itself and writes what it saw into `timeline.json` as `issues`:
+
+| `kind` | What it is | Fatal under `strict=True`? |
+|---|---|---|
+| `console_error` | `console.error(…)` from the page | yes |
+| `console_warning` | `console.warn(…)` from the page | no |
+| `page_error` | an uncaught exception or unhandled rejection | yes |
+| `request_failed` | a request that never got a response | no |
+| `http_error` | a response with status ≥ 400 (3xx redirects are normal) | no |
+| `nonzero_exit` | a `TerminalRecorder` `run()` whose command failed | yes |
+
+Every issue is **attributed to the beat that was running when it fired** —
+`beat` (an index into `beats`), plus the beat's `verb` and `caption` copied
+alongside so the list reads on its own. "The take broke" is not a bug report;
+"the take broke during `click('#refresh')`, under the caption *Refresh reloads
+it*" is. `timeline.md` gets an **Issues** section saying the same thing in
+prose, so a reviewer reading the PR sees it without opening the JSON.
+
+Nothing has to be asked for: **a summary prints on stderr at the end of every
+take**, listing each problem and its beat, or saying plainly that there were
+none.
+
+`TerminalRecorder.run()` additionally records `exit_code` on its beat. The
+shell reports it through an invisible escape sequence in its own prompt, which
+the recorder strips before the terminal ever renders it — so the status is
+known without typing `echo $?` into the demo. It arrives when the prompt comes
+back, which is normally during the `wait_for_prompt()` that follows; a `run()`
+that is never waited on can end the take with `exit_code: null`. Non-bash
+shells that do not expand `$?` in their prompt also leave it null, rather than
+wrong.
+
+### `strict=True`
+
+```python
+with Recorder(Path(__file__).parent, strict=True) as rec:
+    ...
+```
+
+`Recorder(..., strict=True)` / `TerminalRecorder(..., strict=True)` (or
+`DEMO_VIDEO_STRICT=1`) makes the take **raise `StrictTakeFailed` on exit** if it
+recorded any fatal issue, naming the kind, the beat and the message for each.
+Default is off, so a take that would otherwise have shipped silently still
+records everything and still succeeds.
+
+It fails *after* writing demo.mp4, the stills and the timeline. A broken take
+is exactly the one somebody wants to look at, so failing it must not also
+destroy the evidence.
+
+Strict means strict. Chromium writes its own `Failed to load resource: …` to
+the console for anything that 404s or refuses a connection, and that is a real
+console error — so a missing favicon fails a strict take too. Use it when you
+want the demo to be a check that the app works, not when you want it to be
+lenient.
 
 **Timestamps are wall-clock offsets, and the video can drift under them.**
 Chromium's screencast emits a frame when the page paints and nothing pads the
@@ -403,7 +477,11 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    to confirm the story is actually visible; check `ffprobe` duration. Read
    `timeline.md` too — it is the take's own account of what ran and when, so
    a beat that fired at the wrong moment or a caption that never changed
-   shows up there without decoding a frame.
+   shows up there without decoding a frame. **Read the problem summary the
+   recorder prints on stderr**, and the Issues section of `timeline.md`: a
+   demo of an app throwing on every render looks exactly like a demo of a
+   working one, and this is the only place it shows (see **Failing the take
+   on a broken app**).
 6. **Fresh-agent review (required).** You cannot watch the video, and you
    know too much anyway — have a context-free agent watch it for you:
 

--- a/skills/demo-video/helpers/demo_recording/__init__.py
+++ b/skills/demo-video/helpers/demo_recording/__init__.py
@@ -8,7 +8,11 @@ Storyboards import from here:
 """
 
 from .core import (
+    ISSUE_KINDS,
+    MAX_ISSUES,
+    STRICT_KINDS,
     TIMELINE_SCHEMA,
+    StrictTakeFailed,
     media_duration,
     render_timeline_md,
     stitch,
@@ -20,8 +24,12 @@ from .terminal import TerminalRecorder
 from .web import Recorder
 
 __all__ = [
+    "ISSUE_KINDS",
+    "MAX_ISSUES",
+    "STRICT_KINDS",
     "TIMELINE_SCHEMA",
     "Recorder",
+    "StrictTakeFailed",
     "TerminalRecorder",
     "media_duration",
     "render_timeline_md",

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -209,6 +209,9 @@ def tts_clip(
 #   media         str    — the mp4 this timeline describes, e.g. "demo.mp4"
 #   duration      float? — that mp4's real duration (ffprobe), null if absent
 #   beats         list   — the beats, in the order they ran
+#   strict        bool   — whether strict mode was on for this take
+#   issues        list   — the problems the take recorded (see "take issues")
+#   issue_count   int    — how many were seen; > len(issues) only if capped
 #
 # Beat
 #   index     int    — position in `beats`, 0-based
@@ -225,11 +228,77 @@ def tts_clip(
 #   still     str?   — for `shot` beats, the still's path relative to the
 #                      timeline file ("images/01-dashboard.png"); else null
 #   segment   str?   — the segment this beat was recorded in, or null
+#   exit_code int?   — TerminalRecorder `run` beats only: the shell's status
+#                      for that command, or null if it could not be read
 #
 # Only the verb a storyboard calls becomes a beat. The verbs recorders build
 # out of other verbs (`click` glides with `move_to`, `type_into` clicks first)
 # record one beat spanning the whole call, not one per internal step.
 TIMELINE_SCHEMA = 1
+
+# -- take issues -------------------------------------------------------------
+#
+# A demo that looks perfect while the app throws on every render passes any
+# review that only watches pixels. So the recorders also watch the *app*: the
+# browser console, uncaught page exceptions, requests that never completed,
+# responses that came back >= 400, and — for TerminalRecorder — the exit status
+# of every command `run()` typed. Each becomes an issue on the timeline, and
+# each is attributed to the beat that was open when it fired, so a reviewer
+# reads "the take broke during `click('#refresh')`" instead of "the take broke".
+#
+# Issue (part of the envelope's `issues`, same append-only rules as a beat)
+#   kind     str   — one of ISSUE_KINDS below
+#   t        float — seconds from the start of `media` to *observing* it
+#   beat     int?  — index of the beat it is attributed to, null if none was
+#                    open yet (setup, or a page event before the first verb)
+#   verb     str?  — that beat's verb, denormalized so the list reads alone
+#   caption  str   — the caption on screen at the time, same reason
+#   message  str   — one human-readable line
+#   plus kind-specific keys: `url`/`line` (console), `url`/`method`
+#   (request_failed), `url`/`status` (http_error), `exit_code`/`command`
+#   (nonzero_exit)
+#
+# `t` is when the problem was *observed*, which is not always when it happened:
+# Playwright's sync API only delivers page events while it is being called, and
+# a command's exit status is only knowable once the prompt comes back. `beat`
+# is the attribution to trust; `t` is a hint.
+ISSUE_KINDS = (
+    "console_error",    # console.error(...) from the page
+    "console_warning",  # console.warn(...) from the page
+    "page_error",       # an uncaught exception / unhandled rejection
+    "request_failed",   # a request that never got a response at all
+    "http_error",       # a response with status >= 400
+    "nonzero_exit",     # a TerminalRecorder run() whose command failed
+)
+
+# What `strict=True` refuses to pass: the app saying, in its own voice, that it
+# is broken. `console_warning`, `request_failed` and `http_error` are recorded
+# but not fatal on their own — a warning is not a failure, and a request the
+# storyboard never depended on is the recorder's business to report, not to
+# veto.
+#
+# In practice that distinction is narrower than it looks, and deliberately so:
+# Chromium writes its own "Failed to load resource: …" line to the console for
+# every request that fails or comes back >= 400, and that line is a genuine
+# console error. So a strict take *does* fail on a 404 — including a favicon
+# — because the browser complained about it out loud. Strict means strict; a
+# demo of an app that cannot load its own assets is a demo of a broken app.
+# Anything less deterministic than that belongs in the log, not in the verdict.
+STRICT_KINDS = ("console_error", "page_error", "nonzero_exit")
+
+# A page that throws on every render can throw thousands of times. Record the
+# first MAX_ISSUES in full and keep counting the rest — `issue_count` in the
+# envelope stays honest, and timeline.json stays a file somebody can open.
+MAX_ISSUES = 200
+
+
+class StrictTakeFailed(RuntimeError):
+    """A strict take finished, but recorded a problem it refuses to pass.
+
+    Raised out of `__exit__` *after* the mp4, the stills and the timeline have
+    been written — a broken take is exactly the one somebody wants to look at,
+    so failing it must not also destroy the evidence.
+    """
 
 
 def timeline_paths(out_dir: Path | str, segment: str | None = None) -> tuple[Path, Path]:
@@ -298,6 +367,35 @@ def render_timeline_md(doc: dict) -> str:
                 _md_cell(beat.get("caption")),
             )
         )
+    issues = doc.get("issues") or []
+    if issues:
+        total = doc.get("issue_count", len(issues))
+        out += [
+            "",
+            "## Issues",
+            "",
+            f"{total} recorded while this take ran — console errors, failed "
+            f"requests, and non-zero exit codes, each attributed to the beat "
+            f"it fired during. A demo can look perfect and still be a "
+            f"recording of a broken app.",
+            "",
+        ]
+        # A bullet list rather than a table on purpose: a table row starting
+        # `| 0 |` is indistinguishable from a beat row to anything counting
+        # the beat table above.
+        for issue in issues:
+            where = (
+                "before the first beat"
+                if issue.get("beat") is None
+                else f"beat {issue['beat']} (`{_md_cell(issue.get('verb'))}`)"
+            )
+            out.append(
+                f"- **{_md_cell(issue.get('kind'))}** — {where} at "
+                f"{_fmt_t(issue.get('t'))}s: {_md_cell(issue.get('message'))}"
+            )
+        if total > len(issues):
+            out.append(f"- …and {total - len(issues)} more, not recorded.")
+        out.append("")
     stills = [b for b in beats if b.get("still")]
     if stills:
         out += ["", "## Stills", ""]
@@ -382,6 +480,7 @@ class _DemoBase:
         speech: bool | None = None,
         voice_id: str | None = None,
         speech_model: str | None = None,
+        strict: bool | None = None,
     ) -> None:
         # Every setting resolves explicit parameter > DEMO_VIDEO_* env var
         # > built-in default (see SKILL.md for the variable names).
@@ -455,6 +554,13 @@ class _DemoBase:
         self._beats: list[dict] = []
         self._caption = ""
         self._in_beat = False
+        # The problem log (see "take issues" above). `strict` decides whether
+        # a take that recorded a fatal one is allowed to succeed.
+        if strict is None:
+            strict = _env_flag("STRICT")
+        self._strict = bool(strict)
+        self._issues: list[dict] = []
+        self._issue_count = 0
         # Announce narration state up front — a silent recording when the
         # user expected voice (usually the key just isn't in this process's
         # env) is otherwise a confusing surprise only noticed after the fact.
@@ -517,6 +623,9 @@ class _DemoBase:
             # the medium's setup takes (~250 ms for the web recorder's
             # window-frame render, and it is not a constant).
             self._t0 = time.monotonic()
+            # Before _start(), so the very first navigation is watched too —
+            # a page that throws on load is the whole point of this.
+            self._watch_page(self.page)
             self._start()
         except Exception:
             # __exit__ never runs when __enter__ raises — don't leak the
@@ -558,6 +667,150 @@ class _DemoBase:
             for leftover in self._video_dir.glob("*"):
                 leftover.unlink()
             self._video_dir.rmdir()
+            # Always, strict or not, crashed or not: the problems a take
+            # recorded are the one thing nobody thinks to go looking for, so
+            # they have to arrive unasked.
+            self._print_issue_summary()
+        if exc_type is None and self._strict:
+            fatal = [i for i in self._issues if i["kind"] in STRICT_KINDS]
+            if fatal:
+                raise StrictTakeFailed(self._strict_message(fatal))
+
+    # -- take issues --------------------------------------------------------
+
+    def _note_issue(
+        self,
+        kind: str,
+        message: str,
+        beat: dict | None = None,
+        **extra: object,
+    ) -> None:
+        """Log one problem, attributed to `beat` (default: the open one).
+
+        Never raises: it runs inside Playwright event callbacks, where an
+        exception would surface somewhere unrelated and kill a take over a
+        diagnostic.
+        """
+        self._issue_count += 1
+        if len(self._issues) >= MAX_ISSUES:
+            return
+        if beat is None and self._beats:
+            beat = self._beats[-1]
+        record: dict = {
+            "kind": kind,
+            "t": round(time.monotonic() - self._t0, 3),
+            "beat": None if beat is None else beat.get("index"),
+            "verb": None if beat is None else beat.get("verb"),
+            "caption": "" if beat is None else beat.get("caption", ""),
+            "message": message,
+        }
+        record.update(extra)
+        self._issues.append(record)
+
+    def _watch_page(self, page: Page) -> None:
+        """Subscribe to everything the page can say about being broken."""
+        page.on("console", self._on_console)
+        page.on("pageerror", self._on_page_error)
+        page.on("requestfailed", self._on_request_failed)
+        page.on("response", self._on_response)
+
+    def _on_console(self, message) -> None:
+        try:
+            kind = {
+                "error": "console_error",
+                "warning": "console_warning",
+            }.get(message.type)
+            if kind is None:
+                return  # log/info/debug is an app talking, not an app failing
+            where = message.location or {}
+            self._note_issue(
+                kind, message.text,
+                url=where.get("url") or None, line=where.get("lineNumber"),
+            )
+        except Exception:  # noqa: BLE001 - a diagnostic must not kill a take
+            pass
+
+    def _on_page_error(self, error) -> None:
+        try:
+            text = getattr(error, "message", None) or str(error)
+            self._note_issue("page_error", str(text).strip().split("\n")[0])
+        except Exception:  # noqa: BLE001 - a diagnostic must not kill a take
+            pass
+
+    def _on_request_failed(self, request) -> None:
+        try:
+            self._note_issue(
+                "request_failed",
+                f"{request.failure or 'request failed'} — {request.url}",
+                url=request.url, method=request.method,
+            )
+        except Exception:  # noqa: BLE001 - a diagnostic must not kill a take
+            pass
+
+    def _on_response(self, response) -> None:
+        try:
+            # >= 400, not "non-2xx": 3xx is a redirect the browser follows and
+            # is not a fault, and counting it would flag every canonical URL.
+            if response.status < 400:
+                return
+            self._note_issue(
+                "http_error", f"HTTP {response.status} {response.url}",
+                url=response.url, status=response.status,
+            )
+        except Exception:  # noqa: BLE001 - a diagnostic must not kill a take
+            pass
+
+    def _issue_where(self, issue: dict) -> str:
+        if issue.get("beat") is None:
+            return "before the first beat"
+        return f"beat {issue['beat']} ({issue.get('verb')})"
+
+    def _print_issue_summary(self) -> None:
+        """One end-of-take report, on stderr, whether or not anything broke."""
+        if not self._issue_count:
+            print(
+                "demo-video: no console errors, failed requests or non-zero "
+                "exits recorded",
+                file=sys.stderr,
+            )
+            return
+        counts: dict[str, int] = {}
+        for issue in self._issues:
+            counts[issue["kind"]] = counts.get(issue["kind"], 0) + 1
+        tally = ", ".join(f"{k} x{n}" for k, n in sorted(counts.items()))
+        print(
+            f"demo-video: {self._issue_count} problem(s) recorded during this "
+            f"take ({tally})",
+            file=sys.stderr,
+        )
+        for issue in self._issues:
+            print(
+                f"  [{issue['t']:.2f}s] {issue['kind']} in "
+                f"{self._issue_where(issue)}: {issue['message']}",
+                file=sys.stderr,
+            )
+        if self._issue_count > len(self._issues):
+            print(
+                f"  …and {self._issue_count - len(self._issues)} more, over "
+                f"the {MAX_ISSUES}-issue cap",
+                file=sys.stderr,
+            )
+
+    def _strict_message(self, fatal: list[dict]) -> str:
+        shown = fatal[:5]
+        lines = [
+            f"  {i['kind']} in {self._issue_where(i)}: {i['message']}"
+            for i in shown
+        ]
+        if len(fatal) > len(shown):
+            lines.append(f"  …and {len(fatal) - len(shown)} more")
+        return (
+            f"strict=True and this take recorded {len(fatal)} problem(s) the "
+            "app should not have produced:\n" + "\n".join(lines) + "\n"
+            "The recording, its stills and its timeline were still written — "
+            "read timeline.md's Issues section. Pass strict=False (or unset "
+            "DEMO_VIDEO_STRICT) to record anyway."
+        )
 
     # -- beat log -----------------------------------------------------------
 
@@ -622,6 +875,9 @@ class _DemoBase:
             "media": mp4.name,
             "duration": duration,
             "beats": self._beats,
+            "strict": self._strict,
+            "issues": self._issues,
+            "issue_count": self._issue_count,
         }
 
     # -- shared storyboard verbs -------------------------------------------

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -249,8 +249,8 @@ TIMELINE_SCHEMA = 1
 # Issue (part of the envelope's `issues`, same append-only rules as a beat)
 #   kind     str   — one of ISSUE_KINDS below
 #   t        float — seconds from the start of `media` to *observing* it
-#   beat     int?  — index of the beat it is attributed to, null if none was
-#                    open yet (setup, or a page event before the first verb)
+#   beat     int?  — index of the beat it is attributed to, or **null** when no
+#                    beat can honestly claim it (see below)
 #   verb     str?  — that beat's verb, denormalized so the list reads alone
 #   caption  str   — the caption on screen at the time, same reason
 #   message  str   — one human-readable line
@@ -262,6 +262,17 @@ TIMELINE_SCHEMA = 1
 # Playwright's sync API only delivers page events while it is being called, and
 # a command's exit status is only knowable once the prompt comes back. `beat`
 # is the attribution to trust; `t` is a hint.
+#
+# **`beat` is null whenever it cannot be established, and that is a feature.**
+# The obvious implementation — blame the most recently started beat — is wrong
+# in both directions: it hands an error thrown during a three-second hold to
+# whatever beat makes the next Playwright call, quoting a caption that appeared
+# after the error did, and it lets a beat that has already closed claim
+# something that happened after it. So holds pump events as they wait
+# (`_pump_events`), and an event is only attributed to a beat that was open,
+# and had been open since events were last known to be flowing
+# (`_attributed_beat`). A confidently wrong beat index is worse input for a
+# reviewer — or for a conformance gate reading this file — than no answer.
 ISSUE_KINDS = (
     "console_error",    # console.error(...) from the page
     "console_warning",  # console.warn(...) from the page
@@ -289,7 +300,15 @@ STRICT_KINDS = ("console_error", "page_error", "nonzero_exit")
 # A page that throws on every render can throw thousands of times. Record the
 # first MAX_ISSUES in full and keep counting the rest — `issue_count` in the
 # envelope stays honest, and timeline.json stays a file somebody can open.
+# Strict mode counts fatals separately and is *not* capped: a take whose 201st
+# problem is its first console error still has to fail.
 MAX_ISSUES = 200
+
+# How often a hold gives Playwright a chance to deliver queued page events, and
+# how stale that last delivery may be before a beat is no longer allowed to
+# claim an event. See `_pump_events` and `_attributed_beat`.
+PUMP_INTERVAL_S = 0.1
+ATTRIBUTION_SLACK_S = 0.5
 
 
 class StrictTakeFailed(RuntimeError):
@@ -352,21 +371,40 @@ def render_timeline_md(doc: dict) -> str:
         "Written by the demo-video recorder on every clean exit — do not edit "
         "it by hand, re-record instead.",
         "",
-        "| # | start | end | verb | target | caption |",
-        "|---:|---:|---:|---|---|---|",
     ]
+    # The exit column only exists when something in this take has one — a web
+    # timeline would otherwise carry an empty column on every row. A `run` beat
+    # whose status could not be read shows "?" rather than blank, so the
+    # degraded case is visible here and not only in the JSON.
+    shows_exit = any("exit_code" in b for b in beats)
+    if shows_exit:
+        out += [
+            "| # | start | end | verb | target | exit | caption |",
+            "|---:|---:|---:|---|---|---:|---|",
+        ]
+    else:
+        out += [
+            "| # | start | end | verb | target | caption |",
+            "|---:|---:|---:|---|---|---|",
+        ]
     for beat in beats:
         target = beat.get("selector")
-        out.append(
-            "| {} | {} | {} | `{}` | {} | {} |".format(
-                beat.get("index"),
-                _fmt_t(beat.get("t_start")),
-                _fmt_t(beat.get("t_end")),
-                _md_cell(beat.get("verb")),
-                f"`{_md_cell(target)}`" if target else "",
-                _md_cell(beat.get("caption")),
-            )
-        )
+        cells = [
+            str(beat.get("index")),
+            _fmt_t(beat.get("t_start")),
+            _fmt_t(beat.get("t_end")),
+            f"`{_md_cell(beat.get('verb'))}`",
+            f"`{_md_cell(target)}`" if target else "",
+        ]
+        if shows_exit:
+            if "exit_code" not in beat:
+                cells.append("")
+            elif beat["exit_code"] is None:
+                cells.append("?")
+            else:
+                cells.append(_md_cell(beat["exit_code"]))
+        cells.append(_md_cell(beat.get("caption")))
+        out.append("| " + " | ".join(cells) + " |")
     issues = doc.get("issues") or []
     if issues:
         total = doc.get("issue_count", len(issues))
@@ -561,6 +599,12 @@ class _DemoBase:
         self._strict = bool(strict)
         self._issues: list[dict] = []
         self._issue_count = 0
+        # Counted outside the MAX_ISSUES cap: the verdict must not depend on
+        # how much noise came before the thing that matters.
+        self._fatal_count = 0
+        # Offset from _t0 at which Playwright was last known to be delivering
+        # page events. Attribution is only as good as this is fresh.
+        self._pumped_at = 0.0
         # Announce narration state up front — a silent recording when the
         # user expected voice (usually the key just isn't in this process's
         # env) is otherwise a confusing surprise only noticed after the fact.
@@ -627,6 +671,10 @@ class _DemoBase:
             # a page that throws on load is the whole point of this.
             self._watch_page(self.page)
             self._start()
+            # _start() ends in real Playwright work, so events were flowing as
+            # it returned. Without this the first storyboard beat looks like it
+            # began after an unexplained gap and cannot claim anything.
+            self._pumped_at = time.monotonic() - self._t0
         except Exception:
             # __exit__ never runs when __enter__ raises — don't leak the
             # Playwright driver (typical cause: chromium not installed).
@@ -671,10 +719,8 @@ class _DemoBase:
             # recorded are the one thing nobody thinks to go looking for, so
             # they have to arrive unasked.
             self._print_issue_summary()
-        if exc_type is None and self._strict:
-            fatal = [i for i in self._issues if i["kind"] in STRICT_KINDS]
-            if fatal:
-                raise StrictTakeFailed(self._strict_message(fatal))
+        if exc_type is None and self._strict and self._fatal_count:
+            raise StrictTakeFailed(self._strict_message())
 
     # -- take issues --------------------------------------------------------
 
@@ -685,27 +731,84 @@ class _DemoBase:
         beat: dict | None = None,
         **extra: object,
     ) -> None:
-        """Log one problem, attributed to `beat` (default: the open one).
+        """Log one problem, attributed to `beat` (default: whichever beat can
+        honestly claim it, which is often none — see `_attributed_beat`).
 
-        Never raises: it runs inside Playwright event callbacks, where an
-        exception would surface somewhere unrelated and kill a take over a
-        diagnostic.
+        Never raises, and means it: the whole body is guarded. Page events are
+        delivered inside Playwright callbacks and `_record_exit_code` runs from
+        the PTY pump mid-recording, so an exception here would surface
+        somewhere unrelated and lose a take over a diagnostic.
         """
-        self._issue_count += 1
-        if len(self._issues) >= MAX_ISSUES:
+        try:
+            self._issue_count += 1
+            if kind in STRICT_KINDS:
+                # Outside the cap, and before the early return below it: the
+                # verdict must not depend on how much noise preceded this.
+                self._fatal_count += 1
+            if len(self._issues) >= MAX_ISSUES:
+                return
+            if beat is None:
+                beat = self._attributed_beat()
+            record: dict = {
+                "kind": kind,
+                "t": round(time.monotonic() - self._t0, 3),
+                "beat": None if beat is None else beat.get("index"),
+                "verb": None if beat is None else beat.get("verb"),
+                "caption": "" if beat is None else beat.get("caption", ""),
+                "message": message,
+            }
+            record.update(extra)
+            self._issues.append(record)
+        except Exception:  # noqa: BLE001 - a diagnostic must not kill a take
+            pass
+
+    def _attributed_beat(self) -> dict | None:
+        """The beat an event observed *now* may honestly be blamed on.
+
+        `self._beats[-1]` is the most recently *started* beat, which is not the
+        same question. Two conditions, both required:
+
+          * a beat is actually open — storyboard code between two verbs is
+            nobody's beat, and letting a closed beat claim an event that
+            happened after it ended is how "the take broke during wait_for"
+            gets written about something that broke later;
+          * it was already open the last time events are known to have been
+            delivered, so nothing could have fired before it started. Holds
+            pump (`_pump_events`), which keeps this true for ordinary beats;
+            what it screens out is a long *non*-Playwright gap — narration
+            being synthesized, say — with a beat opening at the end of it.
+
+        Otherwise None, and the issue records `beat: null`.
+        """
+        if not self._in_beat or not self._beats:
+            return None
+        beat = self._beats[-1]
+        t_start = beat.get("t_start")
+        if not isinstance(t_start, (int, float)):
+            return None
+        if t_start > self._pumped_at + ATTRIBUTION_SLACK_S:
+            return None
+        return beat
+
+    def _pump_events(self) -> None:
+        """Give Playwright a chance to deliver queued page events.
+
+        The sync API dispatches `console`/`pageerror`/`requestfailed`/`response`
+        only while it is inside a call, so a storyboard sitting still for three
+        seconds queues everything the page throws and hands it all to whichever
+        beat makes the next call. One trivial evaluate per PUMP_INTERVAL_S
+        keeps delivery inside the beat the event belongs to. It paints nothing,
+        touches no DOM, and is skipped if it fails — a pump is a diagnostic
+        convenience, never a reason to lose a take.
+        """
+        now = time.monotonic() - self._t0
+        if now - self._pumped_at < PUMP_INTERVAL_S:
             return
-        if beat is None and self._beats:
-            beat = self._beats[-1]
-        record: dict = {
-            "kind": kind,
-            "t": round(time.monotonic() - self._t0, 3),
-            "beat": None if beat is None else beat.get("index"),
-            "verb": None if beat is None else beat.get("verb"),
-            "caption": "" if beat is None else beat.get("caption", ""),
-            "message": message,
-        }
-        record.update(extra)
-        self._issues.append(record)
+        try:
+            self.page.evaluate("0")
+        except Exception:  # noqa: BLE001 - the page may be closing
+            return
+        self._pumped_at = time.monotonic() - self._t0
 
     def _watch_page(self, page: Page) -> None:
         """Subscribe to everything the page can say about being broken."""
@@ -792,21 +895,28 @@ class _DemoBase:
         if self._issue_count > len(self._issues):
             print(
                 f"  …and {self._issue_count - len(self._issues)} more, over "
-                f"the {MAX_ISSUES}-issue cap",
+                f"the {MAX_ISSUES}-issue cap ({self._fatal_count} of all of "
+                f"them fatal under strict)",
                 file=sys.stderr,
             )
 
-    def _strict_message(self, fatal: list[dict]) -> str:
-        shown = fatal[:5]
+    def _strict_message(self) -> str:
+        recorded = [i for i in self._issues if i["kind"] in STRICT_KINDS]
+        shown = recorded[:5]
         lines = [
             f"  {i['kind']} in {self._issue_where(i)}: {i['message']}"
             for i in shown
         ]
-        if len(fatal) > len(shown):
-            lines.append(f"  …and {len(fatal) - len(shown)} more")
+        if not shown:
+            lines.append(
+                f"  (none of them recorded in detail — every one arrived past "
+                f"the {MAX_ISSUES}-issue cap)"
+            )
+        elif self._fatal_count > len(shown):
+            lines.append(f"  …and {self._fatal_count - len(shown)} more")
         return (
-            f"strict=True and this take recorded {len(fatal)} problem(s) the "
-            "app should not have produced:\n" + "\n".join(lines) + "\n"
+            f"strict=True and this take recorded {self._fatal_count} problem(s) "
+            "the app should not have produced:\n" + "\n".join(lines) + "\n"
             "The recording, its stills and its timeline were still written — "
             "read timeline.md's Issues section. Pass strict=False (or unset "
             "DEMO_VIDEO_STRICT) to record anyway."
@@ -884,9 +994,19 @@ class _DemoBase:
 
     def _idle(self, seconds: float) -> None:
         """Hold for `seconds`. Overridden by media that must keep working
-        (pumping output) while the frame is held."""
-        if seconds > 0:
-            time.sleep(seconds)
+        (pumping output) while the frame is held.
+
+        Sliced against a deadline rather than one flat sleep, so page events
+        are delivered while the beat they belong to is still open. Deadline,
+        not accumulated slices: the pump costs about a millisecond and a
+        storyboard's pacing must not drift by however many of them it took."""
+        end = time.monotonic() + seconds
+        while True:
+            self._pump_events()
+            remaining = end - time.monotonic()
+            if remaining <= 0:
+                return
+            time.sleep(min(PUMP_INTERVAL_S, remaining))
 
     @_beat_verb("pause")
     def pause(self, seconds: float) -> None:

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -30,6 +30,7 @@ import struct
 import subprocess
 import termios
 import time
+from collections import deque
 from pathlib import Path
 
 from .core import _beat_verb, _DemoBase, _env
@@ -138,17 +139,37 @@ _KEYMAP = {
 # see, which is a demo artifact nobody asked for.
 #
 # So the shell says it in its prompt, invisibly. PS1 is prefixed with an OSC
-# escape carrying `$?`, which bash expands per prompt, wraps in \[...\] so
-# readline still measures the prompt correctly, and emits before every prompt
-# it draws. _pump() strips the sequence out of the byte stream before xterm.js
+# escape carrying `$?` **and `\#`, bash's command number**, which bash expands
+# per prompt, wrapped in \[...\] so readline still measures the prompt
+# correctly. _pump() strips the sequence out of the byte stream before xterm.js
 # ever sees it, so nothing about the recording changes.
+#
+# The command number is what makes the status trustworthy rather than merely
+# usually right, and every part of it was measured against a real PTY:
+#
+#   * the shell prints a prompt at startup, before any command — that marker
+#     carries number 1 and belongs to nothing. It is discarded as the first
+#     marker seen, whenever it arrives, which is what makes a slow shell on a
+#     loaded box unable to hand its startup 0 to the first run().
+#   * a prompt redrawn without a command running — an empty Enter, a Ctrl-C at
+#     an idle prompt — repeats the previous number (measured: empty Enter stays
+#     at 2, Ctrl-C at an idle prompt stays at 4 while reporting status 130).
+#     A marker that does not advance the number is discarded.
+#   * commands the storyboard did not wait for still complete in order, so
+#     `run` beats queue and each advancing marker claims the oldest
+#     (measured: `sleep 1.2` then `(exit 9)` typed straight after yields
+#     (0, 5) then (9, 6), and the queue assigns them 0 and 9 respectively).
 #
 # Bash-shaped, like the rest of this recorder (`--norc --noprofile -i`, PS1/PS2
 # from the environment). A shell that does not expand `$?` in its prompt simply
 # never emits a marker, and every `exit_code` stays null rather than wrong.
-_EXIT_PS1 = "\\[\\e]777;demo-video-exit;$?\\a\\]"
+#
+# The namespace is not a security boundary: a program that deliberately prints
+# this exact sequence can hand the recorder any exit status it likes. It is a
+# demo recorder driving a program the storyboard chose, not a sandbox.
+_EXIT_PS1 = "\\[\\e]777;demo-video-exit;$?;\\#\\a\\]"
 _EXIT_OSC = "\x1b]777;demo-video-exit;"
-_EXIT_RE = re.compile(re.escape(_EXIT_OSC) + r"(-?\d+)\x07")
+_EXIT_RE = re.compile(re.escape(_EXIT_OSC) + r"(-?\d+);(\d+)\x07")
 
 
 class TerminalRecorder(_DemoBase):
@@ -207,10 +228,12 @@ class TerminalRecorder(_DemoBase):
         self._proc: subprocess.Popen | None = None
         self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
         self._child_done = False
-        # Exit-status side channel: the run() beat still waiting for its
-        # command's status, and any half-arrived marker held back between
-        # reads (a 65 KB read can split the escape sequence anywhere).
-        self._pending_run: dict | None = None
+        # Exit-status side channel: run() beats still waiting for a status, in
+        # the order they were typed; the last command number seen (None until
+        # the shell's startup prompt arrives); and any half-arrived marker held
+        # back between reads (a 65 KB read can split the sequence anywhere).
+        self._pending_runs: deque[dict] = deque()
+        self._exit_seq: int | None = None
         self._exit_tail = ""
 
     # -- setup / teardown ---------------------------------------------------
@@ -219,10 +242,16 @@ class TerminalRecorder(_DemoBase):
         # Paint the background from the very first frame, so the brief
         # about:blank + xterm-injection period isn't a white flash (it would
         # otherwise show between a preceding segment and the terminal).
+        # `documentElement` is null on Chromium's initial empty document, where
+        # init scripts first run — dereferencing it there threw an uncaught
+        # TypeError on every single take, and took the background paint this
+        # exists to apply down with it (issue #25). Guarded like `body` below
+        # it, and applied again once the document is real.
         context.add_init_script(
             "(() => { const bg = '__BG__';"
-            " document.documentElement.style.background = bg;"
-            " const b = () => { if (document.body) document.body.style.background = bg; };"
+            " const paint = (el) => { if (el) el.style.background = bg; };"
+            " paint(document.documentElement);"
+            " const b = () => { paint(document.documentElement); paint(document.body); };"
             " if (document.body) b(); else addEventListener('DOMContentLoaded', b); })();"
             .replace("__BG__", _TERM_BG)
         )
@@ -275,6 +304,15 @@ class TerminalRecorder(_DemoBase):
         self._idle(0.15)
 
     def _stop(self) -> None:
+        # Whatever _take_exit_markers held back as a possible half-marker was
+        # withheld from the terminal, not dropped — flush it before the page
+        # goes away, or the last frame is missing bytes the program did write.
+        tail, self._exit_tail = self._exit_tail, ""
+        if tail:
+            try:
+                self.page.evaluate("d => window.__termWrite(d)", tail)
+            except Exception:  # noqa: BLE001 - teardown, the page may be gone
+                pass
         proc = getattr(self, "_proc", None)
         if proc is not None and proc.poll() is None:
             proc.terminate()
@@ -343,7 +381,7 @@ class TerminalRecorder(_DemoBase):
         for match in _EXIT_RE.finditer(text):
             kept.append(text[cut:match.start()])
             cut = match.end()
-            self._record_exit_code(int(match.group(1)))
+            self._record_exit_code(int(match.group(1)), int(match.group(2)))
         rest = text[cut:]
         start = rest.rfind(_EXIT_OSC[0])
         if start != -1:
@@ -357,16 +395,33 @@ class TerminalRecorder(_DemoBase):
         kept.append(rest)
         return "".join(kept)
 
-    def _record_exit_code(self, code: int) -> None:
-        """Attribute a status to the run() beat that is waiting for one.
+    def _record_exit_code(self, code: int, seq: int) -> None:
+        """Attribute a status to the oldest run() still waiting for one.
 
-        The shell prints a prompt (and so a marker) for its own startup and
-        after anything else that returns to it, so a marker with no run()
-        outstanding is not this recorder's business and is dropped.
+        `seq` is the shell's command number, and every discard below is a
+        status that would otherwise have been written onto the wrong beat:
+
+          * the first marker of the session is the startup prompt, which
+            reports the shell's own 0 and belongs to no command;
+          * a marker that does not advance the number is a prompt redrawn
+            without a command running (empty Enter, Ctrl-C at an idle prompt),
+            and its status likewise belongs to nothing;
+          * anything else claims the oldest outstanding run(), which is the
+            right one even when the storyboard typed several commands without
+            waiting between them — the shell still executes them in order.
+
+        A marker arriving with nothing outstanding is a command the storyboard
+        did not run (a `send()` that reached the shell, say) and is dropped.
         """
-        beat, self._pending_run = self._pending_run, None
-        if beat is None:
+        if self._exit_seq is None:
+            self._exit_seq = seq
             return
+        if seq <= self._exit_seq:
+            return
+        self._exit_seq = seq
+        if not self._pending_runs:
+            return
+        beat = self._pending_runs.popleft()
         beat["exit_code"] = code
         if code != 0:
             command = beat.get("selector")
@@ -382,6 +437,10 @@ class TerminalRecorder(_DemoBase):
         end = time.monotonic() + seconds
         while True:
             self._pump()
+            # _pump() only reaches Playwright when the program wrote something,
+            # so a quiet hold would deliver no page events and leave issue
+            # attribution pointing at whatever beat came next.
+            self._pump_events()
             remaining = end - time.monotonic()
             if remaining <= 0:
                 return
@@ -424,12 +483,14 @@ class TerminalRecorder(_DemoBase):
         non-zero also logs a `nonzero_exit` issue, and fails the take under
         strict=True."""
         self._type(command)
-        # Claimed after typing, never before: the echo of the command itself
-        # draws no prompt, but anything left over from before it might.
         beat = self._beats[-1] if self._beats else None
         if beat is not None:
             beat["exit_code"] = None
-        self._pending_run = beat
+            # A queue, not a slot: two run()s with no wait between them are
+            # legitimate (`run("sleep 5")` then `run("deploy")`), and a slot
+            # would hand the first command's status to the second beat and
+            # drop the second command's entirely.
+            self._pending_runs.append(beat)
         self._write("\r")
         self._idle(0.2)
 

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -130,6 +130,26 @@ _KEYMAP = {
     "Home": "\x1b[H", "End": "\x1b[F", "PageUp": "\x1b[5~", "PageDown": "\x1b[6~",
 }
 
+# Exit-status side channel.
+#
+# `run()` cannot know how its command ended: the command is still running when
+# the verb returns, and there is exactly one pipe out of the PTY — the same one
+# the recording is made of. Asking (`echo $?`) would type a line the viewer can
+# see, which is a demo artifact nobody asked for.
+#
+# So the shell says it in its prompt, invisibly. PS1 is prefixed with an OSC
+# escape carrying `$?`, which bash expands per prompt, wraps in \[...\] so
+# readline still measures the prompt correctly, and emits before every prompt
+# it draws. _pump() strips the sequence out of the byte stream before xterm.js
+# ever sees it, so nothing about the recording changes.
+#
+# Bash-shaped, like the rest of this recorder (`--norc --noprofile -i`, PS1/PS2
+# from the environment). A shell that does not expand `$?` in its prompt simply
+# never emits a marker, and every `exit_code` stays null rather than wrong.
+_EXIT_PS1 = "\\[\\e]777;demo-video-exit;$?\\a\\]"
+_EXIT_OSC = "\x1b]777;demo-video-exit;"
+_EXIT_RE = re.compile(re.escape(_EXIT_OSC) + r"(-?\d+)\x07")
+
 
 class TerminalRecorder(_DemoBase):
     """Records a terminal session (CLI, REPL, or full-screen TUI).
@@ -158,6 +178,7 @@ class TerminalRecorder(_DemoBase):
         speech: bool | None = None,
         voice_id: str | None = None,
         speech_model: str | None = None,
+        strict: bool | None = None,
         type_delay_ms: int = 45,
     ) -> None:
         # A branded, distinctive default prompt so wait_for_prompt's marker
@@ -167,7 +188,7 @@ class TerminalRecorder(_DemoBase):
             out_dir, segment=segment, accent_rgb=accent_rgb,
             terminal_title=terminal_title, terminal_prompt=prompt,
             viewport=viewport, speech=speech, voice_id=voice_id,
-            speech_model=speech_model,
+            speech_model=speech_model, strict=strict,
         )
         # Match the web recorder's effective caption height. Web composites
         # its page into a scaled, centered window, lifting its bottom:44px
@@ -186,6 +207,11 @@ class TerminalRecorder(_DemoBase):
         self._proc: subprocess.Popen | None = None
         self._decoder = codecs.getincrementaldecoder("utf-8")("replace")
         self._child_done = False
+        # Exit-status side channel: the run() beat still waiting for its
+        # command's status, and any half-arrived marker held back between
+        # reads (a 65 KB read can split the escape sequence anywhere).
+        self._pending_run: dict | None = None
+        self._exit_tail = ""
 
     # -- setup / teardown ---------------------------------------------------
 
@@ -205,7 +231,7 @@ class TerminalRecorder(_DemoBase):
         master, slave = pty.openpty()
         self._fd = master
         env = os.environ.copy()
-        env["PS1"] = self._terminal_prompt
+        env["PS1"] = _EXIT_PS1 + self._terminal_prompt
         env["PS2"] = "> "
         env["TERM"] = "xterm-256color"
         env.setdefault("LANG", "C.UTF-8")
@@ -297,9 +323,58 @@ class TerminalRecorder(_DemoBase):
             if not data:
                 self._child_done = True
                 return
-            text = self._decoder.decode(data)
+            text = self._take_exit_markers(self._decoder.decode(data))
             if text:
                 self.page.evaluate("d => window.__termWrite(d)", text)
+
+    def _take_exit_markers(self, text: str) -> str:
+        """Strip the PS1 exit-status markers out of `text`, recording each.
+
+        The stream is chopped at arbitrary byte offsets, so a marker can span
+        two reads; anything at the tail that could still become one is held
+        back rather than passed through to the terminal.
+        """
+        text = self._exit_tail + text
+        self._exit_tail = ""
+        if _EXIT_OSC[0] not in text:
+            return text
+        kept: list[str] = []
+        cut = 0
+        for match in _EXIT_RE.finditer(text):
+            kept.append(text[cut:match.start()])
+            cut = match.end()
+            self._record_exit_code(int(match.group(1)))
+        rest = text[cut:]
+        start = rest.rfind(_EXIT_OSC[0])
+        if start != -1:
+            candidate = rest[start:]
+            unfinished = _EXIT_OSC.startswith(candidate) or (
+                candidate.startswith(_EXIT_OSC) and "\x07" not in candidate
+            )
+            if unfinished:
+                self._exit_tail = candidate
+                rest = rest[:start]
+        kept.append(rest)
+        return "".join(kept)
+
+    def _record_exit_code(self, code: int) -> None:
+        """Attribute a status to the run() beat that is waiting for one.
+
+        The shell prints a prompt (and so a marker) for its own startup and
+        after anything else that returns to it, so a marker with no run()
+        outstanding is not this recorder's business and is dropped.
+        """
+        beat, self._pending_run = self._pending_run, None
+        if beat is None:
+            return
+        beat["exit_code"] = code
+        if code != 0:
+            command = beat.get("selector")
+            self._note_issue(
+                "nonzero_exit",
+                f"{command!r} exited {code}",
+                beat=beat, exit_code=code, command=command,
+            )
 
     def _idle(self, seconds: float) -> None:
         """Hold the frame while pumping program output, so long-running
@@ -341,8 +416,20 @@ class TerminalRecorder(_DemoBase):
     @_beat_verb("run")
     def run(self, command: str) -> None:
         """Type a shell command visibly and press Enter. Pair with
-        wait_for_prompt() to wait for it to finish."""
+        wait_for_prompt() to wait for it to finish.
+
+        The beat this records gains an `exit_code` once the shell's prompt
+        comes back — usually during the following wait_for_prompt(), which is
+        why the pairing is not merely a suggestion. A command that exits
+        non-zero also logs a `nonzero_exit` issue, and fails the take under
+        strict=True."""
         self._type(command)
+        # Claimed after typing, never before: the echo of the command itself
+        # draws no prompt, but anything left over from before it might.
+        beat = self._beats[-1] if self._beats else None
+        if beat is not None:
+            beat["exit_code"] = None
+        self._pending_run = beat
         self._write("\r")
         self._idle(0.2)
 

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -203,12 +203,13 @@ class Recorder(_DemoBase):
         speech: bool | None = None,
         voice_id: str | None = None,
         speech_model: str | None = None,
+        strict: bool | None = None,
     ) -> None:
         super().__init__(
             out_dir, segment=segment, accent_rgb=accent_rgb,
             terminal_title=terminal_title, terminal_prompt=terminal_prompt,
             viewport=viewport, speech=speech, voice_id=voice_id,
-            speech_model=speech_model,
+            speech_model=speech_model, strict=strict,
         )
         self.base_url = (
             base_url or _env("BASE_URL", "http://localhost:8000")

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,9 +19,9 @@ tests/
 ## Running it
 
 ```sh
-tests/smoke                       # both takes, output to a temp dir
-tests/smoke --web-only            # just the Playwright take
-tests/smoke --terminal-only       # just the PTY/xterm.js take
+tests/smoke                       # every take, output to a temp dir
+tests/smoke --web-only            # just the Playwright takes
+tests/smoke --terminal-only       # just the PTY/xterm.js takes
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -39,23 +39,28 @@ smoke: web first caption 'A small dashboard.' logged at 3.03s, on screen at 2.95
 smoke: web closing caption 'Recorded end to end.' logged at 17.03s, on screen at 16.99s (-40 ms)
 smoke: web beat clock holds across the take (+40 ms)
 smoke: web timeline.json ok (23 beats)
-smoke: web timeline.json records 6 problem(s), 4 of them fatal under strict — take still passed
+smoke: web healthy app under strict=True records no problems
 …
-smoke: web-strict strict=True refused the take, naming beat 0 (goto) (2 fatal issues, artifacts kept)
-smoke: terminal-strict strict=True refused the take, naming beat 1 (run) (2 fatal issues, artifacts kept)
+smoke: web-problems timeline.json records 8 problem(s), 6 of them fatal under strict — take still passed
+smoke: web-strict strict=True refused the take, naming beat 0 (goto) (4 fatal issues, artifacts kept)
+smoke: terminal-problems timeline.json records 2 problem(s), 2 of them fatal under strict — take still passed
+smoke: terminal-race exit status survives a shell that starts 1.2s late (logged 5)
+smoke: terminal-strict strict=True refused the take, naming beat 1 (run) (1 fatal issues, artifacts kept)
 
 smoke: PASSED
 ```
 
-Re-running into the same `--out-dir` is safe: the `web/`, `terminal/`,
-`web-strict/` and `terminal-strict/` subdirectories are deleted before each
-take. That is not tidiness — every
+Re-running into the same `--out-dir` is safe: the seven take subdirectories
+(`web/`, `terminal/`, `web-problems/`, `terminal-problems/`, `terminal-race/`,
+`web-strict/`, `terminal-strict/`) are deleted before each take. Only the first
+two are graded on their video; the rest are short and exist to break in one
+specific way each. That is not tidiness — every
 artifact assertion works by path, so without it a leftover `demo.mp4` from the
 previous run would grade a recorder that produced nothing at all as a pass, and
 recording repeatedly into one directory is exactly how a change to the recorder
 gets verified.
 
-Deleting is bounded. Only those four named subdirectories are ever
+Deleting is bounded. Only those named subdirectories are ever
 removed, and only when each is absent, empty, or carries the
 `.demo-video-smoke` marker file a previous run wrote there. `--out-dir .` in a
 project that has its own `web/` directory gets a refusal naming the path, not a
@@ -220,6 +225,87 @@ that was never drawn, a video that slid further than the search window can see,
 or a run-up that was not quiet. They look identical from inside the window, and
 only the first is the recorder losing a caption.
 
+**Problems** — what the recorder saw *behind* the pixels. This is the axis the
+other four are structurally blind to: a demo of an app throwing `TypeError` on
+every render is pixel-for-pixel a demo of a working one, scores the same luma,
+logs the same beats, and satisfies every post-condition the storyboard checks.
+
+It splits four ways, and no single take answers more than one of them — which
+is why there are seven takes and not two.
+
+**A healthy app must record nothing.** The two graded takes record the plain
+fixture, with `strict=True`, and `check_healthy()` demands an empty `issues`
+list. This is the only assertion here that can fail on **over**-reporting, and
+without it the axis is one-directional: every check below is "at least one
+issue matches", which a recorder that flagged every healthy 2xx as a fatal
+console error satisfies perfectly — while refusing every strict take of every
+working app ever recorded. That is not hypothetical; it was measured passing
+the entire suite before this existed. Recording them strict is the second half:
+over-reporting does not merely get noticed, it aborts the take.
+
+Keeping the graded takes healthy also matters for what they *are*. They are the
+reference demo a reader watches; the fixture hooks belong in takes of their
+own, the way `?secret=1` does.
+
+**A broken app must record what broke, where.** `web-problems/` loads
+`?console-error=1&bad-fetch=<url>`: the fixture logs a `console.error`, throws
+an uncaught error, and fires two doomed requests — a 404 and a connection
+refused on a port nothing is listening on. All four fire **during page load**,
+on purpose, so the recorder's `goto` beat is open and there is a real
+attribution to check. `terminal-problems/` runs `(exit 3)` — a subshell, so the
+recorder's own shell survives, and 3 rather than 1 so the assertion proves the
+*status* was read and not "something failed" inferred from elsewhere.
+
+Two cases in `web-problems/` exist because the obvious implementation of
+attribution — blame `self._beats[-1]` — is wrong in both directions:
+
+- an error thrown **one second into a three-second hold** must land on the
+  `pause`, under the caption that was on screen, not on the caption beat that
+  follows the hold. Without the recorder pumping events as it waits, it lands
+  on the later beat and gets stamped with a line that did not exist when it
+  fired. Both the beat *and* the caption are asserted.
+- an error logged **between two verbs**, where no beat is open, must come back
+  `beat: null`. A confidently wrong index is worse than no answer.
+
+These takes are graded on `timeline.json` alone — nothing about their video is
+checked. They also carry the other half of the strict assertion: the **default**
+recorder tolerates every one of these problems and still writes every artifact.
+
+| Checked | Why |
+|---|---|
+| each deliberate problem appears, by kind and message | the whole axis |
+| …attributed to the beat it fired during — `beat` indexes a real beat *and* that beat's `verb` is the expected one | `verb` alone is a string the recorder could copy from anywhere; `beat` alone is an integer that means nothing. Together they say the attribution is real and right |
+| …or to no beat at all, when none was open | the null case above |
+| …under the caption that was up when it fired | the field a reviewer reads as context; quoting a later line is the failure a wrong beat index produces |
+| `run` beats carry the exit status of their command | hand-written like the beat lists, `{echo ok: 0, (exit 3): 3, sleep 1: 0, (exit 9): 9}` |
+| `nonzero_exit` is in the package's `STRICT_KINDS` | links the recorded data to the policy: recording a failing command that strict would ignore is not catching it |
+| `issue_count` equals `len(issues)` | nothing here comes near the 200 cap, so the two disagreeing means one is wrong |
+| every `kind` is in `ISSUE_KINDS` | the published contract, not whatever the recorder felt like emitting |
+| `timeline.md` has an Issues section naming each, and an exit column | the human-readable half of the log must not say the take was fine |
+
+**An exit status must be right or absent, never wrong.** Two shapes of that,
+both found by review after the first round shipped them silently wrong:
+
+- `terminal-problems/` types `sleep 1` and `(exit 9)` with **no wait between
+  them**. The shell buffers the second and runs it after the first, so both
+  statuses arrive in order and must reach different beats. A single pending
+  slot gave `sleep`'s 0 to `(exit 9)` and dropped the 9 — a *wrong* exit code,
+  which strict passes, rather than a missing one.
+- `terminal-race/` runs against a shell that **sleeps 1.2 s before exec'ing
+  bash**, with typing instant, so `run()` finishes before the shell has printed
+  its first prompt. That prompt reports the shell's own 0, and a recorder that
+  takes the next marker it sees writes that 0 onto the command. Its own take
+  because the condition has to be manufactured: on a normal box the startup
+  prompt always wins, and removing the guard passes every other take here.
+
+**Strict mode must refuse what the default tolerates.** `web-strict/` and
+`terminal-strict/`, deliberately tiny. Each must raise `StrictTakeFailed`, the
+message must **name the beat** (issue #3's acceptance criterion verbatim,
+matched as `beat N (verb)`), it must name the kind the storyboard caused, and
+**demo.mp4 and timeline.json must still be on disk** — a broken take is
+precisely the one somebody wants to look at, so failing it by destroying the
+evidence would be worse than not failing it.
+
 ## Known gaps
 
 Things a pass does **not** prove. They are listed because an assertion nobody
@@ -270,33 +356,38 @@ knows is missing is worse than one that is openly absent.
   hypothetical — a WSL2 box was measured stepping 573 ms backwards inside 8 s,
   which is how the bug was found — but a pass does not prove the fix is still
   in place. Reading the diff does.
-- **The terminal takes carry a recorder bug, and the harness tolerates it.**
-  `TerminalRecorder`'s background init script dereferences `documentElement` on
-  the initial empty document, where it is null, so every terminal take logs a
-  `page_error` before its first beat. The Problems axis asserts on the
-  `nonzero_exit` it deliberately causes, never on "no other issues", precisely
-  so it does not encode that bug as expected. Consequence: **`strict=True`
-  currently fails every terminal take** whatever the demo does, which is why
-  the strict terminal assertion checks that the failure *mentions*
-  `nonzero_exit` rather than merely that it happened. Tracked in
-  [#25](https://github.com/rogvid/skills/issues/25); when it lands, an
-  assertion that a healthy terminal take records nothing becomes possible.
-- **Issue attribution is only as fine-grained as Playwright's event pump.**
-  The sync API delivers `console`/`pageerror`/`requestfailed`/`response`
-  events while it is inside a call, so a page that throws during a `pause()`
-  is attributed to whatever beat is next to touch Playwright. Measured stable
-  across the storyboards here — three consecutive runs put the fixture's two
-  load-time errors on `goto` every time — but that is a property of *these*
-  beats, not a guarantee. `t` is the observation time and can lag the event;
-  `beat` is the attribution to trust.
+- **Issue attribution is bounded, not exact.** Playwright's sync API delivers
+  page events only while it is inside a call, so the recorder pumps every
+  100 ms during a hold and refuses to attribute an event to a beat that has not
+  been open since the last pump. What that leaves: an event fired inside the
+  pump interval of a beat boundary can land on either side of it, and a beat
+  that blocks in a long *non*-Playwright call — narration being synthesized —
+  queues events for its whole duration and gets `beat: null` for all of them.
+  Null is the deliberate answer in both directions, but "null" and "right" are
+  not the same thing and only the second is what a reader wants.
+- **Nothing checks most of an issue's fields.** `kind`, `message`, `beat`,
+  `verb` and one `caption` are asserted; `t`, `url`, `line`, `status`, `method`
+  are not. `t` is knowingly the *observation* time and can sit outside the beat
+  it names — measured at 3.53 s for a `nonzero_exit` whose `run` beat ended at
+  3.4 s. Tracked in [#34](https://github.com/rogvid/skills/issues/34).
+- **Nothing checks popups or new tabs.** The recorder watches one page, so a
+  demo that opens a second one records nothing about it and `strict=True`
+  cannot refuse it. Tracked in
+  [#33](https://github.com/rogvid/skills/issues/33).
 - **Nothing checks the 200-issue cap, or a `run()` that is never waited on.**
   `issue_count` is asserted equal to `len(issues)`, which is the uncapped case
-  only. A take that overflowed, and a `run()` whose prompt never came back and
-  therefore ends with `exit_code: null`, are both unexercised.
-- **Nothing checks a non-bash shell.** The exit status arrives through `$?`
-  expanded in `PS1`, which is a bash behaviour; zsh needs `PROMPT_SUBST` and
-  would silently leave every `exit_code` null. Only `/bin/bash` is recorded
-  here.
+  only — so the path where a fatal issue arrives past the cap and is counted
+  but not recorded is unexercised, as is a `run()` whose prompt never comes
+  back and therefore ends `exit_code: null`.
+- **Nothing checks that the withheld half-marker is flushed.** `_pump` holds
+  back trailing bytes that could still become an exit-status escape, and
+  `_stop` writes them to the terminal on teardown. No assertion reads the final
+  frame, so a regression there would lose the last few bytes of a program's
+  output silently.
+- **Nothing checks a non-bash shell.** The exit status arrives through `$?` and
+  `\#` expanded in `PS1`, which is bash behaviour; zsh needs `PROMPT_SUBST` and
+  would leave every `exit_code` null. Only `/bin/bash` is recorded here — the
+  `terminal-race/` take's slow shell `exec`s it.
 - **Nothing checks audio.** Narration is forced off and no assertion touches the
   aac track, so the whole speech path — `tts_clip`, the `.tts/` cache, the
   `adelay`/`amix` mixing in `_convert` — is untested here.
@@ -307,43 +398,6 @@ knows is missing is worse than one that is openly absent.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.
-
-**Problems** — what the recorder saw *behind* the pixels. This is the axis the
-other four are structurally blind to: a demo of an app throwing `TypeError` on
-every render is pixel-for-pixel a demo of a working one, scores the same luma,
-logs the same beats, and satisfies every post-condition the storyboard checks.
-
-The web take is therefore recorded against a **deliberately broken page**.
-`?console-error=1` makes the fixture log a `console.error` and throw an
-uncaught error while staying usable, and the storyboard then fires two doomed
-requests from one `page.evaluate` — a 404 and a connection refused on a port
-nothing is listening on. The terminal take runs `(exit 3)`: a subshell, so the
-recorder's own shell survives, and 3 rather than 1 so the assertion proves the
-*status* was read and not "something failed" inferred from elsewhere.
-
-Everything above still has to pass on those takes, which is half the
-strict-mode assertion: the **default** recorder tolerates all of it and writes
-every artifact. `check_issues()` then grades `timeline.json`:
-
-| Checked | Why |
-|---|---|
-| each deliberate problem appears, by kind and message | the whole axis |
-| …attributed to the beat it fired during — `beat` indexes a real beat *and* that beat's `verb` is the expected one | `verb` alone is a string the recorder could copy from anywhere; `beat` alone is an integer that means nothing. Together they say the attribution is real and right |
-| `run` beats carry the exit status of their command | `{echo: 0, ls: 0, (exit 3): 3}`, hand-written like the beat lists |
-| `nonzero_exit` is in the package's `STRICT_KINDS` | links the recorded data to the policy without a third take: recording a failing command that strict would ignore is not catching it |
-| `issue_count` equals `len(issues)` | nothing here comes near the 200 cap, so the two disagreeing means one is wrong |
-| every `kind` is in `ISSUE_KINDS` | the published contract, not whatever the recorder felt like emitting |
-| `timeline.md` has an Issues section naming each | the human-readable half of the log must not say the take was fine |
-
-**Strict mode** needs takes of its own — the two above prove the default does
-*not* fail, and nothing about them can prove that anything ever does. So two
-more, deliberately tiny (a few seconds each, nothing worth grading): `web/`'s
-broken page under `strict=True`, and a terminal take that only runs `(exit 3)`.
-Each must raise `StrictTakeFailed`, the message must **name the beat** (issue
-#3's acceptance criterion verbatim, matched as `beat N (verb)`), it must name
-the kind the storyboard caused, and **demo.mp4 and timeline.json must still be
-on disk** — a broken take is precisely the one somebody wants to look at, so
-failing it by destroying the evidence would be worse than not failing it.
 
 Failures accumulate and print together, each naming the file or interaction and
 the number that was wrong. The process exits non-zero if there is even one, and
@@ -367,13 +421,13 @@ Two query-string hooks exist, inert unless asked for:
 
 | URL | Effect | For |
 |---|---|---|
-| `?console-error=1` | logs a `console.error` **and** throws an uncaught error (Playwright `pageerror`), while the page stays usable | the Problems axis. **The web takes load this**, so `/` alone is not what gets recorded |
+| `?console-error=1` | logs a `console.error` **and** throws an uncaught error (Playwright `pageerror`), while the page stays usable | the Problems axis |
+| `?bad-fetch=<url>` | fetches `/definitely-missing.json` (404) and `<url>` (connection refused), both during load | the Problems axis — during load so the failures land inside the recorder's `goto` beat |
 | `?secret=1` | renders `#api-key` holding `sk-live-FAKE0000000000000000` | issue #4, redacting secrets from frames and stills |
 
-The web storyboard leaving the page broken on purpose is the point, not an
-oversight: every other axis has to keep passing over it, which is what proves
-the default recorder tolerates a broken app rather than merely never meeting
-one.
+One hook, one take. The graded `web/` take loads none of them, so the reference
+recording stays a recording of a working app — which is also the assertion that
+the recorder does not invent problems.
 
 That key is not a credential. It is spelled `FAKE` followed by sixteen zeroes so
 both gitleaks and a human read it as scenery — the default ruleset does not flag

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,7 +1,8 @@
 # tests
 
-One smoke test and one fixture app. Together they answer a single question:
-**does the demo-video recorder still produce a real video?**
+One smoke test and one fixture app. Together they answer two questions:
+**does the demo-video recorder still produce a real video, and does it still
+notice when the thing it recorded was broken?**
 
 They are not unit tests. The recorders' interesting behaviour is "shell out to
 ffmpeg, drive a headless browser, come back with an mp4", which nothing short
@@ -38,18 +39,23 @@ smoke: web first caption 'A small dashboard.' logged at 3.03s, on screen at 2.95
 smoke: web closing caption 'Recorded end to end.' logged at 17.03s, on screen at 16.99s (-40 ms)
 smoke: web beat clock holds across the take (+40 ms)
 smoke: web timeline.json ok (23 beats)
+smoke: web timeline.json records 6 problem(s), 4 of them fatal under strict — take still passed
 …
+smoke: web-strict strict=True refused the take, naming beat 0 (goto) (2 fatal issues, artifacts kept)
+smoke: terminal-strict strict=True refused the take, naming beat 1 (run) (2 fatal issues, artifacts kept)
+
 smoke: PASSED
 ```
 
-Re-running into the same `--out-dir` is safe: the `web/` and `terminal/`
-subdirectories are deleted before each take. That is not tidiness — every
+Re-running into the same `--out-dir` is safe: the `web/`, `terminal/`,
+`web-strict/` and `terminal-strict/` subdirectories are deleted before each
+take. That is not tidiness — every
 artifact assertion works by path, so without it a leftover `demo.mp4` from the
 previous run would grade a recorder that produced nothing at all as a pass, and
 recording repeatedly into one directory is exactly how a change to the recorder
 gets verified.
 
-Deleting is bounded. Only `<out-dir>/web/` and `<out-dir>/terminal/` are ever
+Deleting is bounded. Only those four named subdirectories are ever
 removed, and only when each is absent, empty, or carries the
 `.demo-video-smoke` marker file a previous run wrote there. `--out-dir .` in a
 project that has its own `web/` directory gets a refusal naming the path, not a
@@ -67,8 +73,8 @@ test measures.
 
 ## What it asserts
 
-Four independent axes, because a recorder can fail on any one of them while
-looking perfect on the other three.
+Five independent axes, because a recorder can fail on any one of them while
+looking perfect on the other four.
 
 **Artifacts** — `demo.mp4` and every still the storyboard asked for exist, were
 modified by *this* run rather than a previous one, clear a size floor
@@ -264,6 +270,33 @@ knows is missing is worse than one that is openly absent.
   hypothetical — a WSL2 box was measured stepping 573 ms backwards inside 8 s,
   which is how the bug was found — but a pass does not prove the fix is still
   in place. Reading the diff does.
+- **The terminal takes carry a recorder bug, and the harness tolerates it.**
+  `TerminalRecorder`'s background init script dereferences `documentElement` on
+  the initial empty document, where it is null, so every terminal take logs a
+  `page_error` before its first beat. The Problems axis asserts on the
+  `nonzero_exit` it deliberately causes, never on "no other issues", precisely
+  so it does not encode that bug as expected. Consequence: **`strict=True`
+  currently fails every terminal take** whatever the demo does, which is why
+  the strict terminal assertion checks that the failure *mentions*
+  `nonzero_exit` rather than merely that it happened. Tracked in
+  [#25](https://github.com/rogvid/skills/issues/25); when it lands, an
+  assertion that a healthy terminal take records nothing becomes possible.
+- **Issue attribution is only as fine-grained as Playwright's event pump.**
+  The sync API delivers `console`/`pageerror`/`requestfailed`/`response`
+  events while it is inside a call, so a page that throws during a `pause()`
+  is attributed to whatever beat is next to touch Playwright. Measured stable
+  across the storyboards here — three consecutive runs put the fixture's two
+  load-time errors on `goto` every time — but that is a property of *these*
+  beats, not a guarantee. `t` is the observation time and can lag the event;
+  `beat` is the attribution to trust.
+- **Nothing checks the 200-issue cap, or a `run()` that is never waited on.**
+  `issue_count` is asserted equal to `len(issues)`, which is the uncapped case
+  only. A take that overflowed, and a `run()` whose prompt never came back and
+  therefore ends with `exit_code: null`, are both unexercised.
+- **Nothing checks a non-bash shell.** The exit status arrives through `$?`
+  expanded in `PS1`, which is a bash behaviour; zsh needs `PROMPT_SUBST` and
+  would silently leave every `exit_code` null. Only `/bin/bash` is recorded
+  here.
 - **Nothing checks audio.** Narration is forced off and no assertion touches the
   aac track, so the whole speech path — `tts_clip`, the `.tts/` cache, the
   `adelay`/`amix` mixing in `_convert` — is untested here.
@@ -274,6 +307,43 @@ knows is missing is worse than one that is openly absent.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.
+
+**Problems** — what the recorder saw *behind* the pixels. This is the axis the
+other four are structurally blind to: a demo of an app throwing `TypeError` on
+every render is pixel-for-pixel a demo of a working one, scores the same luma,
+logs the same beats, and satisfies every post-condition the storyboard checks.
+
+The web take is therefore recorded against a **deliberately broken page**.
+`?console-error=1` makes the fixture log a `console.error` and throw an
+uncaught error while staying usable, and the storyboard then fires two doomed
+requests from one `page.evaluate` — a 404 and a connection refused on a port
+nothing is listening on. The terminal take runs `(exit 3)`: a subshell, so the
+recorder's own shell survives, and 3 rather than 1 so the assertion proves the
+*status* was read and not "something failed" inferred from elsewhere.
+
+Everything above still has to pass on those takes, which is half the
+strict-mode assertion: the **default** recorder tolerates all of it and writes
+every artifact. `check_issues()` then grades `timeline.json`:
+
+| Checked | Why |
+|---|---|
+| each deliberate problem appears, by kind and message | the whole axis |
+| …attributed to the beat it fired during — `beat` indexes a real beat *and* that beat's `verb` is the expected one | `verb` alone is a string the recorder could copy from anywhere; `beat` alone is an integer that means nothing. Together they say the attribution is real and right |
+| `run` beats carry the exit status of their command | `{echo: 0, ls: 0, (exit 3): 3}`, hand-written like the beat lists |
+| `nonzero_exit` is in the package's `STRICT_KINDS` | links the recorded data to the policy without a third take: recording a failing command that strict would ignore is not catching it |
+| `issue_count` equals `len(issues)` | nothing here comes near the 200 cap, so the two disagreeing means one is wrong |
+| every `kind` is in `ISSUE_KINDS` | the published contract, not whatever the recorder felt like emitting |
+| `timeline.md` has an Issues section naming each | the human-readable half of the log must not say the take was fine |
+
+**Strict mode** needs takes of its own — the two above prove the default does
+*not* fail, and nothing about them can prove that anything ever does. So two
+more, deliberately tiny (a few seconds each, nothing worth grading): `web/`'s
+broken page under `strict=True`, and a terminal take that only runs `(exit 3)`.
+Each must raise `StrictTakeFailed`, the message must **name the beat** (issue
+#3's acceptance criterion verbatim, matched as `beat N (verb)`), it must name
+the kind the storyboard caused, and **demo.mp4 and timeline.json must still be
+on disk** — a broken take is precisely the one somebody wants to look at, so
+failing it by destroying the evidence would be worse than not failing it.
 
 Failures accumulate and print together, each naming the file or interaction and
 the number that was wrong. The process exits non-zero if there is even one, and
@@ -293,13 +363,17 @@ It is deterministic on purpose — no `Math.random()`, no clock on screen, no
 animations. `#refresh` cycles three hard-coded snapshots in order, so a
 recording made today is frame-for-frame the story of one made next year.
 
-Two query-string hooks exist for the queued feature work, inert unless asked
-for:
+Two query-string hooks exist, inert unless asked for:
 
 | URL | Effect | For |
 |---|---|---|
-| `?console-error=1` | logs a `console.error` **and** throws an uncaught error (Playwright `pageerror`), while the page stays usable | issue #3, failing a take on console errors |
+| `?console-error=1` | logs a `console.error` **and** throws an uncaught error (Playwright `pageerror`), while the page stays usable | the Problems axis. **The web takes load this**, so `/` alone is not what gets recorded |
 | `?secret=1` | renders `#api-key` holding `sk-live-FAKE0000000000000000` | issue #4, redacting secrets from frames and stills |
+
+The web storyboard leaving the page broken on purpose is the point, not an
+oversight: every other axis has to keep passing over it, which is what proves
+the default recorder tolerates a broken app rather than merely never meeting
+one.
 
 That key is not a credential. It is spelled `FAKE` followed by sixteen zeroes so
 both gitleaks and a human read it as scenery — the default ruleset does not flag
@@ -328,8 +402,18 @@ insurance against a future release that does start flagging it.
   stable id, and keep it deterministic. If it only matters to one future
   feature, hide it behind a query-string hook the way the two above are, so the
   default recording stays clean.
+- **A new thing for the recorder to notice** (a new issue kind, a new signal) —
+  add it to `ISSUE_KINDS` in `core.py`, decide whether it belongs in
+  `STRICT_KINDS`, make one of the storyboards cause it on purpose, and add a
+  `(kind, message substring, verb)` row to `WEB_ISSUES` / `TERMINAL_ISSUES`.
+  The verb is what makes the row worth writing: an issue that is recorded but
+  attributed nowhere is a problem report with the page number torn off.
 - **A new failure mode to catch** — prefer another assertion in `check_take()`
-  over another take. Takes cost ~15 s each in CI; assertions are free.
+  or `check_issues()` over another take. Takes cost ~15 s each in CI;
+  assertions are free. The two strict takes are the exception that proves it:
+  "the take raises" cannot be asserted about a take that has to succeed for
+  everything else to be graded, so they exist, and they are kept to a few
+  seconds each and graded on nothing else.
 
 **Prove any new assertion can fail.** Break the thing it watches — stub the verb
 out in `skills/demo-video/helpers/`, or blank the fixture — run `tests/smoke`,

--- a/tests/fixture/index.html
+++ b/tests/fixture/index.html
@@ -164,6 +164,8 @@
  *
  * Query-string hooks, inert unless asked for:
  *   ?console-error=1  page logs a console error and throws on load (issue #3)
+ *   ?bad-fetch=<url>  page fetches a missing path and <url>, both on load,
+ *                     so the failures land during the recorder's goto (#3)
  *   ?secret=1         renders #api-key holding an obviously-fake secret (issue #4)
  */
 
@@ -281,6 +283,21 @@ if (params.has("secret")) {
   panel.appendChild(label);
   panel.appendChild(code);
   document.querySelector(".page").appendChild(panel);
+}
+
+if (params.has("bad-fetch")) {
+  // Deliberate network breakage for the failed-request detection work
+  // (issue #3). Two shapes: a response the server answers with 404, and a
+  // request that never gets a response at all — the caller passes a URL on a
+  // port nothing is listening on, since a dead port cannot be hardcoded.
+  //
+  // Fired here, during page load, on purpose: the recorder's goto() is still
+  // open, so these have a beat to be attributed to. Driving them from the
+  // storyboard instead would fire them between beats, where the honest
+  // answer is "no beat" and there is nothing to check attribution against.
+  fetch("/definitely-missing.json").catch(function () {});
+  var refused = params.get("bad-fetch");
+  if (refused && refused !== "1") { fetch(refused).catch(function () {}); }
 }
 
 if (params.has("console-error")) {

--- a/tests/smoke
+++ b/tests/smoke
@@ -20,6 +20,13 @@ short web demo against it with `Recorder`, records a short terminal demo with
 3. **Behaviour** — the storyboard's verbs had their effect. Every
    `caption`/`click`/`type_into`/`spotlight`/`move_to` is followed by a check
    of the observable post-condition it should have caused.
+4. **Problems** — the recorder noticed the app was broken. The web take is
+   recorded against a page that throws on load and fires two doomed requests;
+   the terminal take runs a command that exits 3. None of that is visible in
+   the other three axes — a demo of a broken app is pixel-for-pixel a demo of
+   a working one — so `timeline.json`'s `issues` are graded on their own, and
+   two extra short takes check that `strict=True` refuses what the default
+   tolerates.
 
     tests/smoke                 # both takes
     tests/smoke --web-only
@@ -159,6 +166,68 @@ PROBE_QUIET_S = 2.0
 
 SERVER_START_TIMEOUT_S = 15.0
 
+# -- problems the take should notice (timeline.json `issues`) ----------------
+#
+# The web storyboard records a *deliberately broken* page. `?console-error=1`
+# makes the fixture log a console error and throw an uncaught one while staying
+# usable, and the storyboard then fires two requests that cannot succeed. All
+# four are things a demo can sail past while looking perfect, which is the
+# failure mode this axis exists to catch.
+WEB_PATH = "/?console-error=1"
+MISSING_PATH = "/definitely-missing.json"
+
+# Fired from one page.evaluate() straight after the `wait_for` beat, so both
+# land in a beat this file can name — see WEB_ISSUES. `Promise.all` on two
+# caught fetches: the call returns only once both have failed, so the events
+# are delivered while Playwright is still inside that beat.
+PROBE_FETCH_JS = """(url) => Promise.all([
+  fetch('__MISSING__').catch(() => {}),
+  fetch(url).catch(() => {}),
+])""".replace("__MISSING__", MISSING_PATH)
+
+# The terminal storyboard runs one command that fails. `(exit 3)` is a subshell
+# so the recorder's own shell survives it, and 3 rather than 1 because it
+# proves the *status* was read rather than "something went wrong" inferred
+# from any other signal.
+TERMINAL_FAILING_COMMAND = "(exit 3)"
+
+# Exit status every run() in the terminal storyboard must have logged on its
+# beat. Hand-written, like the beat list: derived from the log it grades, it
+# would agree with the log no matter what the log said.
+TERMINAL_EXIT_CODES = {
+    "echo hello from demo-video": 0,
+    "ls -1": 0,
+    TERMINAL_FAILING_COMMAND: 3,
+}
+
+# (kind, a substring of the message, the verb of the beat it must be
+# attributed to). Each expectation must match at least one issue; `beat` is
+# then checked against the beat list itself, so the attribution has to be a
+# real index and not just a denormalized string that happens to agree.
+#
+# "At least one", not "exactly the set": Chromium adds its own "Failed to load
+# resource" console error for each of the two probe requests, and pinning an
+# exact issue list would make this a test of Chromium's console wording.
+WEB_ISSUES = [
+    ("console_error", "fixture: deliberate console error", "goto"),
+    ("page_error", "fixture: deliberate uncaught error", "goto"),
+    ("http_error", MISSING_PATH, "wait_for"),
+    ("request_failed", "ERR_CONNECTION_REFUSED", "wait_for"),
+]
+TERMINAL_ISSUES = [
+    ("nonzero_exit", f"{TERMINAL_FAILING_COMMAND!r} exited 3", "run"),
+]
+
+# The strict takes are separate and deliberately tiny — a few seconds each
+# against the same broken fixture, recording nothing worth grading. They exist
+# to answer one question the takes above cannot: does `strict=True` actually
+# refuse the take? The takes above answer the other half, by carrying fatal
+# issues through to a clean exit under the default.
+STRICT_CAPTION = "A broken page."
+# The acceptance criterion of issue #3, as a pattern: the failure has to name
+# the beat the problem fired during, not merely that something went wrong.
+STRICT_BEAT_RE = re.compile(r"beat \d+ \((\w+)\)")
+
 # -- timeline (timeline.json / timeline.md) ----------------------------------
 
 # Every beat each storyboard below performs, as (verb, target), in order. It
@@ -167,7 +236,7 @@ SERVER_START_TIMEOUT_S = 15.0
 # taken from the log it is checking would agree with the log no matter what
 # the log said. Editing a storyboard means editing this list.
 WEB_BEATS = [
-    ("goto", "/"),
+    ("goto", WEB_PATH),
     ("wait_for", "#kpi-rev"),
     ("pause", None),
     ("caption", None),
@@ -206,6 +275,9 @@ TERMINAL_BEATS = [
     ("pause", None),
     ("shot", "02-listing"),
     ("caption", None),
+    ("run", TERMINAL_FAILING_COMMAND),
+    ("wait_for_prompt", None),
+    ("caption", None),
     ("shot", "90-caption-off"),
     ("pause", None),
     ("caption", None),
@@ -227,6 +299,7 @@ WEB_CAPTIONS = [
 TERMINAL_CAPTIONS = [
     "A real shell, recorded.",
     "Any command works.",
+    "A failing one is caught.",
     "",
     PROBE_CAPTION,
     "",
@@ -677,13 +750,20 @@ _TRAIL_JS = """() => {
 
 
 def record_web(
-    out_dir: Path, base_url: str
+    out_dir: Path, base_url: str, refused_url: str
 ) -> tuple[list[str], Rect, Rect, tuple[int, int]]:
-    """Land, read a KPI, filter the table, refresh it.
+    """Land, read a KPI, filter the table, refresh it — on a broken page.
 
     Returns the post-condition failures plus two content rects: where the app
     sits inside the composited video, and where it sits in a still (stills are
     captured full-bleed, before compositing).
+
+    The page is loaded with `?console-error=1` and two doomed requests are
+    fired at it, so the take is also the fixture for the problem log: a demo
+    that looks perfect over an app that is throwing. Everything else here still
+    has to pass, because the *default* recorder tolerates all of it — that half
+    of the strict-mode assertion lives in this take, and only the other half
+    needs a take of its own.
     """
     from demo_recording import Recorder
 
@@ -692,16 +772,24 @@ def record_web(
     bg = "el => getComputedStyle(el).backgroundColor"
 
     with Recorder(out_dir, base_url=base_url, speech=False) as rec:
-        rec.goto("/")
+        rec.goto(WEB_PATH)
         rec.wait_for("#kpi-rev")
+        # Not a verb, so no beat of its own: both failures are attributed to
+        # the `wait_for` beat still standing as the most recent one, which is
+        # what WEB_ISSUES asserts.
+        rec.page.evaluate(PROBE_FETCH_JS, refused_url)
         start_ticker(b, rec.page)
         # Doubles as the run-up for the *early* timing probe: the page has
         # finished painting and the caption band does not move until the
         # first caption. See MAX_CAPTION_SKEW_S.
         rec.pause(PROBE_QUIET_S)
-        b.expect("goto('/'), #rows row count", rec.page.locator("#rows tr").count(), 5)
         b.expect(
-            "goto('/'), #status text",
+            f"goto({WEB_PATH!r}), #rows row count",
+            rec.page.locator("#rows tr").count(),
+            5,
+        )
+        b.expect(
+            f"goto({WEB_PATH!r}), #status text",
             rec.page.locator("#status").inner_text(),
             "snapshot 1 of 3",
         )
@@ -709,7 +797,7 @@ def record_web(
         # legible-ish, which the luma metric scores around 10 — above its
         # floor. This resolves that case exactly, with no pixel threshold.
         b.expect(
-            "goto('/'), #refresh background (did the stylesheet apply?)",
+            "goto(…), #refresh background (did the stylesheet apply?)",
             rec.page.eval_on_selector("#refresh", bg),
             "rgb(235, 110, 20)",
         )
@@ -858,6 +946,14 @@ def record_terminal(
         expect_screen(rec, "run('ls -1')", r"^skills$")
         rec.pause(0.8)
         rec.shot("02-listing")
+
+        # A command that fails. The shell survives it (subshell), the screen
+        # shows nothing unusual, and the only evidence anywhere is the exit
+        # status the recorder reads off the prompt — which is the point.
+        rec.caption("A failing one is caught.")
+        check_caption(b, rec.page, "A failing one is caught.")
+        rec.run(TERMINAL_FAILING_COMMAND)
+        expect_prompt(rec, f"run({TERMINAL_FAILING_COMMAND!r})")
 
         rec.caption("")
         check_caption(b, rec.page, "")
@@ -1435,6 +1531,145 @@ def _first_difference(actual: list, expected: list) -> object:
     return f"{min(len(actual), len(expected))} (one list simply ends)"
 
 
+def check_issues(
+    label: str,
+    out_dir: Path,
+    expected: list[tuple[str, str, str]],
+    exit_codes: dict[str, int] | None = None,
+) -> list[str]:
+    """The problems the take noticed, as `timeline.json` records them.
+
+    A recording is not evidence that the thing being recorded works: a demo of
+    an app throwing `TypeError` on every render looks exactly like a demo of a
+    healthy one. This axis grades what the recorder saw *behind* the pixels —
+    the console, the network, and the exit status of every command it typed —
+    and, as much as any of it, whether each problem is attributed to the beat
+    that was running when it fired. "The take broke" is not a bug report; "the
+    take broke during `click('#refresh')`" is.
+    """
+    from demo_recording import ISSUE_KINDS, STRICT_KINDS
+
+    failures: list[str] = []
+    json_path = out_dir / "timeline.json"
+    if not json_path.is_file():
+        return [f"{label}: {json_path} was never written"]
+    try:
+        doc = json.loads(json_path.read_text())
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return [f"{label}: {json_path} is not valid JSON: {exc}"]
+
+    beats = doc.get("beats") or []
+    issues = doc.get("issues")
+    if not isinstance(issues, list):
+        return [
+            f"{label}: timeline.json has no `issues` list ({issues!r}) — the "
+            f"take recorded nothing about whether the app was working"
+        ]
+    if doc.get("strict") is not False:
+        failures.append(
+            f"{label}: timeline.json says strict={doc.get('strict')!r}; this "
+            f"take is recorded with the default, which is off"
+        )
+    if doc.get("issue_count") != len(issues):
+        failures.append(
+            f"{label}: timeline.json counts {doc.get('issue_count')!r} issues "
+            f"but lists {len(issues)} — nothing here should hit the cap, so "
+            f"the two disagreeing means one of them is wrong"
+        )
+    for issue in issues:
+        if issue.get("kind") not in ISSUE_KINDS:
+            failures.append(
+                f"{label}: timeline.json records an issue of unknown kind "
+                f"{issue.get('kind')!r}, not in the package's ISSUE_KINDS"
+            )
+            break
+
+    # -- the problems the storyboard deliberately caused ---------------------
+    for kind, needle, verb in expected:
+        found = [
+            i
+            for i in issues
+            if i.get("kind") == kind and needle in str(i.get("message"))
+        ]
+        if not found:
+            failures.append(
+                f"{label}: nothing in timeline.json records the {kind} the "
+                f"storyboard deliberately caused ({needle!r}). Logged: "
+                f"{[(i.get('kind'), i.get('message')) for i in issues]!r}"
+            )
+            continue
+        issue = found[0]
+        index = issue.get("beat")
+        # Both halves matter. `verb` alone is a string the recorder could have
+        # copied from anywhere; `beat` alone is an integer that means nothing
+        # on its own. Together they say the issue points at a real beat, and
+        # that it is the right one.
+        if not isinstance(index, int) or not 0 <= index < len(beats):
+            failures.append(
+                f"{label}: the {kind} {needle!r} is attributed to beat "
+                f"{index!r}, which is not a beat of this take — the problem "
+                f"is logged but not placed in the story"
+            )
+            continue
+        if beats[index].get("verb") != verb or issue.get("verb") != verb:
+            failures.append(
+                f"{label}: the {kind} {needle!r} fired during {verb!r} but is "
+                f"attributed to beat {index} "
+                f"({beats[index].get('verb')!r}/{issue.get('verb')!r})"
+            )
+
+    # -- every command's exit status, on the beat that ran it ----------------
+    if exit_codes is not None:
+        logged = {
+            str(beat.get("selector")): beat.get("exit_code")
+            for beat in beats
+            if beat.get("verb") == "run"
+        }
+        if logged != exit_codes:
+            failures.append(
+                f"{label}: run() beats logged exit codes {logged!r}, the "
+                f"storyboard's commands exit {exit_codes!r} — a command that "
+                f"failed is indistinguishable from one that worked"
+            )
+        if "nonzero_exit" not in STRICT_KINDS:
+            failures.append(
+                f"{label}: the package's STRICT_KINDS is {STRICT_KINDS!r}, "
+                f"which does not include 'nonzero_exit' — a failing command "
+                f"is recorded but would not fail a strict take"
+            )
+
+    # -- the same problems, readable, in timeline.md -------------------------
+    md_path = out_dir / "timeline.md"
+    markdown = md_path.read_text() if md_path.is_file() else ""
+    if issues and "## Issues" not in markdown:
+        failures.append(
+            f"{label}: timeline.json records {len(issues)} problem(s) but "
+            f"timeline.md has no Issues section — the human-readable half of "
+            f"the log says the take was fine"
+        )
+    for _, needle, _ in expected:
+        if needle not in markdown:
+            failures.append(f"{label}: timeline.md does not mention {needle!r}")
+
+    fatal = [i for i in issues if i.get("kind") in STRICT_KINDS]
+    if not fatal:
+        failures.append(
+            f"{label}: this take is supposed to carry problems a strict take "
+            f"would refuse, and carries none — so it proves nothing about the "
+            f"default tolerating them"
+        )
+    if not failures:
+        # Reaching here at all is the assertion: the take completed, wrote
+        # every artifact, and passed every other axis, while holding problems
+        # that STRICT_KINDS calls fatal. That is the default-mode half of
+        # "strict fails the take and the default does not".
+        print(
+            f"smoke: {label} timeline.json records {len(issues)} problem(s), "
+            f"{len(fatal)} of them fatal under strict — take still passed"
+        )
+    return failures
+
+
 def check_take(
     label: str,
     out_dir: Path,
@@ -1558,9 +1793,14 @@ def check_take(
 def run_web(out_root: Path) -> list[str]:
     out_dir = fresh_take_dir(out_root, "web")
     started = time.time()
+    # Nothing is listening here: free_port() binds only long enough to be told
+    # a number and lets go, so a request to it is refused rather than answered.
+    refused_url = f"http://127.0.0.1:{free_port()}/refused"
     with fixture_server() as base_url:
         try:
-            problems, video_rect, still_rect, size = record_web(out_dir, base_url)
+            problems, video_rect, still_rect, size = record_web(
+                out_dir, base_url, refused_url
+            )
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"web: Recorder raised {type(exc).__name__}: {exc}"]
     return (
@@ -1576,7 +1816,118 @@ def run_web(out_root: Path) -> list[str]:
             size,
         )
         + check_timeline("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
+        + check_issues("web", out_dir, WEB_ISSUES)
     )
+
+
+def check_strict_failure(
+    label: str, out_dir: Path, exc: BaseException | None, kinds: list[str]
+) -> list[str]:
+    """What a refused take must have done besides refusing.
+
+    Three things, and the last two are the ones worth having. It has to raise
+    — but it also has to say *which beat* the problem fired during, which is
+    issue #3's acceptance criterion verbatim, and it has to leave the mp4, the
+    stills and the timeline on disk. A broken take is precisely the one
+    somebody wants to look at; failing it by destroying the evidence would be
+    worse than not failing it.
+    """
+    from demo_recording import STRICT_KINDS, StrictTakeFailed
+
+    failures: list[str] = []
+    if exc is None:
+        return [
+            f"{label}: strict=True recorded a storyboard written to break in a "
+            f"way STRICT_KINDS calls fatal, and the take succeeded — strict "
+            f"mode does not fail anything"
+        ]
+    if not isinstance(exc, StrictTakeFailed):
+        return [
+            f"{label}: strict=True raised {type(exc).__name__} rather than "
+            f"StrictTakeFailed: {exc}"
+        ]
+
+    message = str(exc)
+    for kind in kinds:
+        if kind not in message:
+            failures.append(
+                f"{label}: the strict failure does not mention the {kind} the "
+                f"storyboard caused. It said: {' '.join(message.split())[:300]}"
+            )
+    named = STRICT_BEAT_RE.search(message)
+    if named is None:
+        failures.append(
+            f"{label}: the strict failure never names the beat the problem "
+            f"fired during — 'the take broke' is not a bug report. It said: "
+            f"{' '.join(message.split())[:300]}"
+        )
+
+    json_path = out_dir / "timeline.json"
+    if not (out_dir / "demo.mp4").is_file():
+        failures.append(
+            f"{label}: strict failed the take and no demo.mp4 was written — "
+            f"the recording of the failure is the thing worth keeping"
+        )
+    if not json_path.is_file():
+        failures.append(f"{label}: strict failed the take and wrote no timeline.json")
+        return failures
+    doc = json.loads(json_path.read_text())
+    if doc.get("strict") is not True:
+        failures.append(
+            f"{label}: the refused take's timeline.json says "
+            f"strict={doc.get('strict')!r}"
+        )
+    fatal = [i for i in (doc.get("issues") or []) if i.get("kind") in STRICT_KINDS]
+    if not fatal:
+        failures.append(
+            f"{label}: the take was refused but its timeline.json lists no "
+            f"issue of a kind in STRICT_KINDS — the verdict and the log "
+            f"disagree about why"
+        )
+    if not failures:
+        print(
+            f"smoke: {label} strict=True refused the take, naming "
+            f"{named.group(0) if named else '?'} ({len(fatal)} fatal issues, "
+            f"artifacts kept)"
+        )
+    return failures
+
+
+def run_strict_web(out_root: Path) -> list[str]:
+    """strict=True over the page that throws: the take must not pass."""
+    from demo_recording import Recorder
+
+    out_dir = fresh_take_dir(out_root, "web-strict")
+    raised: BaseException | None = None
+    with fixture_server() as base_url:
+        try:
+            with Recorder(out_dir, base_url=base_url, speech=False, strict=True) as rec:
+                rec.goto(WEB_PATH)
+                rec.wait_for("#kpi-rev")
+                rec.caption(STRICT_CAPTION)
+        except Exception as exc:  # noqa: BLE001 - the raise is the assertion
+            raised = exc
+    return check_strict_failure(
+        "web-strict", out_dir, raised, ["console_error", "page_error"]
+    )
+
+
+def run_strict_terminal(out_root: Path) -> list[str]:
+    """strict=True over a command that exits 3: the take must not pass."""
+    if os.name != "posix":
+        return []
+    from demo_recording import TerminalRecorder
+
+    out_dir = fresh_take_dir(out_root, "terminal-strict")
+    raised: BaseException | None = None
+    try:
+        with TerminalRecorder(out_dir, speech=False, strict=True) as rec:
+            rec.caption(STRICT_CAPTION)
+            rec.run(TERMINAL_FAILING_COMMAND)
+            rec.wait_for_prompt(timeout_s=15)
+    except Exception as exc:  # noqa: BLE001 - the raise is the assertion
+        raised = exc
+    return check_strict_failure("terminal-strict", out_dir, raised, ["nonzero_exit"])
 
 
 def run_terminal(out_root: Path) -> list[str]:
@@ -1613,6 +1964,9 @@ def run_terminal(out_root: Path) -> list[str]:
         )
         + check_timeline(
             "terminal", out_dir, started, TERMINAL_BEATS, TERMINAL_CAPTIONS, size
+        )
+        + check_issues(
+            "terminal", out_dir, TERMINAL_ISSUES, exit_codes=TERMINAL_EXIT_CODES
         )
     )
 
@@ -1677,6 +2031,13 @@ def main() -> int:
             failures += run_web(out_root)
         if not args.web_only:
             failures += run_terminal(out_root)
+        # After the graded takes, never instead of them: these two record
+        # nothing worth looking at, and if a recorder is broken the messages
+        # above are the ones that say how.
+        if not args.terminal_only:
+            failures += run_strict_web(out_root)
+        if not args.web_only:
+            failures += run_strict_terminal(out_root)
     except SmokeFailure as exc:
         failures.append(str(exc))
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -58,6 +58,7 @@ import sys
 import tempfile
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -168,61 +169,133 @@ SERVER_START_TIMEOUT_S = 15.0
 
 # -- problems the take should notice (timeline.json `issues`) ----------------
 #
-# The web storyboard records a *deliberately broken* page. `?console-error=1`
-# makes the fixture log a console error and throw an uncaught one while staying
-# usable, and the storyboard then fires two requests that cannot succeed. All
-# four are things a demo can sail past while looking perfect, which is the
-# failure mode this axis exists to catch.
-WEB_PATH = "/?console-error=1"
+# Four short takes, on top of the two graded ones, because the question splits
+# four ways and no single take answers more than one of them:
+#
+#   web/, terminal/     a *healthy* app records nothing, under strict=True.
+#                       This is the direction the rest of the harness cannot
+#                       see: a recorder that reported every 2xx as a fatal
+#                       error would satisfy every "at least one issue matches"
+#                       assertion below and pass the whole suite.
+#   *-problems/         a broken app records exactly what it broke on, on the
+#                       beat it broke during, and the take still *succeeds*
+#                       under the default.
+#   *-strict/           the same broken app under strict=True does not.
+#
+# The graded takes stay recordings of a working app on purpose. They are the
+# reference demo a reader watches, and the fixture hooks belong in takes of
+# their own — the pattern the sibling PRs use for `?secret=1`.
 MISSING_PATH = "/definitely-missing.json"
 
-# Fired from one page.evaluate() straight after the `wait_for` beat, so both
-# land in a beat this file can name — see WEB_ISSUES. `Promise.all` on two
-# caught fetches: the call returns only once both have failed, so the events
-# are delivered while Playwright is still inside that beat.
-PROBE_FETCH_JS = """(url) => Promise.all([
-  fetch('__MISSING__').catch(() => {}),
-  fetch(url).catch(() => {}),
-])""".replace("__MISSING__", MISSING_PATH)
 
-# The terminal storyboard runs one command that fails. `(exit 3)` is a subshell
-# so the recorder's own shell survives it, and 3 rather than 1 because it
-# proves the *status* was read rather than "something went wrong" inferred
-# from any other signal.
+def web_problem_path(refused_url: str) -> str:
+    """The fixture URL that breaks in all four ways this axis grades.
+
+    Every failure is fired by the page during load, so the recorder's `goto`
+    beat is still open and there is a real attribution to check. Driving them
+    from the storyboard instead would fire them *between* beats, where the only
+    honest answer is `beat: null` — checked separately, see BETWEEN_BEATS.
+    """
+    return f"/?console-error=1&bad-fetch={urllib.parse.quote(refused_url)}"
+
+
+# Thrown one second into a three-second hold, from a timer set before the hold
+# starts. This is the case that made `self._beats[-1]` untenable: with nothing
+# pumping, the error surfaces in whatever beat next calls Playwright — the
+# caption *after* the hold — and gets stamped with a caption that did not exist
+# when it fired. It must land on the `pause`, under the caption that was up.
+LATE_BOOM = "fixture: late boom"
+LATE_BOOM_CAPTION = "Errors during a hold belong to the hold."
+LATE_BOOM_JS = ("() => setTimeout(() => { throw new Error('__M__'); }, 1000)").replace(
+    "__M__", LATE_BOOM
+)
+LATE_BOOM_HOLD_S = 3.0
+
+# Logged from storyboard code between two verbs, where no beat is open. The
+# only honest attribution is none, and `beat: null` is the assertion.
+BETWEEN_BEATS = "fixture: between beats"
+BETWEEN_BEATS_JS = "() => console.error('__M__')".replace("__M__", BETWEEN_BEATS)
+
+# `(exit 3)` is a subshell, so the recorder's own shell survives it, and 3
+# rather than 1 because it proves the *status* was read rather than "something
+# went wrong" inferred from any other signal.
 TERMINAL_FAILING_COMMAND = "(exit 3)"
 
-# Exit status every run() in the terminal storyboard must have logged on its
-# beat. Hand-written, like the beat list: derived from the log it grades, it
+# The regression from the first round of review: two run()s with no wait
+# between them. The shell buffers the second command and runs it after the
+# first, so both statuses arrive in order — a single pending slot handed
+# `sleep`'s 0 to `(exit 9)` and dropped the 9 entirely, which is a *wrong*
+# exit code rather than a missing one, and strict passed a failing command.
+TERMINAL_UNWAITED = ("sleep 1", "(exit 9)")
+
+# The other half of that regression: a shell that has not printed its first
+# prompt yet when run() types. Its startup prompt reports the *shell's* status,
+# 0, and a recorder that takes the next marker it sees writes that 0 onto the
+# command — which is a wrong exit code, not a missing one, and lets a failing
+# command through strict. Reproduced with a shell that sleeps before exec'ing
+# bash, and with typing instant so run() finishes first; a loaded CI box is the
+# real-world version. Written into the take directory rather than shipped,
+# because it exists to be slow and belongs to nothing else.
+TERMINAL_RACE_COMMAND = "(exit 5)"
+TERMINAL_RACE_EXIT = 5
+TERMINAL_RACE_DELAY_S = 1.2
+TERMINAL_RACE_SHELL = '#!/bin/sh\nsleep __DELAY__\nexec /bin/bash "$@"\n'
+
+# Exit status every run() in the problems storyboard must have logged on its
+# beat. Hand-written, like the beat lists: derived from the log it grades, it
 # would agree with the log no matter what the log said.
-TERMINAL_EXIT_CODES = {
-    "echo hello from demo-video": 0,
-    "ls -1": 0,
+TERMINAL_PROBLEM_EXIT_CODES = {
+    "echo ok": 0,
     TERMINAL_FAILING_COMMAND: 3,
+    TERMINAL_UNWAITED[0]: 0,
+    TERMINAL_UNWAITED[1]: 9,
 }
 
-# (kind, a substring of the message, the verb of the beat it must be
-# attributed to). Each expectation must match at least one issue; `beat` is
-# then checked against the beat list itself, so the attribution has to be a
-# real index and not just a denormalized string that happens to agree.
+# Each expectation must match at least one issue. `verb` is the verb of the
+# beat it must be attributed to, or None when the only honest answer is "no
+# beat"; `caption`, when given, is the caption that must be recorded with it.
+# The beat index is checked against the beat list itself, so the attribution
+# has to be a real index and not a denormalized string that happens to agree.
 #
 # "At least one", not "exactly the set": Chromium adds its own "Failed to load
-# resource" console error for each of the two probe requests, and pinning an
-# exact issue list would make this a test of Chromium's console wording.
-WEB_ISSUES = [
-    ("console_error", "fixture: deliberate console error", "goto"),
-    ("page_error", "fixture: deliberate uncaught error", "goto"),
-    ("http_error", MISSING_PATH, "wait_for"),
-    ("request_failed", "ERR_CONNECTION_REFUSED", "wait_for"),
+# resource" console error for each failed request, and pinning an exact list
+# would make this a test of Chromium's console wording. What closes that door
+# is the healthy takes — over-reporting has to fail *somewhere*, and it fails
+# there.
+WEB_PROBLEM_ISSUES = [
+    {
+        "kind": "console_error",
+        "needle": "fixture: deliberate console error",
+        "verb": "goto",
+    },
+    {
+        "kind": "page_error",
+        "needle": "fixture: deliberate uncaught error",
+        "verb": "goto",
+    },
+    {"kind": "http_error", "needle": MISSING_PATH, "verb": "goto"},
+    {"kind": "request_failed", "needle": "ERR_CONNECTION_REFUSED", "verb": "goto"},
+    {
+        "kind": "page_error",
+        "needle": LATE_BOOM,
+        "verb": "pause",
+        "caption": LATE_BOOM_CAPTION,
+    },
+    {"kind": "console_error", "needle": BETWEEN_BEATS, "verb": None},
 ]
-TERMINAL_ISSUES = [
-    ("nonzero_exit", f"{TERMINAL_FAILING_COMMAND!r} exited 3", "run"),
+TERMINAL_PROBLEM_ISSUES = [
+    {
+        "kind": "nonzero_exit",
+        "needle": f"{TERMINAL_FAILING_COMMAND!r} exited 3",
+        "verb": "run",
+    },
+    {
+        "kind": "nonzero_exit",
+        "needle": f"{TERMINAL_UNWAITED[1]!r} exited 9",
+        "verb": "run",
+    },
 ]
 
-# The strict takes are separate and deliberately tiny — a few seconds each
-# against the same broken fixture, recording nothing worth grading. They exist
-# to answer one question the takes above cannot: does `strict=True` actually
-# refuse the take? The takes above answer the other half, by carrying fatal
-# issues through to a clean exit under the default.
 STRICT_CAPTION = "A broken page."
 # The acceptance criterion of issue #3, as a pattern: the failure has to name
 # the beat the problem fired during, not merely that something went wrong.
@@ -236,7 +309,7 @@ STRICT_BEAT_RE = re.compile(r"beat \d+ \((\w+)\)")
 # taken from the log it is checking would agree with the log no matter what
 # the log said. Editing a storyboard means editing this list.
 WEB_BEATS = [
-    ("goto", WEB_PATH),
+    ("goto", "/"),
     ("wait_for", "#kpi-rev"),
     ("pause", None),
     ("caption", None),
@@ -275,9 +348,6 @@ TERMINAL_BEATS = [
     ("pause", None),
     ("shot", "02-listing"),
     ("caption", None),
-    ("run", TERMINAL_FAILING_COMMAND),
-    ("wait_for_prompt", None),
-    ("caption", None),
     ("shot", "90-caption-off"),
     ("pause", None),
     ("caption", None),
@@ -299,7 +369,6 @@ WEB_CAPTIONS = [
 TERMINAL_CAPTIONS = [
     "A real shell, recorded.",
     "Any command works.",
-    "A failing one is caught.",
     "",
     PROBE_CAPTION,
     "",
@@ -750,20 +819,20 @@ _TRAIL_JS = """() => {
 
 
 def record_web(
-    out_dir: Path, base_url: str, refused_url: str
+    out_dir: Path, base_url: str
 ) -> tuple[list[str], Rect, Rect, tuple[int, int]]:
-    """Land, read a KPI, filter the table, refresh it — on a broken page.
+    """Land, read a KPI, filter the table, refresh it.
 
     Returns the post-condition failures plus two content rects: where the app
     sits inside the composited video, and where it sits in a still (stills are
     captured full-bleed, before compositing).
 
-    The page is loaded with `?console-error=1` and two doomed requests are
-    fired at it, so the take is also the fixture for the problem log: a demo
-    that looks perfect over an app that is throwing. Everything else here still
-    has to pass, because the *default* recorder tolerates all of it — that half
-    of the strict-mode assertion lives in this take, and only the other half
-    needs a take of its own.
+    A recording of a *working* app, and recorded with `strict=True` so it has
+    to stay one. That is the assertion the rest of this harness structurally
+    cannot make: every issue check elsewhere is "at least one of these
+    appeared", which a recorder that flagged every healthy response as fatal
+    would satisfy while refusing every real demo ever recorded. Here it would
+    raise, and take the whole take with it.
     """
     from demo_recording import Recorder
 
@@ -771,25 +840,21 @@ def record_web(
     outline = "el => getComputedStyle(el).outlineStyle"
     bg = "el => getComputedStyle(el).backgroundColor"
 
-    with Recorder(out_dir, base_url=base_url, speech=False) as rec:
-        rec.goto(WEB_PATH)
+    with Recorder(out_dir, base_url=base_url, speech=False, strict=True) as rec:
+        rec.goto("/")
         rec.wait_for("#kpi-rev")
-        # Not a verb, so no beat of its own: both failures are attributed to
-        # the `wait_for` beat still standing as the most recent one, which is
-        # what WEB_ISSUES asserts.
-        rec.page.evaluate(PROBE_FETCH_JS, refused_url)
         start_ticker(b, rec.page)
         # Doubles as the run-up for the *early* timing probe: the page has
         # finished painting and the caption band does not move until the
         # first caption. See MAX_CAPTION_SKEW_S.
         rec.pause(PROBE_QUIET_S)
         b.expect(
-            f"goto({WEB_PATH!r}), #rows row count",
+            "goto('/'), #rows row count",
             rec.page.locator("#rows tr").count(),
             5,
         )
         b.expect(
-            f"goto({WEB_PATH!r}), #status text",
+            "goto('/'), #status text",
             rec.page.locator("#status").inner_text(),
             "snapshot 1 of 3",
         )
@@ -797,7 +862,7 @@ def record_web(
         # legible-ish, which the luma metric scores around 10 — above its
         # floor. This resolves that case exactly, with no pixel threshold.
         b.expect(
-            "goto(…), #refresh background (did the stylesheet apply?)",
+            "goto('/'), #refresh background (did the stylesheet apply?)",
             rec.page.eval_on_selector("#refresh", bg),
             "rgb(235, 110, 20)",
         )
@@ -923,7 +988,7 @@ def record_terminal(
             tail = " ".join(str(exc).split())[:200]
             b.fail_if(True, f"after {after}, the shell prompt never came back — {tail}")
 
-    with TerminalRecorder(out_dir, speech=False) as rec:
+    with TerminalRecorder(out_dir, speech=False, strict=True) as rec:
         start_ticker(b, rec.page)
         # Let xterm.js settle, and give the early timing probe below a
         # baseline that is not the browser's first paint. See
@@ -946,14 +1011,6 @@ def record_terminal(
         expect_screen(rec, "run('ls -1')", r"^skills$")
         rec.pause(0.8)
         rec.shot("02-listing")
-
-        # A command that fails. The shell survives it (subshell), the screen
-        # shows nothing unusual, and the only evidence anywhere is the exit
-        # status the recorder reads off the prompt — which is the point.
-        rec.caption("A failing one is caught.")
-        check_caption(b, rec.page, "A failing one is caught.")
-        rec.run(TERMINAL_FAILING_COMMAND)
-        expect_prompt(rec, f"run({TERMINAL_FAILING_COMMAND!r})")
 
         rec.caption("")
         check_caption(b, rec.page, "")
@@ -1534,7 +1591,7 @@ def _first_difference(actual: list, expected: list) -> object:
 def check_issues(
     label: str,
     out_dir: Path,
-    expected: list[tuple[str, str, str]],
+    expected: list[dict],
     exit_codes: dict[str, int] | None = None,
 ) -> list[str]:
     """The problems the take noticed, as `timeline.json` records them.
@@ -1585,7 +1642,8 @@ def check_issues(
             break
 
     # -- the problems the storyboard deliberately caused ---------------------
-    for kind, needle, verb in expected:
+    for want in expected:
+        kind, needle, verb = want["kind"], want["needle"], want["verb"]
         found = [
             i
             for i in issues
@@ -1600,6 +1658,17 @@ def check_issues(
             continue
         issue = found[0]
         index = issue.get("beat")
+        if verb is None:
+            # Fired where no beat was open. Naming one anyway is the failure
+            # mode being guarded: a confident index and a quoted caption, both
+            # invented. `beat: null` is the right answer and the only one.
+            if index is not None or issue.get("verb") is not None:
+                failures.append(
+                    f"{label}: the {kind} {needle!r} fired between beats, with "
+                    f"none open, but is attributed to beat {index!r} "
+                    f"({issue.get('verb')!r}) — the attribution is invented"
+                )
+            continue
         # Both halves matter. `verb` alone is a string the recorder could have
         # copied from anywhere; `beat` alone is an integer that means nothing
         # on its own. Together they say the issue points at a real beat, and
@@ -1616,6 +1685,16 @@ def check_issues(
                 f"{label}: the {kind} {needle!r} fired during {verb!r} but is "
                 f"attributed to beat {index} "
                 f"({beats[index].get('verb')!r}/{issue.get('verb')!r})"
+            )
+            continue
+        # The caption recorded beside an issue is the one a reviewer reads as
+        # context. Quoting a line that only appeared *after* the error is worse
+        # than quoting none, and is exactly what naming a later beat produces.
+        if "caption" in want and issue.get("caption") != want["caption"]:
+            failures.append(
+                f"{label}: the {kind} {needle!r} is recorded under caption "
+                f"{issue.get('caption')!r}, but the line on screen when it "
+                f"fired was {want['caption']!r}"
             )
 
     # -- every command's exit status, on the beat that ran it ----------------
@@ -1647,9 +1726,15 @@ def check_issues(
             f"timeline.md has no Issues section — the human-readable half of "
             f"the log says the take was fine"
         )
-    for _, needle, _ in expected:
-        if needle not in markdown:
-            failures.append(f"{label}: timeline.md does not mention {needle!r}")
+    for want in expected:
+        if want["needle"] not in markdown:
+            failures.append(f"{label}: timeline.md does not mention {want['needle']!r}")
+    if exit_codes is not None and "| exit |" not in markdown:
+        failures.append(
+            f"{label}: timeline.md's beat table has no exit column, so a run() "
+            f"whose status could not be read is invisible in the half SKILL.md "
+            f"calls the take's own account of what ran"
+        )
 
     fatal = [i for i in issues if i.get("kind") in STRICT_KINDS]
     if not fatal:
@@ -1667,6 +1752,50 @@ def check_issues(
             f"smoke: {label} timeline.json records {len(issues)} problem(s), "
             f"{len(fatal)} of them fatal under strict — take still passed"
         )
+    return failures
+
+
+def check_healthy(label: str, out_dir: Path) -> list[str]:
+    """A take of a working app must have found nothing to report.
+
+    This is the only assertion in the file that can fail on *over*-reporting,
+    and without it the whole axis is one-directional. Every problem check is
+    "at least one issue matches", which a recorder that flagged every healthy
+    2xx as a fatal console error satisfies perfectly — while refusing every
+    strict take of every working app ever recorded. Verified as a real gap:
+    that exact injection passed the suite before this existed.
+
+    The take is also recorded with `strict=True`, so over-reporting does not
+    merely get noticed here, it aborts the take and is impossible to miss.
+    """
+    json_path = out_dir / "timeline.json"
+    if not json_path.is_file():
+        return [f"{label}: {json_path} was never written"]
+    try:
+        doc = json.loads(json_path.read_text())
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return [f"{label}: {json_path} is not valid JSON: {exc}"]
+
+    failures: list[str] = []
+    if doc.get("strict") is not True:
+        failures.append(
+            f"{label}: timeline.json says strict={doc.get('strict')!r}; this "
+            f"take is recorded strict, and its passing means nothing otherwise"
+        )
+    issues = doc.get("issues")
+    if not isinstance(issues, list):
+        failures.append(f"{label}: timeline.json has no `issues` list ({issues!r})")
+    elif issues or doc.get("issue_count"):
+        failures.append(
+            f"{label}: nothing is wrong with the fixture app, but the take "
+            f"recorded {doc.get('issue_count')!r} problem(s): "
+            f"{[(i.get('kind'), i.get('message')) for i in issues]!r}. Either "
+            f"the recorder reports healthy behaviour as broken — which would "
+            f"refuse every strict take of every working app — or the fixture "
+            f"really did break."
+        )
+    if not failures:
+        print(f"smoke: {label} healthy app under strict=True records no problems")
     return failures
 
 
@@ -1790,17 +1919,22 @@ def check_take(
 # -- phases ------------------------------------------------------------------
 
 
+def refused_url() -> str:
+    """A URL nothing will answer.
+
+    free_port() binds only long enough to be told a number and lets go, so a
+    request to it is refused at connect rather than answered — which is the
+    `request_failed` shape, distinct from the 404 that `http_error` grades.
+    """
+    return f"http://127.0.0.1:{free_port()}/refused"
+
+
 def run_web(out_root: Path) -> list[str]:
     out_dir = fresh_take_dir(out_root, "web")
     started = time.time()
-    # Nothing is listening here: free_port() binds only long enough to be told
-    # a number and lets go, so a request to it is refused rather than answered.
-    refused_url = f"http://127.0.0.1:{free_port()}/refused"
     with fixture_server() as base_url:
         try:
-            problems, video_rect, still_rect, size = record_web(
-                out_dir, base_url, refused_url
-            )
+            problems, video_rect, still_rect, size = record_web(out_dir, base_url)
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"web: Recorder raised {type(exc).__name__}: {exc}"]
     return (
@@ -1816,8 +1950,121 @@ def run_web(out_root: Path) -> list[str]:
             size,
         )
         + check_timeline("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
-        + check_issues("web", out_dir, WEB_ISSUES)
+        + check_healthy("web", out_dir)
     )
+
+
+def run_web_problems(out_root: Path) -> list[str]:
+    """A short take of a page broken in four ways, under the default.
+
+    Deliberately not the graded take: the reference demo should be a recording
+    of a working app, and a fixture hook gets a take of its own. Everything
+    interesting here is in timeline.json, so nothing about the video is graded.
+    """
+    from demo_recording import Recorder
+
+    out_dir = fresh_take_dir(out_root, "web-problems")
+    dead = refused_url()
+    with fixture_server() as base_url:
+        try:
+            with Recorder(out_dir, base_url=base_url, speech=False) as rec:
+                rec.goto(web_problem_path(dead))
+                rec.wait_for("#kpi-rev")
+
+                # No beat is open here. Whatever this logs must come back with
+                # `beat: null` rather than the closed `wait_for` above it.
+                rec.page.evaluate(BETWEEN_BEATS_JS)
+
+                rec.caption(LATE_BOOM_CAPTION)
+                # Armed *before* the hold, fired one second into it. Nothing
+                # else in the take reaches Playwright during that second.
+                rec.page.evaluate(LATE_BOOM_JS)
+                rec.pause(LATE_BOOM_HOLD_S)
+                rec.caption("The caption after the boom.")
+        except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+            return [f"web-problems: Recorder raised {type(exc).__name__}: {exc}"]
+    return check_issues("web-problems", out_dir, WEB_PROBLEM_ISSUES)
+
+
+def run_terminal_problems(out_root: Path) -> list[str]:
+    """A short take of commands that fail, under the default."""
+    if os.name != "posix":
+        return []
+    from demo_recording import TerminalRecorder
+
+    out_dir = fresh_take_dir(out_root, "terminal-problems")
+    try:
+        with TerminalRecorder(out_dir, speech=False) as rec:
+            rec.caption("Exit codes are recorded.")
+            rec.run("echo ok")
+            rec.wait_for_prompt(timeout_s=15)
+            rec.run(TERMINAL_FAILING_COMMAND)
+            rec.wait_for_prompt(timeout_s=15)
+            # Two commands, one wait. The shell buffers the second and runs it
+            # after the first, so both statuses arrive — in order, and to
+            # different beats. This pair is the regression, not decoration.
+            rec.run(TERMINAL_UNWAITED[0])
+            rec.run(TERMINAL_UNWAITED[1])
+            rec.wait_for_prompt(timeout_s=20)
+    except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+        return [
+            f"terminal-problems: TerminalRecorder raised {type(exc).__name__}: {exc}"
+        ]
+    return check_issues(
+        "terminal-problems",
+        out_dir,
+        TERMINAL_PROBLEM_ISSUES,
+        exit_codes=TERMINAL_PROBLEM_EXIT_CODES,
+    )
+
+
+def run_terminal_race(out_root: Path) -> list[str]:
+    """A shell too slow to have prompted before run() types.
+
+    Its own take because the condition has to be manufactured: on a normal box
+    the startup prompt always beats the first command, so every other take
+    here passes whether or not the recorder handles this. Removing the guard
+    and running the rest of the suite is a pass — measured.
+    """
+    if os.name != "posix":
+        return []
+    from demo_recording import TerminalRecorder
+
+    label = "terminal-race"
+    out_dir = fresh_take_dir(out_root, label)
+    shell = out_dir / "slow-shell"
+    shell.write_text(
+        TERMINAL_RACE_SHELL.replace("__DELAY__", str(TERMINAL_RACE_DELAY_S))
+    )
+    shell.chmod(0o755)
+    try:
+        with TerminalRecorder(
+            out_dir, speech=False, shell=str(shell), type_delay_ms=0
+        ) as rec:
+            rec.run(TERMINAL_RACE_COMMAND)
+            rec.wait_for_prompt(timeout_s=25)
+    except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+        return [f"{label}: TerminalRecorder raised {type(exc).__name__}: {exc}"]
+
+    doc = json.loads((out_dir / "timeline.json").read_text())
+    logged = {
+        str(b.get("selector")): b.get("exit_code")
+        for b in doc.get("beats", [])
+        if b.get("verb") == "run"
+    }
+    if logged != {TERMINAL_RACE_COMMAND: TERMINAL_RACE_EXIT}:
+        return [
+            f"{label}: a shell that took {TERMINAL_RACE_DELAY_S}s to start made "
+            f"run() log {logged!r}, not "
+            f"{{{TERMINAL_RACE_COMMAND!r}: {TERMINAL_RACE_EXIT}}}. The startup "
+            f"prompt's own status was taken for the command's — a wrong exit "
+            f"code, which passes strict, rather than a missing one."
+        ]
+    print(
+        f"smoke: {label} exit status survives a shell that starts "
+        f"{TERMINAL_RACE_DELAY_S}s late (logged {TERMINAL_RACE_EXIT})"
+    )
+    return []
 
 
 def check_strict_failure(
@@ -1898,11 +2145,12 @@ def run_strict_web(out_root: Path) -> list[str]:
     from demo_recording import Recorder
 
     out_dir = fresh_take_dir(out_root, "web-strict")
+    dead = refused_url()
     raised: BaseException | None = None
     with fixture_server() as base_url:
         try:
             with Recorder(out_dir, base_url=base_url, speech=False, strict=True) as rec:
-                rec.goto(WEB_PATH)
+                rec.goto(web_problem_path(dead))
                 rec.wait_for("#kpi-rev")
                 rec.caption(STRICT_CAPTION)
         except Exception as exc:  # noqa: BLE001 - the raise is the assertion
@@ -1965,9 +2213,7 @@ def run_terminal(out_root: Path) -> list[str]:
         + check_timeline(
             "terminal", out_dir, started, TERMINAL_BEATS, TERMINAL_CAPTIONS, size
         )
-        + check_issues(
-            "terminal", out_dir, TERMINAL_ISSUES, exit_codes=TERMINAL_EXIT_CODES
-        )
+        + check_healthy("terminal", out_dir)
     )
 
 
@@ -2031,12 +2277,15 @@ def main() -> int:
             failures += run_web(out_root)
         if not args.web_only:
             failures += run_terminal(out_root)
-        # After the graded takes, never instead of them: these two record
+        # After the graded takes, never instead of them: these four record
         # nothing worth looking at, and if a recorder is broken the messages
         # above are the ones that say how.
         if not args.terminal_only:
+            failures += run_web_problems(out_root)
             failures += run_strict_web(out_root)
         if not args.web_only:
+            failures += run_terminal_problems(out_root)
+            failures += run_terminal_race(out_root)
             failures += run_strict_terminal(out_root)
     except SmokeFailure as exc:
         failures.append(str(exc))


### PR DESCRIPTION
Fixes #3.

A demo that looks perfect while throwing `TypeError` on every render passed
review, and `TerminalRecorder.run()` ignored exit codes, so a failing command
sailed past unnoticed.

Wires `console` / `pageerror` / `requestfailed` / non-2xx responses, attributed
to the beat that was active when they fired (using the beat log from #6), plus
the exit status of every terminal command. All of it lands in `timeline.json`
and a new Issues section in `timeline.md`, and prints as an end-of-take summary
regardless of tooling.

`Recorder(..., strict=True)` refuses the take on `console_error`, `page_error`
or `nonzero_exit` — raised from `__exit__` **after** the mp4, stills and
timeline are written, since a broken take is the one worth looking at.

`TIMELINE_SCHEMA` stays at 1. Every change adds a key; none changes meaning or
type, which is what the contract comment permits without a bump.

Exit status is read via an OSC escape carrying `$?` embedded in the shell's
PS1, stripped from the PTY stream before xterm.js renders it — so nothing
types `echo $?` into the demo. Bash-shaped; a shell that does not expand `$?`
in its prompt yields `exit_code: null` rather than a wrong number.

## What strict does NOT catch — documented, not engineered around

Chromium writes its own console error for anything that 404s, so a strict take
fails on a missing favicon. Filtering that would mean pattern-matching
Chromium's English console wording, which is worse. `console_warning`,
`request_failed` and `http_error` are recorded but not fatal. Nothing catches
what the app swallows — a caught exception, a silently wrong render, a 200
with wrong data.

## Verification

Eleven fault injections, each watched fail: unsubscribed listeners, misattributed
beats, discarded exit status, `nonzero_exit` dropped from `STRICT_KINDS`, the
Issues section removed from `timeline.md`, an off-by-one `issue_count`, the
strict raise deleted, a strict message that does not name the beat, strict
forced on by default, the raise moved ahead of the artifact writes, and an
out-of-contract issue kind.

## Found on the way — read #25 before relying on strict mode

`TerminalRecorder`'s background init script dereferences
`document.documentElement` on Chromium's initial empty document, where it is
null, so **every terminal take throws an uncaught TypeError before its first
beat**. Pre-existing; this PR's instrumentation is what made it visible.
Consequence: `strict=True` currently fails every terminal take regardless of
the demo. Deliberately not fixed here (three PRs are queued against
`terminal.py`), and the smoke assertions are immune to it.

Unverified and documented in `tests/README.md`: the 200-issue cap, a `run()`
never followed by `wait_for_prompt()`, non-bash shells, segments, and
`console_warning` (implemented, nothing emits one).