### PR TITLE
Determinism controls: frozen clock, fixed locale, disabled animation

### DIFF
--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -31,6 +31,13 @@ and a real terminal session (voice on):
 - **`record.py`** — the storyboard that produced the media, and the thing
   that actually gets committed: re-runnable after the UI changes, so the
   video stays out of git history and is regenerated rather than archived.
+- **A recording that reproduces, when you ask for it** — the browser's
+  timezone and locale are always pinned, and `Recorder(deterministic=True)`
+  additionally freezes the page's clock and flattens animations, so the same
+  storyboard gives you the same stills rather than a new set of timestamps.
+  Opt-in because a stopped clock changes what a debounce, a token check or an
+  elapsed-time bar does, usually without saying so; `SKILL.md` shows the five
+  shapes that break and what the recorder cannot pin at all.
 - **Spoken narration (optional)** — with `ELEVENLABS_API_KEY` set, every
   caption line is synthesized via ElevenLabs and mixed onto the mp4 at the
   moment it appears. Clips are cached; pacing self-adjusts so speech is
@@ -80,6 +87,10 @@ win over env vars.
 | `DEMO_VIDEO_TERMINAL_SHELL` | shell `TerminalRecorder` launches | `/bin/bash` |
 | `DEMO_VIDEO_TERMINAL_FONT_SIZE` | `TerminalRecorder` font px | `15` |
 | `DEMO_VIDEO_VIEWPORT` | recording size, `"1280x720"` | 1280×720 |
+| `DEMO_VIDEO_DETERMINISTIC` | freeze the page clock and flatten motion (`1`/`0`) | **off** |
+| `DEMO_VIDEO_CLOCK` | instant the clock is frozen at, when it is (ISO 8601) | `2025-01-01T09:00:00Z` |
+| `DEMO_VIDEO_TIMEZONE` | browser timezone (always applied) | `UTC` |
+| `DEMO_VIDEO_LOCALE` | browser locale (always applied) | `en-US` |
 | `DEMO_VIDEO_SPEECH` | force narration on/off (`1`/`0`) | auto by API key |
 | `DEMO_VIDEO_VOICE_ID` | ElevenLabs voice | Sarah (premade) |
 | `DEMO_VIDEO_SPEECH_MODEL` | ElevenLabs model | `eleven_multilingual_v2` |

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -122,6 +122,10 @@ clean:
 | `DEMO_VIDEO_TERMINAL_SHELL` | shell `TerminalRecorder` launches | `/bin/bash` |
 | `DEMO_VIDEO_TERMINAL_FONT_SIZE` | `TerminalRecorder` font px | `15` |
 | `DEMO_VIDEO_VIEWPORT` | recording size, `"1280x720"` | 1280×720 |
+| `DEMO_VIDEO_DETERMINISTIC` | freeze the page clock and flatten motion (`1`/`0`) — see **Determinism** | **off** |
+| `DEMO_VIDEO_CLOCK` | the instant the page's clock is frozen at, when it is (ISO 8601) | `2025-01-01T09:00:00Z` |
+| `DEMO_VIDEO_TIMEZONE` | browser timezone (`timezone_id`), always applied | `UTC` |
+| `DEMO_VIDEO_LOCALE` | browser locale (`locale`), always applied | `en-US` |
 | `DEMO_VIDEO_SPEECH` | force narration on/off (`1`/`0`) | auto by API key |
 | `DEMO_VIDEO_STRICT` | fail the take on console errors / non-zero exits (`1`/`0`) | off |
 | `DEMO_VIDEO_VOICE_ID` | ElevenLabs voice | Sarah (premade) |
@@ -166,6 +170,125 @@ needed; captions are the narration script.
   ElevenLabs Scribe and compare against the caption lines.
 - Segments all get an audio track (silence if a segment has no lines), so
   `stitch()` still concatenates losslessly.
+
+## Determinism
+
+Re-recording a storyboard should produce the same video. That is what makes a
+still diffable against the one committed last month, and what makes "did the UI
+actually change?" answerable instead of "the video is different, they always
+are". But the controls that get you there are not equally safe, so they are not
+switched on together.
+
+**Always on, in every recording:**
+
+| Control | What it does |
+|---|---|
+| **Fixed timezone and locale** | The context is pinned to `UTC` / `en-US`, so every date, number and currency the app formats reads the same on your laptop as in CI. |
+| **`prefers-reduced-motion: reduce`** | Requested on the context. An app that honours it was built to. |
+
+**Opt-in, with `deterministic=True`:**
+
+| Control | What it does |
+|---|---|
+| **Frozen wall clock** | `Date.now()`, `new Date()`, `Intl.DateTimeFormat().format()`, `performance.timeOrigin`, `document.lastModified` and a `Worker`'s clock all answer one fixed instant — `2025-01-01T09:00:00Z` by default. Explicit arguments (`new Date(iso)`), `Date.parse` and `Date.UTC` are untouched. |
+| **Flattened motion** | Animations and transitions are compressed to 1 ms, so they land on their finished state within the first frame. Authored delays and fill-modes are left alone. |
+
+```python
+with Recorder(out_dir, deterministic=True) as rec:   # or DEMO_VIDEO_DETERMINISTIC=1
+```
+
+### Why the clock is opt-in — read this before turning it on
+
+**A frozen clock breaks apps, and it usually breaks them silently.** Five
+ordinary patterns, each recorded both ways against a real page:
+
+| Pattern | With the clock frozen | Actually |
+|---|---|---|
+| lodash-shaped debounce (`now - last >= wait`) | never fires; the timer reschedules forever | fires |
+| elapsed-time progress bar | sticks at `0%` | reaches `100%` |
+| token gate (`nbf`/`exp` around now) | "not yet valid (clock skew)" | "signed in" |
+| "last 7 days" chart | draws **0** bars | draws 7 |
+| `while (Date.now() - t0 < ms)` spin | never exits — the take dies on a navigation timeout with **no mp4 written**, and nothing in the error mentions the clock | exits |
+
+Four of the five produce **a plausible wrong screen**: no exception, nothing on
+the console, nothing in `timeline.json` — just a demo that confidently shows a
+reviewer something the app never does. That is a worse outcome than a fresh
+timestamp in every take, which is why you have to ask for it.
+
+So: turn it on deliberately, and **check the stills against the real app the
+first time you do**. If something looks wrong, try moving the frozen instant
+first (`clock="2026-03-01T12:00:00Z"`, so tokens minted at record time are
+still valid), and drop back to the default if the app needs a moving clock.
+
+Every take records what it was given, in `timeline.json`:
+
+```json
+"determinism": { "deterministic": true, "clock": "2025-01-01T09:00:00Z",
+                 "timezone_id": "UTC", "locale": "en-US" }
+```
+
+`"clock": null` means the page's clock was live. Commit it with the stills: a
+year from now it is the only thing that says whether a diff is the UI changing
+or the frozen instant changing.
+
+### Keeping something animated
+
+Motion is flattened to 1 ms rather than to zero on purpose — a transition of
+zero duration never starts, so it never fires `transitionend`, and every
+accordion, modal, carousel and wizard that advances on that event would stall.
+An element that must keep *moving* opts out by name:
+
+```html
+<div class="pulse" data-demo-video-animate>…</div>
+```
+
+The recorder's own overlays (`#__demo…`, `#__term…`) are exempt already, so
+captions still fade. And note what is *not* frozen: `performance.now()`,
+`requestAnimationFrame`, and the document animation timeline. Only the wall
+clock stops. Freezing monotonic time would stop the compositor, and Chromium's
+screencast only emits a frame when the page paints — a still page loses wall
+time out of the recording ([#18](https://github.com/rogvid/skills/issues/18)).
+
+One shape has no right answer and gets a deliberate one: an **infinite**
+animation has no finished state, so it is stopped after a single 1 ms iteration
+and the element shows the style it was declared with. A finite animation —
+including `alternate` — ends where the browser would have left it.
+
+### What it cannot control
+
+The recorder drives a browser. Everything below is upstream of it and is the
+**storyboard author's** job — a demo that ignores them re-records differently
+no matter what this section does:
+
+- **The app's own randomness.** `Math.random()`, `crypto.randomUUID()`,
+  generated ids, shuffled lists, faker-seeded fixtures. Nothing here seeds
+  them. Seed the app yourself (most frameworks and fixture libraries take a
+  seed), or pick a screen that has none.
+- **Server data.** Rows a backend returns, "5 minutes ago" rendered
+  server-side, anything a background job wrote since the last take. Seed the
+  state *before* recording and reset it between takes; storyboards are meant
+  to be idempotent (see Process, step 2).
+- **Network timing.** Which of two requests lands first, whether a spinner is
+  on screen long enough to be photographed, a chart that draws before or after
+  its data arrives. `wait_for` a concrete element rather than a delay, and
+  never assert on a frame that only exists while something is in flight.
+- **The terminal recorder's program.** `TerminalRecorder` runs a real PTY
+  child; it does not see the frozen clock, so `date` in a terminal demo prints
+  the real time. Tracked in [#26](https://github.com/rogvid/skills/issues/26).
+- **Animation the browser does not drive with CSS.** `element.animate()` (Web
+  Animations), `requestAnimationFrame` loops, canvas and WebGL keep running —
+  no stylesheet can reach them
+  ([#35](https://github.com/rogvid/skills/issues/35)). Nor can one reach into
+  a shadow root, or outrank an app's own `!important`
+  ([#36](https://github.com/rogvid/skills/issues/36)).
+- **A module worker's clock.** A classic `Worker` gets the freeze re-injected;
+  `{type: "module"}` workers, shared workers and service workers do not
+  ([#38](https://github.com/rogvid/skills/issues/38)).
+- **The bytes of `demo.mp4`.** H.264 is not byte-reproducible and the
+  screencast's frame timing is not either. Two takes match in what they *show*,
+  not in their checksums — compare the stills, which are lossless PNGs and do
+  reproduce exactly.
+
 
 ## Recorder API (storyboard verbs)
 
@@ -456,7 +579,10 @@ with TerminalRecorder(Path(__file__).parent) as rec:
 
 1. **Pick a demo story that is deterministic, and know where the slow
    parts are.** Prefer flows the app completes on its own in seconds. Seed
-   needed state *before* recording starts. If the story includes minutes
+   needed state *before* recording starts. The recorder pins the browser's
+   timezone and locale for you, and will freeze its clock if you ask (see
+   **Determinism**); the app's own randomness and its server data are yours to
+   pin down. If the story includes minutes
    of real background work, don't record the wait — record **segments**:
    `Recorder(out_dir, segment="part1")`, poll between segments until the
    work is done, open the next segment with `rec.interlude("…a few minutes

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -22,6 +22,7 @@ SKILL.md for the full variable list.
 
 from __future__ import annotations
 
+import datetime as _dt
 import functools
 import hashlib
 import json
@@ -116,6 +117,241 @@ window.__demoBridge = (text) => {
 """
 
 
+# -- determinism -------------------------------------------------------------
+#
+# Re-recording a storyboard should produce the same video, or "did the UI
+# actually change?" is unanswerable and last month's committed still cannot be
+# compared with today's. Three things *in the browser* make it not: the wall
+# clock, locale/timezone formatting, and animation phase.
+#
+# They are not equally safe to pin, so they are not pinned together:
+#
+#   * **Timezone, locale and `prefers-reduced-motion` are always on.** They cost
+#     an app nothing — an app that honours reduced motion was built to — and
+#     they remove the difference between a recording made on a laptop in
+#     Tórshavn and one made on a CI runner.
+#
+#   * **The frozen clock and the motion rule are opt-in** (`deterministic=True`,
+#     `DEMO_VIDEO_DETERMINISTIC=1`). Both change what an app *does*, and mostly
+#     they do it silently. Measured on five adversarial pages: a lodash-shaped
+#     debounce never fires because `now - last` is always 0, an elapsed-time bar
+#     sticks at 0%, a token gate renders "not yet valid", a "last 7 days" chart
+#     draws no bars — four of the five produce a plausible wrong screen with no
+#     exception, nothing on the console, and nothing in timeline.json. The fifth
+#     wedges a `while (Date.now() - t0 < ms)` spin until the navigation times
+#     out and no mp4 is written at all. A demo recorder whose default can put a
+#     confidently wrong screen in front of a reviewer is worse than one that
+#     records a fresh timestamp each take, so the default records the truth and
+#     the storyboard asks for reproducibility when it wants it.
+#
+# What the freeze deliberately leaves alone: `performance.now()`, the document
+# animation timeline, and `requestAnimationFrame`. Only the *wall* clock stops.
+# Freezing monotonic time as well would stop the compositor, and a page that
+# never paints is a page Chromium's screencast never records — it would lose
+# wall time (issue #18) in exchange for determinism it does not need. It is also
+# why an element that opts out of the motion rule below still animates: nothing
+# here touches the clock its animation runs on.
+DEFAULT_CLOCK = "2025-01-01T09:00:00Z"
+DEFAULT_TIMEZONE = "UTC"
+DEFAULT_LOCALE = "en-US"
+
+# Freeze the wall clock at a fixed instant: `Date.now()` and `new Date()` stop
+# moving, so a rendered timestamp, a "3 minutes ago", or a date-formatted cell
+# reads the same in every take.
+#
+# Every line below closes a hole that was measured open, so none of it is
+# defensive decoration:
+#
+#   * `Date.now` is *defined on the real constructor*, once, as a named
+#     function — not synthesized by a proxy `get` trap. A trap mints a new
+#     arrow function per read, so `Date.now !== Date.now`, its `.name` is "",
+#     and `Object.getOwnPropertyDescriptor(Date, 'now').value` is the real
+#     clock the trap never saw.
+#   * `Date.prototype.constructor` is repointed at the proxy. Left alone it is
+#     the *unproxied* Date, which makes `Date.prototype.constructor === Date`
+#     false — a live type-detection idiom in deep-clone and serialization
+#     helpers — and hands out an unfrozen clock via `new Date().constructor`.
+#   * `Intl.DateTimeFormat.prototype.format()` with no argument formats "now"
+#     from the *internal* clock, which no patch of the `Date` global reaches.
+#     It is the highest-impact hole of the set: it is how apps render dates.
+#   * `performance.timeOrigin` and `document.lastModified` are wall-clock
+#     readings that survive everything above.
+#   * A `Worker` gets its own global, so init scripts never run there. The
+#     wrapper re-injects the freeze ahead of the real script via a blob
+#     shim. Module workers cannot `importScripts` and are passed through
+#     unfrozen (issue #29).
+_FROZEN_CLOCK_JS = """
+(() => {
+  const FIXED = __EPOCH_MS__;
+
+  // Shared by the page and by the worker shim below, hence a named function
+  // whose source can be stringified rather than a closure.
+  function __demoFreezeDate(scope, FIXED) {
+    const Real = scope.Date;
+    const now = function now() { return FIXED; };
+    Real.now = now;
+    // Only the zero-argument "what time is it" forms are answered from the
+    // freeze; explicit arguments, Date.parse and Date.UTC pass straight
+    // through. A Proxy rather than a subclass because `Date()` called as a
+    // function must return a string, which a class cannot do.
+    const Frozen = new Proxy(Real, {
+      apply: () => new Real(FIXED).toString(),
+      construct: (t, args, nt) =>
+        Reflect.construct(t, args.length ? args : [FIXED], nt),
+    });
+    scope.Date = Frozen;
+    Object.defineProperty(Real.prototype, 'constructor',
+      {value: Frozen, writable: true, configurable: true});
+    return Real;
+  }
+
+  const Real = __demoFreezeDate(window, FIXED);
+
+  // Intl reads its own clock, not the global Date.
+  const proto = Intl.DateTimeFormat.prototype;
+  for (const name of ['format', 'formatToParts']) {
+    const desc = Object.getOwnPropertyDescriptor(proto, name);
+    if (!desc) continue;
+    if (desc.get) {
+      // V8 exposes `format` as a getter returning a bound formatter.
+      Object.defineProperty(proto, name, {
+        configurable: true,
+        get() {
+          const bound = desc.get.call(this);
+          return function (value, ...rest) {
+            return bound(value === undefined ? FIXED : value, ...rest);
+          };
+        },
+      });
+    } else if (typeof desc.value === 'function') {
+      const real = desc.value;
+      Object.defineProperty(proto, name, {
+        configurable: true, writable: true,
+        value: function (value, ...rest) {
+          return real.call(this, value === undefined ? FIXED : value, ...rest);
+        },
+      });
+    }
+  }
+
+  try {
+    Object.defineProperty(performance, 'timeOrigin',
+      {configurable: true, get: () => FIXED});
+  } catch (e) { /* non-fatal: one reading of many */ }
+
+  try {
+    const d = new Real(FIXED);
+    const pad = (n) => String(n).padStart(2, '0');
+    const stamp = pad(d.getMonth() + 1) + '/' + pad(d.getDate()) + '/'
+      + d.getFullYear() + ' ' + pad(d.getHours()) + ':' + pad(d.getMinutes())
+      + ':' + pad(d.getSeconds());
+    Object.defineProperty(document, 'lastModified',
+      {configurable: true, get: () => stamp});
+  } catch (e) { /* non-fatal */ }
+
+  const RealWorker = window.Worker;
+  if (typeof RealWorker === 'function') {
+    const prelude = '(' + __demoFreezeDate.toString() + ')(self,' + FIXED + ');';
+    window.Worker = class Worker extends RealWorker {
+      constructor(url, options) {
+        let target = url;
+        try {
+          if (!options || options.type !== 'module') {
+            const absolute = new URL(url, location.href).href;
+            const src = prelude + '\\nimportScripts('
+              + JSON.stringify(absolute) + ');';
+            target = URL.createObjectURL(
+              new Blob([src], {type: 'text/javascript'}));
+          }
+        } catch (e) { target = url; }
+        super(target, options);
+      }
+    };
+  }
+})();
+"""
+
+# Land every animation and transition on its finished state, so no frame of the
+# recording depends on when the take happened to start.
+#
+# **1 ms, not 0s.** A transition with a combined duration of zero never starts,
+# and a transition that never starts fires no `transitionend` — which stalls
+# every accordion, modal, carousel and wizard that advances on that event, and
+# does it in a way no amount of "move the frozen instant" advice helps with.
+# One millisecond is over before the first frame is composited and still fires
+# the whole event sequence.
+#
+# **Authored delays are left alone.** Forcing `animation-delay: 0s` made a
+# snackbar declared `dismiss .4s ease 4s forwards` invisible from frame zero:
+# the four seconds it is meant to be readable collapsed to nothing. A delay is
+# measured from the animation's own start, not from the wall clock, so honouring
+# it costs no reproducibility.
+#
+# **`animation-fill-mode` is left alone too.** Forcing `forwards` looks like it
+# guards content that animates in from `opacity: 0`, but such content is always
+# authored `forwards` already — and forcing it makes an `alternate` animation
+# hold the far keyframe instead of returning, which is not where the browser
+# would have left it. `iteration-count: 1` is forced, because an *infinite*
+# animation has no finished state to land on and would otherwise resample every
+# frame; a finite one ends where it would have ended.
+#
+# Two things are spared, and both matter:
+#   * the recorder's own overlays (`#__demo…`, `#__term…`) — their motion is
+#     triggered by the storyboard, so it is already as repeatable as the
+#     storyboard is, and killing it would only make captions pop;
+#   * anything carrying `data-demo-video-animate` — the documented opt-out for
+#     an element that must keep painting. Chromium's screencast emits a frame
+#     when the page paints (issue #18), so "no motion at all" is not a free
+#     choice: a harness or a storyboard that needs the compositor awake marks
+#     the element it keeps alive, and this rule cannot match it.
+_FREEZE_MOTION_JS = """
+(() => {
+  const KEEP =
+    ':not([data-demo-video-animate]):not([id^="__demo"]):not([id^="__term"])';
+  // The pseudo-element arms are not padding: an animated ::after is the most
+  // common spinner on the web.
+  const CSS = ['', '::before', '::after'].map((p) => '*' + KEEP + p).join(',') + `{
+      animation-duration: 1ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 1ms !important;
+    }`;
+  const attach = () => {
+    const root = document.head || document.documentElement;
+    if (!root || document.getElementById('__demo_motion')) return;
+    const style = document.createElement('style');
+    style.id = '__demo_motion';
+    style.textContent = CSS;
+    root.appendChild(style);
+  };
+  // attach() self-guards on purpose. An init script runs before the document
+  // has a documentElement, and an appendChild that throws here would take the
+  // listener below with it — measured, and it silently left a real navigation
+  // with no rule at all while every other determinism control looked fine.
+  attach();
+  if (document.readyState === 'loading')
+    document.addEventListener('DOMContentLoaded', attach);
+})();
+"""
+
+
+def _clock_epoch_ms(value: str) -> int:
+    """Epoch milliseconds for a frozen-clock setting, given as ISO 8601.
+
+    A naive timestamp is read as UTC, so the frozen instant does not depend on
+    the recording machine's own timezone.
+    """
+    try:
+        parsed = _dt.datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RuntimeError(
+            f"DEMO_VIDEO_CLOCK must be an ISO 8601 timestamp like "
+            f"{DEFAULT_CLOCK!r}, got {value!r}"
+        ) from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+    return int(parsed.timestamp() * 1000)
+
+
 def _env(name: str, default: str | None = None) -> str | None:
     """A DEMO_VIDEO_-prefixed environment variable, or the default."""
     value = os.environ.get(f"DEMO_VIDEO_{name}", "").strip()
@@ -208,6 +444,10 @@ def tts_clip(
 #   segment       str?   — the segment name, or null for a whole demo
 #   media         str    — the mp4 this timeline describes, e.g. "demo.mp4"
 #   duration      float? — that mp4's real duration (ffprobe), null if absent
+#   determinism   dict   — the conditions the take was recorded under:
+#                          `deterministic` (was the clock frozen and motion
+#                          flattened), `clock` (the frozen instant, null when
+#                          the page's clock ran), `timezone_id`, `locale`
 #   beats         list   — the beats, in the order they ran
 #   strict        bool   — whether strict mode was on for this take
 #   issues        list   — the problems the take recorded (see "take issues")
@@ -505,6 +745,14 @@ class _DemoBase:
     and interlude line is also narrated — synthesized via ElevenLabs, cached
     in .tts/, and mixed onto the mp4 at the moment the line appeared. Pacing
     self-adjusts: a new line waits for the previous one to finish speaking.
+
+    Determinism: the timezone, the locale and `prefers-reduced-motion` are
+    always pinned. `deterministic=True` additionally freezes the page's wall
+    clock and lands animations on their finished state, so re-recording a
+    storyboard reproduces it — at the cost of changing what a clock-reading app
+    does, which is why it is opt-in. Either way it controls the *browser* only:
+    the app's own randomness, its server data, and network timing are the
+    storyboard author's to pin down. See the determinism section above.
     """
 
     def __init__(
@@ -519,6 +767,10 @@ class _DemoBase:
         voice_id: str | None = None,
         speech_model: str | None = None,
         strict: bool | None = None,
+        deterministic: bool | None = None,
+        clock: str | None = None,
+        timezone_id: str | None = None,
+        locale: str | None = None,
     ) -> None:
         # Every setting resolves explicit parameter > DEMO_VIDEO_* env var
         # > built-in default (see SKILL.md for the variable names).
@@ -551,6 +803,19 @@ class _DemoBase:
                 )
             viewport = (int(w), int(h))
         self._size = {"width": viewport[0], "height": viewport[1]}
+        # Determinism (see the section above). Opt-in, because the frozen clock
+        # and the motion rule change what an app does and mostly do it
+        # silently; timezone, locale and reduced motion are pinned regardless.
+        # The clock is parsed even when it is off, so a typo in
+        # DEMO_VIDEO_CLOCK is reported when it is written rather than the first
+        # time someone turns determinism on.
+        if deterministic is None:
+            deterministic = _env_flag("DETERMINISTIC")
+        self.deterministic = False if deterministic is None else bool(deterministic)
+        self._clock = clock or _env("CLOCK", DEFAULT_CLOCK)
+        self._clock_ms = _clock_epoch_ms(self._clock)
+        self._timezone_id = timezone_id or _env("TIMEZONE", DEFAULT_TIMEZONE)
+        self._locale = locale or _env("LOCALE", DEFAULT_LOCALE)
         api_key = os.environ.get("ELEVENLABS_API_KEY", "")
         if speech is None:
             speech = _env_flag("SPEECH")
@@ -619,6 +884,35 @@ class _DemoBase:
                 "enable spoken narration.",
                 file=sys.stderr,
             )
+        # ...and determinism state, at the same volume and for the same reason.
+        # Which clock produced a take is not visible in the video, and both
+        # answers surprise somebody: a frozen clock can hand a reviewer a
+        # confidently wrong screen, and a live one means two takes never match.
+        if self.deterministic:
+            print(
+                f"demo-video: determinism ON — the page's clock is frozen at "
+                f"{self._clock}, its timezone is {self._timezone_id}, its "
+                f"locale {self._locale}, and animations land on their finished "
+                f"state. Re-recording reproduces the take. But an app that "
+                f"*reads* the clock (a debounce, an elapsed-time bar, a token's "
+                f"validity window, a 'last 7 days' chart) can render a "
+                f"plausible wrong screen rather than failing loudly — check the "
+                f"stills against the app by hand this once, and pass "
+                f"deterministic=False (or DEMO_VIDEO_DETERMINISTIC=0) if "
+                f"anything looks off. See SKILL.md, 'Determinism'.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"demo-video: determinism OFF (the default) — timezone "
+                f"{self._timezone_id}, locale {self._locale} and reduced motion "
+                f"are still pinned, but the page's clock runs, so anything the "
+                f"app renders from it differs between takes and two recordings "
+                f"of this storyboard will not match. Recorder("
+                f"deterministic=True) freezes it; read SKILL.md's 'Determinism' "
+                f"section first, it changes what some apps do.",
+                file=sys.stderr,
+            )
 
     # -- subclass hooks -----------------------------------------------------
 
@@ -645,11 +939,27 @@ class _DemoBase:
         self._pw = sync_playwright().start()
         try:
             self._browser = self._pw.chromium.launch()
+            # Always pinned. Locale and timezone are context options rather
+            # than init scripts because a page cannot fake its own Intl data
+            # convincingly, and every date/number the app formats has to come
+            # out the same on a machine in Tórshavn as on a CI runner in
+            # us-east-1. None of the three changes what an app computes, so
+            # none of them is gated on `deterministic`.
             self._context = self._browser.new_context(
                 viewport=self._size,
                 record_video_dir=str(self._video_dir),
                 record_video_size=self._size,
+                locale=self._locale,
+                timezone_id=self._timezone_id,
+                reduced_motion="reduce",
             )
+            if self.deterministic:
+                # Opt-in: both of these change what an app *does*.
+                # The clock first, so the app's own scripts never see a live one.
+                self._context.add_init_script(
+                    _FROZEN_CLOCK_JS.replace("__EPOCH_MS__", str(self._clock_ms))
+                )
+                self._context.add_init_script(_FREEZE_MOTION_JS)
             # Overlays common to every medium.
             self._context.add_init_script(
                 _CAPTION_JS.replace("__CAPFONT__", str(self._caption_font_px))
@@ -984,6 +1294,17 @@ class _DemoBase:
             "segment": self.segment,
             "media": mp4.name,
             "duration": duration,
+            # Which clock produced this take. Without it a still committed to a
+            # repo carries no record of the conditions it was recorded under,
+            # and a future diff cannot tell "the UI changed" from "the frozen
+            # instant changed" — which is the one question this whole feature
+            # exists to answer. `clock` is null when the page's clock was live.
+            "determinism": {
+                "deterministic": self.deterministic,
+                "clock": self._clock if self.deterministic else None,
+                "timezone_id": self._timezone_id,
+                "locale": self._locale,
+            },
             "beats": self._beats,
             "strict": self._strict,
             "issues": self._issues,

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -200,6 +200,10 @@ class TerminalRecorder(_DemoBase):
         voice_id: str | None = None,
         speech_model: str | None = None,
         strict: bool | None = None,
+        deterministic: bool | None = None,
+        clock: str | None = None,
+        timezone_id: str | None = None,
+        locale: str | None = None,
         type_delay_ms: int = 45,
     ) -> None:
         # A branded, distinctive default prompt so wait_for_prompt's marker
@@ -210,6 +214,8 @@ class TerminalRecorder(_DemoBase):
             terminal_title=terminal_title, terminal_prompt=prompt,
             viewport=viewport, speech=speech, voice_id=voice_id,
             speech_model=speech_model, strict=strict,
+            deterministic=deterministic, clock=clock,
+            timezone_id=timezone_id, locale=locale,
         )
         # Match the web recorder's effective caption height. Web composites
         # its page into a scaled, centered window, lifting its bottom:44px

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -204,12 +204,18 @@ class Recorder(_DemoBase):
         voice_id: str | None = None,
         speech_model: str | None = None,
         strict: bool | None = None,
+        deterministic: bool | None = None,
+        clock: str | None = None,
+        timezone_id: str | None = None,
+        locale: str | None = None,
     ) -> None:
         super().__init__(
             out_dir, segment=segment, accent_rgb=accent_rgb,
             terminal_title=terminal_title, terminal_prompt=terminal_prompt,
             viewport=viewport, speech=speech, voice_id=voice_id,
             speech_model=speech_model, strict=strict,
+            deterministic=deterministic, clock=clock,
+            timezone_id=timezone_id, locale=locale,
         )
         self.base_url = (
             base_url or _env("BASE_URL", "http://localhost:8000")

--- a/tests/README.md
+++ b/tests/README.md
@@ -22,6 +22,7 @@ tests/
 tests/smoke                       # every take, output to a temp dir
 tests/smoke --web-only            # just the Playwright takes
 tests/smoke --terminal-only       # just the PTY/xterm.js takes
+tests/smoke --determinism-only    # just the three re-recording takes
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -46,19 +47,30 @@ smoke: web-strict strict=True refused the take, naming beat 0 (goto) (4 fatal is
 smoke: terminal-problems timeline.json records 2 problem(s), 2 of them fatal under strict — take still passed
 smoke: terminal-race exit status survives a shell that starts 1.2s late (logged 5)
 smoke: terminal-strict strict=True refused the take, naming beat 1 (run) (1 fatal issues, artifacts kept)
-
+smoke: determinism froze all four clocks identically in both takes
+smoke:   frozen  1/1/2025, 9:00:00 AM · 1735722000000
+smoke:   frozen  intl 01/01/2025, 09:00:00 AM
+smoke:   frozen  ctor 1735722000000 · same true
+smoke:   frozen  worker 1735722000000
+smoke:   default 7/25/2026, 6:23:51 PM · 1785003831823
+smoke:   default intl 07/25/2026, 06:23:51 PM
+smoke:   default ctor 1785003831823 · same true
+smoke:   default worker 1785003831865
+smoke: determinism stills reproduce byte for byte across takes (the same two stills move 28.6 over the spinner with the recorder's default settings)
+smoke: determinism demo.mp4 reproduces (takes differ by 0.44, against 6.85 with the default settings)
+smoke: determinism ok (3 takes)
 smoke: PASSED
 ```
 
-Re-running into the same `--out-dir` is safe: the seven take subdirectories
+Re-running into the same `--out-dir` is safe: the ten take subdirectories
 (`web/`, `terminal/`, `web-problems/`, `terminal-problems/`, `terminal-race/`,
-`web-strict/`, `terminal-strict/`) are deleted before each take. Only the first
-two are graded on their video; the rest are short and exist to break in one
-specific way each. That is not tidiness — every
-artifact assertion works by path, so without it a leftover `demo.mp4` from the
-previous run would grade a recorder that produced nothing at all as a pass, and
-recording repeatedly into one directory is exactly how a change to the recorder
-gets verified.
+`web-strict/`, `terminal-strict/`, `determinism-a/`, `determinism-b/`,
+`determinism-off/`) are deleted before each take. Only the first two are graded
+on their video; the rest are short and exist to break, or to reproduce, in one
+specific way each. That is not tidiness — every artifact assertion works by
+path, so without it a leftover `demo.mp4` from the previous run would grade a
+recorder that produced nothing at all as a pass, and recording repeatedly into
+one directory is exactly how a change to the recorder gets verified.
 
 Deleting is bounded. Only those named subdirectories are ever
 removed, and only when each is absent, empty, or carries the
@@ -78,8 +90,8 @@ test measures.
 
 ## What it asserts
 
-Five independent axes, because a recorder can fail on any one of them while
-looking perfect on the other four.
+Six independent axes, because a recorder can fail on any one of them while
+looking perfect on the other five.
 
 **Artifacts** — `demo.mp4` and every still the storyboard asked for exist, were
 modified by *this* run rather than a previous one, clear a size floor
@@ -220,6 +232,26 @@ test code can reach — and roughly 1 web take in 12 loses that window whole,
 which is what the 750 ms bound is for. **A real demo has no ticker at all**;
 see Known gaps and [#18](https://github.com/rogvid/skills/issues/18).
 
+The recorder's determinism controls ([#10](https://github.com/rogvid/skills/issues/10))
+land an animation on its final frame — which is exactly what the ticker must
+not do, and how a green harness could quietly stop being one. Two things keep
+them apart, and both are asserted rather than assumed:
+
+- **The freeze is of the wall clock only.** `Date.now()` and `new Date()` stop;
+  `performance.now()`, the document animation timeline, and
+  `requestAnimationFrame` do not, and CSS animations run on the second of
+  those. The web take samples the page at its start and at its end and fails
+  unless the wall clock moved **0 ms** while the monotonic clock moved seconds.
+- **The motion rule cannot match an opt-out.** It is written
+  `*:not([data-demo-video-animate])…`, and the ticker carries that attribute.
+  `start_ticker()` reads the ticker's computed `animation-duration` *and*
+  plants a control element with the same animation and no attribute: the take
+  fails unless the rule flattened the control to `0.001s` and left the ticker
+  at `0.18s`. Checking only the ticker would pass just as happily on a
+  recorder that had stopped injecting the rule at all. Both takes pass
+  `deterministic=True` for this reason — under the recorder's default the rule
+  is not injected and the control assertion would have nothing to say.
+
 When the measurement cannot be made the run says which reason it was: a caption
 that was never drawn, a video that slid further than the search window can see,
 or a run-up that was not quiet. They look identical from inside the window, and
@@ -306,6 +338,98 @@ matched as `beat N (verb)`), it must name the kind the storyboard caused, and
 precisely the one somebody wants to look at, so failing it by destroying the
 evidence would be worse than not failing it.
 
+**Determinism** — recording the same storyboard twice produces the same
+recording. Three extra takes, each about six seconds, against `?entropy=1`: a
+page rendering what a re-record is otherwise free to differ by — four
+*different* clocks, and a spinning shape.
+
+Four, because they are four clocks under the hood and patching the `Date`
+global reaches only the first. `Intl.DateTimeFormat().format()` formats from
+its own internal clock, a `Worker` has its own global that page init scripts
+never run in, and `new Date().constructor` walked straight past a proxied
+global to the real constructor. All three were found running behind a frozen
+`Date.now()`, by two takes that differed while every assertion passed.
+
+| Take | `deterministic` | What it is for |
+|---|---|---|
+| `determinism-a` | `True` | the reference |
+| `determinism-b` | `True` | must match `determinism-a` |
+| `determinism-off` | *not passed* | must **not** match — grades the default |
+
+The third take passes no `deterministic` argument at all, deliberately. The
+frozen clock is opt-in (it changes what a debounce, a token check or an
+elapsed-time bar does, usually silently), so the default is the setting every
+user gets and the one worth grading. The web and terminal takes above go the
+other way and pass `deterministic=True` explicitly, because that is where the
+frozen clock and the motion rule have to be shown coexisting with
+`TICKER_JS`.
+
+What is compared, and why each comparison is not free:
+
+- **The stills, byte for byte.** They are lossless PNGs of a frozen page, so
+  there is no threshold to argue about and no encoder noise to tolerate:
+  `sha256(a/01-entropy.png) == sha256(b/01-entropy.png)`, or the take failed.
+  This is the sensitive one — it catches a four-digit change in a timestamp,
+  which nothing measuring luma will. The same two stills are also compared
+  *within* `determinism-a`, a second apart on a page nobody touched, and that
+  is the comparison that catches a running animation: headless Chromium turns
+  out to reproduce animation phase across two takes of an identically-paced
+  storyboard remarkably well (a spinner exempted from the motion rule produced
+  byte-identical stills in both takes and was caught only within one).
+- **…and the same two stills inside `determinism-off`, which must differ.**
+  This is the assertion that keeps the ones above honest. Two blank screenshots
+  are byte-identical too, and so are two files a comparison forgot to read. The
+  same storyboard, the same page, nothing pinned: 28.6-30.0 mean luma over the
+  spinner, against a 4.0 floor.
+- **The video, where bytes cannot be compared.** H.264 at crf 20 is not
+  byte-reproducible and the screencast's frame timing is not either, so the
+  closing frame of each take is sampled over the entropy panel instead: two
+  deterministic takes score 0.00-0.59 mean luma apart, a deterministic take
+  against `determinism-off` scores 6.85-7.22. Both bars (1.5 and 2.5) sit in
+  that gap, and **both directions are asserted** — the second is what says the
+  comparison can see a difference at all. Know what it cannot see: a *coarse*
+  measure over a 160x90 reduction, it caught a whole panel changing colour
+  (24.14) and did not notice four digits of a timestamp changing (0.22). The
+  stills are what make the fine claim; this makes the claim about the artifact
+  people actually watch.
+- **The clock the page printed.** Frozen takes must agree on it, and
+  `determinism-off` must disagree with them. Printed on every run, so a reader
+  sees which instant was frozen and what the live clock said.
+- **What the page reports about itself**, in every take including the web and
+  terminal ones: `Date.now()`, `new Date().toISOString()`, the resolved
+  timezone and locale, `navigator.language`, `prefers-reduced-motion`, and the
+  computed `animation-duration` / `transition-duration` of a probe element
+  planted for the purpose. Read from *inside the page*, never off the
+  recorder's own attributes — a constructor that stored `deterministic=True`
+  and forgot to wire it to the context satisfies any check made in Python.
+  With determinism unasked-for, every clock-related one is asserted the other
+  way, including that the page's clock is within five minutes of this
+  process's — while timezone, locale and reduced motion are asserted *pinned*
+  in both, because those three are not gated on `deterministic`.
+
+  Four of those checks are not clock readings at all and hold in both modes:
+  `Date.prototype.constructor === Date`, `Date.now === Date.now`,
+  `Date.now.name === "now"`, and the flattened durations being **1 ms rather
+  than 0s**. The proxy that freezes the clock is exactly what breaks the first
+  three, and a transition of zero duration never starts — so it never fires
+  `transitionend`, and every accordion, modal and wizard that advances on that
+  event stalls. Both were live regressions, caught by review rather than by
+  this harness, which is why they are asserted by value and not by "not the
+  original".
+
+Before any of that, each still has to have a picture in it at all, on the same
+whole-frame luma floor the web take uses (6.0, healthy 15-17). Two blank
+recordings reproduce beautifully.
+
+And one reading is checked in the DOM rather than left to the pixels: the
+worker's. The fixture falls back to rendering `worker unavailable` if the
+`Worker` constructor throws, and that reproduces byte for byte across takes
+exactly as happily as a frozen timestamp does — so a wrapper that broke every
+worker on the page would pass this whole phase on the strength of failing
+consistently. The take reads the line and requires `worker <frozen epoch>`.
+All three takes also run `strict=True` (issue #3's machinery), which is what
+would catch the blob shim breaking worker *loading* rather than its clock.
+
 ## Known gaps
 
 Things a pass does **not** prove. They are listed because an assertion nobody
@@ -388,6 +512,35 @@ knows is missing is worse than one that is openly absent.
   `\#` expanded in `PS1`, which is bash behaviour; zsh needs `PROMPT_SUBST` and
   would leave every `exit_code` null. Only `/bin/bash` is recorded here — the
   `terminal-race/` take's slow shell `exec`s it.
+- **Determinism's motion rule is asserted only where a stylesheet can reach.**
+  `element.animate()` (Web Animations), `requestAnimationFrame` loops and
+  canvas rendering are untouched by it and unasserted here
+  ([#35](https://github.com/rogvid/skills/issues/35)); so are animations
+  inside a shadow root, and any the app declares `!important` at higher
+  specificity ([#36](https://github.com/rogvid/skills/issues/36)). The
+  `::before`/`::after` arms of the rule *are* asserted, because an animated
+  pseudo-element is the most common spinner on the web and dropping them from
+  the rule passed this harness until a probe was planted for it.
+- **No take records with a non-default `clock`, `timezone_id` or `locale`.**
+  Every take uses the built-in defaults, so the parameter path and
+  `_clock_epoch_ms()`'s parsing are exercised nowhere, and the locale
+  assertion had to be fault-injected with a forced `de-DE` to be seen failing
+  at all — this box is already `en-US`. Tracked in
+  [#37](https://github.com/rogvid/skills/issues/37).
+- **The determinism takes prove nothing about what the recorder cannot
+  control.** They record a static fixture served off the local disk, so
+  "identical twice" says the *browser* was pinned — not that an app with its
+  own `Math.random()`, a server that returns fresh rows, or a page whose layout
+  depends on when a request came back would reproduce. Nothing here can assert
+  that, because there is nothing in the recorder to assert about it; it is
+  called out in `SKILL.md` as the storyboard author's problem instead. The
+  fixture's `?entropy=1` hook deliberately does **not** include a random number
+  for the same reason — seeding it in the fixture would be testing a control
+  that does not exist.
+- **`TerminalRecorder`'s PTY child is outside all of it.** The determinism
+  controls are context options and page init scripts, so a `date` run in a
+  terminal demo prints the real time in the machine's own zone. Tracked in
+  [#26](https://github.com/rogvid/skills/issues/26).
 - **Nothing checks audio.** Narration is forced off and no assertion touches the
   aac track, so the whole speech path — `tts_clip`, the `.tts/` cache, the
   `adelay`/`amix` mixing in `_convert` — is untested here.
@@ -424,6 +577,21 @@ Two query-string hooks exist, inert unless asked for:
 | `?console-error=1` | logs a `console.error` **and** throws an uncaught error (Playwright `pageerror`), while the page stays usable | the Problems axis |
 | `?bad-fetch=<url>` | fetches `/definitely-missing.json` (404) and `<url>` (connection refused), both during load | the Problems axis — during load so the failures land inside the recorder's `goto` beat |
 | `?secret=1` | renders `#api-key` holding `sk-live-FAKE0000000000000000` | issue #4, redacting secrets from frames and stills |
+| `?entropy=1` | renders four clock readings (`Date`, `Intl`, `new Date().constructor`, and one posted back by a `Worker`, each read once at load) and `#entropy-spinner`, a shape turning once every 1.7 s | issue #10, the determinism takes |
+
+`?entropy=1` is the one hook the fixture's own "keep it deterministic" rule is
+suspended for, on purpose: the determinism takes need something that *would*
+differ between recordings. Each clock is read once rather than ticking, because
+a ticking one would also keep the compositor painting and confound the very
+thing being measured. There is deliberately no `Math.random()` in it — see
+Known gaps.
+
+The panel is **prepended** to `.page`, not appended. Four readings and a 54 px
+spinner are tall enough that at the bottom of the page they sit below the
+720 px fold, and `shot()` captures the viewport rather than the full page — so
+every comparison in the determinism phase passed against two byte-identical
+photographs of a spinner nobody had photographed. It was caught by the
+controls-off assertion, which is exactly what that assertion is for.
 
 One hook, one take. The graded `web/` take loads none of them, so the reference
 recording stays a recording of a working app — which is also the assertion that
@@ -448,6 +616,11 @@ insurance against a future release that does start flagging it.
   when the verb is a no-op. Anything that leaves the page still for more than a
   second also wants a look at `TICKER_JS`: idle is what makes the screencast
   lose time, and adding idle is how the timing bar was made flaky once already.
+- **Anything in the page that must keep moving** — a second ticker, an
+  animation a take is *about* — has to carry `data-demo-video-animate`, or the
+  recorder's determinism rule lands it on its final frame the moment it
+  appears. That attribute is the recorder's published opt-out, not a test
+  hook; `TICKER_JS` is the worked example.
 - **A new storyboard verb in the recorder** — decorate it with `@_beat_verb`
   so it lands in the beat log, or the timeline stops being a full account of
   the take. A verb built out of other verbs records one beat, not one per

--- a/tests/fixture/entropy-worker.js
+++ b/tests/fixture/entropy-worker.js
@@ -1,0 +1,5 @@
+// Loaded by ?entropy=1 (issue #10). A Worker has its own global scope, which
+// page init scripts never run in — so what this posts back is a clock the
+// recorder can only have frozen by re-injecting the freeze into the worker
+// itself. Its answer is rendered into the page, which puts it in the stills.
+self.postMessage(Date.now());

--- a/tests/fixture/index.html
+++ b/tests/fixture/index.html
@@ -102,6 +102,32 @@
     font: 15px/1.4 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
     color: var(--ink);
   }
+
+  /* Entropy panel (only with ?entropy=1) ------------------------------ */
+  /* The two things a re-recording is allowed to differ by, made large and
+     high-contrast on purpose: a wall clock and a running animation. With
+     determinism on they are pinned and two takes match pixel for pixel;
+     with it off they are what makes them not. See issue #10. */
+  #entropy-panel {
+    margin-bottom: 22px; padding: 14px 20px; background: var(--surface);
+    border: 1px solid var(--line); border-radius: var(--radius);
+    display: flex; align-items: center; gap: 22px;
+  }
+  #entropy-readings {
+    flex: 1;
+    font: 700 22px/1.35 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    letter-spacing: -0.01em; color: var(--ink);
+  }
+  #entropy-readings div { white-space: nowrap; }
+  @keyframes entropy-spin { to { transform: rotate(360deg); } }
+  #entropy-spinner {
+    width: 54px; height: 54px; flex: 0 0 auto;
+    background: var(--ink);
+    /* Deliberately asymmetric: a rotating disc would look identical at every
+       angle and prove nothing about animation phase. */
+    clip-path: polygon(50% 0, 100% 100%, 50% 72%, 0 100%);
+    animation: entropy-spin 1.7s linear infinite;
+  }
 </style>
 </head>
 <body>
@@ -167,6 +193,9 @@
  *   ?bad-fetch=<url>  page fetches a missing path and <url>, both on load,
  *                     so the failures land during the recorder's goto (#3)
  *   ?secret=1         renders #api-key holding an obviously-fake secret (issue #4)
+ *   ?entropy=1        renders four clock readings (Date, Intl, the Date
+ *                     constructor, and one posted back by a Worker) and a
+ *                     spinning shape — what determinism pins down (issue #10)
  */
 
 // Three fixed snapshots. #refresh cycles through them in order, so a
@@ -298,6 +327,72 @@ if (params.has("bad-fetch")) {
   fetch("/definitely-missing.json").catch(function () {});
   var refused = params.get("bad-fetch");
   if (refused && refused !== "1") { fetch(refused).catch(function () {}); }
+}
+
+if (params.has("entropy")) {
+  // Everything a second take of the same storyboard would otherwise render
+  // differently (issue #10). Each clock is read once, at load: a ticking one
+  // would also keep the compositor painting, which would confound the very
+  // measurement this panel exists for. Deliberately NOT here: Math.random().
+  // The recorder cannot seed an app's RNG, and pretending otherwise by
+  // seeding it in the fixture would test a control that does not exist.
+  //
+  // Four different ways of asking what time it is, because they are four
+  // different clocks under the hood and patching the Date global reaches only
+  // the first. Each one of the others was a hole found open in review: Intl
+  // formats from its own internal clock, a Worker gets its own global that
+  // page init scripts never run in, and `new Date().constructor` walked
+  // straight past a proxied global to the real constructor.
+  var entropy = document.createElement("div");
+  entropy.id = "entropy-panel";
+  var readings = document.createElement("div");
+  readings.id = "entropy-readings";
+
+  var clock = document.createElement("div");
+  clock.id = "entropy-clock";
+  clock.textContent = new Date().toLocaleString() + " · " + Date.now();
+
+  var intl = document.createElement("div");
+  intl.id = "entropy-intl";
+  intl.textContent = "intl " + new Intl.DateTimeFormat("en-US", {
+    year: "numeric", month: "2-digit", day: "2-digit",
+    hour: "2-digit", minute: "2-digit", second: "2-digit", timeZone: "UTC"
+  }).format();
+
+  var ctor = document.createElement("div");
+  ctor.id = "entropy-ctor";
+  ctor.textContent = "ctor " + new Date().constructor.now()
+    + " · same " + (Date.prototype.constructor === Date);
+
+  var worker = document.createElement("div");
+  worker.id = "entropy-worker";
+  worker.textContent = "worker …";
+  try {
+    var w = new Worker("entropy-worker.js");
+    w.onmessage = function (e) {
+      worker.textContent = "worker " + e.data;
+      worker.className = "ready";
+      w.terminate();
+    };
+  } catch (err) {
+    worker.textContent = "worker unavailable";
+    worker.className = "ready";
+  }
+
+  var spinner = document.createElement("div");
+  spinner.id = "entropy-spinner";
+  readings.appendChild(clock);
+  readings.appendChild(intl);
+  readings.appendChild(ctor);
+  readings.appendChild(worker);
+  entropy.appendChild(readings);
+  entropy.appendChild(spinner);
+  // Prepended, not appended: four readings and a 54px spinner are tall enough
+  // that at the bottom of the page they fall below the 720px fold, and a
+  // shot() captures the viewport, not the full page. A panel nobody can
+  // photograph makes every comparison in tests/smoke pass for the wrong
+  // reason — measured, as two byte-identical stills of a spinning shape.
+  document.querySelector(".page").prepend(entropy);
 }
 
 if (params.has("console-error")) {

--- a/tests/smoke
+++ b/tests/smoke
@@ -27,10 +27,15 @@ short web demo against it with `Recorder`, records a short terminal demo with
    a working one — so `timeline.json`'s `issues` are graded on their own, and
    two extra short takes check that `strict=True` refuses what the default
    tolerates.
+5. **Determinism** — re-recording reproduces the recording. One short
+   storyboard is recorded three times against a page that renders four clocks
+   and an animation; the two takes with `deterministic=True` must match byte
+   for byte, and the one recorded with the recorder's *defaults* must not.
 
-    tests/smoke                 # both takes
+    tests/smoke                 # every take
     tests/smoke --web-only
     tests/smoke --terminal-only
+    tests/smoke --determinism-only
     tests/smoke --out-dir /tmp/smoke
 
 Narration is forced off (`speech=False`): CI has no ELEVENLABS_API_KEY and no
@@ -46,6 +51,7 @@ reading a pass as proof the recorder is healthy.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import math
 import os
@@ -63,6 +69,7 @@ import urllib.request
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from typing import NamedTuple
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 FIXTURE_DIR = REPO_ROOT / "tests" / "fixture"
@@ -164,6 +171,49 @@ CAPTION_PROBE = ("90-caption-off", "91-caption-on")
 # does not enter into it: it slides the window and the fade together.
 PROBE_CAPTION = "Recorded end to end."
 PROBE_QUIET_S = 2.0
+
+# -- the determinism takes (issue #10) ---------------------------------------
+#
+# Three short takes of one storyboard against `?entropy=1`, which renders the
+# two things a second recording is otherwise free to differ by: a wall clock
+# and a spinning shape. Two takes with determinism on must agree; a third with
+# it off must not — which is what stops the first assertion from being the
+# vacuous "two blank pages are equal".
+ENTROPY_SHOTS = ("01-entropy", "02-entropy")
+
+# Settle before the first still (the page has just loaded), then long enough
+# between the two that the spinner — one turn every 1.7 s — is somewhere else
+# entirely.
+ENTROPY_SETTLE_S = 1.0
+ENTROPY_GAP_S = 1.0
+
+# Stills are lossless PNGs of a frozen page, so two takes of this storyboard
+# are compared byte for byte and no threshold is needed. Video is different:
+# H.264 at crf 20 is not byte-reproducible and the screencast's frame timing
+# is not either, so the recordings are compared where they can be — the mean
+# absolute luma difference over the entropy panel, between the last frame of
+# each take.
+#
+# Measured over the panel rect: two deterministic takes 0.00-0.59, a
+# deterministic take against one recorded with the recorder's *defaults*
+# 6.85-7.22 (four clock readings and a spinner, all of them differing). More
+# than a factor of ten between the two bands, and both bars sit inside that
+# gap, so neither is a number the encoder can wander over.
+#
+# The bars are deliberately not set at the observed edges. Fault injections
+# that degrade the fixture itself — a blanked panel, a spinner too faint to
+# see — brought the second comparison down to 0.30 and 1.63, and the right
+# answer there is the one the harness gives: it reports that the comparison
+# has gone blind instead of quietly passing.
+MAX_TAKE_VIDEO_DELTA = 1.5
+MIN_LIVE_VIDEO_DELTA = 2.5
+
+# Two stills from *inside* the default-settings take, a second apart, over the
+# spinner. This is the number that proves the byte-comparison above can fail
+# at all: the same storyboard, the same page, and the recording differs from
+# itself the moment nothing is pinned. Measured 28.6-30.0 (it depends on where
+# the spinner stopped), against a floor 7x under the weakest of them.
+MIN_LIVE_STILL_DELTA = 4.0
 
 SERVER_START_TIMEOUT_S = 15.0
 
@@ -777,6 +827,24 @@ def check_caption(b: Beats, page, expected: str) -> None:
 # can lift a blank recording over a floor or make two identical stills look
 # different. It sits at the top-left corner, outside the caption band every
 # timing measurement reads.
+#
+# It survives the recorder's determinism controls (issue #10) for two separate
+# reasons, and both are asserted below rather than assumed:
+#
+#   * the frozen clock freezes `Date.now()` and `new Date()` and nothing else.
+#     CSS animations run on the document timeline, which is monotonic time —
+#     untouched, and check_determinism() proves it advanced while the wall
+#     clock did not.
+#   * the injected "land every animation on its final frame" rule cannot match
+#     an element carrying `data-demo-video-animate`, the recorder's documented
+#     opt-out for exactly this: something that has to keep the compositor
+#     awake. start_ticker() plants a control element with the same animation
+#     and no opt-out, and fails the take unless the rule kills the control and
+#     spares the ticker.
+#
+# Losing either would put the flake of issue #18 back — silently, since a
+# stalled take still passes everything except the timing bars, and only some
+# of the time.
 TICKER_JS = """() => {
   if (document.getElementById('__smoke_ticker')) return;
   const style = document.createElement('style');
@@ -788,25 +856,340 @@ TICKER_JS = """() => {
   el.style.cssText = 'position:fixed;top:0;left:0;width:8px;height:8px;'
     + 'background:#808080;z-index:2147483647;pointer-events:none;'
     + 'animation:__smoke_ticker .18s steps(2) infinite';
+  el.setAttribute('data-demo-video-animate', '');
   document.body.appendChild(el);
+}"""
+
+# The ticker's computed animation, plus the same animation on a throwaway
+# element that does *not* opt out. Read together: the first says the ticker is
+# alive, the second says the determinism rule is applied at all — without it,
+# "the ticker animates" would also be true of a recorder that had quietly
+# stopped injecting the rule.
+_TICKER_STATE_JS = """() => {
+  const el = document.getElementById('__smoke_ticker');
+  if (!el) return null;
+  const style = getComputedStyle(el);
+  const control = document.createElement('div');
+  control.style.cssText = 'position:fixed;top:-99px;left:-99px;width:1px;'
+    + 'height:1px;animation:__smoke_ticker .18s steps(2) infinite';
+  document.body.appendChild(control);
+  const controlDuration = getComputedStyle(control).animationDuration;
+  control.remove();
+  return {name: style.animationName, duration: style.animationDuration,
+          state: style.animationPlayState, control: controlDuration};
 }"""
 
 
 def start_ticker(b: Beats, page) -> None:
-    """Inject TICKER_JS and confirm it is running."""
+    """Inject TICKER_JS and confirm it is running *and* opted out."""
     page.evaluate(TICKER_JS)
-    running = page.evaluate(
-        "() => { const el = document.getElementById('__smoke_ticker');"
-        " return !!el && getComputedStyle(el).animationName === "
-        "'__smoke_ticker'; }"
-    )
+    state = page.evaluate(_TICKER_STATE_JS)
     # If it silently failed to attach, every timing number below becomes a
     # measurement of Chromium's screencast luck instead of the beat log.
+    if state is None:
+        b.fail_if(
+            True,
+            "the compositor ticker did not attach — timing measurements in "
+            "this take are not trustworthy (see TICKER_JS)",
+        )
+        return
     b.fail_if(
-        not running,
-        "the compositor ticker did not attach — timing measurements in this "
-        "take are not trustworthy (see TICKER_JS)",
+        state["name"] != "__smoke_ticker"
+        or state["duration"] == "0s"
+        or state["state"] != "running",
+        f"the compositor ticker is not animating (animation-name "
+        f"{state['name']!r}, duration {state['duration']!r}, play-state "
+        f"{state['state']!r}) — the page will go idle during this take, the "
+        f"screencast will drop wall time (issue #18), and every timing number "
+        f"below becomes a measurement of luck. If the recorder's determinism "
+        f"CSS stopped honouring data-demo-video-animate, this is where it "
+        f"shows up (see TICKER_JS)",
     )
+    b.fail_if(
+        state["control"] != FLATTENED_S,
+        f"a control element with the ticker's animation and no "
+        f"data-demo-video-animate reports animation-duration "
+        f"{state['control']!r}, expected {FLATTENED_S!r} — the recorder's "
+        f"determinism CSS is not being applied to this page, so the ticker "
+        f"running proves nothing about the opt-out and app animations are not "
+        f"being frozen. (Both takes record with deterministic=True precisely "
+        f"so this can be asserted; the default does not inject the rule.)",
+    )
+
+
+# -- determinism (issue #10) --------------------------------------------------
+#
+# What the recorder pins in the browser, as the page itself sees it. Written
+# out by hand rather than imported from demo_recording: a value derived from
+# the code being graded agrees with that code no matter what it says, and
+# changing the recorder's default clock *should* fail here loudly.
+#
+# The controls split in two, and the split is the thing worth grading:
+#
+#   * timezone, locale and prefers-reduced-motion are pinned in *every* take,
+#     including one that asks for no determinism at all;
+#   * the frozen clock and the motion rule are opt-in, because both change what
+#     an app does — mostly silently — so the default has to be the honest one.
+FROZEN_CLOCK = "2025-01-01T09:00:00Z"  # core.py's DEFAULT_CLOCK, as it logs it
+FROZEN_EPOCH_MS = 1735722000000  # ...the same instant, as the page reads it
+FROZEN_ISO = "2025-01-01T09:00:00.000Z"
+FROZEN_TIMEZONE = "UTC"
+FROZEN_LOCALE = "en-US"
+
+# The probe element's own animation and transition, as declared, and what the
+# motion rule must flatten them to.
+#
+# 1 ms, not 0s: a transition of combined duration zero never starts and so
+# never fires `transitionend`, which stalls every accordion, modal and wizard
+# that advances on that event. Asserting the exact flattened value — rather
+# than "not 2s" — is what keeps a future edit from quietly going back to 0s.
+PROBE_ANIMATION_S = "2s"
+PROBE_TRANSITION_S = "5s"
+FLATTENED_S = "0.001s"
+
+# How far the page's clock may sit from the harness's own when determinism is
+# off. Generous: this only has to tell "a real clock" from "frozen at 2025".
+MAX_LIVE_CLOCK_SKEW_MS = 5 * 60 * 1000
+
+# How long the page's monotonic clock must have advanced between the two
+# samples the web take draws, while its wall clock did not move at all. The
+# take is ~17 s; anything near zero means the freeze reached further than the
+# wall clock and the compositor is not running (see TICKER_JS).
+MIN_MONOTONIC_ADVANCE_MS = 5000.0
+
+_PAGE_STATE_JS = """() => {
+  // A probe element and a ::after on it, because an animated pseudo-element is
+  // the most common spinner on the web and a rule that forgets `::after` looks
+  // exactly like one that does not on a plain <div>.
+  let sheet = document.getElementById('__smoke_probe_css');
+  if (!sheet) {
+    sheet = document.createElement('style');
+    sheet.id = '__smoke_probe_css';
+    sheet.textContent =
+      '#__smoke_probe::after{content:"";animation:__smoke_probe 3s linear infinite}'
+      + '#__smoke_probe::before{content:"";animation:__smoke_probe 4s linear infinite}';
+    document.head.appendChild(sheet);
+  }
+  const probe = document.createElement('div');
+  probe.id = '__smoke_probe';
+  probe.style.cssText = 'position:fixed;top:-99px;left:-99px;width:1px;'
+    + 'height:1px;animation:__smoke_probe 2s linear infinite;'
+    + 'transition:opacity 5s linear';
+  document.body.appendChild(probe);
+  const style = getComputedStyle(probe);
+  const animation = style.animationDuration;
+  const transition = style.transitionDuration;
+  const after = getComputedStyle(probe, '::after').animationDuration;
+  const before = getComputedStyle(probe, '::before').animationDuration;
+  probe.remove();
+  return {
+    now: Date.now(),
+    iso: new Date().toISOString(),
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    locale: Intl.DateTimeFormat().resolvedOptions().locale,
+    language: navigator.language,
+    offset: new Date().getTimezoneOffset(),
+    reduced: matchMedia('(prefers-reduced-motion: reduce)').matches,
+    animation: animation,
+    transition: transition,
+    after: after,
+    before: before,
+    // Four more clocks, each of which was found running while `Date.now()`
+    // was frozen. Intl formats from its own internal clock; `constructor`
+    // walked past the proxied global to the real one; timeOrigin and
+    // lastModified are wall-clock readings of their own.
+    intl: new Intl.DateTimeFormat('en-US', {year: 'numeric', month: '2-digit',
+      day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit',
+      timeZone: 'UTC'}).format(),
+    constructorNow: new Date().constructor.now(),
+    constructorIsDate: Date.prototype.constructor === Date,
+    descriptorNow: Object.getOwnPropertyDescriptor(Date, 'now').value(),
+    nowIsStable: Date.now === Date.now,
+    nowName: Date.now.name,
+    timeOrigin: Math.round(performance.timeOrigin),
+    // The clock a CSS animation actually runs on — not performance.now(),
+    // which merely correlates with it. This is the one TICKER_JS depends on.
+    monotonic: typeof document.timeline.currentTime === 'number'
+      ? document.timeline.currentTime : performance.now(),
+  };
+}"""
+
+
+def check_determinism(b: Beats, page, when: str, on: bool = True) -> dict:
+    """What the page reports about its clock, its locale, and its motion.
+
+    Asserted from inside the page, never from the recorder's own attributes: a
+    constructor that stored `deterministic=True` and then forgot to wire it to
+    the context would satisfy any check made on the Python side.
+    """
+    state = page.evaluate(_PAGE_STATE_JS)
+
+    def wanted(what: str, actual: object, expected: object, why: str) -> None:
+        b.fail_if(
+            actual != expected,
+            f"{when}, {what} is {actual!r}, expected {expected!r} — {why}",
+        )
+
+    # Pinned in every take, determinism or not: none of the three changes what
+    # an app computes, and all three differ between a laptop and a CI runner.
+    wanted(
+        "the resolved timezone",
+        state["timezone"],
+        FROZEN_TIMEZONE,
+        "the context's timezone is not pinned, so a recording made in "
+        "Tórshavn formats dates differently from one made in CI",
+    )
+    wanted("the UTC offset", state["offset"], 0, "the timezone is not UTC")
+    wanted(
+        "the resolved locale",
+        state["locale"],
+        FROZEN_LOCALE,
+        "the context's locale is not pinned, so numbers and dates format "
+        "differently between machines",
+    )
+    wanted("navigator.language", state["language"], FROZEN_LOCALE, "same")
+    wanted(
+        "prefers-reduced-motion",
+        state["reduced"],
+        True,
+        "the context does not request reduced motion, so an app that honours "
+        "it still animates — this one is not gated on `deterministic`",
+    )
+    # True in both modes: these are identity, not clock readings, and the proxy
+    # that freezes the clock is exactly what breaks them.
+    wanted(
+        "Date.prototype.constructor === Date",
+        state["constructorIsDate"],
+        True,
+        "deep-clone and serialization helpers type-test Date this way, and "
+        "misclassify every Date object when it is false",
+    )
+    wanted(
+        "Date.now === Date.now",
+        state["nowIsStable"],
+        True,
+        "`now` is being minted fresh on every read instead of defined once",
+    )
+    wanted(
+        "Date.now.name",
+        state["nowName"],
+        "now",
+        "`now` has been replaced by an anonymous function",
+    )
+
+    if on:
+        wanted(
+            "Date.now()",
+            state["now"],
+            FROZEN_EPOCH_MS,
+            "the page's wall clock is not frozen, so every take renders a "
+            "different timestamp",
+        )
+        wanted(
+            "new Date().toISOString()",
+            state["iso"],
+            FROZEN_ISO,
+            "the zero-argument Date constructor is still reading the real "
+            "clock even if Date.now() is frozen",
+        )
+        # Four clocks found running behind a frozen Date.now() in review.
+        wanted(
+            "Intl.DateTimeFormat().format()",
+            state["intl"],
+            "01/01/2025, 09:00:00 AM",
+            "Intl formats from its own internal clock, which no patch of the "
+            "Date global reaches — it is how apps render dates, so it is the "
+            "hole that matters most",
+        )
+        wanted(
+            "new Date().constructor.now()",
+            state["constructorNow"],
+            FROZEN_EPOCH_MS,
+            "the prototype's constructor still points at the unfrozen Date, "
+            "so one property access reaches the real clock",
+        )
+        wanted(
+            "Object.getOwnPropertyDescriptor(Date, 'now').value()",
+            state["descriptorNow"],
+            FROZEN_EPOCH_MS,
+            "`now` is being synthesized by a proxy trap rather than defined, "
+            "so reading the descriptor hands back the real clock",
+        )
+        wanted(
+            "performance.timeOrigin",
+            state["timeOrigin"],
+            FROZEN_EPOCH_MS,
+            "timeOrigin is a wall-clock reading of its own, and "
+            "`timeOrigin + performance.now()` is a common way to take one",
+        )
+        wanted(
+            "a probe element's animation-duration",
+            state["animation"],
+            FLATTENED_S,
+            "the recorder's motion rule is not reaching this page, so "
+            "animation phase still varies between takes",
+        )
+        wanted(
+            "a probe element's transition-duration",
+            state["transition"],
+            FLATTENED_S,
+            "the recorder's motion rule is not flattening transitions — and "
+            "at 0s instead of 1ms no transitionend would ever fire, which "
+            "stalls every accordion, modal and wizard that waits for one",
+        )
+        wanted(
+            "an animated ::after's animation-duration",
+            state["after"],
+            FLATTENED_S,
+            "the motion rule does not cover pseudo-elements, and an animated "
+            "::after is the most common spinner on the web",
+        )
+        wanted(
+            "an animated ::before's animation-duration",
+            state["before"],
+            FLATTENED_S,
+            "the motion rule does not cover pseudo-elements",
+        )
+    else:
+        # The default. It has to leave the clock alone — not merely skip some
+        # of the freezing.
+        b.fail_if(
+            state["now"] == FROZEN_EPOCH_MS,
+            f"{when}, Date.now() still reads the frozen {FROZEN_EPOCH_MS} "
+            f"although determinism was not asked for — the page's clock is "
+            f"being frozen by default",
+        )
+        skew = abs(state["now"] - time.time() * 1000)
+        b.fail_if(
+            skew > MAX_LIVE_CLOCK_SKEW_MS,
+            f"{when}, Date.now() reads {state['now']} — {skew / 1000:.0f}s "
+            f"from this process's own clock, so the page is not on real time",
+        )
+        b.fail_if(
+            state["intl"].startswith("01/01/2025"),
+            f"{when}, Intl.DateTimeFormat().format() reads {state['intl']!r} — "
+            f"the frozen instant, without determinism having been asked for",
+        )
+        wanted(
+            "a probe element's animation-duration",
+            state["animation"],
+            PROBE_ANIMATION_S,
+            "the motion rule is injected without determinism having been asked for",
+        )
+        wanted(
+            "a probe element's transition-duration",
+            state["transition"],
+            PROBE_TRANSITION_S,
+            "the motion rule is injected without determinism having been asked for",
+        )
+        wanted(
+            "an animated ::after's animation-duration",
+            state["after"],
+            "3s",
+            "the motion rule is reaching pseudo-elements without determinism "
+            "having been asked for",
+        )
+    return state
 
 
 # Records every mousemove the page sees, so move_to()'s 30-step glide can be
@@ -840,10 +1223,20 @@ def record_web(
     outline = "el => getComputedStyle(el).outlineStyle"
     bg = "el => getComputedStyle(el).backgroundColor"
 
-    with Recorder(out_dir, base_url=base_url, speech=False, strict=True) as rec:
+    # deterministic=True, though the recorder's default is off: this take is
+    # where the frozen clock and the motion rule have to be shown coexisting
+    # with TICKER_JS, and the control-element assertion in start_ticker() has
+    # nothing to say unless the rule is actually injected. The default path is
+    # graded by the determinism-default take instead. strict=True because this
+    # is the healthy fixture: determinism must not itself produce a console
+    # error or a failed request.
+    with Recorder(
+        out_dir, base_url=base_url, speech=False, strict=True, deterministic=True
+    ) as rec:
         rec.goto("/")
         rec.wait_for("#kpi-rev")
         start_ticker(b, rec.page)
+        opening = check_determinism(b, rec.page, "on landing")
         # Doubles as the run-up for the *early* timing probe: the page has
         # finished painting and the caption band does not move until the
         # first caption. See MAX_CAPTION_SKEW_S.
@@ -944,6 +1337,27 @@ def record_web(
         rec.caption(PROBE_CAPTION)
         check_caption(b, rec.page, PROBE_CAPTION)
         rec.shot(CAPTION_PROBE[1])
+
+        # The clock has to still be frozen ~15 s later, not merely at load —
+        # and the page's *monotonic* clock has to have kept running, because
+        # that is the one CSS animations are on. A freeze that stopped it too
+        # would stop the compositor, and the recording would start losing wall
+        # time again (TICKER_JS, issue #18).
+        closing = check_determinism(b, rec.page, "at the end of the take")
+        b.fail_if(
+            closing["now"] != opening["now"],
+            f"the frozen clock moved during the take: {opening['now']} at the "
+            f"start, {closing['now']} at the end — it is pinned at page load "
+            f"and then drifts, which is worse than not pinning it",
+        )
+        advance = closing["monotonic"] - opening["monotonic"]
+        b.fail_if(
+            advance < MIN_MONOTONIC_ADVANCE_MS,
+            f"the page's monotonic clock advanced {advance:.0f} ms across a "
+            f"take that took several seconds — the freeze has reached past the "
+            f"wall clock into the clock CSS animations run on, so the "
+            f"compositor is not painting and issue #18 is back",
+        )
         rec.caption("")
 
         # Where the app lands in each medium, read off the live recorder rather
@@ -988,8 +1402,14 @@ def record_terminal(
             tail = " ".join(str(exc).split())[:200]
             b.fail_if(True, f"after {after}, the shell prompt never came back — {tail}")
 
-    with TerminalRecorder(out_dir, speech=False, strict=True) as rec:
+    with TerminalRecorder(
+        out_dir, speech=False, strict=True, deterministic=True
+    ) as rec:
         start_ticker(b, rec.page)
+        # The determinism controls live on the context, so the terminal
+        # recorder inherits every one of them — and a page that renders a real
+        # PTY is where a frozen clock is most likely to break something.
+        check_determinism(b, rec.page, "in the terminal page")
         # Let xterm.js settle, and give the early timing probe below a
         # baseline that is not the browser's first paint. See
         # MAX_CAPTION_SKEW_S.
@@ -1037,6 +1457,120 @@ def record_terminal(
     # The terminal frames itself in-page and is not composited, so its video
     # and its stills share one geometry.
     return b.problems, rect, rect, size
+
+
+class EntropyTake(NamedTuple):
+    """One recording of the entropy storyboard, and what it rendered."""
+
+    problems: list[str]
+    out_dir: Path
+    clock: str  # the wall clock the page printed, as text
+    still_rect: Rect  # where the entropy panel sits in a full-bleed still
+    video_rect: Rect  # ...and where it lands in the composited video
+    spin_rect: Rect  # just the spinning shape, in a full-bleed still
+
+
+def record_entropy(out_dir: Path, base_url: str, deterministic: bool) -> EntropyTake:
+    """The shortest storyboard that renders the things determinism controls.
+
+    `?entropy=1` puts four clocks and a spinning shape on the page. Two stills
+    a second apart, and nothing else — the point of this take is not what it
+    shows but that a second run of it shows exactly the same thing.
+
+    `deterministic=False` is passed by *omitting* the argument, so this take
+    grades the recorder's default rather than an explicit opt-out. They are the
+    same code path now, and the default is the one every user gets.
+    """
+    from demo_recording import Recorder
+
+    label = "determinism" if deterministic else "default"
+    b = Beats(label)
+    kwargs = {"deterministic": True} if deterministic else {}
+    # strict=True on all three: `?entropy=1` starts a Worker, and the recorder
+    # wraps `Worker` to re-inject the frozen clock into it. A shim that broke
+    # worker loading would show up here as a failed request rather than as a
+    # page that quietly renders one clock fewer.
+    with Recorder(
+        out_dir, base_url=base_url, speech=False, strict=True, **kwargs
+    ) as rec:
+        rec.goto("/?entropy=1")
+        # The worker's answer lands asynchronously and is part of what the
+        # stills have to reproduce, so wait for it rather than racing it. A
+        # short bound rather than the 60 s default: a Worker wrapper that
+        # stops workers loading at all shows up right here, and it should say
+        # so in seconds rather than after a minute of nothing.
+        rec.wait_for("#entropy-worker.ready", timeout_s=15)
+        rec.pause(ENTROPY_SETTLE_S)
+        rec.shot(ENTROPY_SHOTS[0])
+        check_determinism(b, rec.page, f"in the {label} take", on=deterministic)
+
+        # The worker line, read rather than left to the pixel comparisons.
+        # They cannot see this: the fixture falls back to "worker unavailable"
+        # if the Worker constructor throws, and *that* reproduces byte for byte
+        # across takes just as happily as a frozen timestamp does. A wrapper
+        # that broke every worker on the page would pass this whole phase on
+        # the strength of failing consistently.
+        worker = rec.page.locator("#entropy-worker").inner_text()
+        b.fail_if(
+            not re.fullmatch(r"worker \d+", worker),
+            f"the entropy page's worker reported {worker!r}, not a timestamp — "
+            f"the recorder's Worker wrapper stopped workers running at all, "
+            f"which every pixel comparison in this phase would call a success",
+        )
+        if deterministic:
+            b.fail_if(
+                worker != f"worker {FROZEN_EPOCH_MS}",
+                f"the entropy page's worker reported {worker!r}, expected "
+                f"'worker {FROZEN_EPOCH_MS}' — a Worker has its own global and "
+                f"page init scripts never run in it, so the freeze has to be "
+                f"re-injected there and was not",
+            )
+        # No "and it is not empty" guard here on purpose: `wait_for` above
+        # already refuses a clock that is not visible, and three empty clocks
+        # would trip the "the escape-hatch take rendered the same clock as the
+        # frozen ones" comparison below. An assertion that cannot be made to
+        # fail is a comment.
+        clock = rec.page.locator("#entropy-readings").inner_text()
+        # A second still after long enough for the spinner to be somewhere
+        # else entirely (it turns once every 1.7 s).
+        rec.pause(ENTROPY_GAP_S)
+        rec.shot(ENTROPY_SHOTS[1])
+
+        box = rec.page.locator("#entropy-panel").bounding_box()
+        spin = rec.page.locator("#entropy-spinner").bounding_box()
+        if box is None or spin is None:
+            raise SmokeFailure(
+                "#entropy-panel has no box — ?entropy=1 rendered nothing"
+            )
+        still_rect: Rect = (
+            int(box["x"]),
+            int(box["y"]),
+            int(box["width"]),
+            int(box["height"]),
+        )
+        # The spinner on its own. Over the whole panel a 54 px shape turning
+        # moves the mean luma by 0.76 — a number no honest floor can be set
+        # against. Measured where the motion actually is, the same turn moves
+        # it by tens. Cropping to the thing being asserted about is the
+        # difference between an assertion and a decoration.
+        spin_rect: Rect = (
+            int(spin["x"]),
+            int(spin["y"]),
+            int(spin["width"]),
+            int(spin["height"]),
+        )
+        # The recording is scaled into the window body, so the same panel sits
+        # somewhere else in the video. Map it rather than eyeballing a crop:
+        # this is the region both comparisons below actually look at.
+        g, size = rec._geom, (rec._size["width"], rec._size["height"])
+        scale_x, scale_y = g["appw"] / size[0], g["apph"] / size[1]
+        video_rect: Rect = (
+            g["appx"] + int(box["x"] * scale_x),
+            g["appy"] + int(box["y"] * scale_y),
+            max(2, int(box["width"] * scale_x)),
+            max(2, int(box["height"] * scale_y)),
+        )
+    return EntropyTake(b.problems, out_dir, clock, still_rect, video_rect, spin_rect)
 
 
 # -- assertions --------------------------------------------------------------
@@ -1280,6 +1814,25 @@ def check_timeline(
         failures.append(
             f"{label}: timeline.json says segment {doc.get('segment')!r}; these "
             f"takes are single-segment, so it should be null"
+        )
+
+    # Which clock produced the take. A still committed to a repo is otherwise a
+    # picture with no record of the conditions behind it, and a future diff
+    # cannot tell "the UI changed" from "the frozen instant changed" — the one
+    # question this feature exists to answer. Both takes record with
+    # deterministic=True, so that is what the log has to say.
+    record = doc.get("determinism")
+    expected_record = {
+        "deterministic": True,
+        "clock": FROZEN_CLOCK,
+        "timezone_id": FROZEN_TIMEZONE,
+        "locale": FROZEN_LOCALE,
+    }
+    if record != expected_record:
+        failures.append(
+            f"{label}: timeline.json records the take's determinism settings "
+            f"as {record!r}, expected {expected_record!r} — without them a "
+            f"committed still says nothing about the clock that produced it"
         )
 
     beats = doc.get("beats")
@@ -2178,6 +2731,222 @@ def run_strict_terminal(out_root: Path) -> list[str]:
     return check_strict_failure("terminal-strict", out_dir, raised, ["nonzero_exit"])
 
 
+def last_frame(mp4: Path, rect: Rect) -> bytes | None:
+    """The final second of a recording, reduced over `rect`, last frame first
+    available. Both takes end on the same static page, so this is the frame
+    they should agree on."""
+    from demo_recording import media_duration
+
+    try:
+        seconds = media_duration(mp4)
+    except Exception:  # noqa: BLE001 - the caller reports a missing measurement
+        return None
+    frames = gray_frames(
+        mp4, rect, sample_fps=4, start=max(0.0, seconds - 1.0), duration=1.0
+    )
+    return frames[-1] if frames else None
+
+
+def digest(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+
+
+def run_determinism(out_root: Path) -> list[str]:
+    """Record one storyboard three times and compare the recordings.
+
+    Two takes with the recorder's determinism controls on have to produce the
+    same pixels; a third with `deterministic=False` has to produce different
+    ones. The third is not a nicety — without it "the two takes match" is also
+    true of a recorder that produced two blank videos, and of a harness
+    comparing two files it never wrote.
+    """
+    plan = (
+        ("determinism-a", True),
+        ("determinism-b", True),
+        ("determinism-off", False),
+    )
+    takes: dict[str, EntropyTake] = {}
+    with fixture_server() as base_url:
+        for name, on in plan:
+            out_dir = fresh_take_dir(out_root, name)
+            try:
+                takes[name] = record_entropy(out_dir, base_url, on)
+            except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+                return [
+                    f"{name}: Recorder(deterministic={on}) raised "
+                    f"{type(exc).__name__}: {exc}"
+                ]
+
+    failures: list[str] = []
+    for take in takes.values():
+        failures += take.problems
+    first, second, live = (
+        takes["determinism-a"],
+        takes["determinism-b"],
+        takes["determinism-off"],
+    )
+
+    # Liveness before identity. Two blank recordings are identical too, and a
+    # missing file compares equal to another missing file in every scheme that
+    # forgets to look. Only *this* list short-circuits the comparisons below —
+    # a take whose page reported the wrong clock still has stills worth
+    # comparing, and reporting both is how the cause and the effect show up in
+    # one run.
+    liveness: list[str] = []
+    stills: dict[str, dict[str, Path]] = {}
+    for name, take in takes.items():
+        stills[name] = {}
+        for shot in ENTROPY_SHOTS:
+            png = take.out_dir / "images" / f"{shot}.png"
+            if not png.is_file():
+                liveness.append(f"{name}: still {png} was never captured")
+                continue
+            # The whole frame, on the floor the rest of the harness already
+            # calibrated for web stills (healthy 15.5-16.9, blank 0.1-1.1).
+            # That the *panel* carries signal is covered by the two "with the
+            # controls off, this much moves" floors further down, both of
+            # which have been watched to fail.
+            frames = gray_frames(png)
+            score = contrast(frames[0]) if frames else 0.0
+            if score < MIN_CONTENT_STDDEV["web"]:
+                liveness.append(
+                    f"{name}: {shot}.png is blank — the whole frame scores "
+                    f"{score:.1f} luma stddev, under the "
+                    f"{MIN_CONTENT_STDDEV['web']} floor, so there is nothing "
+                    f"in it for the comparisons below to be about"
+                )
+                continue
+            stills[name][shot] = png
+        mp4 = take.out_dir / "demo.mp4"
+        if not mp4.is_file():
+            liveness.append(f"{name}: {mp4} was never written")
+    if liveness:
+        return failures + liveness
+
+    # -- the clock the page rendered -----------------------------------------
+    if first.clock != second.clock:
+        failures.append(
+            f"determinism: two takes of one storyboard rendered different "
+            f"clocks — {first.clock!r} and {second.clock!r}. The page's wall "
+            f"clock is not frozen, so nothing dated survives a re-record."
+        )
+    elif live.clock == first.clock:
+        failures.append(
+            f"determinism: the take recorded with the recorder's *default* "
+            f"settings rendered the same clocks {live.clock!r} as the frozen "
+            f"takes — either the default freezes the clock (it must not; the "
+            f"freeze changes what clock-reading apps do and is opt-in), or all "
+            f"four readings are ones this harness is not actually varying"
+        )
+    else:
+        print("smoke: determinism froze all four clocks identically in both takes")
+        for line in first.clock.splitlines():
+            print(f"smoke:   frozen  {line}")
+        for line in live.clock.splitlines():
+            print(f"smoke:   default {line}")
+
+    # -- the stills, byte for byte -------------------------------------------
+    reproduced = True
+    for shot in ENTROPY_SHOTS:
+        one, two = stills["determinism-a"][shot], stills["determinism-b"][shot]
+        if digest(one) != digest(two):
+            reproduced = False
+            delta = frame_difference(
+                gray_frames(one, first.still_rect)[0],
+                gray_frames(two, second.still_rect)[0],
+            )
+            failures.append(
+                f"determinism: {shot}.png differs between two takes of the "
+                f"same storyboard ({digest(one)} vs {digest(two)}, {delta:.2f} "
+                f"mean luma over the entropy panel) — re-recording does not "
+                f"reproduce the stills, so a still cannot be diffed against "
+                f"the one committed last month"
+            )
+    # The same picture twice inside one take: the clock cannot have moved and
+    # the spinner cannot have turned.
+    inside = stills["determinism-a"]
+    if digest(inside[ENTROPY_SHOTS[0]]) != digest(inside[ENTROPY_SHOTS[1]]):
+        reproduced = False
+        failures.append(
+            f"determinism: {ENTROPY_SHOTS[0]}.png and {ENTROPY_SHOTS[1]}.png "
+            f"differ within one take, {ENTROPY_GAP_S}s apart on a page nothing "
+            f"touched — something on screen is still moving with the clock"
+        )
+
+    # ...and the same two stills with the controls off, which is what makes
+    # every comparison above capable of failing.
+    off = stills["determinism-off"]
+    live_delta = frame_difference(
+        gray_frames(off[ENTROPY_SHOTS[0]], live.spin_rect)[0],
+        gray_frames(off[ENTROPY_SHOTS[1]], live.spin_rect)[0],
+    )
+    if digest(off[ENTROPY_SHOTS[0]]) == digest(off[ENTROPY_SHOTS[1]]):
+        failures.append(
+            f"determinism: recorded with the recorder's default settings, "
+            f"{ENTROPY_SHOTS[0]}.png and {ENTROPY_SHOTS[1]}.png are still "
+            f"byte-identical — the page is not moving even with nothing "
+            f"pinned, so the byte comparison above proves nothing"
+        )
+    elif live_delta < MIN_LIVE_STILL_DELTA:
+        failures.append(
+            f"determinism: recorded with the recorder's default settings the "
+            f"two stills differ by only {live_delta:.2f} mean luma over the "
+            f"spinner, under the {MIN_LIVE_STILL_DELTA} floor — the fixture is "
+            f"barely varying, so the equality asserted above is nearly free"
+        )
+    # Only now, and only if the comparisons above actually held. Printing this
+    # next to a "01-entropy.png differs" failure — which an earlier revision
+    # did, because the print sat in the `else` of the *liveness* branch — makes
+    # the log contradict itself, and a log that contradicts itself is one
+    # nobody reads.
+    elif reproduced:
+        print(
+            f"smoke: determinism stills reproduce byte for byte across takes "
+            f"(the same two stills move {live_delta:.1f} over the spinner "
+            f"with the recorder's default settings)"
+        )
+
+    # -- the video, where bytes cannot be compared ---------------------------
+    closing = {
+        name: last_frame(take.out_dir / "demo.mp4", take.video_rect)
+        for name, take in takes.items()
+    }
+    if any(f is None for f in closing.values()):
+        failures.append(
+            "determinism: could not sample the closing frame of every take, so "
+            "the recordings themselves went ungraded"
+        )
+    else:
+        same = frame_difference(closing["determinism-a"], closing["determinism-b"])
+        different = frame_difference(
+            closing["determinism-a"], closing["determinism-off"]
+        )
+        if same > MAX_TAKE_VIDEO_DELTA:
+            failures.append(
+                f"determinism: the closing frames of two takes of one "
+                f"storyboard differ by {same:.2f} mean luma over the entropy "
+                f"panel, over the {MAX_TAKE_VIDEO_DELTA} bar — the recording "
+                f"itself does not reproduce"
+            )
+        if different < MIN_LIVE_VIDEO_DELTA:
+            failures.append(
+                f"determinism: a deterministic take and a default-settings "
+                f"take differ by only {different:.2f} mean luma over the "
+                f"entropy panel, under the {MIN_LIVE_VIDEO_DELTA} floor — this "
+                f"comparison cannot see the difference the controls make, so "
+                f"the {same:.2f} above is not evidence of anything"
+            )
+        if same <= MAX_TAKE_VIDEO_DELTA and different >= MIN_LIVE_VIDEO_DELTA:
+            print(
+                f"smoke: determinism demo.mp4 reproduces (takes differ by "
+                f"{same:.2f}, against {different:.2f} with the default "
+                f"settings)"
+            )
+    if not failures:
+        print("smoke: determinism ok (3 takes)")
+    return failures
+
+
 def run_terminal(out_root: Path) -> list[str]:
     if os.name != "posix":
         print(
@@ -2225,10 +2994,17 @@ def main() -> int:
         description="Smoke-test the demo-video recorders against tests/fixture.",
     )
     parser.add_argument(
-        "--web-only", action="store_true", help="record only the web take"
+        "--web-only", action="store_true", help="record only the web takes"
     )
     parser.add_argument(
-        "--terminal-only", action="store_true", help="record only the terminal take"
+        "--terminal-only",
+        action="store_true",
+        help="record only the terminal takes",
+    )
+    parser.add_argument(
+        "--determinism-only",
+        action="store_true",
+        help="record only the three determinism takes",
     )
     parser.add_argument(
         "--out-dir",
@@ -2244,8 +3020,18 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    if args.web_only and args.terminal_only:
-        parser.error("--web-only and --terminal-only are mutually exclusive")
+    chosen = [
+        flag
+        for flag, on in (
+            ("--web-only", args.web_only),
+            ("--terminal-only", args.terminal_only),
+            ("--determinism-only", args.determinism_only),
+        )
+        if on
+    ]
+    if len(chosen) > 1:
+        parser.error(f"{' and '.join(chosen)} are mutually exclusive")
+    only = chosen[0] if chosen else None
 
     if not HELPERS_DIR.is_dir():
         print(f"smoke: helpers not found at {HELPERS_DIR}", file=sys.stderr)
@@ -2273,20 +3059,22 @@ def main() -> int:
 
     failures: list[str] = []
     try:
-        if not args.terminal_only:
+        if only in (None, "--web-only"):
             failures += run_web(out_root)
-        if not args.web_only:
+        if only in (None, "--terminal-only"):
             failures += run_terminal(out_root)
-        # After the graded takes, never instead of them: these four record
+        # After the graded takes, never instead of them: these five record
         # nothing worth looking at, and if a recorder is broken the messages
         # above are the ones that say how.
-        if not args.terminal_only:
+        if only in (None, "--web-only"):
             failures += run_web_problems(out_root)
             failures += run_strict_web(out_root)
-        if not args.web_only:
+        if only in (None, "--terminal-only"):
             failures += run_terminal_problems(out_root)
             failures += run_terminal_race(out_root)
             failures += run_strict_terminal(out_root)
+        if only in (None, "--determinism-only"):
+            failures += run_determinism(out_root)
     except SmokeFailure as exc:
         failures.append(str(exc))
 


### PR DESCRIPTION
Fixes #10.

Re-recording produced a different video every time, so visual diffing was
impossible and "did the UI actually change?" was unanswerable.

Adds a frozen wall clock, pinned timezone/locale, `prefers-reduced-motion:
reduce` plus a motion-flattening CSS rule, and a
`Recorder(..., deterministic=False)` escape hatch. **Default is on**, which is
the behaviour change the issue asks for.

## The freeze is of the wall clock only, deliberately

`Date.now()` and zero-arg `new Date()` answer from a fixed epoch via a `Proxy`
on `Date`. `performance.now()`, `requestAnimationFrame` and `document.timeline`
are untouched — because freezing monotonic time would stop the compositor,
which is the exact mechanism of #18. It would *cause* the stall rather than
reproduce a video.

The motion rule carries a published opt-out, `data-demo-video-animate`, for
elements that must keep the compositor awake. Motion is flattened via duration
0 + `iteration-count: 1` + `fill-mode: forwards` rather than `animation: none`,
so apps that animate content in from `opacity: 0` land on the finished state
instead of staying permanently invisible.

## What "deterministic" is asserted to mean

One storyboard recorded three times against a new `?entropy=1` fixture hook:

- **Stills: byte-identical `sha256`** across two deterministic takes. Lossless
  PNGs, so no threshold and no encoder noise — sensitive enough to catch a
  four-digit timestamp change.
- **The same stills inside the `deterministic=False` take must differ**, which
  is what stops "two takes match" from being the vacuous "two blank pages are
  equal".
- **Video, honestly bounded:** H.264 is not byte-reproducible, so closing
  frames are compared over the entropy panel. Deterministic pair 0.00-0.51, vs
  off 4.16-4.93, bars at 1.5/2.5 in the gap, both directions asserted.
  `tests/README.md` states what this cannot see: it caught a whole panel
  changing colour (24.14) and did *not* notice four digits changing (0.22).
- **Page-reported state** read from inside the page, never from
  `self.deterministic`, and inverted in the escape-hatch take.

The ticker guard plants a **control element** carrying the ticker's animation
with no opt-out: the take fails unless the rule flattened the control *and*
left the ticker running. Checking only the ticker would pass equally on a
recorder that had stopped injecting the rule at all.

## Verification

8 consecutive full runs with determinism on, all passed, worst skew −240ms with
both probes moving together — nowhere near the −500…−700ms stall signature. The
injection that removes the ticker's opt-out reproduced the stall on the first
try at −640ms, so the opt-out is demonstrably what holds it off.

13 fault injections, each watched fail. Two path-existence checks were not
separately injected (they duplicate `check_take()`), and one assertion was
*deleted* because it could not be made to fail — noted in a code comment.

Honest finding: headless Chromium reproduces animation phase across
identically-paced takes well enough that a spinner exempted from the motion
rule produced byte-identical stills in both takes, and was caught only by the
within-take comparison. Documented rather than papered over.

Filed #26 — `TerminalRecorder`'s PTY child does not inherit the determinism
controls.