### PR TITLE
Capture agent-readable evidence per beat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ frames/
 # Left behind only when a take crashes before the recorder cleans up.
 .video/
 .frame.png
+# Per-beat evidence: greppable plaintext of the app's DOM (or terminal),
+# regenerated wholesale on every take. SKILL.md says why it is not committed.
+evidence/
 
 # Smoke-test recordings. tests/smoke records into a temp dir by default; this
 # covers pointing it back into the repo (tests/smoke --out-dir tests/out).

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ frames/
 .frame.png
 # Per-beat evidence: greppable plaintext of the app's DOM (or terminal),
 # regenerated wholesale on every take. SKILL.md says why it is not committed.
+# It is read by the reviewing agent in the same pipeline that produced it and
+# nowhere else (issue #50).
 evidence/
 
 # Smoke-test recordings. tests/smoke records into a temp dir by default; this

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -58,6 +58,36 @@ The words, and what each fixture element they belong to is for:
   SDCT  #sd-token-control  the same, inside the shadow root
   LATE  a caption          set before the value in it was registered
 
+...and the ?evidence=1 panel (issue #9), whose shapes leak into a *text* dump
+of the page rather than into a picture of it:
+
+  WSPC  #ev-ws-key         indented on its own line in hand-written markup
+  BLED  #ev-bleed-key      in a card whose label also renders outside it
+  CHLD  #ev-child-key      split into text nodes that are ordinary on their own
+  LBLD  #ev-label-src      an accessible name sourced from outside the subtree
+  SLOT  #ev-slot-light     light DOM slotted into a redacted shadow host
+  VALU  #ev-value-key      an input value that lives on the property
+  TICK  #ev-tick-key       rewritten every 25 ms with a value nothing has seen
+  ATTR  #ev-spot-attrs     a data-* attribute the page never renders
+  JSON  #ev-spot-attrs     the same, inside a JSON blob in another attribute
+
+...and three that never render at all — they exist only inside tests/smoke, one
+per assertion about how the writer handles a value it was told about:
+
+  PRNT  a printed line      echoed by a command in the terminal take, where
+                            register_secret() is the only defence (issue #5)
+  STAL  a planted file      a previous take's evidence, which a re-record into
+                            the same folder has to delete
+  CUTT  a padded list item  positioned so the markup cap cuts through it, which
+                            is the only place "mask, then cap" is observable.
+                            It is the one with more than sixteen zeroes — that
+                            length is what makes the straddle arithmetic land,
+                            hence the wider run below
+
+The word list is what keeps this narrow, not the run length: every literal is a
+four-letter word followed by nothing but zeroes, and lengthening the run admits
+no string the word list did not already admit.
+
 The terminal half of redaction (issue #5) adds a family of its own, and they
 are not all `sk-live-` shaped because the shapes themselves are what is being
 tested. **No allowlist entry was added for any of them, and none is needed** —
@@ -95,5 +125,5 @@ neither. Verified by running gitleaks over the whole tree, not assumed.
 """
 paths = ['''^skills/demo-video/helpers/assets/''']
 regexes = [
-  '''sk-live-(FAKE|CTRL|TYPE|BIG|BGC|SHDW|SHTY|IFRM|PSEU|TFRM|ZOOM|SVGT|DEEP|CLSD|STMP|LATE|TKCT|SDCT)0{4,16}''',
+  '''sk-live-(FAKE|CTRL|TYPE|BIG|BGC|SHDW|SHTY|IFRM|PSEU|TFRM|ZOOM|SVGT|DEEP|CLSD|STMP|LATE|TKCT|SDCT|WSPC|BLED|CHLD|LBLD|SLOT|VALU|TICK|ATTR|JSON|PRNT|STAL|CUTT)0{4,24}''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -70,15 +70,13 @@ of the page rather than into a picture of it:
   LBLD  #ev-label-src      an accessible name sourced from outside the subtree
   SLOT  #ev-slot-light     light DOM slotted into a redacted shadow host
   VALU  #ev-value-key      an input value that lives on the property
-  TICK  #ev-tick-key       rewritten every 25 ms with a value nothing has seen
+  TICK  #ev-tick-key       rewritten every 5 ms with a value nothing has seen
   ATTR  #ev-spot-attrs     a data-* attribute the page never renders
   JSON  #ev-spot-attrs     the same, inside a JSON blob in another attribute
 
-...and three that never render at all — they exist only inside tests/smoke, one
+...and two that never render at all — they exist only inside tests/smoke, one
 per assertion about how the writer handles a value it was told about:
 
-  PRNT  a printed line      echoed by a command in the terminal take, where
-                            register_secret() is the only defence (issue #5)
   STAL  a planted file      a previous take's evidence, which a re-record into
                             the same folder has to delete
   CUTT  a padded list item  positioned so the markup cap cuts through it, which
@@ -92,9 +90,19 @@ comparing a registered value against a *transformation* of:
 
   HATT  #ev-attr-card      mirrored into title/data-value/aria-label and an
                            input value on siblings nothing redacts
-  HIDE  #ev-hide-card      mirrored into elements CSS hides four different ways
-  WRAP  a terminal line    split by a wrap at the last column
+  VEIL  #ev-veil-card      mirrored into elements CSS hides four different ways
+                           (**not** the terminal family's HIDE below — the two
+                           were the same tag for one rebase, and `sk-live-HIDE`
+                           with eight zeroes is a *prefix* of the terminal
+                           one's sixteen, so each take's byte sweep could have
+                           matched the other's literal)
   AMPS  #ev-spot-amp       contains an `&`, which outerHTML writes `&amp;`
+
+The wrap shape in `terminal-wrap/` is `zz-wrap-` + zeroes and gets **no**
+allowlist entry, for the same reason the terminal family below gets none: it
+matches no rule in the default set, and it cannot be `sk-live-` shaped because
+the stream scrubber's shape net would mask it before it ever reached the screen
+— which is the whole thing that take is trying to put there.
 
 `AMPS` is the one entry that is not "tag then zeroes": it is
 `sk-live-AMPS0000&sig=0000000000`, and the `&sig=` in the middle is the entire
@@ -142,6 +150,6 @@ neither. Verified by running gitleaks over the whole tree, not assumed.
 """
 paths = ['''^skills/demo-video/helpers/assets/''']
 regexes = [
-  '''sk-live-(FAKE|CTRL|TYPE|BIG|BGC|SHDW|SHTY|IFRM|PSEU|TFRM|ZOOM|SVGT|DEEP|CLSD|STMP|LATE|TKCT|SDCT|WSPC|BLED|CHLD|LBLD|SLOT|VALU|TICK|ATTR|JSON|PRNT|STAL|CUTT|HATT|HIDE|WRAP)0{4,24}''',
+  '''sk-live-(FAKE|CTRL|TYPE|BIG|BGC|SHDW|SHTY|IFRM|PSEU|TFRM|ZOOM|SVGT|DEEP|CLSD|STMP|LATE|TKCT|SDCT|WSPC|BLED|CHLD|LBLD|SLOT|VALU|TICK|ATTR|JSON|STAL|CUTT|HATT|VEIL)0{4,24}''',
   '''sk-live-AMPS0000&sig=0000000000''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -25,13 +25,16 @@ sharp-text reference measured off the same frame. The third is typed by
 tests/smoke into #token as a Secret(...), so that the two ways of registering a
 secret can be proved apart. Note this entry is belt-and-braces, not
 load-bearing: the default ruleset does not flag that literal with or without
-this config — every one is spelled with a four-letter word followed by nothing
+this config — every one is spelled as a short all-caps tag followed by nothing
 but zeroes, precisely so no scanner and no human mistakes any of them for a
 credential. They are kept so that a future gitleaks release which does start
 flagging them cannot turn the job red for strings that were never secrets. The
-pattern is anchored to that fixed word list and a run of four to sixteen
-literal zeroes — the lengths the fixture actually renders. It masks nothing
-else.
+pattern is anchored to that fixed, closed word list and a run of literal zeroes.
+It masks nothing else.
+
+(The tags are four letters apart from `BIG` and `BGC`, which are three. An
+earlier version of this note said "four-letter word" as though it were a rule;
+it is not one, and the word list is what does the narrowing.)
 
 The words, and what each fixture element they belong to is for:
 
@@ -84,9 +87,23 @@ per assertion about how the writer handles a value it was told about:
                             length is what makes the straddle arithmetic land,
                             hence the wider run below
 
+...and four more from the second review round, each a channel the recorder was
+comparing a registered value against a *transformation* of:
+
+  HATT  #ev-attr-card      mirrored into title/data-value/aria-label and an
+                           input value on siblings nothing redacts
+  HIDE  #ev-hide-card      mirrored into elements CSS hides four different ways
+  WRAP  a terminal line    split by a wrap at the last column
+  AMPS  #ev-spot-amp       contains an `&`, which outerHTML writes `&amp;`
+
+`AMPS` is the one entry that is not "tag then zeroes": it is
+`sk-live-AMPS0000&sig=0000000000`, and the `&sig=` in the middle is the entire
+point of the shape. It is listed as its own alternative rather than by
+loosening the pattern, so the closed word list still does the narrowing.
+
 The word list is what keeps this narrow, not the run length: every literal is a
-four-letter word followed by nothing but zeroes, and lengthening the run admits
-no string the word list did not already admit.
+short all-caps tag from that list followed by zeroes, and lengthening the run
+admits no string the word list did not already admit.
 
 The terminal half of redaction (issue #5) adds a family of its own, and they
 are not all `sk-live-` shaped because the shapes themselves are what is being
@@ -125,5 +142,6 @@ neither. Verified by running gitleaks over the whole tree, not assumed.
 """
 paths = ['''^skills/demo-video/helpers/assets/''']
 regexes = [
-  '''sk-live-(FAKE|CTRL|TYPE|BIG|BGC|SHDW|SHTY|IFRM|PSEU|TFRM|ZOOM|SVGT|DEEP|CLSD|STMP|LATE|TKCT|SDCT|WSPC|BLED|CHLD|LBLD|SLOT|VALU|TICK|ATTR|JSON|PRNT|STAL|CUTT)0{4,24}''',
+  '''sk-live-(FAKE|CTRL|TYPE|BIG|BGC|SHDW|SHTY|IFRM|PSEU|TFRM|ZOOM|SVGT|DEEP|CLSD|STMP|LATE|TKCT|SDCT|WSPC|BLED|CHLD|LBLD|SLOT|VALU|TICK|ATTR|JSON|PRNT|STAL|CUTT|HATT|HIDE|WRAP)0{4,24}''',
+  '''sk-live-AMPS0000&sig=0000000000''',
 ]

--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -40,9 +40,12 @@ and a real terminal session (voice on):
 - **`evidence/beat-NN.json`** — what was on screen at every beat, in text:
   the page's ARIA tree (or the terminal's rendered screen), the spotlight
   target's markup, capped and explicitly truncated. An agent reviewing the
-  demo reads what the app said instead of inferring it from pixels. Plain
-  text, so it is masked against registered secrets *and* against whatever
-  `redact()` is covering — and it is **not committed**; `SKILL.md` says why.
+  demo reads what the app said instead of inferring it from pixels. It is
+  plain text, which makes it the one artifact a pixel control cannot protect
+  for free — so the recorder reads what `redact()` is covering out of the page
+  and masks *that* out too, refuses to write page text it cannot vouch for,
+  and clears what a previous take left behind. It is **not committed**;
+  `SKILL.md` explains both decisions and what they still do not cover.
 - **A recording that reproduces, when you ask for it** — the browser's
   timezone and locale are always pinned, and `Recorder(deterministic=True)`
   additionally freezes the page's clock and flattens animations, so the same

--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -37,6 +37,12 @@ and a real terminal session (voice on):
 - **`record.py`** — the storyboard that produced the media, and the thing
   that actually gets committed: re-runnable after the UI changes, so the
   video stays out of git history and is regenerated rather than archived.
+- **`evidence/beat-NN.json`** — what was on screen at every beat, in text:
+  the page's ARIA tree (or the terminal's rendered screen), the spotlight
+  target's markup, capped and explicitly truncated. An agent reviewing the
+  demo reads what the app said instead of inferring it from pixels. Plain
+  text, so it is masked against registered secrets *and* against whatever
+  `redact()` is covering — and it is **not committed**; `SKILL.md` says why.
 - **A recording that reproduces, when you ask for it** — the browser's
   timezone and locale are always pinned, and `Recorder(deterministic=True)`
   additionally freezes the page's clock and flattens animations, so the same
@@ -57,6 +63,8 @@ and a real terminal session (voice on):
 - `ffmpeg` on PATH.
 - Chromium for Playwright, once per machine:
   `uv run --with playwright playwright install chromium`
+- Playwright **1.49 or newer** for per-beat evidence (`aria_snapshot`).
+  Storyboards declare `playwright` unpinned, so a fresh resolve has it.
 - Optional: an ElevenLabs API key for narration (free tier works — the
   default voice is a premade one, and rate limits are retried).
 - Terminal demos (`TerminalRecorder`) are **Unix-only** (they use a PTY).
@@ -98,6 +106,7 @@ win over env vars.
 | `DEMO_VIDEO_TIMEZONE` | browser timezone (always applied) | `UTC` |
 | `DEMO_VIDEO_LOCALE` | browser locale (always applied) | `en-US` |
 | `DEMO_VIDEO_SPEECH` | force narration on/off (`1`/`0`) | auto by API key |
+| `DEMO_VIDEO_EVIDENCE` | write `evidence/beat-NN.json` per beat (`1`/`0`) | **on** |
 | `DEMO_VIDEO_VOICE_ID` | ElevenLabs voice | Sarah (premade) |
 | `DEMO_VIDEO_SPEECH_MODEL` | ElevenLabs model | `eleven_multilingual_v2` |
 | `DEMO_VIDEO_SKILL_DIR` | where storyboards find this skill | the constant baked into each storyboard |

--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -44,8 +44,13 @@ and a real terminal session (voice on):
   plain text, which makes it the one artifact a pixel control cannot protect
   for free — so the recorder reads what `redact()` is covering out of the page
   and masks *that* out too, refuses to write page text it cannot vouch for,
-  and clears what a previous take left behind. It is **not committed**;
-  `SKILL.md` explains both decisions and what they still do not cover.
+  and clears what a previous take left behind. "What renders in the clear"
+  means **painted**: an attribute, an input's `value`, and anything CSS hides
+  by any mechanism do not count, because a value that is only in one of those
+  was in no frame either. Matching is exact modulo whitespace in either
+  direction, HTML entities and JSON escaping — a stated list, not an open
+  promise. It is **not committed**; `SKILL.md` explains every one of those
+  decisions and where they stop.
 - **A recording that reproduces, when you ask for it** — the browser's
   timezone and locale are always pinned, and `Recorder(deterministic=True)`
   additionally freezes the page's clock and flattens animations, so the same

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -39,9 +39,13 @@ Each demo gets one folder (suggested: `docs/guides/<YYYY-MM-DD>-<slug>/`):
 | `timeline.md` | The same log rendered for humans, stills embedded | yes |
 | `guide.md` | Optional written guide embedding the stills | yes |
 | `demo.mp4` | The recording (mp4 only — gifs get too big) | **no** — regenerate it, or attach it to the PR |
+| `evidence/beat-NN.json` | **A working file, not an artifact.** What was on screen at each beat, in text — read by the reviewing agent in the same run that produced it, then thrown away. Greppable plaintext of a real app's DOM | **no** — gitignore it |
 | `frames/` | Review frames pulled out of `demo.mp4`, plus the sheet you hand a reviewer | **no** — a working file of a review; `beat_frames(out_dir)` regenerates it |
 
-The storyboard is the durable artifact, not the video. See **Commit the
+The storyboard is the durable artifact, not the video. The last two rows are
+neither: they are inputs to a review that happens once, derived from a video
+that is itself not committed, and both are in this repo's `.gitignore`
+([#50](https://github.com/rogvid/skills/issues/50)). See **Commit the
 storyboard, not the media** in the Process section.
 
 ## Setup (once per project)
@@ -609,6 +613,10 @@ set of paths — four on the web, one in the terminal — and nothing else:
     recorder reads what each redacted element renders and masks that text out
     of every evidence file. Read **Per-beat evidence** before trusting it, and
     do not commit `evidence/`.
+  - What that harvest reads is also masked out of `timeline.json` and
+    `timeline.md`, which *are* committed. Without it a caption or a selector
+    holding a redacted element's text would come back `[redacted]` in the
+    evidence and in the clear in the file you are asked to check in.
 - **A screenshot the storyboard takes itself** — `rec.page.screenshot(...)`
   rather than `rec.shot(...)` — still goes through the page, so the CSS mask
   applies; but any artifact your storyboard writes by hand (a `page.content()`
@@ -808,16 +816,16 @@ off.
   "aria": "- banner:\n  - heading \"Northwind Ops\" [level=1]\n- text: Revenue $128,400 …",
   "scope_aria": "- text: $128,400",
   "html": "<div id=\"kpi-rev\">$128,400</div>",
-  "redacted": ["#api-key"],
   "truncated": [], "limits": { "aria": 12000, "html": 8000 } }
 ```
 
 | Field | What it is |
 |---|---|
 | `aria` | **`Recorder`**: the page's ARIA snapshot — a compact YAML tree of roles and accessible names, the same thing `expect(...).toMatchAriaSnapshot` compares. Semantic, ~10× smaller than the markup, and stable across restyling, which is why it is preferred over raw HTML |
-| `scope` / `scope_aria` / `html` | the current `spotlight()` target: its selector, its own ARIA tree, and its `outerHTML`. All three are null when no spotlight is up |
+| `scope` / `scope_aria` / `html` | the current `spotlight()` target: its selector, its own ARIA tree, and its `outerHTML` with every value-bearing attribute stripped. All three are null when no spotlight is up |
 | `screen` | **`TerminalRecorder`**: the rendered screen, ANSI resolved by xterm.js, scrollback included — the same text `wait_for_text()` matches against |
 | `truncated` / `limits` | which fields were cut, and at what budget. A cut field also says so inline where it stops |
+| `omitted` | present *instead of* the page text when the recorder would have had to guess — see below. `timeline.json` is unaffected |
 
 **`outerHTML` is only ever the spotlight target's, never the page's.** A whole
 document's markup is an order of magnitude bigger than its ARIA tree and
@@ -845,22 +853,61 @@ carry across:
   with `[redacted]`, as everywhere else;
 - **the rendered text of everything `redact()` is covering** is read out of the
   page as the take runs — the matched element and every node under it, shadow
-  roots at every depth, `::before`/`::after` content, input values, and
-  value-bearing attributes — and every occurrence of any of it is replaced
-  too, in every beat's evidence, including beats recorded before the value
-  first appeared. `redact()` never tells the recorder what the element *says*,
-  so this is the step that turns a pixel control into a text one;
+  roots at every depth, light DOM assigned into a `<slot>`, `::before`/`::after`
+  content, input values, value-bearing attributes, and any element an
+  `aria-labelledby` points at, however far away it is — and every occurrence of
+  any of it is replaced too, in every beat's evidence, including beats recorded
+  before the value first appeared. `redact()` never tells the recorder what the
+  element *says*, so this is the step that turns a pixel control into a text
+  one. Whitespace is elastic on both sides of the match: `textContent` carries
+  the source's own indentation and an ARIA tree does not, and a value on its own
+  line in hand-written HTML is otherwise the most ordinary leak there is;
 - markup is elided structurally as well as by substring, because a value split
   across tags (`sk-live-<b>FAKE</b>`) has a `textContent` a string mask finds
-  and an `outerHTML` it does not.
+  and an `outerHTML` it does not. Where the split value is a *registered* one
+  rather than a redacted element's, the markup is **withheld** for that beat
+  with a line saying so — there is no safe way to edit a value out of a
+  serialization that interleaves it with elements;
+- `outerHTML` also drops every value-bearing attribute — `data-*`, `title`,
+  `alt`, `placeholder`, `aria-label`, `href`, `src` — from every element, not
+  just redacted ones. An attribute nothing renders was in no frame, no still,
+  no caption and no narration clip, so serializing it would make evidence the
+  only place it exists.
+
+**A harvested string is only used as a mask if it renders nowhere outside the
+mask.** Harvesting every node of a redacted card also harvests its label, and
+`redact("#revenue-card")` would otherwise register "Revenue" as a forbidden
+literal and rewrite every unrelated paragraph in every file. That rule is not a
+guess about what a secret looks like: a string that renders in the clear
+somewhere the mask does not cover is already in the frames and the stills, so
+masking it in a text file buys nothing and costs the file its meaning.
+
+"Renders outside" is narrower than it sounds, and each exclusion was a leak:
+hidden elements do not count (an `aria-labelledby` source can be `display:none`
+and still name a redacted element), `<script>` text does not count (it is
+source, not screen), light DOM slotted into a redacted element counts as
+*inside* it, and **the recorder's own caption bar does not count at all** —
+captioning a redacted value would otherwise exempt it from masking everywhere,
+turning one mistake in the frames into the same mistake in `timeline.json`.
 
 Nothing reaches the disk until the take exits cleanly and the mask has been
 verified: the documents are built in memory and written beside `timeline.json`,
-so a take that dies on a `SecretLeak` has no evidence file to delete. If a
-document cannot be made safe — or if the recorder cannot read what `redact()`
-is hiding for a given beat — it fails the take, or writes that beat's evidence
-as `{"omitted": …}` with no page text in it, rather than writing something it
-cannot vouch for.
+so a take that dies on a `SecretLeak` has no evidence file to delete — and a
+take that *succeeds* first deletes any evidence a previous recording into the
+same folder left behind, since re-running `record.py` into the same directory is
+the normal way to use this skill and yesterday's files would otherwise sit there
+holding the value you just added a `redact()` for. If a document cannot be made
+safe, the take fails.
+
+**A page that repaints while it is being read gets no page text.** The ARIA
+snapshot is a protocol call and the harvest is a page evaluation, so they cannot
+be one operation: a card rewritten on a 25 ms interval — a countdown, a ticker,
+a rotating token — hands the harvest one value and the snapshot the next. The
+harvest is therefore taken on both sides of the snapshot and the two must agree;
+if they will not settle, that beat's evidence is written as `{"omitted": …}`
+with no `aria`, `scope_aria` or `html` in it. On a page where something inside a
+redacted region never holds still, expect most beats to come back that way —
+`timeline.json` is unaffected, and it is the safe direction.
 
 **What it still does not cover:**
 
@@ -869,10 +916,21 @@ cannot vouch for.
   whole terminal, scrubbed for registered secrets only. A command that
   *prints* a value nobody registered writes it here verbatim — the same
   exposure the recording already has, in a form that greps.
-- **`url` and `title` are scrubbed, not redacted.** A token in a query string
-  that nobody registered lands in the file.
-- **Only exact substrings match**, the same limit `register_secret()` has:
-  the same value rendered with different whitespace is a different string.
+- **`url` and `title` go through the registered-secret scrub and nothing
+  else.** A token in a query string that nobody registered lands in the file —
+  `redact()` cannot name it, because nothing renders it, and the harvest that
+  turns redaction into text masking therefore never sees it. If your demo
+  navigates through a magic link, a `?token=`, or a session id in a path,
+  `register_secret()` it: that is the author's job and there is no mechanism
+  here that does it for you
+  ([issue #50](https://github.com/rogvid/skills/issues/50)).
+- **Accessible names are still names.** `alt` and `title` become an element's
+  accessible name, so they are in `aria` by design even though they are
+  stripped from `html`. That is what a screen-reader user perceives; if it is a
+  secret, redact the element.
+- **Only exact substrings match**, modulo whitespace — the same limit
+  `register_secret()` has. A value rendered with a soft hyphen, or split across
+  two elements that are not both redacted, is a different string.
 - **The ARIA snapshot needs Playwright ≥ 1.49.** Older versions get a null
   `aria` and an `aria_format` saying so, rather than a fallback nobody tests.
 
@@ -1182,6 +1240,11 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    **Review frames** above): a `click('#refresh')` in the margin answers
    the question you are asking before they look at anything.
 
+   A tmpdir, or `frames/` beside `demo.mp4` if the reviewer needs a stable
+   path. Either way they are working files — `frames/` is gitignored for the
+   same reason `evidence/` is, and for the same reason the mp4 they came out
+   of is.
+
    Dispatch a subagent told NOTHING about the feature (any context-free
    reviewer works: a fresh session or process fed only `frames/`, if the
    harness has no subagents): read the frames in order; reply with
@@ -1217,7 +1280,9 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    from the two by `beat_frames(out_dir)` — anchor the pattern to the demo
    folder rather than writing a bare `frames/`, which matches a directory
    of that name anywhere in the repo), `.tts/` narration caches, and
-   `<demo folder>/evidence/`.
+   `<demo folder>/evidence/` — the last two are **working files**, inputs to
+   a review that happens once, and the file table at the top of this skill
+   says so in the same column that says the mp4 is not committed.
 
    **`evidence/` is not committed either, and for a stronger reason than the
    mp4.** It is regenerated wholesale on every take, so it would churn

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -54,7 +54,9 @@ storyboard, not the media** in the Process section.
    once per machine: `uv run --with playwright playwright install chromium`
    (on a fresh Linux box add `--with-deps` for system libraries). If a
    later run resolves a newer Playwright that wants a newer browser
-   build, re-run this command.
+   build, re-run this command. Playwright **1.49 or newer** for per-beat
+   evidence — `locator.aria_snapshot()` arrived there, and the older
+   `page.accessibility` API it replaced has since been removed.
 3. **Learn how the app runs** (dev server command, port, how to build the
    frontend, how to seed data). If the project documents this, follow it;
    otherwise ask. Reuse an already-running server.
@@ -129,6 +131,7 @@ clean:
 | `DEMO_VIDEO_LOCALE` | browser locale (`locale`), always applied | `en-US` |
 | `DEMO_VIDEO_SPEECH` | force narration on/off (`1`/`0`) | auto by API key |
 | `DEMO_VIDEO_STRICT` | fail the take on console errors / non-zero exits (`1`/`0`) | off |
+| `DEMO_VIDEO_EVIDENCE` | write `evidence/beat-NN.json` per beat (`1`/`0`) — see **Per-beat evidence** | **on** |
 | `DEMO_VIDEO_VOICE_ID` | ElevenLabs voice | Sarah (premade) |
 | `DEMO_VIDEO_SPEECH_MODEL` | ElevenLabs model | `eleven_multilingual_v2` |
 | `DEMO_VIDEO_SKILL_DIR` | where storyboards find this skill | the constant baked into each storyboard |
@@ -601,6 +604,11 @@ set of paths — four on the web, one in the terminal — and nothing else:
 - **Non-visual channels are untouched.** The value still exists in the DOM
   (`page.content()`), in the app's network traffic, and in whatever the app
   logs. Redaction hides it from the *recording*, not from the machine.
+  - The one place this skill *does* dump the DOM is `evidence/beat-NN.json`,
+    and it is plain text, so it cannot inherit a pixel control for free: the
+    recorder reads what each redacted element renders and masks that text out
+    of every evidence file. Read **Per-beat evidence** before trusting it, and
+    do not commit `evidence/`.
 - **A screenshot the storyboard takes itself** — `rec.page.screenshot(...)`
   rather than `rec.shot(...)` — still goes through the page, so the CSS mask
   applies; but any artifact your storyboard writes by hand (a `page.content()`
@@ -665,6 +673,8 @@ key is fine, renaming one is not:
   `spotlight`).
 - `still` is a path relative to the timeline file, so `timeline.md`'s embeds
   and any tooling resolve the same way.
+- `evidence` is a path, the same way — the beat's own account of what was on
+  screen. See **Per-beat evidence** below.
 - `exit_code` appears on `TerminalRecorder` `run` beats — see **Failing the
   take** below.
 - `issues` is what the recorder saw *behind* the pixels; `issue_count` is how
@@ -775,6 +785,116 @@ record in parts is a demo nobody wants to review by scrubbing.
 downstream reads it; `beat_frames(out_dir)` from `demo_recording` regenerates
 it from `demo.mp4` and `timeline.json` without re-recording, and clears the
 previous run's frames first.
+
+## Per-beat evidence (`evidence/beat-NN.json`)
+
+A reviewing agent handed frames has to infer what the page said from pixels.
+The recorder is *driving* the page, so at the end of every beat it also writes
+down what was on screen, in text, next to the frame that beat's timestamps
+point at. No storyboard changes; it is a byproduct of recording, like the
+timeline. `Recorder(..., evidence=False)` or `DEMO_VIDEO_EVIDENCE=0` turns it
+off.
+
+```json
+{ "schema": 1, "generated_by": "demo-video", "recorder": "Recorder",
+  "segment": null, "media": "demo.mp4",
+  "beat": { "index": 6, "t_start": 5.31, "t_end": 5.44, "verb": "shot",
+            "selector": "01-dashboard", "caption": "A small dashboard.",
+            "still": "images/01-dashboard.png",
+            "evidence": "evidence/beat-06.json" },
+  "scope": "#kpi-rev",
+  "url": "http://localhost:3000/", "title": "Northwind Ops",
+  "aria_format": "aria-yaml",
+  "aria": "- banner:\n  - heading \"Northwind Ops\" [level=1]\n- text: Revenue $128,400 …",
+  "scope_aria": "- text: $128,400",
+  "html": "<div id=\"kpi-rev\">$128,400</div>",
+  "redacted": ["#api-key"],
+  "truncated": [], "limits": { "aria": 12000, "html": 8000 } }
+```
+
+| Field | What it is |
+|---|---|
+| `aria` | **`Recorder`**: the page's ARIA snapshot — a compact YAML tree of roles and accessible names, the same thing `expect(...).toMatchAriaSnapshot` compares. Semantic, ~10× smaller than the markup, and stable across restyling, which is why it is preferred over raw HTML |
+| `scope` / `scope_aria` / `html` | the current `spotlight()` target: its selector, its own ARIA tree, and its `outerHTML`. All three are null when no spotlight is up |
+| `screen` | **`TerminalRecorder`**: the rendered screen, ANSI resolved by xterm.js, scrollback included — the same text `wait_for_text()` matches against |
+| `truncated` / `limits` | which fields were cut, and at what budget. A cut field also says so inline where it stops |
+
+**`outerHTML` is only ever the spotlight target's, never the page's.** A whole
+document's markup is an order of magnitude bigger than its ARIA tree and
+carries two things nobody put on screen: the text of every inline `<script>`,
+and `srcdoc` attributes — i.e. source code and whole embedded documents. The
+clone that gets serialized drops both, along with `<style>`, the recorder's own
+overlays, and anything `redact()` is covering.
+
+Fields are capped (12 000 characters of ARIA or screen text, 8 000 of markup)
+and truncation is **marked, never silent** — a TUI's scrollback is 5 000 lines,
+and an uncapped `evidence/` outgrows the mp4 it describes.
+
+### Evidence is plain text — what that means for secrets
+
+**This is the artifact where a secret is cheapest to find**, and it is worth
+being blunt about why: everything else this skill writes is pixels, and
+`redact()` is a *pixel* control. It covers where a value renders. The value is
+still in the DOM — and an evidence file is a text dump of that DOM. "It is
+blurred in the video" is no protection here at all.
+
+So evidence is masked twice over, and the second one is what makes redaction
+carry across:
+
+- every registered secret (`register_secret()`, a typed `Secret`) is replaced
+  with `[redacted]`, as everywhere else;
+- **the rendered text of everything `redact()` is covering** is read out of the
+  page as the take runs — the matched element and every node under it, shadow
+  roots at every depth, `::before`/`::after` content, input values, and
+  value-bearing attributes — and every occurrence of any of it is replaced
+  too, in every beat's evidence, including beats recorded before the value
+  first appeared. `redact()` never tells the recorder what the element *says*,
+  so this is the step that turns a pixel control into a text one;
+- markup is elided structurally as well as by substring, because a value split
+  across tags (`sk-live-<b>FAKE</b>`) has a `textContent` a string mask finds
+  and an `outerHTML` it does not.
+
+Nothing reaches the disk until the take exits cleanly and the mask has been
+verified: the documents are built in memory and written beside `timeline.json`,
+so a take that dies on a `SecretLeak` has no evidence file to delete. If a
+document cannot be made safe — or if the recorder cannot read what `redact()`
+is hiding for a given beat — it fails the take, or writes that beat's evidence
+as `{"omitted": …}` with no page text in it, rather than writing something it
+cannot vouch for.
+
+**What it still does not cover:**
+
+- **`TerminalRecorder` has no `redact()`** (that is
+  [issue #5](https://github.com/rogvid/skills/issues/5)), so `screen` is the
+  whole terminal, scrubbed for registered secrets only. A command that
+  *prints* a value nobody registered writes it here verbatim — the same
+  exposure the recording already has, in a form that greps.
+- **`url` and `title` are scrubbed, not redacted.** A token in a query string
+  that nobody registered lands in the file.
+- **Only exact substrings match**, the same limit `register_secret()` has:
+  the same value rendered with different whitespace is a different string.
+- **The ARIA snapshot needs Playwright ≥ 1.49.** Older versions get a null
+  `aria` and an `aria_format` saying so, rather than a fallback nobody tests.
+
+**Evidence is not committed.** Gitignore `evidence/`. It is a byproduct
+regenerated on every take, it churns completely on each re-record, and — the
+reason that matters — it is greppable plaintext of a real app's DOM, which is
+exactly the thing a git history should not carry permanently and cannot be
+made to forget afterwards. `timeline.json` and `timeline.md` stay the
+committed, diffable record of what the demo showed; evidence is for the
+reviewer looking at *this* take, alongside `demo.mp4`, which is not committed
+either.
+
+### Naming, and merged segments
+
+A beat's `index` is its position in **its own take**, so two segments of one
+demo both start at 0. Two things make that a non-event: a segment's evidence
+carries the segment in its filename
+(`evidence/part1.seg.beat-03.json`, mirroring `<segment>.seg.timeline.json`),
+and the path is written **onto the beat** as `evidence` rather than derived
+from `index` by whoever reads the log. Read the pointer, never rebuild it —
+then a merge that renumbers beats has only to carry the string across, and
+every evidence file names its own `segment` and `index` internally anyway.
 
 ## Failing the take on a broken app
 
@@ -1049,7 +1169,8 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    recorder prints on stderr**, and the Issues section of `timeline.md`: a
    demo of an app throwing on every render looks exactly like a demo of a
    working one, and this is the only place it shows (see **Failing the take
-   on a broken app**).
+   on a broken app**). To check what a *specific* frame showed without
+   decoding it, open the beat's `evidence` file — that is what it is for.
 6. **Fresh-agent review (required).** You cannot watch the video, and you
    know too much anyway — have a context-free agent watch it for you. The
    recorder has already written what they need: `frames/`, one PNG per
@@ -1095,7 +1216,17 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    segment parts, `*.seg.timeline.*`, `<demo folder>/frames/` (regenerated
    from the two by `beat_frames(out_dir)` — anchor the pattern to the demo
    folder rather than writing a bare `frames/`, which matches a directory
-   of that name anywhere in the repo), and `.tts/` narration caches.
+   of that name anywhere in the repo), `.tts/` narration caches, and
+   `<demo folder>/evidence/`.
+
+   **`evidence/` is not committed either, and for a stronger reason than the
+   mp4.** It is regenerated wholesale on every take, so it would churn
+   completely on each re-record and diff as noise — but the deciding argument
+   is that it is greppable plaintext of a real app's DOM and terminal, which
+   is precisely what a git history should not carry permanently and cannot be
+   made to forget afterwards. It is a per-take artifact for the reviewer
+   looking at *this* recording, like the mp4. `timeline.md` is what a reader
+   six months from now gets.
 
    To put the demo in front of a reviewer, drag `demo.mp4` into a PR
    comment box — GitHub hosts it and renders a real player. That upload has

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -882,13 +882,29 @@ guess about what a secret looks like: a string that renders in the clear
 somewhere the mask does not cover is already in the frames and the stills, so
 masking it in a text file buys nothing and costs the file its meaning.
 
-"Renders outside" is narrower than it sounds, and each exclusion was a leak:
-hidden elements do not count (an `aria-labelledby` source can be `display:none`
-and still name a redacted element), `<script>` text does not count (it is
-source, not screen), light DOM slotted into a redacted element counts as
-*inside* it, and **the recorder's own caption bar does not count at all** —
-captioning a redacted value would otherwise exempt it from masking everywhere,
-turning one mistake in the frames into the same mistake in `timeline.json`.
+"Renders outside" means **painted**, which is narrower than it sounds, and every
+relaxation of it has been a leak:
+
+- only **text nodes and `::before`/`::after` content** count. An attribute never
+  does — not `title`, `alt`, `placeholder`, `aria-label`, `data-*`, `content` or
+  `srcdoc` — and neither does an input's `value`. A copy-to-clipboard button
+  carrying the key it copies in `title` is ordinary UI, and it was enough to
+  exempt that key from masking in every evidence file *and* in `timeline.json`.
+  The same reasoning already strips those attributes out of `html`;
+- **hidden means hidden by any mechanism the browser will admit to**:
+  `display`, `visibility`, `opacity`, `content-visibility`, a box under 2×2 CSS
+  pixels (the screen-reader-only clip), and a box entirely off the top or left
+  of the document (the `-9999px` skip link). Only `display:none` was excluded
+  for one round, which was the one shape the fixture happened to use;
+- `<script>` text does not count — it is source, not screen;
+- light DOM slotted into a redacted element counts as *inside* it;
+- and **the recorder's own caption bar does not count at all** — captioning a
+  redacted value would otherwise exempt it from masking everywhere, turning one
+  mistake in the frames into the same mistake in `timeline.json`.
+
+What is left uncovered is occlusion: an element painted underneath an opaque
+sibling, or clipped away by a `clip-path` on an ancestor, still counts as
+rendered ([issue #69](https://github.com/rogvid/skills/issues/69)).
 
 Nothing reaches the disk until the take exits cleanly and the mask has been
 verified: the documents are built in memory and written beside `timeline.json`,
@@ -901,7 +917,7 @@ safe, the take fails.
 
 **A page that repaints while it is being read gets no page text.** The ARIA
 snapshot is a protocol call and the harvest is a page evaluation, so they cannot
-be one operation: a card rewritten on a 25 ms interval — a countdown, a ticker,
+be one operation: a card rewritten on a 5 ms interval — a countdown, a ticker,
 a rotating token — hands the harvest one value and the snapshot the next. The
 harvest is therefore taken on both sides of the snapshot and the two must agree;
 if they will not settle, that beat's evidence is written as `{"omitted": …}`
@@ -928,9 +944,25 @@ redacted region never holds still, expect most beats to come back that way —
   accessible name, so they are in `aria` by design even though they are
   stripped from `html`. That is what a screen-reader user perceives; if it is a
   secret, redact the element.
-- **Only exact substrings match**, modulo whitespace — the same limit
-  `register_secret()` has. A value rendered with a soft hyphen, or split across
-  two elements that are not both redacted, is a different string.
+- **Matching is exact, modulo a stated list of transformations — and that list
+  is the boundary, not a promise to keep growing.** Every leak this feature has
+  had was the same shape: a comparison between a value somebody registered and
+  a transformation of that value the code did not anticipate. Three are
+  handled, and they are handled by normalizing rather than by special cases:
+
+  | Transformation | Where it comes from | How it is matched |
+  |---|---|---|
+  | whitespace the value has, the text does not | `textContent` keeps the source's indentation; an ARIA tree does not | a run of whitespace in the value matches any run in the text |
+  | whitespace the text has, the value does not | a terminal wrapping at the last column; anything that reflows | inside a token of 8+ characters, every character may be followed by whitespace |
+  | HTML entities and character references | `outerHTML` writes `&` as `&amp;`, NBSP as `&nbsp;` | entities are resolved before the check, in `html` and in the end-of-document guard |
+  | JSON string escapes | the guard runs over the serialized document, where a newline is `\n` | resolved the same way, so the guard cannot miss what the mask missed |
+
+  **Not** handled, and not planned: case differences, Unicode normalization
+  forms and confusables, percent- / base64- / backslash-encoding, a value the
+  app itself reformats (inserted hyphens, an ellipsis, a thousands separator),
+  and a value split across two elements that are not both redacted. This is an
+  asymptotic surface; a demo whose secret survives one of those is a demo whose
+  author should `redact()` the element rather than rely on a string match.
 - **The ARIA snapshot needs Playwright ≥ 1.49.** Older versions get a null
   `aria` and an `aria_format` saying so, rather than a fallback nobody tests.
 

--- a/skills/demo-video/helpers/demo_recording/__init__.py
+++ b/skills/demo-video/helpers/demo_recording/__init__.py
@@ -8,6 +8,10 @@ Storyboards import from here:
 """
 
 from .core import (
+    EVIDENCE_DIR,
+    EVIDENCE_LIMITS,
+    EVIDENCE_SCHEMA,
+    EVIDENCE_TRUNCATED,
     FRAMES_SCHEMA,
     ISSUE_KINDS,
     MAX_ISSUES,
@@ -19,6 +23,7 @@ from .core import (
     SecretLeak,
     StrictTakeFailed,
     beat_frames,
+    evidence_name,
     frames_paths,
     media_duration,
     render_frames_md,
@@ -34,19 +39,24 @@ from .terminal import TerminalRecorder
 from .web import Recorder
 
 __all__ = [
+    "EVIDENCE_DIR",
+    "EVIDENCE_LIMITS",
+    "EVIDENCE_SCHEMA",
+    "EVIDENCE_TRUNCATED",
     "FRAMES_SCHEMA",
     "ISSUE_KINDS",
     "MAX_ISSUES",
+    "Recorder",
     "SCENE_MIN_SPAN_S",
     "SECRET_MASK",
     "STRICT_KINDS",
-    "TIMELINE_SCHEMA",
-    "Recorder",
     "Secret",
     "SecretLeak",
     "StrictTakeFailed",
+    "TIMELINE_SCHEMA",
     "TerminalRecorder",
     "beat_frames",
+    "evidence_name",
     "frames_paths",
     "media_duration",
     "render_frames_md",

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -35,6 +35,7 @@ import urllib.error
 import urllib.request
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from html import unescape as html_unescape
 from pathlib import Path
 from types import TracebackType
 
@@ -644,6 +645,33 @@ EVIDENCE_HTML_WITHHELD = (
     "across elements here, and there is no safe way to edit it out of the "
     "serialization. The ARIA snapshot above is unaffected.]"
 )
+
+# A token this long or longer, found with whitespace *inside* it, was broken by
+# something that reflowed the text rather than written that way. A terminal wrap
+# is the case that matters: xterm.js emits one buffer row per line, so a 28-
+# character credential that crosses column 120 comes back as
+# `"…sk-live-WRAP0000\n00000000…"` and an exact search finds neither half.
+#
+# Eight is where "no natural text breaks this in the middle" starts being true.
+# Below it, allowing whitespace between every character turns a two-character
+# mask into a pattern that matches ordinary prose — `ok` would match `o k`, and
+# over-masking is the failure this whole `outside` machinery exists to prevent.
+# Above it, the cost of being wrong is that a value the author registered gets
+# masked in one more place than strictly necessary.
+EVIDENCE_WRAP_MIN_TOKEN = 8
+
+# The escapes `json.dumps` introduces, undone for *detection* by
+# `_evidence_probe`. The backstop runs over the serialized document, where a
+# newline is the two characters `\` and `n` — which no amount of elastic
+# whitespace in a pattern can match, so the backstop used to miss exactly what
+# the mask missed. A backstop that fails in the same direction as the thing it
+# backs up is not one.
+_JSON_STRING_ESCAPE = re.compile(r'\\[nrtbf"/\\]')
+_JSON_ESCAPES = {
+    r"\n": "\n", r"\r": "\r", r"\t": "\t", r"\b": "\b", r"\f": "\f",
+    r"\"": '"', r"\/": "/", "\\\\": "\\",
+}
+_JSON_UNICODE_ESCAPE = re.compile(r"\\u([0-9a-fA-F]{4})")
 
 # Harvested text shorter than this is not used as a mask. `redact()` pointed at
 # an element rendering "$" would otherwise replace every dollar sign in every
@@ -2232,22 +2260,98 @@ class _DemoBase:
         return tuple(sorted(literals, key=len, reverse=True))
 
     def _evidence_re(self, literal: str) -> "re.Pattern[str]":
-        """`literal` as a pattern whose whitespace is elastic.
+        """`literal` as a pattern whose whitespace is elastic in both directions.
 
-        The harvest reads `textContent`, which carries the source's own
-        indentation: a value on its own line in hand-written HTML comes back as
-        `'\\n      wombatxray7714\\n    '`. An ARIA tree renders the same value
-        as `- code: wombatxray7714`, and `str.replace` between those two finds
-        nothing at all — the single most ordinary shape there is, leaking in
-        every file. So every run of whitespace in the literal matches any run of
-        whitespace in the text, and the ends are trimmed before matching.
+        Every leak this has had is the same shape: a comparison between a value
+        somebody registered and *a transformation of that value* that the code
+        did not anticipate. Whitespace is where two of those transformations
+        land, and they pull opposite ways:
+
+          * **Whitespace the literal has and the text does not.** The harvest
+            reads `textContent`, which carries the source's own indentation: a
+            value on its own line in hand-written HTML comes back as
+            `'\\n      wombatxray7714\\n    '`, while an ARIA tree renders it
+            `- code: wombatxray7714`. So a run of whitespace in the literal
+            matches any run in the text, and the ends are trimmed.
+          * **Whitespace the text has and the literal does not.** Anything that
+            reflows text inserts it. `__termText()` emits one xterm.js buffer
+            row per line joined with newlines and does not consult `isWrapped`,
+            so a credential crossing the last column arrives split in two —
+            `"…sk-live-WRAP0000\\n00000000…"` — fully legible, trivially
+            recovered with `tr -d '\\n'`, and matched by neither half of an
+            exact search. So inside a token of `EVIDENCE_WRAP_MIN_TOKEN`
+            characters or more, every character may be followed by whitespace.
+
+        The token-length floor is what keeps the second rule from eating the
+        page: separating the characters of a short mask by `\\s*` makes it match
+        ordinary prose, and over-masking is the failure `_evidence_forbidden`'s
+        whole `outside` rule exists to prevent. See `EVIDENCE_WRAP_MIN_TOKEN`.
+
+        What this does **not** normalize is written down in SKILL.md, under
+        "What it still does not cover". This is an asymptotic surface and the
+        boundary is stated rather than chased.
         """
         pattern = self._evidence_res.get(literal)
         if pattern is None:
-            tokens = [re.escape(t) for t in literal.split()]
-            pattern = re.compile(r"\s+".join(tokens) if tokens else re.escape(literal))
+            tokens = literal.split()
+            if not tokens:
+                pattern = re.compile(re.escape(literal))
+            else:
+                parts = []
+                for token in tokens:
+                    if len(token) >= EVIDENCE_WRAP_MIN_TOKEN:
+                        parts.append(r"\s*".join(re.escape(c) for c in token))
+                    else:
+                        parts.append(re.escape(token))
+                pattern = re.compile(r"\s+".join(parts))
             self._evidence_res[literal] = pattern
         return pattern
+
+    @staticmethod
+    def _evidence_probe(text: str) -> str:
+        """`text` with the escapes a *serializer* added resolved. Detection only.
+
+        Never written anywhere — this exists so the two checks that ask "is a
+        forbidden value still in here" can see through the encodings the writer
+        itself introduces on the way to disk:
+
+          * **HTML entity escaping.** `outerHTML` writes `&` as `&amp;`, `<` as
+            `&lt;`, a non-breaking space as `&nbsp;`. A registered
+            `sk-live-AMPS0000&sig=0000000000` — an ordinary shape for a
+            presigned URL or a SAS token — is in the markup in full and matches
+            no raw search, so the mask left it and the backstop waved it
+            through, in a file whose `aria` said `[redacted]` two lines above.
+          * **JSON string escaping.** The backstop runs over `json.dumps(doc)`,
+            where a newline is the two characters `\\n`. Elastic whitespace in
+            the pattern cannot match that, so the backstop missed every wrapped
+            value the mask missed — the two failed identically, which is the
+            one thing a backstop must not do.
+
+        Resolving both, on a copy, costs one pass and removes the whole class.
+        The output is deliberately not valid markup or valid JSON; nothing may
+        serialize it.
+        """
+        probe = _JSON_STRING_ESCAPE.sub(
+            lambda m: _JSON_ESCAPES.get(m.group(0), m.group(0)), text
+        )
+        probe = _JSON_UNICODE_ESCAPE.sub(
+            lambda m: chr(int(m.group(1), 16)), probe
+        )
+        return html_unescape(probe)
+
+    def _evidence_holds(self, text: str, literals: "tuple[str, ...]") -> str | None:
+        """The first forbidden literal still findable in `text`, or None.
+
+        Checked against the text as written *and* against
+        `_evidence_probe(text)`, because a value that only survives in an
+        escaped form is exactly as readable to whoever opens the file.
+        """
+        probed = self._evidence_probe(text)
+        for literal in literals:
+            pattern = self._evidence_re(literal)
+            if pattern.search(text) or pattern.search(probed):
+                return literal
+        return None
 
     def _evidence_mask(self, text: str, forbidden: tuple[str, ...]) -> str:
         for literal in forbidden:
@@ -2298,19 +2402,27 @@ class _DemoBase:
         }
         doc.update(payload)
         doc = self._evidence_scrub_deep(doc, forbidden)  # type: ignore[assignment]
-        # Markup is the one field a substring mask cannot finish the job on. A
-        # value written `harbor<b>zenith</b>7725` has a `textContent` the mask
-        # finds and an `outerHTML` it does not, and only elements the *mask*
-        # reached are elided structurally (web.py) — a `register_secret()` value
-        # split across tags in an ordinary paragraph is reached by neither. So
-        # the tags are stripped and the bare text re-checked, and markup that
-        # still holds a forbidden value is withheld rather than published: the
-        # field is a convenience, and there is no safe way to edit a value out
-        # of markup that interleaves it with elements.
+        # Markup is the one field a substring mask cannot finish the job on, and
+        # it has two ways of hiding a value from one:
+        #
+        #   * **structure.** A value written `harbor<b>zenith</b>7725` has a
+        #     `textContent` the mask finds and an `outerHTML` it does not, and
+        #     only elements the *mask* reached are elided structurally (web.py)
+        #     — a `register_secret()` value split across tags in an ordinary
+        #     paragraph is reached by neither. So the tags are stripped.
+        #   * **entity escaping.** `outerHTML` writes `&` as `&amp;`, so a
+        #     registered `…AMPS0000&sig=0000000000` is in the file whole and
+        #     matches no raw search. `_evidence_holds` resolves entities before
+        #     looking, which is the only reason this branch sees it at all.
+        #
+        # Markup that still holds a forbidden value after both is withheld
+        # rather than published: the field is a convenience, and there is no
+        # safe way to edit a value out of markup that interleaves it with
+        # elements or spells it in character references.
         html = doc.get("html")
         if isinstance(html, str):
             bare = re.sub(r"<[^>]*>", "", html)
-            if any(self._evidence_re(lit).search(bare) for lit in forbidden):
+            if self._evidence_holds(bare, forbidden) is not None:
                 doc["html"] = EVIDENCE_HTML_WITHHELD
         truncated: list[str] = []
         for field, limit in EVIDENCE_LIMITS.items():
@@ -2328,18 +2440,25 @@ class _DemoBase:
         # about a plain string value, and this file does not pretend otherwise.
         # What it does reach is everything the walker structurally cannot: a
         # field added to this schema by a later slice that is built after the
-        # scrub, a non-string key, a literal that only exists once JSON
-        # escaping has run. The grading that can actually fail is the byte
-        # sweep over `evidence/` in tests/smoke.
+        # scrub, a non-string key, a literal that only exists once serialization
+        # has run. The grading that can actually fail is the byte sweep over
+        # `evidence/` in tests/smoke.
+        #
+        # It goes through `_evidence_holds` rather than `in`, and that is the
+        # difference between a backstop and a comment. `json.dumps` writes a
+        # newline as the two characters `\` and `n`, so a plain substring test
+        # here missed every wrapped value the mask missed — failing in the same
+        # direction as the thing it backs up, which is the one thing it must
+        # not do.
         blob = json.dumps(doc, ensure_ascii=False)
-        for literal in forbidden:
-            if literal in blob:
-                raise SecretLeak(
-                    f"a beat's evidence still holds a {len(literal)}-character "
-                    f"value that is registered or redacted, after masking — so "
-                    f"the recorder cannot vouch for what it was about to write. "
-                    f"No evidence file, no mp4 and no timeline were written."
-                )
+        held = self._evidence_holds(blob, forbidden)
+        if held is not None:
+            raise SecretLeak(
+                f"a beat's evidence still holds a {len(held)}-character "
+                f"value that is registered or redacted, after masking — so "
+                f"the recorder cannot vouch for what it was about to write. "
+                f"No evidence file, no mp4 and no timeline were written."
+            )
         return doc
 
     def _build_evidence(self) -> None:

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -2339,6 +2339,24 @@ class _DemoBase:
         )
         return html_unescape(probe)
 
+    def _recoverable_secret(self, text: str) -> str | None:
+        """The first registered secret recoverable from `text`, or None.
+
+        The same matching an evidence file gets — whitespace elastic in both
+        directions, entity and serializer escapes resolved — pointed at a
+        medium's *finished output* rather than at a document, so a final
+        redaction check and the evidence writer cannot disagree about whether
+        a value is present.
+
+        A terminal screen is what needs it. `__termText()` joins xterm.js
+        buffer rows with newlines and does not consult `isWrapped`, so a
+        credential crossing the last column is two rows with a newline through
+        the middle, and `secret in screen` sees neither half — the same blind
+        spot the evidence mask had, in the check that decides whether the
+        frames are safe to keep.
+        """
+        return self._evidence_holds(text, tuple(self._secrets))
+
     def _evidence_holds(self, text: str, literals: "tuple[str, ...]") -> str | None:
         """The first forbidden literal still findable in `text`, or None.
 

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -636,12 +636,26 @@ EVIDENCE_LIMITS = {
 }
 EVIDENCE_TRUNCATED = "\n…[demo-video: truncated here, {n} more characters]"
 
+# What `html` says instead of markup when a registered or redacted value is
+# interleaved with elements inside it. Spelled out rather than left null, so a
+# reader can tell "no spotlight was up" from "the markup was withheld".
+EVIDENCE_HTML_WITHHELD = (
+    "[demo-video: markup withheld — a registered or redacted value is split "
+    "across elements here, and there is no safe way to edit it out of the "
+    "serialization. The ARIA snapshot above is unaffected.]"
+)
+
 # Harvested text shorter than this is not used as a mask. `redact()` pointed at
 # an element rendering "$" would otherwise replace every dollar sign in every
 # evidence file, which costs the evidence its meaning and hides nothing: a
 # one-character secret is not one. Registered secrets are masked at any length
 # — `register_secret()` was told, explicitly, that the value matters.
 EVIDENCE_MIN_MASK_LEN = 2
+
+# Print a warning past this much evidence in one take. Not a cap — the
+# per-field budgets are the cap — but a large accessibility tree times a long
+# storyboard is a real cost (issue #49) and it should not arrive silently.
+EVIDENCE_DIR_WARN_BYTES = 2_000_000
 
 
 def evidence_name(index: int, segment: str | None = None) -> str:
@@ -1459,6 +1473,12 @@ class _DemoBase:
         self._evidence_on = True if evidence is None else bool(evidence)
         self._evidence: list[tuple[dict, dict]] = []
         self._evidence_masks: set[str] = set()
+        # Text the page renders *outside* every redacted subtree, deduplicated
+        # across beats. A harvested string found in here is rendered in the
+        # clear somewhere, so masking it would only damage the evidence — see
+        # `_evidence_forbidden`.
+        self._evidence_outside: set[str] = set()
+        self._evidence_res: dict[str, re.Pattern[str]] = {}
         self._evidence_docs: list[tuple[Path, dict]] = []
         # Announce narration state up front — a silent recording when the
         # user expected voice (usually the key just isn't in this process's
@@ -2102,11 +2122,15 @@ class _DemoBase:
         finally:
             # Captured before `t_end` is stamped, so the round trips it costs
             # are accounted for *inside* the beat that paid for them and no
-            # unexplained gap opens up between one beat and the next.
-            if self._evidence_on:
-                self._capture_evidence(record)
-            record["t_end"] = round(time.monotonic() - self._t0, 3)
-            self._in_beat = False
+            # unexplained gap opens up between one beat and the next. Nested
+            # try/finally so `t_end` is stamped even when the capture refuses
+            # (a SecretLeak out of a medium's payload is fatal, on purpose).
+            try:
+                if self._evidence_on:
+                    self._capture_evidence(record)
+            finally:
+                record["t_end"] = round(time.monotonic() - self._t0, 3)
+                self._in_beat = False
 
     def _write_beat_frames(self, doc: dict) -> None:
         """Extract this take's review frames (a no-op for a segment).
@@ -2131,17 +2155,22 @@ class _DemoBase:
         return {}
 
     def _capture_evidence(self, beat: dict) -> None:
-        """Buffer one beat's evidence. Never raises.
+        """Buffer one beat's evidence.
 
-        A capture failure must not lose a take that is otherwise fine — the
-        beat gets a file saying what went wrong instead, which keeps the
-        `evidence` pointer on every beat pointing at something real. The one
-        failure that is *not* survivable — a redacted element whose rendered
-        text could not be read, and therefore could not be masked — is handled
-        in the medium's payload, which returns `omitted` rather than raising.
+        Raises only SecretLeak, and that exclusion is the whole point of the
+        handler below rather than an afterthought. A broad `except` here would
+        swallow one — this runs in a `finally`, and everything a medium's
+        payload touches (the mask, the page) is a place SecretLeak comes from.
+        Catching it would turn a control that used to kill a take into one that
+        prints a line and lets the mp4 be written. Every other failure is a
+        diagnostic and must not lose an otherwise fine take: the beat gets a
+        file saying what went wrong, which keeps the `evidence` pointer on
+        every beat pointing at something real.
         """
         try:
             payload = self._evidence_payload()
+        except SecretLeak:
+            raise
         except Exception as exc:  # noqa: BLE001 - a diagnostic must not kill a take
             payload = {"error": f"{type(exc).__name__}: {exc}"}
             print(
@@ -2152,32 +2181,77 @@ class _DemoBase:
             )
         self._evidence.append((beat, payload))
 
+    @staticmethod
+    def _flatten(text: str) -> str:
+        """Whitespace collapsed to single spaces, ends trimmed."""
+        return " ".join(text.split())
+
     def _evidence_forbidden(self) -> tuple[str, ...]:
         """Every literal that must not appear in an evidence file, longest first.
 
         Two sources, and the second is the reason this exists at all:
 
           * `self.secrets` — text somebody registered. `scrub()` already covers
-            this everywhere else.
+            this everywhere else, and nothing below can drop one: the author
+            said explicitly that the value matters.
           * `self._evidence_masks` — the *rendered text of everything redact()
             is covering*, read out of the page as the take ran. `redact()` is a
             pixel control: it hides where a value renders and leaves the value
             in the DOM, so a text dump of that DOM is not protected by it at
             all. This is what makes evidence inherit redaction.
 
+        **A harvested string is only used as a mask if it appears nowhere
+        outside the redacted subtrees**, and without that rule this feature
+        destroys the artifact it exists to produce. Harvesting *every* node of a
+        redacted card also harvests its label: `redact("#revenue-card")` around
+        a `<span>Revenue</span>` would otherwise register "Revenue" as a global
+        forbidden literal and rewrite every unrelated paragraph in every file as
+        `[redacted] for the quarter was $128,400`. Worse, a card holding
+        `sk-<i>live</i>-CHLD…` harvests the text nodes "sk-" and "live" on their
+        own and rewrites every other key on the page.
+
+        The rule is not a heuristic about what a secret looks like: a string
+        that also renders *in the clear* somewhere the mask does not cover is,
+        by construction, not being hidden by that mask — it is in the frames, in
+        the stills and in the video. Masking it in a text file buys nothing and
+        costs the file its meaning. What is left is exactly what only exists
+        behind the mask.
+
         Longest first so overlapping values (a token, and the header line
         holding it) mask the larger one whole instead of leaving its tail.
         """
+        outside = "\n".join(self._evidence_outside)
         literals = set(self._secrets)
-        literals |= {
-            text for text in self._evidence_masks
-            if len(text.strip()) >= EVIDENCE_MIN_MASK_LEN
-        }
+        for text in self._evidence_masks:
+            flat = self._flatten(text)
+            if len(flat) < EVIDENCE_MIN_MASK_LEN:
+                continue
+            if flat in outside:
+                continue  # rendered in the clear elsewhere: not this mask's
+            literals.add(text)
         return tuple(sorted(literals, key=len, reverse=True))
+
+    def _evidence_re(self, literal: str) -> "re.Pattern[str]":
+        """`literal` as a pattern whose whitespace is elastic.
+
+        The harvest reads `textContent`, which carries the source's own
+        indentation: a value on its own line in hand-written HTML comes back as
+        `'\\n      wombatxray7714\\n    '`. An ARIA tree renders the same value
+        as `- code: wombatxray7714`, and `str.replace` between those two finds
+        nothing at all — the single most ordinary shape there is, leaking in
+        every file. So every run of whitespace in the literal matches any run of
+        whitespace in the text, and the ends are trimmed before matching.
+        """
+        pattern = self._evidence_res.get(literal)
+        if pattern is None:
+            tokens = [re.escape(t) for t in literal.split()]
+            pattern = re.compile(r"\s+".join(tokens) if tokens else re.escape(literal))
+            self._evidence_res[literal] = pattern
+        return pattern
 
     def _evidence_mask(self, text: str, forbidden: tuple[str, ...]) -> str:
         for literal in forbidden:
-            text = text.replace(literal, SECRET_MASK)
+            text = self._evidence_re(literal).sub(SECRET_MASK, text)
         return text
 
     def _evidence_scrub_deep(self, value: object, forbidden: tuple[str, ...]) -> object:
@@ -2224,6 +2298,20 @@ class _DemoBase:
         }
         doc.update(payload)
         doc = self._evidence_scrub_deep(doc, forbidden)  # type: ignore[assignment]
+        # Markup is the one field a substring mask cannot finish the job on. A
+        # value written `harbor<b>zenith</b>7725` has a `textContent` the mask
+        # finds and an `outerHTML` it does not, and only elements the *mask*
+        # reached are elided structurally (web.py) — a `register_secret()` value
+        # split across tags in an ordinary paragraph is reached by neither. So
+        # the tags are stripped and the bare text re-checked, and markup that
+        # still holds a forbidden value is withheld rather than published: the
+        # field is a convenience, and there is no safe way to edit a value out
+        # of markup that interleaves it with elements.
+        html = doc.get("html")
+        if isinstance(html, str):
+            bare = re.sub(r"<[^>]*>", "", html)
+            if any(self._evidence_re(lit).search(bare) for lit in forbidden):
+                doc["html"] = EVIDENCE_HTML_WITHHELD
         truncated: list[str] = []
         for field, limit in EVIDENCE_LIMITS.items():
             text = doc.get(field)
@@ -2270,16 +2358,72 @@ class _DemoBase:
             for beat, payload in self._evidence
         ]
 
+    def _stale_evidence(self, keep: set[Path] | None = None) -> list[Path]:
+        """This take's own evidence files that this take is not writing.
+
+        Only files this take's naming owns — `beat-NN.json` for a whole demo,
+        `<segment>.seg.beat-NN.json` for a segment — so re-recording one segment
+        of a multi-segment demo does not delete the others.
+        """
+        directory = self.out_dir / EVIDENCE_DIR
+        if not directory.is_dir():
+            return []
+        prefix = f"{self.segment}.seg." if self.segment else ""
+        mine = re.compile(rf"^{re.escape(prefix)}beat-\d+\.json$")
+        keep = keep or set()
+        return [
+            path
+            for path in sorted(directory.glob("*.json"))
+            if mine.match(path.name) and path not in keep
+        ]
+
+    def _clear_stale_evidence(self, keep: set[Path] | None = None) -> None:
+        """Delete evidence a previous take into this directory left behind.
+
+        Re-recording into the same folder is how this skill is *meant* to be
+        used — `record.py` is committed precisely so it can be re-run — and a
+        take that adds `redact()` (or simply has fewer beats than the last one)
+        would otherwise leave the previous take's files sitting beside its own,
+        holding the very value the new take was written to hide. Nothing else
+        here has that shape: the mp4 is overwritten, and a still is only kept
+        because it might be a committed guide. Evidence is never committed, so
+        there is no such thing as one worth keeping.
+        """
+        for path in self._stale_evidence(keep):
+            try:
+                path.unlink()
+            except OSError:
+                print(
+                    f"demo-video: WARNING — could not delete {path}, which is "
+                    f"a previous take's evidence and may hold a value this "
+                    f"take redacts",
+                    file=sys.stderr,
+                )
+
     def _write_evidence(self) -> None:
+        # Runs even when there is nothing to write, and even with evidence
+        # switched off: a previous take's files are the hazard, not this one's.
+        keep = {path for path, _ in self._evidence_docs}
+        self._clear_stale_evidence(keep)
         if not self._evidence_docs:
             return
         (self.out_dir / EVIDENCE_DIR).mkdir(parents=True, exist_ok=True)
         for path, doc in self._evidence_docs:
             path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+        total = sum(path.stat().st_size for path, _ in self._evidence_docs)
         print(
             f"wrote {self.out_dir / EVIDENCE_DIR} "
-            f"({len(self._evidence_docs)} beats)"
+            f"({len(self._evidence_docs)} beats, {total // 1024} kB)"
         )
+        if total > EVIDENCE_DIR_WARN_BYTES:
+            print(
+                f"demo-video: evidence/ is {total // 1024} kB over "
+                f"{len(self._evidence_docs)} beats. The per-field caps are "
+                f"working, but this app's accessibility tree is large — pass "
+                f"Recorder(evidence=False) (or DEMO_VIDEO_EVIDENCE=0) if the "
+                f"round trips are costing more than the files are worth.",
+                file=sys.stderr,
+            )
 
     def _media_path(self) -> Path:
         """The mp4 this take converts to on exit."""
@@ -2302,12 +2446,30 @@ class _DemoBase:
         # before the registration keep the value (no recorder can un-paint a
         # caption), but the files this skill tells people to commit do not
         # have to.
-        beats = [self._scrub_deep(beat) for beat in self._beats]
+        #
+        # ...and against what redact() turned out to be covering, which
+        # `scrub()` alone does not know about. The harvest exists for the
+        # evidence files, but timeline.json and timeline.md are the files this
+        # skill tells people to *commit* — a caption or a selector holding a
+        # redacted element's text coming back `[redacted]` in evidence and in
+        # the clear in the committed log is the worse half of that pair.
+        #
+        # Note the coupling this creates: with `evidence=False` nothing
+        # harvests, so this falls back to `scrub()` alone. Turning evidence off
+        # is turning off the only thing that reads what redact() hides.
+        forbidden = self._evidence_forbidden()
+        beats = [
+            self._evidence_scrub_deep(self._scrub_deep(beat), forbidden)
+            for beat in self._beats
+        ]
         # The issue log too: it quotes console messages, request URLs and
         # process output — none of it authored, all of it capable of carrying
         # a secret the app printed, and all of it written into the same two
         # committed files.
-        issues = [self._scrub_deep(issue) for issue in self._issues]
+        issues = [
+            self._evidence_scrub_deep(self._scrub_deep(issue), forbidden)
+            for issue in self._issues
+        ]
         return {
             "schema": TIMELINE_SCHEMA,
             "generated_by": "demo-video",
@@ -2428,7 +2590,15 @@ class _DemoBase:
         rather than claiming a general cleanup, because "cleaned up" without a
         list is exactly the sentence people believe and do not check.
         """
-        gone: list[str] = []
+        # A previous take's evidence, before anything else. This take wrote
+        # none — the documents never left memory — but the folder may hold the
+        # last take's, and the reason this take is failing is usually that
+        # somebody has just added a `redact()` for a value those files contain.
+        # Unlike a still, no evidence file is ever a committed artifact, so
+        # there is nothing here worth preserving.
+        stale = self._stale_evidence()
+        self._clear_stale_evidence()
+        gone: list[str] = [f"{EVIDENCE_DIR}/{p.name}" for p in stale if not p.exists()]
         for path in self._shots + [self.out_dir / ".frame.png"]:
             try:
                 if path.is_file():

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -557,6 +557,9 @@ def tts_clip(
 #                      merge — so `(segment, segment_index)` names a beat the
 #                      same way before and after `stitch`, which `index` alone
 #                      cannot (see issue #22).
+#   evidence  str?   — path, relative to the timeline file, of this beat's
+#                      evidence file ("evidence/beat-04.json"); null when
+#                      evidence capture is off. See "per-beat evidence" below
 #   exit_code int?   — TerminalRecorder `run` beats only: the shell's status
 #                      for that command, or null if it could not be read
 #
@@ -564,6 +567,101 @@ def tts_clip(
 # out of other verbs (`click` glides with `move_to`, `type_into` clicks first)
 # record one beat spanning the whole call, not one per internal step.
 TIMELINE_SCHEMA = 1
+
+# -- per-beat evidence -------------------------------------------------------
+#
+# A reviewing agent handed only frames has to infer the DOM from pixels. The
+# recorder is *driving* the page — it has the real thing — so at the end of
+# every beat it also writes down what was on screen, in text, next to the
+# frame the beat's timestamps point at.
+#
+# What is captured, per medium:
+#
+#   Recorder          the page's ARIA snapshot (Playwright's `aria_snapshot`,
+#                     a compact YAML tree of roles and accessible names) —
+#                     semantic, an order of magnitude smaller than the markup,
+#                     and stable across restyling. Plus `url` and `title`. When
+#                     a spotlight is up, the same snapshot *scoped to the
+#                     spotlight target* and that element's `outerHTML`.
+#   TerminalRecorder  the rendered screen, ANSI already stripped by xterm.js
+#                     (`_screen()`), scrollback included.
+#
+# **`outerHTML` is only ever the spotlight target's, never the page's**, and
+# that is a safety decision as much as a size one. `document.body.outerHTML`
+# on the smoke fixture is 24 kB against 2.3 kB of ARIA, and it carries two
+# things ARIA does not: the text of every inline `<script>`, and `srcdoc`
+# attributes — i.e. source code and whole embedded documents that nobody put
+# on screen. The clone that is serialized drops both (see web.py).
+#
+# **Evidence is plain text, and that makes it the leak path with the fewest
+# natural defences.** Every other artifact this package writes is pixels, and
+# `redact()` is a *pixel* control: it covers where a value renders and leaves
+# the value in the DOM, which is exactly what is being dumped here. So:
+#
+#   * every string written is masked against the registered secrets *and*
+#     against the rendered text of everything `redact()` is covering, harvested
+#     from the page at capture time (see `Recorder._redacted_rendered_text`);
+#   * nothing reaches the disk until the take has exited cleanly and the mask
+#     has been verified — the documents are built in memory and written
+#     alongside timeline.json, so a take that dies on a SecretLeak leaves no
+#     evidence file to delete;
+#   * a document that still holds a forbidden literal when it is serialized
+#     raises SecretLeak and kills the take rather than being written.
+#
+# Naming, and issue #22. A beat's `index` is its position in *its own take*, so
+# two segments of one demo both start at 0. Evidence therefore does two things
+# that make renumbering a non-event: a segment's files carry the segment in
+# their name (`evidence/part1.seg.beat-03.json`, mirroring how
+# `<segment>.seg.timeline.json` is named), and the path is written *onto the
+# beat* as `evidence` rather than derived from `index` by whoever reads the
+# log. A merge that renumbers beats (issue #7) has only to carry that string
+# across; nothing has to be renamed, and every evidence file names its own
+# `segment` and `index` internally.
+EVIDENCE_SCHEMA = 1
+EVIDENCE_DIR = "evidence"
+
+# Per-field character budgets. A TUI's scrollback is 5000 lines and a real
+# app's ARIA tree is unbounded, so an uncapped evidence directory is bigger
+# than the mp4 it describes. Truncation is *marked*, never silent: a reviewer
+# reading a cut-off tree has to be able to tell it was cut off, and the file
+# says so twice — inline where the text stops, and in `truncated`.
+EVIDENCE_MAX_ARIA = 12_000
+EVIDENCE_MAX_HTML = 8_000
+EVIDENCE_MAX_SCREEN = 12_000
+EVIDENCE_LIMITS = {
+    "aria": EVIDENCE_MAX_ARIA,
+    "scope_aria": EVIDENCE_MAX_ARIA,
+    "html": EVIDENCE_MAX_HTML,
+    "screen": EVIDENCE_MAX_SCREEN,
+}
+EVIDENCE_TRUNCATED = "\n…[demo-video: truncated here, {n} more characters]"
+
+# Harvested text shorter than this is not used as a mask. `redact()` pointed at
+# an element rendering "$" would otherwise replace every dollar sign in every
+# evidence file, which costs the evidence its meaning and hides nothing: a
+# one-character secret is not one. Registered secrets are masked at any length
+# — `register_secret()` was told, explicitly, that the value matters.
+EVIDENCE_MIN_MASK_LEN = 2
+
+
+def evidence_name(index: int, segment: str | None = None) -> str:
+    """The file one beat's evidence is written as.
+
+    Mirrors `timeline_paths`: a whole demo writes `beat-04.json`, a segment
+    writes `<segment>.seg.beat-04.json`, so two segments of one demo never
+    collide and no merge has to rename anything (issue #22).
+    """
+    stem = f"{segment}.seg." if segment else ""
+    return f"{stem}beat-{index:02d}.json"
+
+
+def _cap_text(text: str, limit: int) -> tuple[str, int]:
+    """`text` cut to `limit` characters, with an explicit marker. -> (text, cut)"""
+    if len(text) <= limit:
+        return text, 0
+    cut = len(text) - limit
+    return text[:limit] + EVIDENCE_TRUNCATED.format(n=cut), cut
+
 
 # -- take issues -------------------------------------------------------------
 #
@@ -1224,6 +1322,7 @@ class _DemoBase:
         clock: str | None = None,
         timezone_id: str | None = None,
         locale: str | None = None,
+        evidence: bool | None = None,
     ) -> None:
         # Every setting resolves explicit parameter > DEMO_VIDEO_* env var
         # > built-in default (see SKILL.md for the variable names).
@@ -1347,6 +1446,20 @@ class _DemoBase:
         # Stills this take wrote, so a take that fails to verify its mask can
         # take them back off disk (they are full-bleed, and may hold it).
         self._shots: list[Path] = []
+        # Per-beat evidence (see "per-beat evidence" above). Buffered as
+        # (beat record, medium payload) and only turned into files on a clean
+        # exit — nothing plaintext reaches the disk before the mask has been
+        # verified, which is why there is no evidence file for
+        # _discard_artifacts to take back. `_evidence_masks` accumulates the
+        # rendered text of everything redact() is covering; the union is
+        # applied to *every* beat's evidence on the way out, so a value first
+        # seen at beat 20 is masked out of beat 3 as well.
+        if evidence is None:
+            evidence = _env_flag("EVIDENCE")
+        self._evidence_on = True if evidence is None else bool(evidence)
+        self._evidence: list[tuple[dict, dict]] = []
+        self._evidence_masks: set[str] = set()
+        self._evidence_docs: list[tuple[Path, dict]] = []
         # Announce narration state up front — a silent recording when the
         # user expected voice (usually the key just isn't in this process's
         # env) is otherwise a confusing surprise only noticed after the fact.
@@ -1619,6 +1732,34 @@ class _DemoBase:
                 f"({type(exc_check).__name__}: {exc_check}), so nothing can "
                 f"vouch for what is in the frames. This take wrote no mp4."
             )
+        # Evidence documents are assembled **after** the mask has been vouched
+        # for and only when there is still a take to keep — the same treatment
+        # an unverifiable mask gets, because evidence is the one artifact that
+        # is plain text and a pixel control never protected it.
+        #
+        # It runs after `_stop()` deliberately, and that is safe rather than
+        # merely convenient: the captures were buffered per beat while the page
+        # was alive, and this turns them into documents in memory — it opens no
+        # beat, touches no page, and writes no file. Nothing here can add
+        # content to the recording after the verifier has vouched for it, which
+        # is the property the ordering above exists to protect.
+        if exc_type is None and unmasked is None:
+            try:
+                self._build_evidence()
+            except SecretLeak as leak:
+                unmasked = leak
+            except Exception as exc_build:  # noqa: BLE001 - same verdict
+                # Not a leak that was found, but a document nobody can say is
+                # clean — which is the same verdict for the same reason. The
+                # message says which of the two happened, because "could not be
+                # verified" and "holds a secret" send an author to different
+                # places.
+                unmasked = SecretLeak(
+                    f"this take's evidence could not be assembled "
+                    f"({type(exc_build).__name__}: {exc_build}), so the "
+                    f"recorder cannot say whether it holds a registered or "
+                    f"redacted value. This take wrote no mp4."
+                )
         clean = exc_type is None and unmasked is None
         video = self.page.video
         self._context.close()
@@ -1629,6 +1770,10 @@ class _DemoBase:
             if clean and webm and webm.exists():
                 self._convert(webm)
             if clean:
+                # Before the timeline, because every beat in it carries an
+                # `evidence` path: a timeline pointing at files that are not
+                # there yet is the one ordering a reader can be caught by.
+                self._write_evidence()
                 # The beat log is the durable, diffable record of the take — it
                 # outlives the mp4, which is not committed. Written after
                 # conversion so `duration` is the encoder's answer, not a guess.
@@ -1943,11 +2088,23 @@ class _DemoBase:
             # can use it without knowing which kind of timeline it is reading.
             "segment_index": len(self._beats),
         }
+        if self._evidence_on:
+            # Written onto the beat rather than left for a reader to derive
+            # from `index`, so a merge that renumbers beats (issue #7) does
+            # not silently repoint every beat at somebody else's evidence.
+            record["evidence"] = (
+                f"{EVIDENCE_DIR}/{evidence_name(record['index'], self.segment)}"
+            )
         record.update(extra)
         self._beats.append(record)
         try:
             yield record
         finally:
+            # Captured before `t_end` is stamped, so the round trips it costs
+            # are accounted for *inside* the beat that paid for them and no
+            # unexplained gap opens up between one beat and the next.
+            if self._evidence_on:
+                self._capture_evidence(record)
             record["t_end"] = round(time.monotonic() - self._t0, 3)
             self._in_beat = False
 
@@ -1960,6 +2117,169 @@ class _DemoBase:
         frames themselves instead of taking this paragraph's word for it.
         """
         write_beat_frames(self.out_dir, doc, "this take")
+
+    # -- per-beat evidence (see the section at the top of this file) --------
+
+    def _evidence_payload(self) -> dict:
+        """What this medium can say about the screen right now.
+
+        Overridden per medium (`Recorder` -> ARIA + outerHTML, `TerminalRecorder`
+        -> the rendered screen). A payload of `{"omitted": reason}` is the
+        medium refusing to hand over page text it cannot vouch for; the file is
+        still written, and says so.
+        """
+        return {}
+
+    def _capture_evidence(self, beat: dict) -> None:
+        """Buffer one beat's evidence. Never raises.
+
+        A capture failure must not lose a take that is otherwise fine — the
+        beat gets a file saying what went wrong instead, which keeps the
+        `evidence` pointer on every beat pointing at something real. The one
+        failure that is *not* survivable — a redacted element whose rendered
+        text could not be read, and therefore could not be masked — is handled
+        in the medium's payload, which returns `omitted` rather than raising.
+        """
+        try:
+            payload = self._evidence_payload()
+        except Exception as exc:  # noqa: BLE001 - a diagnostic must not kill a take
+            payload = {"error": f"{type(exc).__name__}: {exc}"}
+            print(
+                f"demo-video: could not capture evidence for beat "
+                f"{beat.get('index')} ({beat.get('verb')}): "
+                f"{type(exc).__name__}: {exc}",
+                file=sys.stderr,
+            )
+        self._evidence.append((beat, payload))
+
+    def _evidence_forbidden(self) -> tuple[str, ...]:
+        """Every literal that must not appear in an evidence file, longest first.
+
+        Two sources, and the second is the reason this exists at all:
+
+          * `self.secrets` — text somebody registered. `scrub()` already covers
+            this everywhere else.
+          * `self._evidence_masks` — the *rendered text of everything redact()
+            is covering*, read out of the page as the take ran. `redact()` is a
+            pixel control: it hides where a value renders and leaves the value
+            in the DOM, so a text dump of that DOM is not protected by it at
+            all. This is what makes evidence inherit redaction.
+
+        Longest first so overlapping values (a token, and the header line
+        holding it) mask the larger one whole instead of leaving its tail.
+        """
+        literals = set(self._secrets)
+        literals |= {
+            text for text in self._evidence_masks
+            if len(text.strip()) >= EVIDENCE_MIN_MASK_LEN
+        }
+        return tuple(sorted(literals, key=len, reverse=True))
+
+    def _evidence_mask(self, text: str, forbidden: tuple[str, ...]) -> str:
+        for literal in forbidden:
+            text = text.replace(literal, SECRET_MASK)
+        return text
+
+    def _evidence_scrub_deep(self, value: object, forbidden: tuple[str, ...]) -> object:
+        """`_evidence_mask` over a whole structure, keys included.
+
+        Keys as well as values: a payload key is a string the recorder chose
+        today, but the schema is append-only and the next slice to add a field
+        may not be. Masking both costs nothing and removes a hole nobody would
+        think to look for.
+        """
+        if isinstance(value, str):
+            return self._evidence_mask(value, forbidden)
+        if isinstance(value, dict):
+            return {
+                self._evidence_mask(str(key), forbidden)
+                if isinstance(key, str) else key:
+                self._evidence_scrub_deep(item, forbidden)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [self._evidence_scrub_deep(item, forbidden) for item in value]
+        return value
+
+    def _evidence_doc(self, beat: dict, payload: dict) -> dict:
+        """One evidence document: masked, then capped, then checked.
+
+        Order matters and is not interchangeable. Masking runs *before*
+        capping, because capping first can cut a secret in half and leave its
+        first twenty characters as the last thing in the file — which no later
+        substring search would find.
+        """
+        forbidden = self._evidence_forbidden()
+        doc: dict = {
+            "schema": EVIDENCE_SCHEMA,
+            "generated_by": "demo-video",
+            "recorder": type(self).__name__,
+            "segment": self.segment,
+            "media": self._media_path().name,
+            "beat": {
+                key: beat.get(key)
+                for key in ("index", "t_start", "t_end", "verb", "selector",
+                            "caption", "still", "evidence")
+            },
+        }
+        doc.update(payload)
+        doc = self._evidence_scrub_deep(doc, forbidden)  # type: ignore[assignment]
+        truncated: list[str] = []
+        for field, limit in EVIDENCE_LIMITS.items():
+            text = doc.get(field)
+            if not isinstance(text, str):
+                continue
+            capped, cut = _cap_text(text, limit)
+            if cut:
+                truncated.append(field)
+                doc[field] = capped
+        doc["truncated"] = sorted(truncated)
+        doc["limits"] = {k: v for k, v in EVIDENCE_LIMITS.items() if k in doc}
+        # A backstop over the *serialized bytes*, not a second opinion on the
+        # masking above — run against the same list, it cannot disagree with it
+        # about a plain string value, and this file does not pretend otherwise.
+        # What it does reach is everything the walker structurally cannot: a
+        # field added to this schema by a later slice that is built after the
+        # scrub, a non-string key, a literal that only exists once JSON
+        # escaping has run. The grading that can actually fail is the byte
+        # sweep over `evidence/` in tests/smoke.
+        blob = json.dumps(doc, ensure_ascii=False)
+        for literal in forbidden:
+            if literal in blob:
+                raise SecretLeak(
+                    f"a beat's evidence still holds a {len(literal)}-character "
+                    f"value that is registered or redacted, after masking — so "
+                    f"the recorder cannot vouch for what it was about to write. "
+                    f"No evidence file, no mp4 and no timeline were written."
+                )
+        return doc
+
+    def _build_evidence(self) -> None:
+        """Turn the buffered captures into documents. Writes nothing.
+
+        Separate from writing on purpose: a document that cannot be made safe
+        raises here, before the first byte of the first file has been written,
+        so the failure cannot leave half an evidence directory behind.
+        """
+        if not self._evidence_on:
+            return
+        out = self.out_dir / EVIDENCE_DIR
+        self._evidence_docs = [
+            (out / evidence_name(beat["index"], self.segment),
+             self._evidence_doc(beat, payload))
+            for beat, payload in self._evidence
+        ]
+
+    def _write_evidence(self) -> None:
+        if not self._evidence_docs:
+            return
+        (self.out_dir / EVIDENCE_DIR).mkdir(parents=True, exist_ok=True)
+        for path, doc in self._evidence_docs:
+            path.write_text(json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+        print(
+            f"wrote {self.out_dir / EVIDENCE_DIR} "
+            f"({len(self._evidence_docs)} beats)"
+        )
 
     def _media_path(self) -> Path:
         """The mp4 this take converts to on exit."""
@@ -2122,9 +2442,11 @@ class _DemoBase:
                 )
         print(
             "demo-video: the take could not verify its mask, so it wrote no "
-            "mp4 and no timeline, and deleted "
+            "mp4, no timeline and no evidence, and deleted "
             + (", ".join(gone) if gone else "nothing (it had written nothing)")
-            + ". The raw capture in .video/ is gone too.",
+            + ". The raw capture in .video/ is gone too. (Per-beat evidence is "
+            "held in memory until a clean exit precisely so there is nothing "
+            "to take back here — it is the one artifact that is plain text.)",
             file=sys.stderr,
         )
 

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -899,19 +899,29 @@ class TerminalRecorder(_DemoBase):
                 f"take ({type(exc).__name__}), so nothing can vouch for what "
                 f"is in the frames. This take wrote no mp4."
             ) from exc
-        for secret in self.secrets:
-            if secret in screen:
-                raise SecretLeak(
-                    f"a registered secret ({len(secret)} chars) is on the "
-                    f"terminal screen at the end of the take, so it is in the "
-                    f"frames. The output scrubber masks what it can see in the "
-                    f"byte stream; a value written in two pieces at different "
-                    f"cursor positions is contiguous on screen and in no "
-                    f"substring of the stream, and nothing can mask that after "
-                    f"the fact. This take wrote no mp4, no timeline, and kept "
-                    f"no stills. Keep the value off the screen: print a "
-                    f"placeholder, or do not run the command that shows it."
-                )
+        # `_recoverable_secret`, not `secret in screen`. `_screen()` joins one
+        # buffer row per line and does not consult `isWrapped`, so a value
+        # crossing the last column is two rows with a newline through it —
+        # on screen contiguously, in this string not at all. A plain substring
+        # test sees neither half and vouches for a frame with the credential
+        # in it. That is the same blind spot the evidence mask had, in the
+        # check that decides whether the frames may be kept, so the two now
+        # share one matcher and cannot disagree.
+        found = self._recoverable_secret(screen)
+        if found is not None:
+            raise SecretLeak(
+                f"a registered secret ({len(found)} chars) is on the "
+                f"terminal screen at the end of the take, so it is in the "
+                f"frames. The output scrubber masks what it can see in the "
+                f"byte stream; a value written in two pieces at different "
+                f"cursor positions is contiguous on screen and in no "
+                f"substring of the stream, and a value the terminal wrapped "
+                f"is contiguous on screen and split by a newline here — "
+                f"nothing can mask either after the fact. This take wrote no "
+                f"mp4, no timeline, and kept no stills. Keep the value off "
+                f"the screen: print a placeholder, or do not run the command "
+                f"that shows it."
+            )
 
     def _take_exit_markers(self, text: str) -> str:
         """Strip the PS1 exit-status markers out of `text`, recording each.
@@ -1080,9 +1090,17 @@ class TerminalRecorder(_DemoBase):
         (e.g. "C-c"); or a single literal character ("q", "j", "/").
 
         Refuses a registered secret spelled out one keystroke at a time. That
-        is authored text like `run()`'s, and it is the one call whose beat log
-        entry a scrub cannot clean: the beat records the keys joined by
-        spaces, which no literal match on the value can see."""
+        is authored text like `run()`'s, and the beat opens before the refusal
+        — so the log records the keys **joined by spaces**, which is the value
+        with whitespace inserted between every character.
+
+        A literal match on the value cannot see that, and for one release this
+        docstring said a scrub therefore could not clean it. It can now: the
+        beat-log scrub matches a run of eight or more non-space characters with
+        whitespace allowed between them, because that is the same shape a
+        terminal line wrap produces (issue #9). The refusal is still the
+        control that matters — a secret spelled into a TUI is on screen — but
+        the log entry behind it is no longer in the clear."""
         self._no_secrets("".join(names), "key()")
         for name in names:
             seq = _KEYMAP.get(name)

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -633,6 +633,7 @@ class TerminalRecorder(_DemoBase):
         clock: str | None = None,
         timezone_id: str | None = None,
         locale: str | None = None,
+        evidence: bool | None = None,
         type_delay_ms: int = 45,
     ) -> None:
         # A branded, distinctive default prompt so wait_for_prompt's marker
@@ -644,7 +645,7 @@ class TerminalRecorder(_DemoBase):
             viewport=viewport, speech=speech, voice_id=voice_id,
             speech_model=speech_model, strict=strict,
             deterministic=deterministic, clock=clock,
-            timezone_id=timezone_id, locale=locale,
+            timezone_id=timezone_id, locale=locale, evidence=evidence,
         )
         # Match the web recorder's effective caption height. Web composites
         # its page into a scaled, centered window, lifting its bottom:44px
@@ -1147,3 +1148,24 @@ class TerminalRecorder(_DemoBase):
         output first so the latest screen state is captured)."""
         self._pump()
         return super().shot(name)
+
+    # -- evidence (issue #9) ------------------------------------------------
+
+    def _evidence_payload(self) -> dict:
+        """The rendered screen at the end of this beat.
+
+        `_screen()` is what `wait_for_text` already matches against: xterm.js's
+        own view of the buffer, ANSI sequences resolved rather than stripped by
+        a regex, visible rows and scrollback both. It is the terminal's exact
+        analogue of the web recorder's ARIA snapshot — what a reader would see,
+        with none of the paint.
+
+        **Nothing here is redacted, and that is not an oversight.**
+        `TerminalRecorder` has no `redact()` at all (issue #5 is the PTY
+        scrubber), so the only thing between a printed credential and this file
+        is `register_secret()`, which `core`'s writer applies. A command that
+        prints a value nobody registered writes it here verbatim — the same
+        exposure the recording itself already has, in a form that greps.
+        SKILL.md says so where an author will read it.
+        """
+        return {"screen": self._screen()}

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -29,7 +29,14 @@ import time
 from pathlib import Path
 from urllib.parse import urlparse
 
-from .core import Secret, SecretLeak, _beat_verb, _DemoBase, _env
+from .core import (
+    SECRET_MASK,
+    Secret,
+    SecretLeak,
+    _beat_verb,
+    _DemoBase,
+    _env,
+)
 
 # Pastel gradient behind the window — matches the terminal recorder's
 # background so web and terminal demos share one look.
@@ -589,6 +596,165 @@ _CSS_ONLY_JS = """(sel) => {
 }"""
 
 
+# -- evidence (issue #9) -----------------------------------------------------
+#
+# Everything a redacted element *renders*, as text, so the evidence writer can
+# mask it. This is the whole reason evidence can inherit redaction:
+# `redact("#api-key")` never tells the recorder what `#api-key` says, and a
+# dump of the DOM is not covered by a control that paints over pixels.
+#
+# It runs in the page rather than through Playwright's engine, once per frame
+# instead of once per selector per frame, and it finds the same elements the
+# mask does two ways:
+#
+#   * `[data-demo-redact]` — the marker `wear()` stamps on every element the
+#     mask has actually reached, including inside open shadow roots;
+#   * the registered selectors themselves, re-resolved here, which covers an
+#     element that entered the DOM since the last checkpoint. `redact()` only
+#     accepts plain CSS, so `querySelectorAll` can parse every one of them.
+#
+# Shadow roots are walked at every depth, because `textContent` stops at the
+# boundary and a value two roots down is the ordinary composition of "redact a
+# card" and "the card is a web component" — the same shape the mask's own
+# `deep()` exists for.
+#
+# **Every node in the subtree is harvested on its own, not just the element the
+# selector matched**, and that is not thoroughness for its own sake. Redacting
+# a *wrapper* is the ordinary call (`redact("#hero-card")` where the value is
+# the 44 px child), and the wrapper's `textContent` is the label and the value
+# run together — a single string that appears nowhere in an ARIA tree, which
+# renders them as separate nodes. Harvesting only the matched element masked
+# five of the eight keys on the smoke fixture and left three in the clear.
+#
+# `::before`/`::after` content is read too, from the computed style, because
+# generated content has no node to hold it — and Chromium *does* put it in the
+# accessibility tree, so it reaches an evidence file by a route no walk of the
+# DOM would find.
+_EVIDENCE_HARVEST_JS = r"""(selectors) => {
+  const MARK = '__MARK__';
+  const ATTRS = ['value', 'title', 'alt', 'placeholder', 'aria-label',
+                 'content', 'srcdoc', 'data-value'];
+  const out = [];
+  const push = (s) => { if (typeof s === 'string' && s.trim()) out.push(s); };
+  const roots = [document];
+  const findRoots = (root) => {
+    let all;
+    try { all = root.querySelectorAll('*'); } catch (e) { return; }
+    for (const el of all) {
+      if (el.shadowRoot) { roots.push(el.shadowRoot); findRoots(el.shadowRoot); }
+    }
+  };
+  findRoots(document);
+  // Every node the subtree renders through, shadow roots at every depth.
+  const walk = (node, acc) => {
+    if (!node) return acc;
+    acc.push(node);
+    let kids = [];
+    try { kids = node.querySelectorAll ? node.querySelectorAll('*') : []; }
+    catch (e) { kids = []; }
+    for (const kid of kids) {
+      acc.push(kid);
+      if (kid.shadowRoot) walk(kid.shadowRoot, acc);
+    }
+    if (node.shadowRoot) walk(node.shadowRoot, acc);
+    return acc;
+  };
+  const harvest = (el) => {
+    for (const node of walk(el, [])) {
+      push(node.textContent);
+      if (typeof node.value === 'string') push(node.value);
+      // Individual text nodes as well as the concatenation: an accessible
+      // name is built per element, so the pieces are what a tree shows.
+      for (const child of node.childNodes || []) {
+        if (child.nodeType === 3) push(child.nodeValue);
+      }
+      if (node.nodeType !== 1) continue;  // a shadow root has no attrs or style
+      for (const a of ATTRS) {
+        try { push(node.getAttribute(a)); } catch (e) { /* exotic attr */ }
+      }
+      for (const which of ['::before', '::after']) {
+        let content;
+        try { content = getComputedStyle(node, which).content; }
+        catch (e) { continue; }
+        if (!content || content === 'none' || content === 'normal') continue;
+        push(content);
+        // Computed `content` comes back quoted and escaped; the tree shows
+        // the string itself, so push that too.
+        const quoted = /^"([\s\S]*)"$/.exec(content);
+        if (quoted) push(quoted[1].replace(/\\(.)/g, '$1'));
+      }
+    }
+  };
+  for (const root of roots) {
+    for (const sel of selectors.concat(['[' + MARK + ']'])) {
+      let hits = [];
+      try { hits = root.querySelectorAll(sel); } catch (e) { continue; }
+      for (const hit of hits) harvest(hit);
+    }
+  }
+  return out;
+}"""
+
+# The spotlight target's markup, cleaned, from a *clone* — nothing here may
+# touch the live page, which is being recorded.
+#
+# Three things come out that `outerHTML` would otherwise put in a file nobody
+# expects to hold them:
+#
+#   * `<script>` and `<style>` text, and `srcdoc` — source code and whole
+#     embedded documents, none of it on screen. The smoke fixture's own key
+#     literals are in its inline script, which is how this was noticed.
+#   * anything the mask is covering: its children are replaced by the mask
+#     text and its value-bearing attributes removed. Matched by the marker
+#     *and* by the registered selectors, so an element the mask reached and an
+#     element it is about to reach are treated the same.
+#   * the recorder's own furniture — the covers, the paint gate, the caption
+#     bar, the cursor — which is chrome, not app.
+#
+# The structural elision matters beyond tidiness: a value split across tags
+# (`sk-live-<b>FAKE</b>`) has a `textContent` the string mask can find and an
+# `outerHTML` it cannot, so a mask built only out of substring replacement
+# would leave it in the markup whole.
+_EVIDENCE_HTML_JS = r"""(el, opts) => {
+  const [MARK, COVER, SELECTORS, MASK] = opts;
+  const clone = el.cloneNode(true);
+  const drop = (root, sel) => {
+    let hits = [];
+    try { hits = root.querySelectorAll(sel); } catch (e) { return; }
+    for (const hit of hits) hit.remove();
+  };
+  drop(clone, 'script,style,template,noscript,link,meta');
+  drop(clone, '[' + COVER + '],[id^="__demo"],[id^="__term"]');
+  let framed = [];
+  try { framed = clone.querySelectorAll('[srcdoc]'); } catch (e) { framed = []; }
+  for (const node of framed) node.setAttribute('srcdoc', MASK);
+  const hide = (node) => {
+    for (const a of ['value', 'title', 'alt', 'placeholder', 'aria-label',
+                     'href', 'src', 'srcdoc', 'content', 'data-value']) {
+      try { node.removeAttribute(a); } catch (e) { /* exotic attr */ }
+    }
+    node.textContent = MASK;
+  };
+  for (const sel of SELECTORS.concat(['[' + MARK + ']'])) {
+    let hits = [];
+    try { hits = clone.querySelectorAll(sel); } catch (e) { continue; }
+    for (const hit of hits) hide(hit);
+    // querySelectorAll never returns the root it was called on, and the root
+    // is exactly the element a storyboard spotlights and redacts together.
+    try { if (clone.matches && clone.matches(sel)) hide(clone); }
+    catch (e) { /* an ancestor-relative selector cannot match a clone */ }
+  }
+  return clone.outerHTML;
+}"""
+
+# Transient frame failures, classified the same way `_mask_selector` does:
+# frames come and go several times a second on ad-slot- and embed-heavy apps,
+# and a diagnostic must not be the reason a take dies.
+_EVIDENCE_TRANSIENT = (
+    "detach", "navigat", "execution context was destroyed", "target closed",
+)
+
+
 class Recorder(_DemoBase):
     """Playwright page wrapper that records video and captures guide stills.
 
@@ -621,6 +787,7 @@ class Recorder(_DemoBase):
         clock: str | None = None,
         timezone_id: str | None = None,
         locale: str | None = None,
+        evidence: bool | None = None,
     ) -> None:
         super().__init__(
             out_dir, segment=segment, accent_rgb=accent_rgb,
@@ -628,7 +795,7 @@ class Recorder(_DemoBase):
             viewport=viewport, speech=speech, voice_id=voice_id,
             speech_model=speech_model, strict=strict,
             deterministic=deterministic, clock=clock,
-            timezone_id=timezone_id, locale=locale,
+            timezone_id=timezone_id, locale=locale, evidence=evidence,
         )
         self.base_url = (
             base_url or _env("BASE_URL", "http://localhost:8000")
@@ -636,6 +803,11 @@ class Recorder(_DemoBase):
         # The recording is composited into a window and scaled down (~0.8),
         # so captions are rendered larger to stay readable in the final mp4.
         self._caption_font_px = 34
+        # What spotlight() is currently pointing at, which is what a beat's
+        # evidence is scoped to. Held here rather than read back out of the
+        # page: `window.__spotEl` is an element handle, not a selector, and the
+        # selector is the thing worth writing down.
+        self._spotlit: str | None = None
 
     def _frame_geometry(self) -> dict:
         """Where the window and the app video sit in the final frame.
@@ -1047,6 +1219,102 @@ class Recorder(_DemoBase):
         """
         self._nav_pending = True
 
+    # -- evidence (issue #9) ------------------------------------------------
+
+    def _redacted_rendered_text(self) -> list[str]:
+        """Everything the mask is covering, as text, across every frame.
+
+        Raises if the *main* frame cannot be read. A sub-frame that refuses is
+        logged and skipped: frames detach and re-attach constantly on
+        embed-heavy apps, and nothing a sub-frame renders reaches an evidence
+        file anyway — the ARIA snapshot is taken of the top document's `body`
+        and stops at an `iframe` node, and the markup dump replaces `srcdoc`
+        wholesale. Harvesting sub-frames is defence in depth, so failing to is
+        survivable; failing on the main frame is not.
+        """
+        found: list[str] = []
+        script = _EVIDENCE_HARVEST_JS.replace("__MARK__", REDACT_MARK_ATTR)
+        frames = list(self.page.frames)
+        main = self.page.main_frame
+        for frame in frames:
+            try:
+                found += frame.evaluate(script, self._redacted) or []
+            except Exception as exc:  # noqa: BLE001 - classified, then re-raised
+                if frame is main:
+                    raise
+                detail = str(exc)
+                if not any(t in detail.lower() for t in _EVIDENCE_TRANSIENT):
+                    raise
+                print(
+                    f"demo-video: a sub-frame could not be read while "
+                    f"collecting what redact() hides ({type(exc).__name__}); "
+                    f"nothing it renders reaches an evidence file, and the "
+                    f"next beat tries again.",
+                    file=sys.stderr,
+                )
+        return found
+
+    def _aria(self, locator) -> tuple[str | None, str]:
+        """(snapshot, format) for one locator's accessibility tree.
+
+        Playwright's `aria_snapshot` arrived in 1.49 and `page.accessibility`
+        — the API issue #9 was written against — has since been removed, so
+        there is exactly one way to do this and no second, untested branch
+        pretending otherwise. An older Playwright gets a null snapshot and a
+        format that says why, rather than a fallback nobody here can exercise.
+        """
+        if not hasattr(locator, "aria_snapshot"):
+            return None, "unavailable: this Playwright predates 1.49"
+        return locator.aria_snapshot(), "aria-yaml"
+
+    def _evidence_payload(self) -> dict:
+        """What was on screen at the end of this beat, as text.
+
+        The ARIA snapshot is the primary artifact and the page's is always
+        taken: it is what lets a reviewer say what was on screen without
+        decoding a frame. `outerHTML` is the spotlight target's only — never
+        the page's — because the markup of a whole document is an order of
+        magnitude larger than its ARIA tree and carries script text and
+        `srcdoc` documents that were never on screen at all.
+        """
+        # The marker attribute the elision below matches on is stamped by the
+        # mask, and the mask is re-asserted at checkpoints. Take one now so the
+        # page's idea of what is covered is not one re-render out of date.
+        self._checkpoint()
+        if self._redacted:
+            try:
+                self._evidence_masks.update(self._redacted_rendered_text())
+            except Exception as exc:  # noqa: BLE001 - refuse, never guess
+                # The one failure that must not degrade into a written file:
+                # without this text the writer cannot mask what redact() is
+                # hiding, and a DOM dump is not protected by a pixel cover.
+                return {
+                    "omitted": (
+                        f"the recorder could not read what redact() is "
+                        f"covering ({type(exc).__name__}), so no page text was "
+                        f"captured for this beat"
+                    )
+                }
+        aria, aria_format = self._aria(self.page.locator("body"))
+        payload: dict = {
+            "scope": self._spotlit,
+            "url": self.page.url,
+            "title": self.page.title(),
+            "aria_format": aria_format,
+            "aria": aria,
+            "scope_aria": None,
+            "html": None,
+            "redacted": list(self._redacted),
+        }
+        if self._spotlit:
+            target = self.page.locator(self._spotlit).first
+            payload["scope_aria"] = self._aria(target)[0]
+            payload["html"] = target.evaluate(
+                _EVIDENCE_HTML_JS,
+                [REDACT_MARK_ATTR, REDACT_COVER_ATTR, self._redacted, SECRET_MASK],
+            )
+        return payload
+
     # -- storyboard verbs ---------------------------------------------------
 
     @_beat_verb("goto")
@@ -1120,6 +1388,11 @@ class Recorder(_DemoBase):
             self.page.locator(selector).first.evaluate(
                 "el => window.__demoSpotlight(el)"
             )
+        # Set after the highlight actually landed, so a selector that matched
+        # nothing (and raised above) never becomes the scope of a beat's
+        # evidence — a scope naming an element that is not there would put
+        # `"html": null` in the file with no explanation.
+        self._spotlit = selector or None
         self.pause(0.3)
 
     @_beat_verb("move_to")

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -630,12 +630,22 @@ _CSS_ONLY_JS = """(sel) => {
 # generated content has no node to hold it — and Chromium *does* put it in the
 # accessibility tree, so it reaches an evidence file by a route no walk of the
 # DOM would find.
+# It returns **both halves in one pass**: what the redacted subtrees render,
+# and what everything else renders. The second is not a nicety — see
+# `_evidence_forbidden`: a harvested string that also appears outside the mask
+# is rendered in the clear, so masking it costs the evidence its meaning and
+# hides nothing. Computing them apart would let the page move in between and
+# make the two disagree about which is which.
 _EVIDENCE_HARVEST_JS = r"""(selectors) => {
   const MARK = '__MARK__';
+  const COVER = '__COVER__';
   const ATTRS = ['value', 'title', 'alt', 'placeholder', 'aria-label',
                  'content', 'srcdoc', 'data-value'];
-  const out = [];
-  const push = (s) => { if (typeof s === 'string' && s.trim()) out.push(s); };
+  const inside = [];
+  const outside = [];
+  const add = (bucket, s) => {
+    if (typeof s === 'string' && s.trim()) bucket.push(s);
+  };
   const roots = [document];
   const findRoots = (root) => {
     let all;
@@ -645,54 +655,165 @@ _EVIDENCE_HARVEST_JS = r"""(selectors) => {
     }
   };
   findRoots(document);
-  // Every node the subtree renders through, shadow roots at every depth.
-  const walk = (node, acc) => {
-    if (!node) return acc;
+
+  // Everything the mask is covering, found the same two ways the mask itself
+  // works: the marker it stamps, and the registered selectors re-resolved.
+  const marked = [];
+  for (const root of roots) {
+    for (const sel of selectors.concat(['[' + MARK + ']'])) {
+      let hits = [];
+      try { hits = root.querySelectorAll(sel); } catch (e) { continue; }
+      for (const hit of hits) if (marked.indexOf(hit) === -1) marked.push(hit);
+    }
+  }
+  // Ancestry in the **flattened** tree, which is the one that renders:
+  // `contains()` stops at a shadow boundary, and a light node assigned to a
+  // <slot> is painted wherever the slot is, not where the DOM puts it. Walking
+  // the DOM instead would call a value slotted into a redacted wrapper
+  // "rendered in the clear", exempt it from masking, and publish it.
+  const covered = (node) => {
+    let n = node;
+    while (n) {
+      if (marked.indexOf(n) !== -1) return true;
+      if (n.assignedSlot) { n = n.assignedSlot; continue; }
+      if (n.nodeType === 11) { n = n.host || null; continue; }
+      n = n.parentNode;
+    }
+    return false;
+  };
+
+  // Every node a subtree renders through: light descendants, shadow roots at
+  // every depth, and — because a shadow root renders its host's light children
+  // wherever a <slot> puts them — whatever is assigned to each slot.
+  const walk = (node, acc, seen) => {
+    if (!node || seen.indexOf(node) !== -1) return acc;
+    seen.push(node);
     acc.push(node);
     let kids = [];
     try { kids = node.querySelectorAll ? node.querySelectorAll('*') : []; }
     catch (e) { kids = []; }
     for (const kid of kids) {
-      acc.push(kid);
-      if (kid.shadowRoot) walk(kid.shadowRoot, acc);
+      if (seen.indexOf(kid) === -1) { seen.push(kid); acc.push(kid); }
+      if (kid.shadowRoot) walk(kid.shadowRoot, acc, seen);
+      if (kid.tagName === 'SLOT' && kid.assignedNodes) {
+        let slotted = [];
+        try { slotted = kid.assignedNodes({flatten: true}); } catch (e) { slotted = []; }
+        for (const node2 of slotted) walk(node2, acc, seen);
+      }
     }
-    if (node.shadowRoot) walk(node.shadowRoot, acc);
+    if (node.shadowRoot) walk(node.shadowRoot, acc, seen);
     return acc;
   };
-  const harvest = (el) => {
-    for (const node of walk(el, [])) {
-      push(node.textContent);
-      if (typeof node.value === 'string') push(node.value);
-      // Individual text nodes as well as the concatenation: an accessible
-      // name is built per element, so the pieces are what a tree shows.
-      for (const child of node.childNodes || []) {
-        if (child.nodeType === 3) push(child.nodeValue);
-      }
-      if (node.nodeType !== 1) continue;  // a shadow root has no attrs or style
-      for (const a of ATTRS) {
-        try { push(node.getAttribute(a)); } catch (e) { /* exotic attr */ }
-      }
-      for (const which of ['::before', '::after']) {
-        let content;
-        try { content = getComputedStyle(node, which).content; }
-        catch (e) { continue; }
-        if (!content || content === 'none' || content === 'normal') continue;
-        push(content);
-        // Computed `content` comes back quoted and escaped; the tree shows
-        // the string itself, so push that too.
-        const quoted = /^"([\s\S]*)"$/.exec(content);
-        if (quoted) push(quoted[1].replace(/\\(.)/g, '$1'));
+
+  const readPseudo = (bucket, node) => {
+    for (const which of ['::before', '::after']) {
+      let content;
+      try { content = getComputedStyle(node, which).content; }
+      catch (e) { continue; }
+      if (!content || content === 'none' || content === 'normal') continue;
+      add(bucket, content);
+      // Computed `content` comes back quoted and escaped; the tree shows the
+      // string itself, so add that too.
+      const quoted = /^"([\s\S]*)"$/.exec(content);
+      if (quoted) add(bucket, quoted[1].replace(/\\(.)/g, '$1'));
+    }
+  };
+
+  const readNode = (bucket, node) => {
+    add(bucket, node.textContent);
+    if (typeof node.value === 'string') add(bucket, node.value);
+    // Individual text nodes as well as the concatenation: an accessible name
+    // is built per element, so the pieces are what a tree shows.
+    for (const child of node.childNodes || []) {
+      if (child.nodeType === 3) add(bucket, child.nodeValue);
+    }
+    if (node.nodeType !== 1) return;  // a shadow root has no attrs or style
+    for (const a of ATTRS) {
+      try { add(bucket, node.getAttribute(a)); } catch (e) { /* exotic attr */ }
+    }
+    readPseudo(bucket, node);
+    // An accessible name can be built from an element the subtree does not
+    // contain. aria-labelledby/describedby are the two ways to say so, and the
+    // text they point at reaches an ARIA snapshot as this node's own name.
+    for (const rel of ['aria-labelledby', 'aria-describedby']) {
+      let ids;
+      try { ids = (node.getAttribute(rel) || '').split(/\s+/); } catch (e) { continue; }
+      for (const id of ids) {
+        if (!id) continue;
+        let ref = null;
+        try {
+          const root = node.getRootNode();
+          ref = root.getElementById ? root.getElementById(id)
+                                    : document.getElementById(id);
+        } catch (e) { ref = null; }
+        if (ref) { add(bucket, ref.textContent); readPseudo(bucket, ref); }
       }
     }
   };
+
+  for (const el of marked) {
+    for (const node of walk(el, [], [])) readNode(inside, node);
+  }
+  // ...and everything the page *renders* that the mask is not covering.
+  //
+  // "Renders" is load-bearing and was learned the hard way. A first version
+  // collected the text of every node, which included the page's own inline
+  // `<script>` — so every literal in the fixture's source counted as "on
+  // screen in the clear" and four keys stopped being masked at all. A hidden
+  // element is the same mistake in miniature: an `aria-labelledby` source can
+  // be `display:none` and still supply a redacted element's accessible name,
+  // and exempting it because its text "appears outside" would be exempting it
+  // on the strength of text nobody can read.
+  const NOT_RENDERED = {SCRIPT: 1, STYLE: 1, TEMPLATE: 1, NOSCRIPT: 1,
+                        LINK: 1, META: 1, HEAD: 1, TITLE: 1};
+  // The recorder's own furniture does not get a vote on what the *app* renders
+  // in the clear. The caption bar is the one that matters: a storyboard that
+  // captions a redacted card's value puts that value into an element outside
+  // the mask, and counting it here would exempt the value from masking in
+  // every evidence file *and* in timeline.json — turning one authoring mistake
+  // in the frames, which no recorder can undo, into the same mistake in the
+  // files this skill tells people to commit, which it can.
+  const CHROME = '__MARKER_IDS__';
+  const chrome = (node) => {
+    let n = node;
+    while (n) {
+      if (n.nodeType === 1) {
+        const id = n.id || '';
+        if (id.slice(0, CHROME.length) === CHROME) return true;
+        if (id.slice(0, 6) === '__term') return true;
+        try { if (n.hasAttribute(COVER)) return true; } catch (e) { /* ignore */ }
+      }
+      if (n.nodeType === 11) { n = n.host || null; continue; }
+      n = n.parentNode;
+    }
+    return false;
+  };
+  const rendered = (node) => {
+    if (NOT_RENDERED[node.tagName]) return false;
+    if (chrome(node)) return false;
+    try {
+      if (typeof node.checkVisibility === 'function') return node.checkVisibility();
+    } catch (e) { /* fall through */ }
+    return true;
+  };
   for (const root of roots) {
-    for (const sel of selectors.concat(['[' + MARK + ']'])) {
-      let hits = [];
-      try { hits = root.querySelectorAll(sel); } catch (e) { continue; }
-      for (const hit of hits) harvest(hit);
+    let all = [];
+    try { all = root.querySelectorAll('*'); } catch (e) { continue; }
+    for (const node of all) {
+      if (covered(node) || !rendered(node)) continue;
+      for (const child of node.childNodes || []) {
+        if (child.nodeType === 3) add(outside, child.nodeValue);
+      }
+      if (typeof node.value === 'string') add(outside, node.value);
+      for (const a of ATTRS) {
+        try { add(outside, node.getAttribute(a)); } catch (e) { /* exotic */ }
+      }
+      readPseudo(outside, node);
     }
   }
-  return out;
+  const flat = (list) => list.map((s) => s.split(/\s+/).join(' ').trim())
+                             .filter((s) => s).join('\n');
+  return {inside: inside, outside: flat(outside)};
 }"""
 
 # The spotlight target's markup, cleaned, from a *clone* — nothing here may
@@ -717,6 +838,16 @@ _EVIDENCE_HARVEST_JS = r"""(selectors) => {
 # would leave it in the markup whole.
 _EVIDENCE_HTML_JS = r"""(el, opts) => {
   const [MARK, COVER, SELECTORS, MASK] = opts;
+  // Value-bearing attributes. Every one of these can hold a string the page
+  // never rendered — a `data-token`, a `data-cfg` holding a whole JSON config,
+  // an `href` carrying a session id — and none is structure. Stripped from
+  // *every* element, not only redacted ones: `redact()` covers where a value
+  // renders, and an attribute that renders nowhere was never in a frame, a
+  // still, a caption or the TTS cache. Serializing it here would make this
+  // feature the only place it exists. `id`, `class`, `role` and `style` stay,
+  // because they are what makes the markup worth reading.
+  const VALUED = ['value', 'title', 'alt', 'placeholder', 'aria-label',
+                  'href', 'src', 'srcdoc', 'content', 'action', 'poster'];
   const clone = el.cloneNode(true);
   const drop = (root, sel) => {
     let hits = [];
@@ -725,34 +856,78 @@ _EVIDENCE_HTML_JS = r"""(el, opts) => {
   };
   drop(clone, 'script,style,template,noscript,link,meta');
   drop(clone, '[' + COVER + '],[id^="__demo"],[id^="__term"]');
-  let framed = [];
-  try { framed = clone.querySelectorAll('[srcdoc]'); } catch (e) { framed = []; }
-  for (const node of framed) node.setAttribute('srcdoc', MASK);
-  const hide = (node) => {
-    for (const a of ['value', 'title', 'alt', 'placeholder', 'aria-label',
-                     'href', 'src', 'srcdoc', 'content', 'data-value']) {
+  const strip = (node) => {
+    for (const a of VALUED) {
       try { node.removeAttribute(a); } catch (e) { /* exotic attr */ }
     }
-    node.textContent = MASK;
+    // Every data-* attribute, whatever it is called. A whitelist would only
+    // ever be a list of the ones somebody happened to think of.
+    let names = [];
+    try { names = Array.prototype.slice.call(node.attributes || [])
+      .map((a) => a.name); } catch (e) { names = []; }
+    for (const name of names) {
+      if (name.slice(0, 5) === 'data-') {
+        try { node.removeAttribute(name); } catch (e) { /* ignore */ }
+      }
+    }
   };
-  for (const sel of SELECTORS.concat(['[' + MARK + ']'])) {
-    let hits = [];
-    try { hits = clone.querySelectorAll(sel); } catch (e) { continue; }
-    for (const hit of hits) hide(hit);
-    // querySelectorAll never returns the root it was called on, and the root
-    // is exactly the element a storyboard spotlights and redacts together.
-    try { if (clone.matches && clone.matches(sel)) hide(clone); }
-    catch (e) { /* an ancestor-relative selector cannot match a clone */ }
+  const hide = (node) => {
+    // textContent replaces the whole subtree, so every descendant of a
+    // redacted element goes with it — which is what makes redacting a wrapper
+    // enough.
+    node.textContent = MASK;
+    strip(node);
+  };
+  const isRedacted = (node) => {
+    if (node.nodeType !== 1) return false;
+    if (node.hasAttribute && node.hasAttribute(MARK)) return true;
+    for (const sel of SELECTORS) {
+      try { if (node.matches && node.matches(sel)) return true; }
+      catch (e) { /* an ancestor-relative selector cannot match here */ }
+    }
+    return false;
+  };
+  // Elide *before* stripping attributes, because the marker is itself a
+  // data-* attribute and stripping would take it with everything else.
+  //
+  // The spotlight target may be a *descendant* of what was redacted —
+  // `wear()` marks only the element a selector matched, so spotlighting the
+  // value inside a redacted card lands here with nothing in the clone marked
+  // at all. Ancestry is checked on the live element, across shadow
+  // boundaries, and covers the whole clone when it hits.
+  let ancestor = el;
+  let inherited = false;
+  while (ancestor) {
+    if (isRedacted(ancestor)) { inherited = true; break; }
+    if (ancestor.nodeType === 11) { ancestor = ancestor.host || null; continue; }
+    ancestor = ancestor.parentNode;
   }
+  if (inherited) {
+    hide(clone);
+  } else {
+    let nodes = [];
+    try { nodes = Array.prototype.slice.call(clone.querySelectorAll('*')); }
+    catch (e) { nodes = []; }
+    for (const node of nodes) if (isRedacted(node)) hide(node);
+  }
+  let all = [];
+  try { all = [clone].concat(Array.prototype.slice.call(
+    clone.querySelectorAll('*'))); } catch (e) { all = [clone]; }
+  for (const node of all) strip(node);
   return clone.outerHTML;
 }"""
 
-# Transient frame failures, classified the same way `_mask_selector` does:
-# frames come and go several times a second on ad-slot- and embed-heavy apps,
-# and a diagnostic must not be the reason a take dies.
-_EVIDENCE_TRANSIENT = (
-    "detach", "navigat", "execution context was destroyed", "target closed",
-)
+# How many times a beat's capture is retried when the redacted region moves
+# while it is being read. Three, because the window is two round trips wide
+# (~30 ms) and anything that will not hold still across three of those is a
+# page whose mask cannot be built from a snapshot at all — at which point the
+# beat's page text is dropped rather than written from a stale mask.
+EVIDENCE_HARVEST_TRIES = 3
+
+# How many distinct "what the page renders outside the mask" readings to keep.
+# One per beat on a static page, one per *change* on a live one — and it is
+# held for the whole take, so it needs a ceiling.
+EVIDENCE_OUTSIDE_MAX = 200
 
 
 class Recorder(_DemoBase):
@@ -1221,38 +1396,26 @@ class Recorder(_DemoBase):
 
     # -- evidence (issue #9) ------------------------------------------------
 
-    def _redacted_rendered_text(self) -> list[str]:
-        """Everything the mask is covering, as text, across every frame.
+    def _harvest(self) -> tuple[list[str], str]:
+        """(what the mask covers, what the page renders outside it).
 
-        Raises if the *main* frame cannot be read. A sub-frame that refuses is
-        logged and skipped: frames detach and re-attach constantly on
-        embed-heavy apps, and nothing a sub-frame renders reaches an evidence
-        file anyway — the ARIA snapshot is taken of the top document's `body`
-        and stops at an `iframe` node, and the markup dump replaces `srcdoc`
-        wholesale. Harvesting sub-frames is defence in depth, so failing to is
-        survivable; failing on the main frame is not.
+        **The main frame only, and that is not an omission.** Nothing a
+        sub-frame renders can reach an evidence file: `aria_snapshot` is taken
+        of the top document's `body` and stops at the `iframe` node, and the
+        markup dump strips `srcdoc` along with every other value-bearing
+        attribute. Harvesting sub-frames was written first and removed — it was
+        code whose only defence was an argument that nothing needs it, which is
+        the kind that rots. The claim is held up instead by the byte sweep in
+        tests/smoke, which requires the fixture's in-iframe key to be absent
+        from every evidence file.
         """
-        found: list[str] = []
-        script = _EVIDENCE_HARVEST_JS.replace("__MARK__", REDACT_MARK_ATTR)
-        frames = list(self.page.frames)
-        main = self.page.main_frame
-        for frame in frames:
-            try:
-                found += frame.evaluate(script, self._redacted) or []
-            except Exception as exc:  # noqa: BLE001 - classified, then re-raised
-                if frame is main:
-                    raise
-                detail = str(exc)
-                if not any(t in detail.lower() for t in _EVIDENCE_TRANSIENT):
-                    raise
-                print(
-                    f"demo-video: a sub-frame could not be read while "
-                    f"collecting what redact() hides ({type(exc).__name__}); "
-                    f"nothing it renders reaches an evidence file, and the "
-                    f"next beat tries again.",
-                    file=sys.stderr,
-                )
-        return found
+        script = (
+            _EVIDENCE_HARVEST_JS.replace("__MARK__", REDACT_MARK_ATTR)
+            .replace("__COVER__", REDACT_COVER_ATTR)
+            .replace("__MARKER_IDS__", "__demo")
+        )
+        found = self.page.evaluate(script, self._redacted) or {}
+        return list(found.get("inside") or []), str(found.get("outside") or "")
 
     def _aria(self, locator) -> tuple[str | None, str]:
         """(snapshot, format) for one locator's accessibility tree.
@@ -1267,34 +1430,8 @@ class Recorder(_DemoBase):
             return None, "unavailable: this Playwright predates 1.49"
         return locator.aria_snapshot(), "aria-yaml"
 
-    def _evidence_payload(self) -> dict:
-        """What was on screen at the end of this beat, as text.
-
-        The ARIA snapshot is the primary artifact and the page's is always
-        taken: it is what lets a reviewer say what was on screen without
-        decoding a frame. `outerHTML` is the spotlight target's only — never
-        the page's — because the markup of a whole document is an order of
-        magnitude larger than its ARIA tree and carries script text and
-        `srcdoc` documents that were never on screen at all.
-        """
-        # The marker attribute the elision below matches on is stamped by the
-        # mask, and the mask is re-asserted at checkpoints. Take one now so the
-        # page's idea of what is covered is not one re-render out of date.
-        self._checkpoint()
-        if self._redacted:
-            try:
-                self._evidence_masks.update(self._redacted_rendered_text())
-            except Exception as exc:  # noqa: BLE001 - refuse, never guess
-                # The one failure that must not degrade into a written file:
-                # without this text the writer cannot mask what redact() is
-                # hiding, and a DOM dump is not protected by a pixel cover.
-                return {
-                    "omitted": (
-                        f"the recorder could not read what redact() is "
-                        f"covering ({type(exc).__name__}), so no page text was "
-                        f"captured for this beat"
-                    )
-                }
+    def _capture_page(self) -> dict:
+        """One pass: the ARIA snapshot, the URL, and the spotlight target."""
         aria, aria_format = self._aria(self.page.locator("body"))
         payload: dict = {
             "scope": self._spotlit,
@@ -1304,7 +1441,6 @@ class Recorder(_DemoBase):
             "aria": aria,
             "scope_aria": None,
             "html": None,
-            "redacted": list(self._redacted),
         }
         if self._spotlit:
             target = self.page.locator(self._spotlit).first
@@ -1314,6 +1450,73 @@ class Recorder(_DemoBase):
                 [REDACT_MARK_ATTR, REDACT_COVER_ATTR, self._redacted, SECRET_MASK],
             )
         return payload
+
+    def _evidence_payload(self) -> dict:
+        """What was on screen at the end of this beat, as text.
+
+        The ARIA snapshot is the primary artifact and the page's is always
+        taken: it is what lets a reviewer say what was on screen without
+        decoding a frame. `outerHTML` is the spotlight target's only — never
+        the page's — because the markup of a whole document is an order of
+        magnitude larger than its ARIA tree and carries script text and
+        `srcdoc` documents that were never on screen at all.
+
+        **The harvest and the snapshot are separate round trips, and a page
+        that repaints between them is a leak.** `aria_snapshot()` is a
+        protocol call, not something a page evaluation can produce, so they
+        cannot literally be one operation. A card rewritten on a 25 ms
+        `setInterval` — a countdown, a ticker, a rotating token — hands the
+        harvest one value and the snapshot the next, and the mask is then built
+        from a value the snapshot does not contain.
+
+        So the harvest is taken on *both* sides of the snapshot and the two
+        must agree. If they do not, the redacted region moved while the page
+        was being read and this beat's capture is retried; if it will not
+        settle, the beat's page text is dropped rather than written from a mask
+        that is known to be out of date. Both harvests feed the mask either
+        way, so a value seen on either side is masked everywhere.
+
+        A checkpoint first, and the *ordering* is the point rather than the
+        frequency — `_checkpoint()` is throttled and `_idle` calls it anyway.
+        What is about to happen is a read of the text of everything `redact()`
+        covers, turned into the mask every evidence file and both timeline
+        files are scrubbed against. Taking that reading a quarter-second after
+        the last time anyone asked the browser whether the cover is still on
+        the elements means building the mask from a stale idea of what is
+        hidden. It also puts a cannot-verify-the-mask refusal on this path for
+        real rather than in principle: `_capture_evidence` runs in a `finally`
+        and must let a `SecretLeak` through, and this is where one comes from.
+        """
+        self._checkpoint()
+        if not self._redacted:
+            return self._capture_page()
+        for attempt in range(EVIDENCE_HARVEST_TRIES):
+            before, outside = self._harvest()
+            payload = self._capture_page()
+            after, outside_after = self._harvest()
+            self._evidence_masks.update(before)
+            self._evidence_masks.update(after)
+            # Bounded, because a page whose content changes every beat yields a
+            # distinct "outside" every time and this would otherwise grow with
+            # the storyboard. Past the bound the recorder stops learning that a
+            # string renders in the clear, which over-masks — the safe
+            # direction, and the one worth erring in.
+            if len(self._evidence_outside) < EVIDENCE_OUTSIDE_MAX:
+                self._evidence_outside.add(outside)
+                self._evidence_outside.add(outside_after)
+            if set(before) == set(after):
+                return payload
+            if attempt == EVIDENCE_HARVEST_TRIES - 1:
+                return {
+                    "omitted": (
+                        f"what redact() is covering changed "
+                        f"{EVIDENCE_HARVEST_TRIES} times while this beat's "
+                        f"page text was being read, so the mask could not be "
+                        f"built from what the snapshot actually saw. No page "
+                        f"text was captured for this beat."
+                    )
+                }
+        raise AssertionError("unreachable")
 
     # -- storyboard verbs ---------------------------------------------------
 

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -788,12 +788,35 @@ _EVIDENCE_HARVEST_JS = r"""(selectors) => {
     }
     return false;
   };
+  // "Rendered" has to mean *painted*, and every relaxation of that has been a
+  // leak. checkVisibility() with no arguments models `display` and
+  // `content-visibility` and nothing else, so `opacity: 0`,
+  // `visibility: hidden`, an .sr-only clip and `left: -9999px` all reported
+  // true — and a value sitting in any of them was read as "already on screen
+  // in the clear" and dropped from the mask, in every evidence file and in
+  // timeline.json. Four conditions, each conservative on purpose: the cost of
+  // being too strict here is masking one string more than necessary, and the
+  // cost of being too lax is publishing a credential.
+  const MIN_PAINT_PX = 2;
   const rendered = (node) => {
     if (NOT_RENDERED[node.tagName]) return false;
     if (chrome(node)) return false;
     try {
-      if (typeof node.checkVisibility === 'function') return node.checkVisibility();
-    } catch (e) { /* fall through */ }
+      if (typeof node.checkVisibility === 'function' &&
+          !node.checkVisibility({opacityProperty: true, visibilityProperty: true,
+                                 contentVisibilityAuto: true})) return false;
+    } catch (e) { /* an older Chromium: the geometry test below still applies */ }
+    // ...and geometry, which checkVisibility() models nothing about. A
+    // screen-reader-only span is 1x1 with a clip; a skip link is at -9999px.
+    // Both are visible to the accessibility tree, both are on nobody's screen.
+    let rect;
+    try { rect = node.getBoundingClientRect(); } catch (e) { return false; }
+    if (!rect) return false;
+    if (rect.width < MIN_PAINT_PX || rect.height < MIN_PAINT_PX) return false;
+    // Off the top or left of the document entirely. Deliberately *not* a
+    // viewport test: content below the fold is painted as soon as anyone
+    // scrolls, and the recorder scrolls.
+    if (rect.right <= 0 || rect.bottom <= 0) return false;
     return true;
   };
   for (const root of roots) {
@@ -801,12 +824,22 @@ _EVIDENCE_HARVEST_JS = r"""(selectors) => {
     try { all = root.querySelectorAll('*'); } catch (e) { continue; }
     for (const node of all) {
       if (covered(node) || !rendered(node)) continue;
+      // Text nodes and generated content, and nothing else. Attributes and
+      // `value` used to be read here too, on the assumption that this bucket
+      // was collecting "what the page shows" — but `title`, `alt`,
+      // `placeholder`, `aria-label`, `data-*` and `srcdoc` are not painted by
+      // anything, and neither is the value of a password field or of an input
+      // nobody has scrolled to. A copy-to-clipboard button carrying the key it
+      // copies in `title` is ordinary UI, and it was enough to exempt that key
+      // from masking everywhere.
+      //
+      // The same reasoning removed inline <script> text from this bucket one
+      // round earlier, and `srcdoc` is a whole embedded document — the same
+      // category, arrived at the same way. Note the feature contradicted
+      // itself until this line changed: _EVIDENCE_HTML_JS strips exactly these
+      // attributes from the markup *because* nothing renders them.
       for (const child of node.childNodes || []) {
         if (child.nodeType === 3) add(outside, child.nodeValue);
-      }
-      if (typeof node.value === 'string') add(outside, node.value);
-      for (const a of ATTRS) {
-        try { add(outside, node.getAttribute(a)); } catch (e) { /* exotic */ }
       }
       readPseudo(outside, node);
     }
@@ -1464,7 +1497,7 @@ class Recorder(_DemoBase):
         **The harvest and the snapshot are separate round trips, and a page
         that repaints between them is a leak.** `aria_snapshot()` is a
         protocol call, not something a page evaluation can produce, so they
-        cannot literally be one operation. A card rewritten on a 25 ms
+        cannot literally be one operation. A card rewritten on a 5 ms
         `setInterval` — a countdown, a ticker, a rotating token — hands the
         harvest one value and the snapshot the next, and the mask is then built
         from a value the snapshot does not contain.

--- a/tests/README.md
+++ b/tests/README.md
@@ -80,8 +80,7 @@ smoke: evidence a registered secret spans the markup budget (chars 7984-8016 of 
 smoke: evidence ok (18 beats as shapes.seg.beat-NN.json, 12 leak shapes clean, 4 controls intact, 2 beat(s) refused a moving target)
 smoke: terminal-problems timeline.json records 2 problem(s), 2 of them fatal under strict — take still passed
 smoke: terminal-race exit status survives a shell that starts 1.2s late (logged 5)
-smoke: terminal-problems a printed secret is masked out of the screen dump, and the line around it survives
-smoke: terminal-wrap a registered secret split by a line wrap at column 120 (chars 112-140) is masked in both halves
+smoke: terminal-wrap a registered secret split by a line wrap at column 120 (chars 112-140) is still refused, and keeps nothing
 smoke: terminal-strict strict=True refused the take, naming beat 1 (run) (1 fatal issues, artifacts kept)
 smoke: determinism froze all four clocks identically in both takes
 smoke:   frozen  1/1/2025, 9:00:00 AM · 1735722000000
@@ -1018,11 +1017,14 @@ point, and both are checked on the screen text and the byte sweep against a
 leaks a *prefix*, and a take rendering the first 111 characters in the clear
 was measured passing a check for the token itself.
 
-**`key()` must refuse too.** It is the one verb whose beat log a scrub cannot
-clean: the beat records the keys joined by spaces, and no literal match on the
-value can see `'s k - l i v e - …'` in `timeline.json`. So the call raises
-rather than the log leaking, and the take asserts nothing reached the screen
-first.
+**`key()` must refuse too**, and its beat log used to leak whether it did or
+not. The beat opens before the refusal, so it records the keys joined by
+spaces, and no *literal* match on the value can see `'s k - l i v e - …'` in
+`timeline.json`. That is the same shape a terminal line wrap produces, and the
+beat-log scrub now matches it (issue #9): `terminal-redaction/` requires three
+scrubbed selectors, not two, and reverting the elasticity puts that string back
+in the committed log. The refusal is still the control that matters — a secret
+spelled into a TUI is on screen — but it is no longer the only one.
 
 **`run()` and `send()` must refuse.** Both are authored text echoed on camera,
 the terminal's `caption()`. Each is called with a registered value, must raise
@@ -1192,10 +1194,16 @@ the round that introduced it was reviewed:
 | `ATTR`, `JSON` | `data-*` attributes the page never renders, which only exist in evidence because the markup dump is a surface this feature created |
 | `BLED` | in a card whose *label* also renders outside it — the mirror defect, below — and **captioned** by the storyboard, which is the case that reaches `timeline.json` |
 | `HATT` | mirrored into `title`, `data-value`, `aria-label` and an input's `value` on siblings nothing redacts. The harvest read those when deciding what "renders in the clear", so a copy-to-clipboard button carrying the key it copies exempted that key from masking **everywhere**. None of those channels is painted by anything, and `_EVIDENCE_HTML_JS` already strips the same attributes out of `html` on exactly that reasoning — the feature contradicted itself for a round |
-| `HIDE` | the same trick in CSS: a `.sr-only` clip, `opacity:0`, `visibility:hidden`, `left:-9999px`. `checkVisibility()` called with no arguments reports all four visible; it models `display` and `content-visibility` and nothing else, and `display:none` was the one shape this fixture happened to use. Measured leaking into `timeline.json` and `timeline.md` as well as all six evidence files |
+| `VEIL` | the same trick in CSS: a `.sr-only` clip, `opacity:0`, `visibility:hidden`, `left:-9999px`. `checkVisibility()` called with no arguments reports all four visible; it models `display` and `content-visibility` and nothing else, and `display:none` was the one shape this fixture happened to use. Measured leaking into `timeline.json` and `timeline.md` as well as all six evidence files |
 | `AMPS` | a registered secret containing `&`, which `outerHTML` writes `&amp;`. The mask searched the raw literal, the withhold fallback stripped tags but not entities, and the end-of-document backstop was a plain `in` — all three missed, and the file came out with `aria` reading `token=[redacted]` and `html` carrying the value in full |
 
-One literal covers each of `HATT` and `HIDE` rather than one per channel, and
+`VEIL` is spelled that way because the terminal family already has a `HIDE`
+(a value cut by a cursor-hide escape), and `sk-live-HIDE` with eight zeroes is
+a **prefix** of the terminal one's sixteen — so each take's byte sweep would
+have matched the other's literal. Found by a rename in this repo doing exactly
+that.
+
+One literal covers each of `HATT` and `VEIL` rather than one per channel, and
 that is deliberate: every element in a family holds the same value, so any
 single channel regressing puts that value back into `outside` and un-masks it
 everywhere. One assertion, four shapes, and the failure names the family.
@@ -1283,36 +1291,49 @@ It is also the only take that records with `segment=`, so
 ([#22](https://github.com/rogvid/skills/issues/22)).
 
 `terminal-wrap/` is the take for the one transformation the terminal
-introduces on its own. `__termText()` walks the xterm.js buffer a row at a time
-and joins with newlines without consulting `isWrapped`, so a credential that
-crosses the last column arrives split — and the mask was elastic about
-whitespace the *literal* has and exact about whitespace the *text* has, so it
-matched neither half. The end-of-document backstop was a plain `in` over
-`json.dumps` output, where a newline is the two characters `\n`, so it missed in
-the same direction; a backstop that fails the way the thing it backs up fails is
-not one.
+introduces on its own. `_screen()` walks the xterm.js buffer a row at a time and
+joins with newlines without consulting `isWrapped`, so a credential crossing the
+last column is two rows with a newline through the middle: contiguous to a
+viewer, contiguous in the frames, and a substring of nothing. Two mechanisms
+missed it for that one reason — the evidence mask, and
+`_verify_redaction_final()`, which is the check that decides whether the mp4 may
+be written at all and which asked `secret in screen`. They now share one
+matcher and cannot disagree.
 
-`terminal-problems/` could never provoke it — `echo printed-below` plus a
-20-character secret is ~60 columns against a 120-column terminal — so this take
-measures `term.cols` at record time and pads the line so that
-`TERMINAL_WRAP_HEAD` characters of the secret land before the boundary. The
-geometry is asserted and printed (`chars 112-140` at column 120), because a take
-that quietly stopped wrapping would be a test of an ordinary echo. The sweep
-that grades it deletes whitespace from both sides before comparing, which is
-what a reader with `tr -d` does.
+Three things about the take are forced rather than chosen, and each was found by
+the take failing loudly:
 
-`terminal-problems/` carries the last piece: a command *prints* a registered
-secret, and the screen dump must mask it while the word printed beside it
-survives. `TerminalRecorder` has no `redact()` at all
-([#5](https://github.com/rogvid/skills/issues/5)), so `register_secret()` is
-the entire defence for its evidence. The surviving word is looked for in
-`screen` **only** — it is a word in the command, and the command is in the beat
-record embedded in the same file, so searching the file finds it whether or not
-one character of the terminal was captured. Written the easy way first, and an
-injected `{"screen": ""}` payload was measured passing it.
+- **the value is printed by a script**, not by a `run()` argument. A command
+  line is echoed, and a registered secret in one trips `run()`'s own guard
+  ([#5](https://github.com/rogvid/skills/issues/5));
+- **it is registered *after* it is printed.** The stream scrubber masks what it
+  knows about as the bytes go past, so a value registered up front never reaches
+  the buffer and the shape cannot exist. Late registration is the ordinary shape
+  of the mistake — a token rotates into output before the storyboard names it —
+  and what is on screen at the end of the take is in the frames whenever it was
+  registered;
+- **it is `zz-wrap-` shaped, not `sk-live-`.** The scrubber's shape net
+  (`sk-[A-Za-z0-9_-]{16,}` among others) masks an `sk-live-` value whether or not
+  anyone registered it, so such a value can never reach the screen. `zz-` matches
+  no shape, exactly as `terminal-redaction/`'s own `TCTL` control does.
 
-`tests/smoke --evidence-only` records just this take and the refusal take,
-which is what makes an injection loop over this axis affordable.
+The take measures `term.cols` at record time and pads so `TERMINAL_WRAP_HEAD`
+characters land before the boundary; the geometry is asserted and printed
+(`chars 112-140` at column 120), because a take that quietly stopped wrapping
+would be a test of an ordinary echo. It is graded on the refusal **and** on what
+survived it — `SKILL.md` promises a `SecretLeak` keeps nothing, and a terminal
+still is the raw screen.
+
+**The same elasticity closed a leak `key()` documented as unfixable.** `key()`
+refuses a registered secret spelled one keystroke at a time, but the beat opens
+before the refusal, so `timeline.json` recorded the keys **joined by spaces** —
+`s k - l i v e - K E Y D 0 0 …`, which is the value with whitespace inserted
+between every character and which no literal match could see. The docstring said
+so. `terminal-redaction/` now requires **three** scrubbed selectors rather than
+two, and reverting the elasticity puts that string back in the log.
+
+`tests/smoke --evidence-only` records just the evidence take and the refusal
+take, which is what makes an injection loop over this axis affordable.
 
 ## Known gaps
 
@@ -1421,11 +1442,14 @@ knows is missing is worse than one that is openly absent.
   rest of the line keeps its colour. In this fixture the colour is reset
   inside the same run, so removing that re-emission changes no pixel here.
   It is cosmetic either way — nothing about *what* is hidden depends on it.
-- **Only SGR-interleaved secrets are caught, and only that is tested.** A
-  value broken up by a cursor movement — a redrawn progress line, a TUI
-  painting in two passes, a terminal-wrapped line — is not contiguous on
-  screen and is deliberately not matched (see SKILL.md). Nothing here records
-  such a program, so the harness does not measure how common that is.
+- **Only SGR-interleaved secrets are caught by the *stream* scrubber, and only
+  that is tested.** A value broken up by a cursor movement — a redrawn progress
+  line, a TUI painting in two passes — is not contiguous in the stream and is
+  deliberately not matched there (see SKILL.md); what catches it is
+  `_verify_redaction_final()` on the finished screen. A **wrapped** line is the
+  mirror case: contiguous on screen, split in `_screen()`, and it used to defeat
+  that check too — `terminal-wrap/` is the take for it. Nothing here records a
+  redrawn progress line, so the harness does not measure how common that is.
 - **Shape detection is graded on how a token is *split*, not on the pattern
   list.** All four patterns are printed unregistered and pixel-graded — `ghp_`
   on the `shp`, `str` and `anc` rows, `sk-` on `pau`, `AKIA` on `aws`, a JWT
@@ -1576,9 +1600,10 @@ knows is missing is worse than one that is openly absent.
   rendered terminal and `register_secret()` is the only thing masked out of it,
   because `TerminalRecorder` has no `redact()` at all
   ([#5](https://github.com/rogvid/skills/issues/5)).
-  `terminal-problems/` proves the registered path reaches the screen dump and
-  `terminal-wrap/` proves it survives the line wrap; a value nobody registered
-  is written verbatim, and there is nothing yet to assert about it.
+  `terminal-redaction/` proves the registered path reaches the screen dump and
+  the byte sweep over every file the take wrote, evidence included; a value
+  nobody registered and matching no shape is written verbatim, and there is
+  nothing yet to assert about it.
 - **A crash that is not a `SecretLeak` skips the stale-evidence clearing**
   ([#79](https://github.com/rogvid/skills/issues/79)), the end-of-document
   guard runs after capping and so cannot see a literal cut in half by a budget

--- a/tests/README.md
+++ b/tests/README.md
@@ -23,7 +23,8 @@ problem takes, `redaction/` — the web recorder against a page that renders
 a secret, plus a second few-second take that must *fail* — `segments/`,
 one demo recorded in two parts and joined with `stitch()`,
 `terminal-redaction/`, the redaction question asked of the PTY output path,
-and `evidence-caps/`, four seconds against a deliberately bloated page.
+and `evidence/`, a few seconds against the shapes that leak into text and into
+nothing else.
 
 ## Running it
 
@@ -34,6 +35,7 @@ tests/smoke --terminal-only       # just the PTY/xterm.js takes
 tests/smoke --determinism-only    # just the three re-recording takes
 tests/smoke --redaction-only      # just the secret-redaction takes
 tests/smoke --segments-only       # just the two-segment take and its stitch
+tests/smoke --evidence-only       # just the per-beat evidence takes
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -62,7 +64,8 @@ smoke: redaction #api-key is blurred in every frame of demo.mp4 (worst 1.5 vs co
 smoke: redaction all 9 masked elements are blurred in the review frames (18 gradable of 31; worst #a4-card 0.2 vs control 21.8 in beat-23.png, 1%, bar 7%)
 smoke: redaction still 01-key-blurred.png ok (key 1.0, token 2.9, control 39.3)
 smoke: redaction .tts/ holds 2 clips — the narrated lines, and nothing for the refused one
-smoke: redaction none of the 13 secrets appears verbatim in any of the 45 files the take wrote (31 of them per-beat evidence, which the controls prove is not empty)
+smoke: redaction evidence ok (34 beats, 90 kB, largest 3369 bytes)
+smoke: redaction none of the 13 secrets appears verbatim in any of the 48 files the take wrote (34 of them per-beat evidence, which the controls prove is not empty)
 smoke: segments recorded 2 parts, each with its own beat log (part1 6.8s, part2 7.8s)
 smoke: segments part1's probe caption is +0 ms from where its own segment puts it (-120 ms in part1.seg.mp4, -120 ms in demo.mp4)
 smoke: segments part2's probe caption is +0 ms from where its own segment puts it (-80 ms in part2.seg.mp4, -80 ms in demo.mp4)
@@ -72,9 +75,12 @@ smoke: segments timeline.json ok (15 beats)
 …
 smoke: web-problems timeline.json records 8 problem(s), 6 of them fatal under strict — take still passed
 smoke: web-strict strict=True refused the take, naming beat 0 (goto) (4 fatal issues, artifacts kept)
-smoke: evidence-caps aria cut to 12000 and html to 8000 characters, both marked (untruncated beat 2 left alone)
+smoke: evidence a SecretLeak raised while capturing a beat kills the take and keeps nothing
+smoke: evidence a registered secret spans the markup budget (chars 7984-8016 of 72716, budget 8000)
+smoke: evidence ok (16 beats as shapes.seg.beat-NN.json, 9 leak shapes clean, 4 controls intact, 2 beat(s) refused a moving target)
 smoke: terminal-problems timeline.json records 2 problem(s), 2 of them fatal under strict — take still passed
 smoke: terminal-race exit status survives a shell that starts 1.2s late (logged 5)
+smoke: terminal-problems a printed secret is masked out of the screen dump, and the line around it survives
 smoke: terminal-strict strict=True refused the take, naming beat 1 (run) (1 fatal issues, artifacts kept)
 smoke: determinism froze all four clocks identically in both takes
 smoke:   frozen  1/1/2025, 9:00:00 AM · 1735722000000
@@ -95,9 +101,9 @@ Re-running into the same `--out-dir` is safe: the take subdirectories
 (`web/`, `terminal/`, `segments/`, `redaction/`, `terminal-redaction/`,
 `terminal-cursor-leak-clean/`, `terminal-cursor-leak-crash/`,
 `terminal-cursor-leak-tail/`, `web-problems/`, `terminal-problems/`,
-`terminal-race/`, `web-strict/`, `terminal-strict/`, `evidence-caps/`,
-`determinism-a/`, `determinism-b/`, `determinism-off/`) are deleted before each
-take. Only the first two are graded
+`terminal-race/`, `web-strict/`, `terminal-strict/`, `evidence/`,
+`evidence-leak-fatal/`, `determinism-a/`, `determinism-b/`,
+`determinism-off/`) are deleted before each take. Only the first two are graded
 on their video; the rest are short and exist to break, or to reproduce, in one
 specific way each. That is not tidiness — every artifact assertion works by
 path, so without it a leftover `demo.mp4` from the previous run would grade a
@@ -1123,59 +1129,162 @@ selector in `scope`, carry `$128,400` in `scope_aria` and `id="kpi-rev"` in
 `html`; the beat that *clears* the spotlight must carry neither, or the scope
 outlives the highlight.
 
-**The size cap needs its own take** (`evidence-caps/`, four seconds). The
-fixture's whole ARIA tree is 2.3 kB against a 12 kB cap, so truncation cannot
-be provoked on it, and slackening the cap to meet the fixture would be grading
-the wrong number. The take appends 900 list items to the page and spotlights
-them, and then:
+**The size cap is graded in the same take.** The fixture's whole ARIA tree is
+2.3 kB against a 12 kB cap, so truncation cannot be provoked on it, and
+slackening the cap to meet the fixture would be grading the wrong number. The
+take appends 900 list items to the page and spotlights them, and then:
 
 - the `pause` beat **before** the bloat must come back with `truncated == []`
   and an ARIA tree under the cap — a recorder that marked every field
   truncated would satisfy everything else here;
-- the `pause` beat **after** it must have both `aria` and `html` in
-  `truncated`, both carrying the marker text inline where they stop, and both
-  cut *to* the budget (`limit < len(field) <= limit + marker`) rather than
-  merely under some ceiling;
+- the `pause` beat **after** it must have `aria`, `scope_aria` *and* `html` in
+  `truncated`, all three carrying the marker text inline where they stop, and
+  all three cut *to* the budget (`limit < len(field) <= limit + marker`) rather
+  than merely under some ceiling. All three, because a cap applied to `aria`
+  and not to `scope_aria` is a cap on a third of what a spotlight beat writes;
 - the package's own `EVIDENCE_LIMITS` and `EVIDENCE_SCHEMA` must equal the
   numbers written in `tests/smoke`. Reading the caps off the code being graded
   would agree with it whatever it says; asserting they match means widening one
   has to be done on purpose.
 
-Per file the ceiling is 64 kB, per directory 512 kB — observed 39 kB across 23
-web beats and 9 kB across 18 terminal ones, so both are there to catch a cap
-that stopped being applied, not to tune anything.
+`screen` is the fourth budget and no take here bloats a TUI far enough to reach
+it, so it is graded as the **contract of `_cap_text` itself** — under its
+budget nothing is cut, 500 over it exactly 500 are, the marker is there, and
+the result never exceeds budget plus marker. That is a unit check, stated as
+one, and it is the only assertion on this axis that does not come from a
+recording.
+
+Per file the ceiling is 136 kB and per directory 512 kB — observed 39 kB across
+23 web beats and 9 kB across 18 terminal ones. The file ceiling is deliberately
+loose because **the caps count characters and it counts bytes**: 32 000
+characters of CJK is ~96 kB of UTF-8 before JSON escaping, so a tight byte
+ceiling would fail on a legitimately-capped file. What grades the caps is the
+character count per field above; this only catches one that stopped being
+applied at all.
 
 **Evidence is the fifth leak path, and it is the one with no pixels in it.**
 Every other artifact here is an image; `redact()` is a *pixel* control, and the
 value it covers is still in the DOM — which is what an evidence file is a dump
-of. So the `redaction/` take grades it directly, and the grading is a matched
-pair for the same reason the sharpness bars are:
+of. Two takes grade it, and they grade different halves.
 
-- none of the 13 literals in `REDACT_LITERALS` may appear in any evidence file
-  — the keys rendered by the app, the ones typed as `Secret(...)`, the hero
-  value inside a redacted *wrapper*, the ones behind a shadow root and an
-  iframe, and all five sufficiency shapes;
-- **`sk-live-CTRL…` and `sk-live-BGC…` — the two controls, never redacted —
-  must be found in there.** Without that half, "no secret appears" is equally
-  true of an empty `evidence/`, of files holding nothing but a beat record, and
-  of a recorder that masked every string it wrote. It is the same anti-vacuity
-  guard `MIN_CONTROL_EDGE` is for the pixels;
-- and `evidence/` must hold exactly one file per beat, since the sweep is only
-  a statement about the files that are there.
+`redaction/` sweeps its evidence for the same 13 literals as everything else,
+which works only because that take now **sets a spotlight**. For one review
+round it did not, `html` was null in all 31 files, and the entire `outerHTML`
+surface sat outside the sweep — the take with the secrets in it graded none of
+the field most likely to carry one. It also runs `check_evidence`, because the
+sweep alone grades nothing: replacing `_evidence_payload` with a constant
+returning two control strings **passed the whole take**, sweep and all.
 
-The whole-directory `rglob` sweep at the end of `check_redaction` picks the
-evidence files up too, with no exemptions, and its summary line now says how
-many of the files it swept were evidence.
+`evidence/` is the take for the shapes that leak into *text and nothing else*.
+It records `?evidence=1`, redacts seven cards, registers two values, and sweeps
+for nine literals — every one of which was readable in `evidence/*.json` when
+this was first reviewed:
 
-What makes those files clean is described in SKILL.md: the recorder reads the
-rendered text of everything `redact()` covers — every node in the subtree,
-shadow roots at every depth, `::before`/`::after` content, input values and
-value-bearing attributes — and masks it out of every beat's evidence.
-Harvesting only the element the selector *matched* was measured masking five of
-the eight fixture keys and leaving three in the clear, because redacting a
-wrapper is the ordinary call and the wrapper's `textContent` is the label and
-the value run together — one string that appears nowhere in an ARIA tree, which
-renders them as separate nodes.
+| shape | why a picture never sees it |
+|---|---|
+| `WSPC` | a value indented on its own line in hand-written markup. `textContent` returns `"\n      sk-live-WSPC…\n    "`; the ARIA tree returns `sk-live-WSPC…`; `str.replace` between them finds nothing. **The most ordinary shape there is** — the older fixture escaped it only because every key was assigned from JS, which makes one unpadded text node |
+| `TICK` | rewritten every 5 ms. The capture reads the page three times, so the harvest sees one value and the snapshot the next |
+| `LBLD` | the accessible name of a redacted card, sourced by `aria-labelledby` from a `display:none` element outside it. On nobody's screen, in nobody's frame, and in the ARIA tree. The card carries `role="group"` deliberately: a plain `<div>` has no role, an ARIA snapshot shows it no name, and the shape would prove nothing |
+| `SLOT` | light DOM slotted into a redacted element *inside* a shadow root. The redacted element's own `textContent` is empty and the value is a light child of the host — inside the redaction in the flattened tree, outside it in the DOM. It takes two separate mechanisms to hold: walking `assignedNodes()` when harvesting, and following `assignedSlot` when deciding what counts as outside |
+| `VALU` | an `<input>` value set from JS, so there is no `value` **attribute** to read — only the property |
+| `CHLD` | a key whose characters are three text nodes, each an ordinary string alone |
+| `ATTR`, `JSON` | `data-*` attributes the page never renders, which only exist in evidence because the markup dump is a surface this feature created |
+| `BLED` | in a card whose *label* also renders outside it — the mirror defect, below — and **captioned** by the storyboard, which is the case that reaches `timeline.json` |
+
+Three of those were written the wrong way first and passed while proving
+nothing: the slotted value was a DOM descendant of the redacted element, the
+labelled card had no role, and the input's value was an attribute. Each was
+found by injecting the fault the shape exists to catch and watching the run
+stay green. **A leak fixture that cannot be made to fail is a comment**, the
+same as an assertion.
+
+The sweep runs over **every file the take wrote**, not only `evidence/`. That
+is what catches the storyboard's captioned value in `timeline.json` and
+`timeline.md` — the two files this skill tells people to commit. The harvest
+that keeps a redacted value out of the evidence has to reach them too, or the
+same string is `[redacted]` in one file and in the clear in the one beside it.
+
+Against the secrets, `EVIDENCE_KEEP`: four strings that must **survive** — the
+sentence sharing a word with a redacted card's label, an ordinary KPI, the text
+of the element whose attributes hold keys, and a table row. Without that half,
+every assertion above is satisfied by a recorder that captured nothing, and by
+one that masked everything. Both happened: harvesting every node of a redacted
+card also harvests its label, and an earlier round rewrote every unrelated
+paragraph as `[redacted] for the quarter was steady.` A card holding
+`sk-<i>live</i>-CHLD…` registered `"live"` and rewrote every other key on the
+page.
+
+The rule that fixes it — a harvested string is a mask only if it renders
+nowhere outside the mask — turns on what "renders outside" means, and two
+readings of that were wrong before this one:
+
+- a first version counted the page's own inline `<script>` text, so every
+  literal in the fixture's source read as "already on screen in the clear" and
+  four keys stopped being masked at all;
+- the second counted the recorder's **own caption bar**. A storyboard that
+  captions a redacted card's value writes that value into an element outside
+  the mask — so the value was exempted everywhere, and one authoring mistake in
+  the frames (which no recorder can undo) became the same mistake in
+  `timeline.json` (which it can). Recorder chrome does not get a vote on what
+  the app renders.
+
+Five more assertions in that take, each for a claim that would otherwise be
+untested:
+
+- **The refusal.** Two beats run while the rotating card is live and must come
+  back `omitted`, with no `aria`, `scope_aria` or `html` — and a third, after
+  the card is removed, must **not**, or "every beat refuses" would satisfy the
+  first one and grade nothing. Injecting a payload that always refuses fails
+  the third *and* all four `EVIDENCE_KEEP` controls, which is the shape the
+  whole axis is built on.
+- **Elided, not withheld.** A third spotlight lands on `#ev-child-card`, which
+  the take *redacts*, and its markup must come back as the target's own tag
+  wrapped around one `[redacted]` — two tags, nothing between them.
+  `querySelectorAll('*')` never returns the element it was called on, so a
+  serializer that elides only descendants misses exactly the element a
+  storyboard redacts and spotlights together. What it writes instead is
+  `sk-<i>live</i>[redacted]`: elided wherever the substring mask happened to
+  reach, in the clear everywhere else, and passing every other assertion here
+  — measured. Counting the tags is what catches it.
+- **A refusal in the capture is fatal.** `evidence-leak-fatal/` records three
+  beats with a `Recorder` subclass whose `_evidence_payload` raises
+  `SecretLeak`, and the take must die with that exception and leave **nothing**
+  — no mp4, no timeline, no evidence. `_capture_evidence()` runs in a `finally`
+  and wraps the payload in a broad `except` so a diagnostic cannot lose an
+  otherwise fine take; a `SecretLeak` travelling that path was being swallowed,
+  and the take passed with the mp4 written. Injected rather than provoked, on
+  purpose: every real source of one is also a source elsewhere in the take, so
+  a fixture would not say which path refused.
+- **Mask-then-cap, where the two meet.** The take re-pads a list item until a
+  registered secret's characters *span* the 8 000-character markup budget
+  (asserted, and printed: `chars 7984-8016`), then looks for 12- and
+  20-character heads of it as well as the whole literal. Cap first and the
+  head survives as the last thing in the file, which a search for the literal
+  misses — injecting that order leaves `sk-live-CUTT` in the evidence and only
+  the 12-character search finds it.
+- **Stale evidence.** Two files are planted in `evidence/` before the take, as
+  a previous recording would have left them: one this take's naming owns,
+  which must be deleted, and one belonging to another segment, which must not.
+  `record.py` is committed precisely so it can be re-run into the same folder,
+  and yesterday's files would otherwise sit there holding the value you added a
+  `redact()` for today.
+
+It is also the only take that records with `segment=`, so
+`evidence/<segment>.seg.beat-NN.json` is exercised rather than merely designed
+([#22](https://github.com/rogvid/skills/issues/22)).
+
+`terminal-problems/` carries the last piece: a command *prints* a registered
+secret, and the screen dump must mask it while the word printed beside it
+survives. `TerminalRecorder` has no `redact()` at all
+([#5](https://github.com/rogvid/skills/issues/5)), so `register_secret()` is
+the entire defence for its evidence. The surviving word is looked for in
+`screen` **only** — it is a word in the command, and the command is in the beat
+record embedded in the same file, so searching the file finds it whether or not
+one character of the terminal was captured. Written the easy way first, and an
+injected `{"screen": ""}` payload was measured passing it.
+
+`tests/smoke --evidence-only` records just this take and the refusal take,
+which is what makes an injection loop over this axis affordable.
 
 ## Known gaps
 
@@ -1402,14 +1511,16 @@ knows is missing is worse than one that is openly absent.
   one being right makes the rest right — but a merge that moved some of a
   segment's beats and not others would be caught only by the ordering and
   coverage checks, which are much coarser.
-- **Nothing checks `stitch()`, segments, or `interlude()`.** Single-segment
-  takes only — so `<segment>.seg.timeline.json`, and the merge
-  [#7](https://github.com/rogvid/skills/issues/7) will build on it, are
-  unexercised. That includes evidence's segment-aware filenames
-  (`evidence/<segment>.seg.beat-NN.json`), which exist precisely so a merge
-  never has to rename anything
-  ([#22](https://github.com/rogvid/skills/issues/22)) and which no take here
-  produces.
+- **No segmented take writes evidence, so a merged timeline's `evidence`
+  pointers are unexercised.** The `evidence/` take records with `segment=`, so
+  `evidence/<segment>.seg.beat-NN.json` and the scoped stale-file clearing are
+  exercised; `segments/` is what actually merges two parts, and it is graded on
+  its beats rather than its evidence. So the half of
+  [#22](https://github.com/rogvid/skills/issues/22) that matters to
+  [#7](https://github.com/rogvid/skills/issues/7) — a merged timeline whose
+  renumbered beats still point at the right files — has never run. The naming
+  exists precisely so a merge has to rename nothing, and nothing here checks
+  that it did not have to.
 - **Nothing reads the evidence the way its acceptance criterion means it.**
   "A reviewer can state what was on screen" is graded as a list of substrings
   that must and must not be in each beat's capture. That is enough to catch an
@@ -1417,33 +1528,45 @@ knows is missing is worse than one that is openly absent.
   handed only `evidence/` could actually narrate the demo is the same
   unautomatable question as `SKILL.md` step 6's fresh-agent review, and
   nothing here asks it.
-- **Evidence's `omitted` path is unexercised.** When the recorder cannot read
-  what `redact()` is covering it writes that beat's evidence with no page text
-  and a reason. Provoking it needs a frame that fails mid-capture, which no
-  fixture here manufactures — so the branch that *refuses* rather than
-  guessing is read-only coverage.
 - **The recorder's own end-of-document guard cannot be shown catching a leak.**
   Before writing, each evidence document is re-checked over its serialized
   bytes for anything registered or redacted. It runs against the same list the
-  masking does, so for a plain string value it cannot disagree with it — turn
-  the masking off and the guard raises `SecretLeak` and kills the take
-  (measured), which is a *different* failure from the one the byte sweep
-  grades. It is there for what the walker structurally cannot reach — a field
-  a later slice adds after the scrub, a non-string key — and this file does not
-  claim more for it than that. What can actually fail is the sweep over
-  `evidence/`.
+  masking does, so for a plain string value it **cannot disagree with it** —
+  this is not a second opinion and nothing here should be read as saying it is.
+  It exists for what the walker structurally cannot reach: a field a later
+  slice adds *after* the scrub, or a secret that ends up in a dict key. What
+  actually grades this axis is the byte sweep over `evidence/`.
 - **`url` and `title` are only scrubbed for registered secrets.** No take puts
   an unregistered value in a query string, so the one path where evidence
-  records something the app never rendered on screen is untested.
+  records something the app never rendered on screen is untested
+  ([#50](https://github.com/rogvid/skills/issues/50)).
 - **Nothing records with `evidence=False`.** The off switch, and the
   `DEMO_VIDEO_EVIDENCE=0` env var behind it, are exercised nowhere — every
-  take here writes evidence.
-- **Terminal evidence has no redaction to inherit.** `screen` is the whole
-  rendered terminal, scrubbed for registered secrets only, because
-  `TerminalRecorder` has no `redact()` at all
-  ([#5](https://github.com/rogvid/skills/issues/5)). A command that prints a
-  value nobody registered writes it into `evidence/` verbatim, and no
-  assertion here says otherwise because there is nothing yet to assert.
+  take here writes evidence
+  ([#48](https://github.com/rogvid/skills/issues/48)).
+- **Terminal evidence has no `redact()` to inherit.** `screen` is the whole
+  rendered terminal and `register_secret()` is the only thing masked out of it,
+  because `TerminalRecorder` has no `redact()` at all
+  ([#5](https://github.com/rogvid/skills/issues/5)).
+  `terminal-problems/` proves the registered path reaches the screen dump; a
+  value nobody registered is written verbatim, and there is nothing yet to
+  assert about it.
+- **Sub-frames are not harvested, and the argument that they need not be is
+  not itself asserted.** Nothing an iframe renders can reach an evidence file
+  — `aria_snapshot` is taken of the top document's `body` and stops at the
+  `iframe` node, and the markup dump strips `srcdoc` — so the harvest is
+  main-frame only. What holds that up is the byte sweep requiring the
+  fixture's in-iframe key to be absent, which is a consequence of the claim
+  rather than the claim itself. A future change that made `aria` descend into
+  frames would be caught; one that made only `html` do so, on a page with no
+  iframe in the spotlight, would not.
+- **`checkVisibility()` is the whole definition of "renders in the clear".**
+  The rule that keeps the mask from eating the page exempts any string that
+  renders outside the mask, and "renders" is one browser API call. An element
+  hidden some way that API does not model — clipped to zero size, painted
+  under an opaque sibling, `opacity` on an ancestor — counts as rendered, and
+  a value visible only there would go unmasked. Only `display:none` and
+  `content-visibility` are exercised here.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.
@@ -1605,6 +1728,16 @@ the crop and looking at it before it was believed.
   *before* the masking pass in `_evidence_doc` rather than after. Anything
   assembled after that pass is plaintext the recorder never checked, and only
   the end-of-document guard stands between it and the file.
+- **A new way for a value to reach evidence without reaching a picture** —
+  add it to the `?evidence=1` panel, add a literal to `EVIDENCE_SECRETS`, and
+  allowlist its shape in `.gitleaks.toml`. **Then check `EVIDENCE_KEEP` still
+  holds.** Every leak fixed here has a mirror defect: the mask that reaches
+  the new shape is the same mask that can eat an unrelated paragraph, and a
+  run where all nine secrets are absent because all nine files are
+  `[redacted]` is not a pass. Write the shape in the *markup*, the way a
+  person writes HTML, rather than assigning it from JS — an unpadded text node
+  is precisely the case that does not leak, and building the fixture that way
+  is how this axis passed for a round while five shapes walked through it.
 
 **Prove any new assertion can fail.** Break the thing it watches — stub the verb
 out in `skills/demo-video/helpers/`, or blank the fixture — run `tests/smoke`,

--- a/tests/README.md
+++ b/tests/README.md
@@ -77,10 +77,11 @@ smoke: web-problems timeline.json records 8 problem(s), 6 of them fatal under st
 smoke: web-strict strict=True refused the take, naming beat 0 (goto) (4 fatal issues, artifacts kept)
 smoke: evidence a SecretLeak raised while capturing a beat kills the take and keeps nothing
 smoke: evidence a registered secret spans the markup budget (chars 7984-8016 of 72716, budget 8000)
-smoke: evidence ok (16 beats as shapes.seg.beat-NN.json, 9 leak shapes clean, 4 controls intact, 2 beat(s) refused a moving target)
+smoke: evidence ok (18 beats as shapes.seg.beat-NN.json, 12 leak shapes clean, 4 controls intact, 2 beat(s) refused a moving target)
 smoke: terminal-problems timeline.json records 2 problem(s), 2 of them fatal under strict — take still passed
 smoke: terminal-race exit status survives a shell that starts 1.2s late (logged 5)
 smoke: terminal-problems a printed secret is masked out of the screen dump, and the line around it survives
+smoke: terminal-wrap a registered secret split by a line wrap at column 120 (chars 112-140) is masked in both halves
 smoke: terminal-strict strict=True refused the take, naming beat 1 (run) (1 fatal issues, artifacts kept)
 smoke: determinism froze all four clocks identically in both takes
 smoke:   frozen  1/1/2025, 9:00:00 AM · 1735722000000
@@ -101,8 +102,8 @@ Re-running into the same `--out-dir` is safe: the take subdirectories
 (`web/`, `terminal/`, `segments/`, `redaction/`, `terminal-redaction/`,
 `terminal-cursor-leak-clean/`, `terminal-cursor-leak-crash/`,
 `terminal-cursor-leak-tail/`, `web-problems/`, `terminal-problems/`,
-`terminal-race/`, `web-strict/`, `terminal-strict/`, `evidence/`,
-`evidence-leak-fatal/`, `determinism-a/`, `determinism-b/`,
+`terminal-race/`, `terminal-wrap/`, `web-strict/`, `terminal-strict/`,
+`evidence/`, `evidence-leak-fatal/`, `determinism-a/`, `determinism-b/`,
 `determinism-off/`) are deleted before each take. Only the first two are graded
 on their video; the rest are short and exist to break, or to reproduce, in one
 specific way each. That is not tidiness — every artifact assertion works by
@@ -1176,9 +1177,9 @@ sweep alone grades nothing: replacing `_evidence_payload` with a constant
 returning two control strings **passed the whole take**, sweep and all.
 
 `evidence/` is the take for the shapes that leak into *text and nothing else*.
-It records `?evidence=1`, redacts seven cards, registers two values, and sweeps
-for nine literals — every one of which was readable in `evidence/*.json` when
-this was first reviewed:
+It records `?evidence=1`, redacts nine cards, registers two values, and sweeps
+for twelve literals — every one of which was readable in `evidence/*.json` when
+the round that introduced it was reviewed:
 
 | shape | why a picture never sees it |
 |---|---|
@@ -1190,6 +1191,14 @@ this was first reviewed:
 | `CHLD` | a key whose characters are three text nodes, each an ordinary string alone |
 | `ATTR`, `JSON` | `data-*` attributes the page never renders, which only exist in evidence because the markup dump is a surface this feature created |
 | `BLED` | in a card whose *label* also renders outside it — the mirror defect, below — and **captioned** by the storyboard, which is the case that reaches `timeline.json` |
+| `HATT` | mirrored into `title`, `data-value`, `aria-label` and an input's `value` on siblings nothing redacts. The harvest read those when deciding what "renders in the clear", so a copy-to-clipboard button carrying the key it copies exempted that key from masking **everywhere**. None of those channels is painted by anything, and `_EVIDENCE_HTML_JS` already strips the same attributes out of `html` on exactly that reasoning — the feature contradicted itself for a round |
+| `HIDE` | the same trick in CSS: a `.sr-only` clip, `opacity:0`, `visibility:hidden`, `left:-9999px`. `checkVisibility()` called with no arguments reports all four visible; it models `display` and `content-visibility` and nothing else, and `display:none` was the one shape this fixture happened to use. Measured leaking into `timeline.json` and `timeline.md` as well as all six evidence files |
+| `AMPS` | a registered secret containing `&`, which `outerHTML` writes `&amp;`. The mask searched the raw literal, the withhold fallback stripped tags but not entities, and the end-of-document backstop was a plain `in` — all three missed, and the file came out with `aria` reading `token=[redacted]` and `html` carrying the value in full |
+
+One literal covers each of `HATT` and `HIDE` rather than one per channel, and
+that is deliberate: every element in a family holds the same value, so any
+single channel regressing puts that value back into `outside` and un-masks it
+everywhere. One assertion, four shapes, and the failure names the family.
 
 Three of those were written the wrong way first and passed while proving
 nothing: the slotted value was a DOM descendant of the redacted element, the
@@ -1272,6 +1281,25 @@ untested:
 It is also the only take that records with `segment=`, so
 `evidence/<segment>.seg.beat-NN.json` is exercised rather than merely designed
 ([#22](https://github.com/rogvid/skills/issues/22)).
+
+`terminal-wrap/` is the take for the one transformation the terminal
+introduces on its own. `__termText()` walks the xterm.js buffer a row at a time
+and joins with newlines without consulting `isWrapped`, so a credential that
+crosses the last column arrives split — and the mask was elastic about
+whitespace the *literal* has and exact about whitespace the *text* has, so it
+matched neither half. The end-of-document backstop was a plain `in` over
+`json.dumps` output, where a newline is the two characters `\n`, so it missed in
+the same direction; a backstop that fails the way the thing it backs up fails is
+not one.
+
+`terminal-problems/` could never provoke it — `echo printed-below` plus a
+20-character secret is ~60 columns against a 120-column terminal — so this take
+measures `term.cols` at record time and pads the line so that
+`TERMINAL_WRAP_HEAD` characters of the secret land before the boundary. The
+geometry is asserted and printed (`chars 112-140` at column 120), because a take
+that quietly stopped wrapping would be a test of an ordinary echo. The sweep
+that grades it deletes whitespace from both sides before comparing, which is
+what a reader with `tr -d` does.
 
 `terminal-problems/` carries the last piece: a command *prints* a registered
 secret, and the screen dump must mask it while the word printed beside it
@@ -1548,9 +1576,24 @@ knows is missing is worse than one that is openly absent.
   rendered terminal and `register_secret()` is the only thing masked out of it,
   because `TerminalRecorder` has no `redact()` at all
   ([#5](https://github.com/rogvid/skills/issues/5)).
-  `terminal-problems/` proves the registered path reaches the screen dump; a
-  value nobody registered is written verbatim, and there is nothing yet to
-  assert about it.
+  `terminal-problems/` proves the registered path reaches the screen dump and
+  `terminal-wrap/` proves it survives the line wrap; a value nobody registered
+  is written verbatim, and there is nothing yet to assert about it.
+- **A crash that is not a `SecretLeak` skips the stale-evidence clearing**
+  ([#79](https://github.com/rogvid/skills/issues/79)), the end-of-document
+  guard runs after capping and so cannot see a literal cut in half by a budget
+  ([#80](https://github.com/rogvid/skills/issues/80)), and an unsegmented take
+  never clears a previous *segmented* take's evidence
+  ([#81](https://github.com/rogvid/skills/issues/81)). All three fail safe —
+  nothing new is written — and all three are exercised by nothing here.
+- **The normalization boundary is stated, not tested to its edges.** Matching
+  is exact modulo whitespace in either direction, HTML entities and JSON string
+  escapes — the four transformations `SKILL.md` lists, each with a shape here.
+  Case differences, Unicode normalization forms and confusables, percent- and
+  base64-encoding, and a value the app itself reformats are all outside it and
+  are exercised by nothing. That is a deliberate boundary rather than a gap to
+  close: it is an asymptotic surface, and the answer for a value that survives
+  one of those is `redact()` on the element, not a longer list here.
 - **Sub-frames are not harvested, and the argument that they need not be is
   not itself asserted.** Nothing an iframe renders can reach an evidence file
   — `aria_snapshot` is taken of the top document's `body` and stops at the
@@ -1560,13 +1603,18 @@ knows is missing is worse than one that is openly absent.
   rather than the claim itself. A future change that made `aria` descend into
   frames would be caught; one that made only `html` do so, on a page with no
   iframe in the spotlight, would not.
-- **`checkVisibility()` is the whole definition of "renders in the clear".**
-  The rule that keeps the mask from eating the page exempts any string that
-  renders outside the mask, and "renders" is one browser API call. An element
-  hidden some way that API does not model — clipped to zero size, painted
-  under an opaque sibling, `opacity` on an ancestor — counts as rendered, and
-  a value visible only there would go unmasked. Only `display:none` and
-  `content-visibility` are exercised here.
+- **"Renders in the clear" still cannot see occlusion.** The rule that keeps
+  the mask from eating the page exempts any string that renders outside it, and
+  "renders" is now four conditions: `checkVisibility()` with `opacityProperty`,
+  `visibilityProperty` and `contentVisibilityAuto` set; a box of at least 2×2
+  CSS pixels; a box not entirely off the top or left of the document; and no
+  attribute or input `value` counting at all. `HIDE` exercises the first three
+  through four shapes at once. What none of it models is an element **painted
+  underneath an opaque sibling**, or clipped away by a `clip-path` on an
+  *ancestor* rather than on itself — both count as rendered, and a value
+  visible only there would go unmasked
+  ([#69](https://github.com/rogvid/skills/issues/69)). Deciding that properly
+  needs per-node hit testing, which is a different order of cost.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,9 +1,10 @@
 # tests
 
-One smoke test and one fixture app. Together they answer three questions:
+One smoke test and one fixture app. Together they answer four questions:
 **does the demo-video recorder still produce a real video, does it still notice
-when the thing it recorded was broken, and does a registered secret stay out of
-everything it produces?**
+when the thing it recorded was broken, does a registered secret stay out of
+everything it produces, and can a reader say what each frame showed without
+decoding one?**
 
 They are not unit tests. The recorders' interesting behaviour is "shell out to
 ffmpeg, drive a headless browser, come back with an mp4", which nothing short
@@ -20,8 +21,9 @@ tests/
 Takes: `web/` and `terminal/` (the two media), the determinism pair, the
 problem takes, `redaction/` — the web recorder against a page that renders
 a secret, plus a second few-second take that must *fail* — `segments/`,
-one demo recorded in two parts and joined with `stitch()`, and
-`terminal-redaction/`, the redaction question asked of the PTY output path.
+one demo recorded in two parts and joined with `stitch()`,
+`terminal-redaction/`, the redaction question asked of the PTY output path,
+and `evidence-caps/`, four seconds against a deliberately bloated page.
 
 ## Running it
 
@@ -38,7 +40,10 @@ tests/smoke --keep                # keep the temp dir even when it passes
 
 Prerequisites: `uv`, `ffmpeg`/`ffprobe` on PATH, and Chromium for Playwright
 (`uv run --with playwright playwright install chromium`; add `--with-deps` on a
-fresh Linux box). A pass looks like this, and takes about half a minute:
+fresh Linux box). The script's PEP 723 header pins **Playwright ≥ 1.49**:
+per-beat evidence uses `locator.aria_snapshot()`, which arrived there, and the
+`page.accessibility` API it replaced has since been removed outright. A pass
+looks like this, and takes about half a minute:
 
 ```
 smoke: serving …/tests/fixture at http://127.0.0.1:36321
@@ -51,12 +56,13 @@ smoke: web beat clock holds across the take (+40 ms)
 smoke: web timeline.json ok (23 beats)
 smoke: web each review frame shows its own beat's caption state (10 captioned frames from 11.2, 4 bare ones to 3.3; 9 within 0.75s of a caption change and not graded)
 smoke: web frames/ ok (23 beat frames, each byte-identical to the demo.mp4 frame it claims to be)
+smoke: web evidence ok (23 beats, 39 kB, largest 2468 bytes)
 smoke: web healthy app under strict=True records no problems
 smoke: redaction #api-key is blurred in every frame of demo.mp4 (worst 1.5 vs control 52.0, 3%)
 smoke: redaction all 9 masked elements are blurred in the review frames (18 gradable of 31; worst #a4-card 0.2 vs control 21.8 in beat-23.png, 1%, bar 7%)
 smoke: redaction still 01-key-blurred.png ok (key 1.0, token 2.9, control 39.3)
 smoke: redaction .tts/ holds 2 clips — the narrated lines, and nothing for the refused one
-smoke: redaction no artifact holds either secret verbatim
+smoke: redaction none of the 13 secrets appears verbatim in any of the 45 files the take wrote (31 of them per-beat evidence, which the controls prove is not empty)
 smoke: segments recorded 2 parts, each with its own beat log (part1 6.8s, part2 7.8s)
 smoke: segments part1's probe caption is +0 ms from where its own segment puts it (-120 ms in part1.seg.mp4, -120 ms in demo.mp4)
 smoke: segments part2's probe caption is +0 ms from where its own segment puts it (-80 ms in part2.seg.mp4, -80 ms in demo.mp4)
@@ -66,6 +72,7 @@ smoke: segments timeline.json ok (15 beats)
 …
 smoke: web-problems timeline.json records 8 problem(s), 6 of them fatal under strict — take still passed
 smoke: web-strict strict=True refused the take, naming beat 0 (goto) (4 fatal issues, artifacts kept)
+smoke: evidence-caps aria cut to 12000 and html to 8000 characters, both marked (untruncated beat 2 left alone)
 smoke: terminal-problems timeline.json records 2 problem(s), 2 of them fatal under strict — take still passed
 smoke: terminal-race exit status survives a shell that starts 1.2s late (logged 5)
 smoke: terminal-strict strict=True refused the take, naming beat 1 (run) (1 fatal issues, artifacts kept)
@@ -88,9 +95,9 @@ Re-running into the same `--out-dir` is safe: the take subdirectories
 (`web/`, `terminal/`, `segments/`, `redaction/`, `terminal-redaction/`,
 `terminal-cursor-leak-clean/`, `terminal-cursor-leak-crash/`,
 `terminal-cursor-leak-tail/`, `web-problems/`, `terminal-problems/`,
-`terminal-race/`, `web-strict/`, `terminal-strict/`, `determinism-a/`,
-`determinism-b/`, `determinism-off/`) are deleted before each take. Only the
-first two are graded
+`terminal-race/`, `web-strict/`, `terminal-strict/`, `evidence-caps/`,
+`determinism-a/`, `determinism-b/`, `determinism-off/`) are deleted before each
+take. Only the first two are graded
 on their video; the rest are short and exist to break, or to reproduce, in one
 specific way each. That is not tidiness — every artifact assertion works by
 path, so without it a leftover `demo.mp4` from the previous run would grade a
@@ -1071,6 +1078,105 @@ The `tail` arm needs a narration tail and the smoke run has no
 `_finish_line()` reads, and the one `_start_line()` sets from
 `media_duration(clip)`. Same code path, no key required.
 
+**Evidence** — every beat left `evidence/beat-NN.json`, a text account of what
+was on screen. Its acceptance criterion ([#9](https://github.com/rogvid/skills/issues/9))
+is that *a reviewer given only those files can state what the frame showed
+without seeing an image*, which is not a sentence a test can assert. It is
+asserted as its consequence instead: named facts about the fixture app, written
+out by hand in `WEB_EVIDENCE` / `TERMINAL_EVIDENCE`, looked for in the page text
+the recorder captured for the beat that showed them.
+
+**The lists come in pairs, and the second one is the one that bites.**
+
+| beat | must be readable | must **not** be |
+|---|---|---|
+| `shot("01-dashboard")` | `$128,400`, `snapshot 1 of 3`, `Refresh`, `Harbor Supply Co.`, `Ferrari Logistics`, and the caption `A small dashboard.` | `$134,950`, `snapshot 2 of 3` |
+| `shot("02-filtered")` | `Harbor Supply Co.`, `Seattle`, `Filter by city.` | `Ferrari Logistics`, `Cascade Outfitters`, `Pine & Poplar` |
+| `shot("03-refreshed")` | `$134,950`, `snapshot 2 of 3`, `Refresh reloads it.` | `$128,400`, `snapshot 1 of 3` |
+| `shot("01-echo")` (terminal) | `echo hello from demo-video` **and** `hello from demo-video` | `ls -1`, `AGENTS.md` |
+| `shot("02-listing")` (terminal) | `ls -1`, `skills`, `tests`, and the earlier `hello from demo-video` still in scrollback | — |
+
+Without the right-hand column every one of these passes on a recorder that
+captured the page **once** and wrote the same dump into all 23 files: `$128,400`
+appears in that dump, so does `Refresh`, so does everything else. With it, a
+single stale capture fails on the first beat that should have moved on. The
+same shape does the work in `02-filtered`: the evidence has to show the four
+rows the filter *removed* are gone, which is the fixture's own post-condition
+restated in text.
+
+The facts are searched in the **page text only** — `aria`, `scope_aria`,
+`html`, `screen` — never in the beat record embedded alongside them. Every
+caption is in `beat.caption` already, so searching the whole file for one would
+pass on a recorder that captured no page text at all: the assertion has to be
+about what the page said, not about the log quoting itself.
+
+Structure, checked both directions like the stills: every beat in
+`timeline.json` names an `evidence` path, every named file exists and parses,
+`evidence/` holds nothing no beat names, and each file's embedded beat block
+matches that beat's `index`, `verb`, `selector`, `caption` and both timestamps.
+Without that last check every file could hold the same screen and the facts
+above would still be found *somewhere*.
+
+**The spotlight scope** is graded on its own, because it is what the issue says
+the capture is scoped to: the `spotlight("#kpi-rev")` beat must name that
+selector in `scope`, carry `$128,400` in `scope_aria` and `id="kpi-rev"` in
+`html`; the beat that *clears* the spotlight must carry neither, or the scope
+outlives the highlight.
+
+**The size cap needs its own take** (`evidence-caps/`, four seconds). The
+fixture's whole ARIA tree is 2.3 kB against a 12 kB cap, so truncation cannot
+be provoked on it, and slackening the cap to meet the fixture would be grading
+the wrong number. The take appends 900 list items to the page and spotlights
+them, and then:
+
+- the `pause` beat **before** the bloat must come back with `truncated == []`
+  and an ARIA tree under the cap — a recorder that marked every field
+  truncated would satisfy everything else here;
+- the `pause` beat **after** it must have both `aria` and `html` in
+  `truncated`, both carrying the marker text inline where they stop, and both
+  cut *to* the budget (`limit < len(field) <= limit + marker`) rather than
+  merely under some ceiling;
+- the package's own `EVIDENCE_LIMITS` and `EVIDENCE_SCHEMA` must equal the
+  numbers written in `tests/smoke`. Reading the caps off the code being graded
+  would agree with it whatever it says; asserting they match means widening one
+  has to be done on purpose.
+
+Per file the ceiling is 64 kB, per directory 512 kB — observed 39 kB across 23
+web beats and 9 kB across 18 terminal ones, so both are there to catch a cap
+that stopped being applied, not to tune anything.
+
+**Evidence is the fifth leak path, and it is the one with no pixels in it.**
+Every other artifact here is an image; `redact()` is a *pixel* control, and the
+value it covers is still in the DOM — which is what an evidence file is a dump
+of. So the `redaction/` take grades it directly, and the grading is a matched
+pair for the same reason the sharpness bars are:
+
+- none of the 13 literals in `REDACT_LITERALS` may appear in any evidence file
+  — the keys rendered by the app, the ones typed as `Secret(...)`, the hero
+  value inside a redacted *wrapper*, the ones behind a shadow root and an
+  iframe, and all five sufficiency shapes;
+- **`sk-live-CTRL…` and `sk-live-BGC…` — the two controls, never redacted —
+  must be found in there.** Without that half, "no secret appears" is equally
+  true of an empty `evidence/`, of files holding nothing but a beat record, and
+  of a recorder that masked every string it wrote. It is the same anti-vacuity
+  guard `MIN_CONTROL_EDGE` is for the pixels;
+- and `evidence/` must hold exactly one file per beat, since the sweep is only
+  a statement about the files that are there.
+
+The whole-directory `rglob` sweep at the end of `check_redaction` picks the
+evidence files up too, with no exemptions, and its summary line now says how
+many of the files it swept were evidence.
+
+What makes those files clean is described in SKILL.md: the recorder reads the
+rendered text of everything `redact()` covers — every node in the subtree,
+shadow roots at every depth, `::before`/`::after` content, input values and
+value-bearing attributes — and masks it out of every beat's evidence.
+Harvesting only the element the selector *matched* was measured masking five of
+the eight fixture keys and leaving three in the clear, because redacting a
+wrapper is the ordinary call and the wrapper's `textContent` is the label and
+the value run together — one string that appears nowhere in an ARIA tree, which
+renders them as separate nodes.
+
 ## Known gaps
 
 Things a pass does **not** prove. They are listed because an assertion nobody
@@ -1296,6 +1402,48 @@ knows is missing is worse than one that is openly absent.
   one being right makes the rest right — but a merge that moved some of a
   segment's beats and not others would be caught only by the ordering and
   coverage checks, which are much coarser.
+- **Nothing checks `stitch()`, segments, or `interlude()`.** Single-segment
+  takes only — so `<segment>.seg.timeline.json`, and the merge
+  [#7](https://github.com/rogvid/skills/issues/7) will build on it, are
+  unexercised. That includes evidence's segment-aware filenames
+  (`evidence/<segment>.seg.beat-NN.json`), which exist precisely so a merge
+  never has to rename anything
+  ([#22](https://github.com/rogvid/skills/issues/22)) and which no take here
+  produces.
+- **Nothing reads the evidence the way its acceptance criterion means it.**
+  "A reviewer can state what was on screen" is graded as a list of substrings
+  that must and must not be in each beat's capture. That is enough to catch an
+  empty capture, a stale one, and a page that moved on — but whether an agent
+  handed only `evidence/` could actually narrate the demo is the same
+  unautomatable question as `SKILL.md` step 6's fresh-agent review, and
+  nothing here asks it.
+- **Evidence's `omitted` path is unexercised.** When the recorder cannot read
+  what `redact()` is covering it writes that beat's evidence with no page text
+  and a reason. Provoking it needs a frame that fails mid-capture, which no
+  fixture here manufactures — so the branch that *refuses* rather than
+  guessing is read-only coverage.
+- **The recorder's own end-of-document guard cannot be shown catching a leak.**
+  Before writing, each evidence document is re-checked over its serialized
+  bytes for anything registered or redacted. It runs against the same list the
+  masking does, so for a plain string value it cannot disagree with it — turn
+  the masking off and the guard raises `SecretLeak` and kills the take
+  (measured), which is a *different* failure from the one the byte sweep
+  grades. It is there for what the walker structurally cannot reach — a field
+  a later slice adds after the scrub, a non-string key — and this file does not
+  claim more for it than that. What can actually fail is the sweep over
+  `evidence/`.
+- **`url` and `title` are only scrubbed for registered secrets.** No take puts
+  an unregistered value in a query string, so the one path where evidence
+  records something the app never rendered on screen is untested.
+- **Nothing records with `evidence=False`.** The off switch, and the
+  `DEMO_VIDEO_EVIDENCE=0` env var behind it, are exercised nowhere — every
+  take here writes evidence.
+- **Terminal evidence has no redaction to inherit.** `screen` is the whole
+  rendered terminal, scrubbed for registered secrets only, because
+  `TerminalRecorder` has no `redact()` at all
+  ([#5](https://github.com/rogvid/skills/issues/5)). A command that prints a
+  value nobody registered writes it into `evidence/` verbatim, and no
+  assertion here says otherwise because there is nothing yet to assert.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.
@@ -1433,7 +1581,10 @@ the crop and looking at it before it was believed.
   literal to the `REDACT_*` constants in `tests/smoke`, allowlist its shape in
   `.gitleaks.toml`, and give it *both* a masked and an unmasked measurement.
   A redaction assertion with nothing sharp to compare against is the most
-  dangerous kind of vacuous test: it passes on a black frame.
+  dangerous kind of vacuous test: it passes on a black frame. Adding it to
+  `REDACT_LITERALS` carries it into the evidence sweep for free — but check
+  that a *control* of the same kind is still found in `evidence/`, or that
+  sweep is grading an empty directory.
 - **A new thing the *terminal* scrubber must hide** — add a line to
   `term_printer_script()`, a literal to the `TERM_*` constants, a row to
   `TERM_MASKED_ROWS`, and allowlist the shape in `.gitleaks.toml`. Keep it 28
@@ -1441,6 +1592,19 @@ the crop and looking at it before it was believed.
   which are what it is measured against. If it is meant to be caught by shape
   rather than registration, do not register it — that separation is the only
   thing that says the two mechanisms work apart.
+- **A new fact evidence must record** — add a `(verb, target, present, absent)`
+  row to `WEB_EVIDENCE` / `TERMINAL_EVIDENCE`. **Fill in `absent`.** A `present`
+  list alone passes on a recorder that dumped the page once and copied it into
+  every beat, which is the failure mode this axis exists to catch; `absent`
+  is what the previous screen showed and must not still be there. Both lists
+  are facts about `fixture/index.html`, written by hand, never read back off a
+  recording.
+- **A new field in an evidence document** — give it a budget in
+  `EVIDENCE_LIMITS` if it can grow, mirror that number in
+  `EVIDENCE_LIMITS_EXPECTED` in `tests/smoke`, and make sure it is built
+  *before* the masking pass in `_evidence_doc` rather than after. Anything
+  assembled after that pass is plaintext the recorder never checked, and only
+  the end-of-document guard stands between it and the file.
 
 **Prove any new assertion can fail.** Break the thing it watches — stub the verb
 out in `skills/demo-video/helpers/`, or blank the fixture — run `tests/smoke`,

--- a/tests/fixture/index.html
+++ b/tests/fixture/index.html
@@ -294,6 +294,13 @@
  *   ?entropy=1        renders four clock readings (Date, Intl, the Date
  *                     constructor, and one posted back by a Worker) and a
  *                     spinning shape — what determinism pins down (issue #10)
+ *   ?evidence=1       renders the shapes that leak into a *text* dump of the
+ *                     page but not into a picture of it: whitespace-padded
+ *                     markup, an accessible name sourced from outside the
+ *                     subtree, slotted light DOM, a property-only input
+ *                     value, a value rewritten every 25 ms, a value split
+ *                     across elements, and value-bearing attributes nothing
+ *                     renders (issue #9)
  */
 
 // Three fixed snapshots. #refresh cycles through them in order, so a
@@ -720,6 +727,113 @@ if (params.has("gate-attack")) {
     });
   }, 16);
   setTimeout(function () { clearInterval(attack); }, 2000);
+}
+
+if (params.has("evidence")) {
+  // Per-beat evidence (issue #9) is a *text* dump of the page, so it leaks in
+  // shapes that no pixel assertion has ever had to care about. Each element
+  // here is one of those shapes, and every one of them reached an evidence
+  // file readable before it existed.
+  //
+  // Its own hook rather than rows in `?secret=1`, because that panel's exact
+  // rect is what the redaction take measures sharpness over: adding to it
+  // moves the crops and silently regrades the pixel assertions.
+  //
+  // The keys are written into the *markup* below rather than assigned from JS
+  // on purpose. `el.textContent = "…"` produces one unpadded text node, which
+  // is precisely the case that does *not* leak — the fixture was passing by
+  // accident until this panel was written the way a human writes HTML.
+  var ev = document.createElement("div");
+  ev.id = "ev-panel";
+  ev.style.cssText =
+    "position:fixed;top:8px;left:8px;width:520px;z-index:5;background:#fff;" +
+    "border:1px solid #d8d2c6;border-radius:8px;padding:8px 10px;" +
+    "font:12px/1.5 ui-monospace,monospace;color:#1c1a17;";
+  ev.innerHTML = [
+    // L1 — a value on its own line, indented, the way hand-written HTML puts
+    // it. textContent comes back "\n      sk-live-WSPC…\n    " while the ARIA
+    // tree says "sk-live-WSPC…", and a plain str.replace between the two
+    // finds nothing at all.
+    '<div id="ev-ws-card"><span class="lbl">Whitespace key</span>',
+    '  <code id="ev-ws-key">',
+    '    sk-live-WSPC00000000',
+    '  </code>',
+    '</div>',
+    // The mirror defect: a redacted card whose *label* is an ordinary word
+    // that also renders, unredacted, elsewhere on the page. Harvesting every
+    // node of the card registers "Revenue" as a mask unless the harvest knows
+    // what else the page renders.
+    '<div id="ev-bleed-card"><span class="lbl">Revenue</span>',
+    '  <code id="ev-bleed-key">sk-live-BLED00000000</code>',
+    '</div>',
+    // "live" is in here on purpose too: the split key below breaks into the
+    // text nodes "sk-", "live" and "-CHLD…", and a harvest that masked every
+    // one of them would rewrite every other key on the page.
+    '<p id="ev-bleed-outside">Revenue for the quarter was steady, and the ',
+    'feed is live.</p>',
+    // ...and the same defect one level meaner: a key whose own characters are
+    // split into text nodes that are each ordinary strings on their own.
+    '<div id="ev-child-card"><span class="lbl">Split key</span>',
+    '  <code id="ev-child-key">sk-<i>live</i>-CHLD00000000</code>',
+    '</div>',
+    // L2 — the accessible name comes from an element *outside* the redacted
+    // subtree, so no walk of that subtree can find it.
+    // display:none on purpose: aria-labelledby names a hidden element just as
+    // happily as a visible one, so this value is on nobody's screen and in
+    // nobody's frame — and it is still the redacted card's accessible name.
+    '<span id="ev-label-src" style="display:none">sk-live-LBLD00000000</span>',
+    // role= is load-bearing: a plain <div> has no role, so an ARIA snapshot
+    // shows no accessible name for it and the shape would prove nothing. With
+    // a role, the hidden element's text *is* this card's name in the tree.
+    '<div id="ev-labelled-card" role="group" aria-labelledby="ev-label-src">',
+    '  <span class="lbl">Labelled elsewhere</span></div>',
+    // L4 — light DOM slotted into a redacted element that lives *inside* a
+    // shadow root. The redacted element is #ev-slot-inner below, whose own
+    // textContent is empty: the value is a light child of the host, painted
+    // through the <slot>. It is inside the redaction in the flattened tree and
+    // outside it in the DOM, and only one of those is what renders.
+    '<div id="ev-slot-card"><span id="ev-slot-light">',
+    'sk-live-SLOT00000000</span></div>',
+    // An input value that lives on the *property*. Set from JS below, with no
+    // `value` attribute at all, so reading attributes finds nothing.
+    '<div id="ev-value-card"><span class="lbl">Field</span>',
+    '  <input id="ev-value-key" readonly></div>',
+    // L3 — rewritten every 5 ms with a value nothing has seen before, which
+    // is what a countdown, a ticker or a rotating token does.
+    '<div id="ev-tick-card"><span class="lbl">Rotating</span>',
+    '  <code id="ev-tick-key">sk-live-TICK00000000</code></div>',
+    // L5/L6 live in a spotlight target that is deliberately NOT redacted.
+    // Their values are registered as secrets instead, which is the other half
+    // of the contract: register_secret() has to reach markup too.
+    '<div id="ev-spot-split">a token: harbor<b>zenith</b>7725 </div>',
+    '<div id="ev-spot-attrs" data-token="sk-live-ATTR00000000"',
+    '  data-cfg=\'{"key":"sk-live-JSON00000000"}\'>nothing rendered here</div>'
+  ].join("\n");
+  document.body.appendChild(ev);
+
+  // The slot host: a shadow root whose <slot> renders the light child above,
+  // wrapped in the element the take actually redacts.
+  var slotHost = document.getElementById("ev-slot-card");
+  var slotRoot = slotHost.attachShadow({ mode: "open" });
+  slotRoot.innerHTML =
+    '<span class="lbl">Slotted</span> ' +
+    '<span id="ev-slot-inner"><slot></slot></span>';
+
+  // Property, not attribute: `getAttribute("value")` returns null for this.
+  document.getElementById("ev-value-key").value = "sk-live-VALU00000000";
+
+  // A fresh value every 5 ms. Deliberately faster than the ~15 ms a capture
+  // spends reading the page (harvest, ARIA snapshot, harvest): at 25 ms the
+  // three round trips often fit between two ticks, and the recorder's refusal
+  // to straddle a repaint went untested about half the time.
+  var tick = 0;
+  setInterval(function () {
+    var el = document.getElementById("ev-tick-key");
+    if (el) {
+      tick += 1;
+      el.textContent = "sk-live-TICK" + String(tick).padStart(8, "0");
+    }
+  }, 5);
 }
 
 if (params.has("console-error")) {

--- a/tests/fixture/index.html
+++ b/tests/fixture/index.html
@@ -298,7 +298,7 @@
  *                     page but not into a picture of it: whitespace-padded
  *                     markup, an accessible name sourced from outside the
  *                     subtree, slotted light DOM, a property-only input
- *                     value, a value rewritten every 25 ms, a value split
+ *                     value, a value rewritten every 5 ms, a value split
  *                     across elements, and value-bearing attributes nothing
  *                     renders (issue #9)
  */
@@ -807,7 +807,52 @@ if (params.has("evidence")) {
     // of the contract: register_secret() has to reach markup too.
     '<div id="ev-spot-split">a token: harbor<b>zenith</b>7725 </div>',
     '<div id="ev-spot-attrs" data-token="sk-live-ATTR00000000"',
-    '  data-cfg=\'{"key":"sk-live-JSON00000000"}\'>nothing rendered here</div>'
+    '  data-cfg=\'{"key":"sk-live-JSON00000000"}\'>nothing rendered here</div>',
+    // B1a — the value is inside a redacted card AND mirrored into attributes
+    // on siblings that are *not* redacted. The harvest reads those attributes
+    // when deciding what "renders in the clear", so every one of them was
+    // enough to exempt the key from masking everywhere: in all six evidence
+    // files, and — because the storyboard captions it — in timeline.json and
+    // timeline.md as well.
+    //
+    // A copy-to-clipboard button carrying the key it copies is ordinary UI,
+    // which is what makes this the shape a real app hits first. `srcdoc`,
+    // `alt`, `placeholder` and `content` reach the harvest through the
+    // identical getAttribute() path and need no separate element here; the
+    // input below is the one channel that does, because its value lives on the
+    // property and no attribute holds it.
+    '<div id="ev-attr-card"><span class="lbl">Copyable key</span>',
+    '  <code id="ev-attr-key">sk-live-HATT00000000</code>',
+    '</div>',
+    '<button id="ev-attr-title" title="sk-live-HATT00000000">Copy</button>',
+    '<button id="ev-attr-data" data-value="sk-live-HATT00000000">Copy</button>',
+    '<button id="ev-attr-label" aria-label="sk-live-HATT00000000">Copy</button>',
+    '<input id="ev-attr-input" readonly>',
+    // B1b — the same trick with CSS instead of attributes. Every one of these
+    // is reported visible by `checkVisibility()` called with no arguments,
+    // which models `display` and `content-visibility` and nothing else. Only
+    // the `display:none` case above was ever excluded, and that is the one
+    // shape this fixture happened to use.
+    '<div id="ev-hide-card"><span class="lbl">Mirrored key</span>',
+    '  <code id="ev-hide-key">sk-live-HIDE00000000</code>',
+    '</div>',
+    // A screen-reader-only clip: 1x1 with the content clipped away. In the
+    // accessibility tree, on nobody\'s screen.
+    '<span id="ev-hide-sr" style="position:absolute;width:1px;height:1px;',
+    'overflow:hidden;clip-path:inset(50%);white-space:nowrap">',
+    'sk-live-HIDE00000000</span>',
+    '<span id="ev-hide-opacity" style="opacity:0">sk-live-HIDE00000000</span>',
+    '<span id="ev-hide-vis" style="visibility:hidden">sk-live-HIDE00000000</span>',
+    '<span id="ev-hide-off" style="position:absolute;left:-9999px">',
+    'sk-live-HIDE00000000</span>',
+    // B3 — a registered secret containing an ampersand, which `outerHTML`
+    // writes as `&amp;`. The mask searches for the raw literal and misses; the
+    // withhold fallback strips tags but not entities and misses; the
+    // end-of-document backstop is a raw substring test and misses. The file
+    // came out with `aria` saying `token=[redacted]` and `html` carrying the
+    // value in full, two lines apart. `&` in a credential is ordinary — a
+    // presigned URL, a SAS token.
+    '<div id="ev-spot-amp">token=sk-live-AMPS0000&amp;sig=0000000000</div>'
   ].join("\n");
   document.body.appendChild(ev);
 
@@ -821,6 +866,14 @@ if (params.has("evidence")) {
 
   // Property, not attribute: `getAttribute("value")` returns null for this.
   document.getElementById("ev-value-key").value = "sk-live-VALU00000000";
+
+  // ...and the same, on an input that is *outside* every redacted card. The
+  // harvest used to read `node.value` when deciding what renders in the clear,
+  // so this one field exempted the key in #ev-attr-card from masking. An
+  // input's value is not painted in the general case at all — a password field
+  // renders dots — and this is the only channel in that family that no
+  // attribute carries.
+  document.getElementById("ev-attr-input").value = "sk-live-HATT00000000";
 
   // A fresh value every 5 ms. Deliberately faster than the ~15 ms a capture
   // spends reading the page (harvest, ARIA snapshot, harvest): at 25 ms the

--- a/tests/fixture/index.html
+++ b/tests/fixture/index.html
@@ -833,18 +833,18 @@ if (params.has("evidence")) {
     // which models `display` and `content-visibility` and nothing else. Only
     // the `display:none` case above was ever excluded, and that is the one
     // shape this fixture happened to use.
-    '<div id="ev-hide-card"><span class="lbl">Mirrored key</span>',
-    '  <code id="ev-hide-key">sk-live-HIDE00000000</code>',
+    '<div id="ev-veil-card"><span class="lbl">Mirrored key</span>',
+    '  <code id="ev-veil-key">sk-live-VEIL00000000</code>',
     '</div>',
     // A screen-reader-only clip: 1x1 with the content clipped away. In the
     // accessibility tree, on nobody\'s screen.
-    '<span id="ev-hide-sr" style="position:absolute;width:1px;height:1px;',
+    '<span id="ev-veil-sr" style="position:absolute;width:1px;height:1px;',
     'overflow:hidden;clip-path:inset(50%);white-space:nowrap">',
-    'sk-live-HIDE00000000</span>',
-    '<span id="ev-hide-opacity" style="opacity:0">sk-live-HIDE00000000</span>',
-    '<span id="ev-hide-vis" style="visibility:hidden">sk-live-HIDE00000000</span>',
-    '<span id="ev-hide-off" style="position:absolute;left:-9999px">',
-    'sk-live-HIDE00000000</span>',
+    'sk-live-VEIL00000000</span>',
+    '<span id="ev-veil-opacity" style="opacity:0">sk-live-VEIL00000000</span>',
+    '<span id="ev-veil-vis" style="visibility:hidden">sk-live-VEIL00000000</span>',
+    '<span id="ev-veil-off" style="position:absolute;left:-9999px">',
+    'sk-live-VEIL00000000</span>',
     // B3 — a registered secret containing an ampersand, which `outerHTML`
     // writes as `&amp;`. The mask searches for the raw literal and misses; the
     // withhold fallback strips tags but not entities and misses; the

--- a/tests/smoke
+++ b/tests/smoke
@@ -289,6 +289,13 @@ BETWEEN_BEATS_JS = "() => console.error('__M__')".replace("__M__", BETWEEN_BEATS
 # went wrong" inferred from any other signal.
 TERMINAL_FAILING_COMMAND = "(exit 3)"
 
+# A secret a *command prints*, and a plain marker printed beside it. The
+# terminal has no redact() (issue #5), so `register_secret()` is the whole
+# defence for its evidence — and the marker is what keeps "the secret is
+# absent" from being a statement about an empty screen dump.
+TERMINAL_PRINTED_MARKER = "printed-below"
+TERMINAL_PRINTED_SECRET = "sk-live-PRNT00000000"
+
 # The regression from the first round of review: two run()s with no wait
 # between them. The shell buffers the second command and runs it after the
 # first, so both statuses arrive in order — a single pending slot handed
@@ -313,6 +320,14 @@ TERMINAL_RACE_SHELL = '#!/bin/sh\nsleep __DELAY__\nexec /bin/bash "$@"\n'
 # beat. Hand-written, like the beat lists: derived from the log it grades, it
 # would agree with the log no matter what the log said.
 TERMINAL_PROBLEM_EXIT_CODES = {
+    # The beat's `selector` is the command as *logged*, and the secret in it
+    # was registered before it was typed — so the timeline records the mask,
+    # not the value. `[redacted]` is core.py's SECRET_MASK, written out by hand
+    # for the same reason every other expectation in this file is: a value read
+    # off the code being graded agrees with it whatever it says. That this beat
+    # is here at all is a second assertion — the command a run() logs has to
+    # survive being scrubbed.
+    f"echo {TERMINAL_PRINTED_MARKER} [redacted]": 0,
     "echo ok": 0,
     TERMINAL_FAILING_COMMAND: 3,
     TERMINAL_UNWAITED[0]: 0,
@@ -802,13 +817,17 @@ EVIDENCE_TRUNCATED_MAX = len(
     "\n…[demo-video: truncated here, 999999999 more characters]"
 )
 
-# One file's ceiling: the three text fields at their caps (32 000 characters)
-# plus JSON escaping of a newline-dense YAML tree, plus the beat block. Well
-# clear of the ~3.3 kB a healthy fixture beat writes, and it exists to catch a
-# cap that stopped being applied rather than to tune anything.
-MAX_EVIDENCE_FILE_BYTES = 64_000
+# One file's ceiling. The caps are counted in *characters* and this is bytes,
+# and the two are not the same number: UTF-8 spends up to four bytes on one
+# character, and JSON escaping of a newline-dense YAML tree adds more. So the
+# ceiling is the three text fields at their caps (32 000 characters) times four,
+# plus room for the beat block — deliberately loose, because the assertion that
+# actually grades the caps counts characters per field in run_evidence(). This
+# only catches a cap that stopped being applied at all, on a file that a
+# character count never sees because it is the wrong unit.
+MAX_EVIDENCE_FILE_BYTES = 4 * 32_000 + 8_000
 # ...and the directory's, which is the "do not bloat the evidence folder" half.
-# Observed: 76 kB for the 23-beat web take, 40 kB for the 18-beat terminal one.
+# Observed: 39 kB for the 23-beat web take, 9 kB for the 18-beat terminal one.
 MAX_EVIDENCE_DIR_BYTES = 512_000
 
 # What a reviewer must be able to read out of one beat's evidence, and what
@@ -871,13 +890,26 @@ TERMINAL_EVIDENCE = [
     ),
 ]
 
-# -- the evidence cap take ----------------------------------------------------
+# -- the evidence take (issue #9) ---------------------------------------------
 #
-# Truncation cannot be provoked on the fixture as it stands — its whole ARIA
-# tree is 2.3 kB against a 12 kB cap — and slackening the cap to meet it would
-# be grading the wrong number. So one short take bloats the page on purpose,
-# and is graded on nothing else. Its own take rather than a hook in a graded
-# one: 900 list items would change what the reference recording shows.
+# One short take against `?evidence=1`, graded on its evidence files and
+# nothing else — no video, no stills. It carries three things the graded takes
+# structurally cannot:
+#
+#   1. **The leak shapes.** Every element in that panel reached an evidence
+#      file readable during review, and none of them is visible to any pixel
+#      assertion ever written here: a value is not less legible in JSON for
+#      having been covered on screen. They are graded by a byte sweep, the same
+#      way redaction is, with unredacted controls proving the sweep is not
+#      looking at an empty file.
+#   2. **The size cap.** Truncation cannot be provoked on the fixture as it
+#      stands — its whole ARIA tree is 2.3 kB against a 12 kB cap — and
+#      slackening the cap to meet the fixture would be grading the wrong
+#      number. So the take bloats the page on purpose.
+#   3. **The segment naming.** It records with `segment=`, which no other take
+#      here does, so `evidence/<segment>.seg.beat-NN.json` is exercised rather
+#      than merely designed (issue #22).
+EVIDENCE_SEGMENT = "shapes"
 EVIDENCE_BLOAT_ID = "smoke-bloat"
 EVIDENCE_BLOAT_ITEMS = 900
 EVIDENCE_BLOAT_JS = """(n) => {
@@ -891,6 +923,148 @@ EVIDENCE_BLOAT_JS = """(n) => {
   }
   document.body.appendChild(box);
 }""".replace("__ID__", EVIDENCE_BLOAT_ID)
+
+# Values the `?evidence=1` panel renders inside elements the take redacts, or
+# registers as secrets. None may survive in any evidence file. Each is one
+# shape, and every one of them leaked before the fix named beside it.
+#
+#   WSPC  indented on its own line in hand-written markup. textContent comes
+#         back padded with newlines, the ARIA tree does not, and str.replace
+#         between the two finds nothing — the most ordinary shape there is.
+#   BLED  inside a card whose *label* also renders outside it. It must be
+#         masked while "Revenue" must not (see EVIDENCE_KEEP).
+#   CHLD  split into text nodes that are ordinary strings on their own.
+#   LBLD  the accessible name of a redacted element, sourced from an element
+#         outside its subtree via aria-labelledby.
+#   SLOT  light DOM slotted into a redacted shadow host — assigned into the
+#         subtree, not a descendant of it.
+#   VALU  an input value, which lives on the property and not the attribute.
+#   TICK  rewritten every 25 ms, so the harvest and the ARIA snapshot see
+#         different values unless the capture refuses to straddle a repaint.
+#   ATTR  a data-* attribute nothing renders, reached only because the markup
+#         dump is a new surface this feature created.
+#   JSON  the same, inside a JSON blob in another attribute.
+EVIDENCE_SECRETS = {
+    "the whitespace-padded key": "sk-live-WSPC00000000",
+    "the key whose label also renders outside it": "sk-live-BLED00000000",
+    "the key split across child elements": "sk-live-CHLD00000000",
+    "the accessible name sourced from outside the subtree": "sk-live-LBLD00000000",
+    "the key slotted into a redacted shadow host": "sk-live-SLOT00000000",
+    "the input value that lives on the property": "sk-live-VALU00000000",
+    "the key rewritten every 25 ms": "sk-live-TICK",
+    "the data-* attribute nothing renders": "sk-live-ATTR00000000",
+    "the key inside a JSON attribute": "sk-live-JSON00000000",
+}
+# The elements the take redacts, and the two it registers as text instead.
+# `#ev-spot-*` are deliberately **not** redacted: their values are registered
+# with register_secret(), which is the other half of the contract — a mask that
+# only elides what redact() names leaves a registered value in the markup.
+EVIDENCE_REDACT = [
+    "#ev-ws-card",
+    "#ev-bleed-card",
+    "#ev-child-card",
+    "#ev-labelled-card",
+    # Inside a shadow root, wrapping a <slot>. Its own textContent is empty and
+    # the value it paints is a light child of the *host* — inside the redaction
+    # in the flattened tree, outside it in the DOM.
+    "#ev-slot-inner",
+    "#ev-value-card",
+    "#ev-tick-card",
+]
+EVIDENCE_REGISTER = ["harborzenith7725"]
+
+# A caption naming a value that `redact()` covers and nobody registered. It is
+# not refused — correctly: `register_secret()` was never told about it, and the
+# words are in the frames from the moment they are drawn. What the recorder can
+# still do is keep them out of the files it *writes*, and `timeline.json` and
+# `timeline.md` are the two this skill tells people to commit. Without the
+# harvest reaching them, the same string is `[redacted]` in the evidence and in
+# the clear in the log beside it.
+EVIDENCE_BLEED_CAPTION = "The card shows sk-live-BLED00000000 today."
+# Planted in evidence/ *before* the take, as if a previous recording into the
+# same folder had left it there. It must not survive.
+EVIDENCE_STALE_SECRET = "sk-live-STAL00000000"
+
+# ...and what must **survive**. This is the half that stops the sweep above
+# from passing by masking everything, and it is not hypothetical: harvesting
+# every node of a redacted card also harvests its label, and an earlier round
+# of this feature rewrote every unrelated paragraph on the page as
+# `[redacted] for the quarter was steady.`
+#
+#   Revenue …   the label inside a redacted card, which also renders outside it
+#   live        a text node inside the split key, which is a substring of every
+#               other `sk-live-…` on the page
+#   $128,400    an ordinary value on the page, present to catch a mask that
+#               went wide enough to eat the app
+EVIDENCE_KEEP = {
+    "the sentence that shares a word with a redacted card's label": "Revenue for the quarter was steady, and the feed is live.",
+    "an ordinary KPI the mask must not reach": "$128,400",
+    "the text of the element whose attributes hold keys": "nothing rendered here",
+    "a table row from the app under the panel": "Harbor Supply Co.",
+}
+
+# The three spotlight targets, and what each proves about the markup dump.
+#
+#   #ev-spot-split  holds a registered secret written `harbor<b>zenith</b>7725`.
+#                   Its textContent is the value and its outerHTML is not, so
+#                   no substring mask can reach it — the markup must be
+#                   withheld outright rather than published half-cleaned.
+#   #ev-spot-attrs  renders the string "nothing rendered here" and carries two
+#                   attributes holding keys. Neither was ever in a frame, a
+#                   still, a caption or the TTS cache; serializing them would
+#                   make this feature the only place they exist.
+#   #ev-child-card  is *itself redacted*, and holds a value split across tags.
+#                   Both halves of that matter and they pull opposite ways: the
+#                   split makes a substring mask useless on the markup, and the
+#                   redaction makes it unnecessary, because the whole subtree
+#                   can be elided structurally. `querySelectorAll('*')` never
+#                   returns the element it was called on, so a serializer that
+#                   only elides *descendants* leaves the spotlight target — the
+#                   one element a storyboard redacts and spotlights together —
+#                   in the clear, and then withholds the markup as a
+#                   consolation. Elided markup is worth reading and withheld
+#                   markup is not, so the difference is graded.
+EVIDENCE_SPLIT_TARGET = "#ev-spot-split"
+EVIDENCE_ATTR_TARGET = "#ev-spot-attrs"
+EVIDENCE_REDACTED_TARGET = "#ev-child-card"
+EVIDENCE_HTML_WITHHELD_MARKER = "[demo-video: markup withheld"
+# core.py's SECRET_MASK, written out by hand for the same reason every other
+# expectation in this file is: a value read off the code being graded agrees
+# with it whatever it says.
+SECRET_MASK_EXPECTED = "[redacted]"
+
+# A registered secret placed so that the html cap cuts *through* it. The
+# ordering "mask, then cap" is only load-bearing where the two meet: cap first
+# and the tail of a value survives as the last thing in the file, which no
+# later substring search finds. Arranged rather than hoped for — the take
+# re-pads until the value straddles the budget, and asserts that it did.
+EVIDENCE_STRADDLE = "sk-live-CUTT00000000000000000000"
+EVIDENCE_STRADDLE_JS = """(opts) => {
+  const [id, secret, budget] = opts;
+  const box = document.getElementById(id);
+  if (!box) return null;
+  const item = document.createElement('li');
+  item.id = 'smoke-straddle';
+  box.insertBefore(item, box.firstChild);
+  // Solve for the padding rather than scan for it: serialization is
+  // deterministic, so one measurement gives the offset the value starts at
+  // and the rest is arithmetic. A few correction passes cover the case where
+  // the padding itself changes the markup's length (it does not here, but a
+  // fixed point costs three iterations and assumes nothing).
+  let pad = Math.max(0, budget - Math.floor(secret.length / 2));
+  for (let attempt = 0; attempt < 6; attempt++) {
+    item.textContent = 'x'.repeat(pad) + secret;
+    const html = box.outerHTML;
+    const at = html.indexOf(secret);
+    if (at === -1) return null;
+    if (at < budget && at + secret.length > budget) {
+      return {at: at, length: html.length, pad: pad};
+    }
+    pad += (budget - Math.floor(secret.length / 2)) - at;
+    if (pad < 0) return null;
+  }
+  return null;
+}"""
 
 # -- redaction (issue #4) ----------------------------------------------------
 #
@@ -1001,6 +1175,12 @@ REDACT_REFUSED_SELECTORS = [
     "#api-key:has-text('sk-live')",
 ]
 
+# Spotlit mid-take so this take's evidence carries `html` at all. `#hero-card`
+# rather than `#api-key`: the storyboard redacts the *wrapper*, so the markup
+# serializer has to elide a subtree it was never handed directly — and the
+# 44px value inside it is the one a reader would recognise.
+REDACT_SPOTLIGHT = "#hero-card"
+
 REDACT_SHOTS = ["01-key-blurred", "02-mask-repaired", "03-token-typed"]
 # Taken while the paint gate is deliberately up and being attacked. Graded the
 # other way round from the rest: in this one even the *controls* — unredacted,
@@ -1025,6 +1205,32 @@ REDACT_LEAK_CAPTION = f"Paste {REDACT_TYPED} to connect."
 # keep it — no recorder can un-paint a caption — but every file the take
 # writes must come back with it masked once it is registered.
 REDACT_LATE_CAPTION = f"Rotating {REDACT_LATE} now."
+
+# ...and for the redaction take, whose evidence is what the byte sweep in
+# check_redaction() is actually sweeping. Without these the sweep is a
+# statement about whatever the files happen to contain, which a constant
+# payload holding two control strings satisfies perfectly — measured: a
+# `_evidence_payload` replaced by a hardcoded dict passed the whole take.
+#
+# The facts are the *unredacted* halves of the `?secret=1` panel, so they say
+# the page was really read while the keys beside them were really masked.
+REDACT_EVIDENCE = [
+    (
+        "shot",
+        REDACT_SHOTS[0],
+        [
+            "Control key (never redacted)",
+            "sk-live-CTRL0000000000000000",
+            "Hero control (never redacted)",
+            REDACT_CAPTION,
+        ],
+        [],
+    ),
+]
+# The spotlight beat: `html` is the redacted wrapper's own markup, so it has to
+# carry the wrapper's id and none of the value inside it.
+REDACT_EVIDENCE_SCOPE = (REDACT_SPOTLIGHT, "[redacted]", 'id="hero-card"')
+
 
 # The recorder's narration defaults, written out by hand so this file computes
 # the cache path the way core.py does rather than by asking core.py. If either
@@ -2866,7 +3072,14 @@ def record_redaction(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
 
         rec.caption(REDACT_CAPTION)
         check_caption(b, rec.page, REDACT_CAPTION)
+        # A spotlight, so this take's evidence carries `html` — the markup of a
+        # redacted element, serialized. Without one the field is null in every
+        # file, the whole `outerHTML` surface sits outside the byte sweep
+        # below, and the take that has secrets in it grades none of it.
+        rec.spotlight(REDACT_SPOTLIGHT)
+        rec.hold(1.0)
         rec.shot(REDACT_SHOTS[0])
+        rec.spotlight()
 
         # DOM-level checks. Not the proof — the pixels are — but they say
         # *why* when the pixels fail, and the control ones prove the mask is
@@ -5158,7 +5371,7 @@ def check_redaction(out_dir: Path, info: dict, started_at: float) -> list[str]:
 
 
 def evidence_docs(
-    label: str, out_dir: Path
+    label: str, out_dir: Path, segment: str | None = None
 ) -> tuple[list[dict], list[dict], list[str]]:
     """(beats, evidence documents, failures) for one take, paired by index.
 
@@ -5168,11 +5381,19 @@ def evidence_docs(
     both-directions check the stills already get, and for the same reason. A
     dangling pointer sends a reviewer to a file that was never written; an
     orphan file is a beat the log forgot.
+
+    The expected filename is *computed here*, deliberately, and that is not the
+    anti-pattern SKILL.md warns a reader about. A reader has to follow the
+    `evidence` pointer, because nothing promises them the naming; a test that
+    followed the pointer alone would agree with whatever name the recorder
+    chose. Both are graded: the pointer must say what this function computed,
+    and the file the pointer names must be the one on disk.
     """
     failures: list[str] = []
-    timeline = out_dir / "timeline.json"
+    stem = f"{segment}.seg.timeline" if segment else "timeline"
+    timeline = out_dir / f"{stem}.json"
     if not timeline.is_file():
-        return [], [], [f"{label}: timeline.json was never written"]
+        return [], [], [f"{label}: {timeline.name} was never written"]
     beats = json.loads(timeline.read_text()).get("beats") or []
     directory = out_dir / EVIDENCE_DIR_NAME
     if not directory.is_dir():
@@ -5184,11 +5405,12 @@ def evidence_docs(
                 f"{len(beats)} beats and wrote an account of none of them"
             ],
         )
+    prefix = f"{segment}.seg." if segment else ""
     docs: list[dict] = []
     for position, beat in enumerate(beats):
         # Computed here rather than imported, so a change to how evidence is
         # named fails loudly instead of being agreed with.
-        wanted = f"{EVIDENCE_DIR_NAME}/beat-{position:02d}.json"
+        wanted = f"{EVIDENCE_DIR_NAME}/{prefix}beat-{position:02d}.json"
         if beat.get("evidence") != wanted:
             failures.append(
                 f"{label}: beat {position} ({beat.get('verb')!r}) points at "
@@ -5212,7 +5434,11 @@ def evidence_docs(
             docs.append(json.loads(path.read_text()))
         except (json.JSONDecodeError, UnicodeDecodeError) as exc:
             failures.append(f"{label}: {path.name} is not valid JSON: {exc}")
-    on_disk = sorted(p.name for p in directory.glob("*.json"))
+    # Only files this take's naming owns. A multi-segment demo writes all its
+    # segments into one evidence/, so another segment's files are neither this
+    # take's orphans nor its business.
+    mine = re.compile(rf"^{re.escape(prefix)}beat-\d+\.json$")
+    on_disk = sorted(p.name for p in directory.glob("*.json") if mine.match(p.name))
     named = sorted(Path(b["evidence"]).name for b in beats if b.get("evidence"))
     if on_disk != named:
         failures.append(
@@ -5220,7 +5446,9 @@ def evidence_docs(
             f"name {named!r} — a beat captured nothing, or something was "
             f"captured that no beat owns"
         )
-    total = sum(p.stat().st_size for p in directory.glob("*.json"))
+    total = sum(
+        p.stat().st_size for p in directory.glob("*.json") if mine.match(p.name)
+    )
     if total > MAX_EVIDENCE_DIR_BYTES:
         failures.append(
             f"{label}: {EVIDENCE_DIR_NAME}/ is {total // 1024} kB over "
@@ -5564,6 +5792,61 @@ def run_web_problems(out_root: Path) -> list[str]:
     return check_issues("web-problems", out_dir, WEB_PROBLEM_ISSUES)
 
 
+def check_terminal_evidence_secret(out_dir: Path) -> list[str]:
+    """A registered secret a command *printed* must not survive in `screen`.
+
+    The terminal's evidence is the whole rendered buffer, and it is the only
+    medium here with no `redact()` at all (issue #5) — so `register_secret()`
+    is the entire defence, and it has to be shown reaching the screen dump.
+    The word printed beside the secret is the anti-vacuity half: it is on the
+    same screen, it is not a secret, and a capture that wrote nothing satisfies
+    "the secret is absent" perfectly.
+
+    That half is looked for in **`screen` only**, never in the whole file. The
+    beat record embedded alongside carries the command as logged, and the
+    marker is a word in that command — so searching the file finds it whether
+    or not a single character of the terminal was captured. Written the easy
+    way first, and an injected `{"screen": ""}` payload was measured passing
+    it.
+
+    The secret is searched the other way round, over the whole file: the
+    absence of a credential is a claim about every byte written, not about one
+    field.
+    """
+    failures: list[str] = []
+    directory = out_dir / EVIDENCE_DIR_NAME
+    files = sorted(directory.glob("*.json"))
+    if not files:
+        return ["terminal-problems: the take wrote no evidence at all"]
+    holding = sorted(p.name for p in files if TERMINAL_PRINTED_SECRET in p.read_text())
+    if holding:
+        failures.append(
+            f"terminal-problems: a registered secret a command printed is "
+            f"readable in {holding!r}. TerminalRecorder has no redact(), so "
+            f"register_secret() is the only thing between a printed credential "
+            f"and this file."
+        )
+    screens = []
+    for path in files:
+        try:
+            screens.append(evidence_screen_text(json.loads(path.read_text())))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            failures.append(f"terminal-problems: {path.name} is not valid JSON")
+    if TERMINAL_PRINTED_MARKER not in "\n".join(screens):
+        failures.append(
+            f"terminal-problems: {TERMINAL_PRINTED_MARKER!r} is in no evidence "
+            f"file's `screen`, so the terminal holding the secret was never "
+            f"captured and its absence proves nothing. It is printed on the "
+            f"same line as the secret, so a screen dump that has one has both."
+        )
+    if not failures:
+        print(
+            "smoke: terminal-problems a printed secret is masked out of the "
+            "screen dump, and the line around it survives"
+        )
+    return failures
+
+
 def run_terminal_problems(out_root: Path) -> list[str]:
     """A short take of commands that fail, under the default."""
     if os.name != "posix":
@@ -5574,6 +5857,12 @@ def run_terminal_problems(out_root: Path) -> list[str]:
     try:
         with TerminalRecorder(out_dir, speech=False) as rec:
             rec.caption("Exit codes are recorded.")
+            # A secret a *command prints*. Registered before it is echoed, so
+            # the only thing that can keep it out of the screen dump is the
+            # writer applying `register_secret()` to the terminal payload.
+            rec.register_secret(TERMINAL_PRINTED_SECRET)
+            rec.run(f"echo {TERMINAL_PRINTED_MARKER} {TERMINAL_PRINTED_SECRET}")
+            rec.wait_for_prompt(timeout_s=15)
             rec.run("echo ok")
             rec.wait_for_prompt(timeout_s=15)
             rec.run(TERMINAL_FAILING_COMMAND)
@@ -5593,7 +5882,7 @@ def run_terminal_problems(out_root: Path) -> list[str]:
         out_dir,
         TERMINAL_PROBLEM_ISSUES,
         exit_codes=TERMINAL_PROBLEM_EXIT_CODES,
-    )
+    ) + check_terminal_evidence_secret(out_dir)
 
 
 def run_terminal_race(out_root: Path) -> list[str]:
@@ -6180,7 +6469,14 @@ def run_redaction(out_root: Path) -> list[str]:
             return [f"redaction: Recorder raised {type(exc).__name__}: {exc}"]
         problems += check_unmatched_redaction(out_root, base_url)
         problems += check_storyboard_leak_discards(out_root, base_url)
-    return problems + check_redaction(out_dir, info, started)
+    return (
+        problems
+        # Before the byte sweep in check_redaction(), and not instead of it:
+        # the sweep says no secret is in these files, and this says the files
+        # are an account of the page. Neither is worth anything alone.
+        + check_evidence("redaction", out_dir, REDACT_EVIDENCE, REDACT_EVIDENCE_SCOPE)
+        + check_redaction(out_dir, info, started)
+    )
 
 
 def _segment_parts(out_dir: Path) -> list[str]:
@@ -7649,54 +7945,236 @@ def run_terminal_redaction(out_root: Path) -> list[str]:
     return problems + check_terminal_redaction(out_dir, info, started)
 
 
-def run_evidence_caps(out_root: Path) -> list[str]:
-    """A four-second take whose only job is the evidence size cap.
+def check_evidence_leak_is_fatal(out_root: Path, base_url: str) -> list[str]:
+    """A `SecretLeak` raised while capturing evidence must kill the take.
 
-    The fixture's whole ARIA tree is 2.3 kB against a 12 kB cap, so truncation
-    has to be provoked: 900 list items put both the page tree and the
-    spotlight target's markup well past their budgets. Graded on nothing else
-    — no video, no stills, no timeline beyond the evidence pointers.
+    This is the one assertion here about a *caller* rather than about a file,
+    and it exists because the caller was the bug. `_capture_evidence()` runs
+    inside a `finally` and wraps the medium's payload in `except Exception`,
+    because a diagnostic that cannot be collected must not lose a take that is
+    otherwise fine. But `SecretLeak` travels that same path — the payload
+    re-asserts the mask and reads the page, and both are places it comes from
+    — so the broad handler turned the one refusal that *must* be fatal into a
+    printed line and a written mp4. A guard defeated by its own caller is
+    worse than no guard: everything downstream still reads as verified.
+
+    Injected rather than provoked, deliberately. Every real source of a
+    `SecretLeak` in a payload is also a source somewhere else in the take, so
+    a fixture that provoked one would not say *which* path refused. A
+    subclass whose `_evidence_payload` raises names exactly the path under
+    test and nothing else.
+
+    Graded on the verdict *and* on what survived it: `SKILL.md` promises
+    unconditionally that a `SecretLeak` keeps nothing, and "the take raised"
+    is equally true of one that raised after writing the mp4.
     """
-    from demo_recording import EVIDENCE_LIMITS, EVIDENCE_SCHEMA
+    from demo_recording import Recorder, SecretLeak
 
+    label = "evidence-leak-fatal"
+    injected = "injected: the mask could not be verified for this beat"
+
+    class LeakyEvidence(Recorder):
+        def _evidence_payload(self) -> dict:
+            raise SecretLeak(injected)
+
+    out_dir = fresh_take_dir(out_root, label)
     failures: list[str] = []
-    # The package's own constants against the ones written above. Everything
-    # below is a statement about those numbers, so a cap quietly widened by ten
-    # has to fail here rather than pass by agreeing with itself.
+    raised: BaseException | None = None
+    try:
+        with LeakyEvidence(out_dir, base_url=base_url, speech=False) as rec:
+            rec.goto("/")
+            rec.wait_for("#kpi-rev")
+            rec.pause(0.2)
+    except SecretLeak as exc:
+        raised = exc
+    except Exception as exc:  # noqa: BLE001 - any other verdict is a failure
+        return [f"{label}: expected SecretLeak, got {type(exc).__name__}: {exc}"]
+    if raised is None:
+        failures.append(
+            f"{label}: a beat whose evidence capture raised SecretLeak finished "
+            f"cleanly. The refusal was swallowed by the broad `except` that is "
+            f"there for diagnostics, so a control that used to kill a take now "
+            f"prints a line and lets the mp4 be written."
+        )
+    elif injected not in str(raised):
+        failures.append(
+            f"{label}: the take raised SecretLeak {str(raised)[:120]!r}, which "
+            f"is not the one this injected — something else refused and the "
+            f"path under test was never reached"
+        )
+    left = sorted(
+        str(p.relative_to(out_dir))
+        for p in out_dir.rglob("*")
+        if p.is_file() and p.name != MARKER_NAME
+    )
+    if left:
+        failures.append(
+            f"{label}: {left!r} survived a take that died on a SecretLeak out "
+            f"of its evidence capture. SKILL.md says a SecretLeak keeps "
+            f"nothing, and an mp4 left behind by a refused take is read by "
+            f"everything downstream as a verified one."
+        )
+    if not failures:
+        print(
+            "smoke: evidence a SecretLeak raised while capturing a beat kills "
+            "the take and keeps nothing"
+        )
+    return failures
+
+
+def run_evidence(out_root: Path) -> list[str]:
+    """The evidence take: leak shapes, the size cap, and segment naming.
+
+    Graded on `evidence/` alone — no video, no stills, no timing. Everything it
+    records is either a shape that leaks into *text* and into nothing else, or
+    a page big enough to make the caps do something.
+    """
+    from demo_recording import EVIDENCE_LIMITS, EVIDENCE_SCHEMA, Recorder
+
+    label = "evidence"
+    failures: list[str] = []
+    # The package's own constants against the ones written at the top of this
+    # file. Everything below is a statement about those numbers, so a cap
+    # quietly widened by ten has to fail here rather than pass by agreeing
+    # with itself.
     if dict(EVIDENCE_LIMITS) != EVIDENCE_LIMITS_EXPECTED:
         failures.append(
-            f"evidence-caps: the package caps evidence at {dict(EVIDENCE_LIMITS)!r}, "
+            f"{label}: the package caps evidence at {dict(EVIDENCE_LIMITS)!r}, "
             f"this harness grades {EVIDENCE_LIMITS_EXPECTED!r} — one of them "
             f"moved without the other"
         )
     if EVIDENCE_SCHEMA != EVIDENCE_SCHEMA_EXPECTED:
         failures.append(
-            f"evidence-caps: the package exports EVIDENCE_SCHEMA "
-            f"{EVIDENCE_SCHEMA!r}, this harness grades "
-            f"{EVIDENCE_SCHEMA_EXPECTED!r}"
+            f"{label}: the package exports EVIDENCE_SCHEMA {EVIDENCE_SCHEMA!r}, "
+            f"this harness grades {EVIDENCE_SCHEMA_EXPECTED!r}"
         )
 
-    from demo_recording import Recorder
+    # `screen` is the terminal's field, and no take here bloats a TUI far
+    # enough to reach a 12 000-character budget — so its cap is graded as the
+    # contract of the function that applies it, and this file says plainly
+    # that that is a unit check rather than a recording. The other three are
+    # graded end to end below.
+    from demo_recording.core import _cap_text
 
-    out_dir = fresh_take_dir(out_root, "evidence-caps")
+    for field, limit in sorted(EVIDENCE_LIMITS_EXPECTED.items()):
+        short, cut = _cap_text("x" * (limit - 1), limit)
+        if cut or short != "x" * (limit - 1):
+            failures.append(
+                f"{label}: _cap_text() cut text already inside the {field} "
+                f"budget ({cut} characters removed)"
+            )
+        long, cut = _cap_text("y" * (limit + 500), limit)
+        if cut != 500:
+            failures.append(
+                f"{label}: _cap_text() says it removed {cut} characters from a "
+                f"{field}-sized field 500 over its budget"
+            )
+        if EVIDENCE_MARKER not in long or not long.startswith("y" * limit):
+            failures.append(
+                f"{label}: _cap_text() on a {field}-sized field returned "
+                f"{long[-60:]!r} — a cut with no marker where it stops"
+            )
+        if len(long) > limit + EVIDENCE_TRUNCATED_MAX:
+            failures.append(
+                f"{label}: _cap_text() left {len(long)} characters for a {limit} budget"
+            )
+
+    out_dir = fresh_take_dir(out_root, label)
+    # A previous take's evidence, planted. `record.py` is committed precisely so
+    # it can be re-run into the same folder, and a re-record that *adds* a
+    # redact() (or simply has fewer beats) would otherwise leave the old files
+    # sitting beside the new ones holding the value the new take exists to
+    # hide. Two files, because the clearing has to be scoped: one this take's
+    # naming owns and one belonging to another segment of the same demo, which
+    # must survive — deleting that would break a multi-segment re-record.
+    (out_dir / EVIDENCE_DIR_NAME).mkdir(parents=True, exist_ok=True)
+    stale = out_dir / EVIDENCE_DIR_NAME / f"{EVIDENCE_SEGMENT}.seg.beat-99.json"
+    stale.write_text(json.dumps({"aria": EVIDENCE_STALE_SECRET}) + "\n")
+    other = out_dir / EVIDENCE_DIR_NAME / "othersegment.seg.beat-00.json"
+    other.write_text(json.dumps({"aria": "another segment's beat"}) + "\n")
+
+    straddle: dict | None = None
     with fixture_server() as base_url:
         try:
-            with Recorder(out_dir, base_url=base_url, speech=False) as rec:
-                rec.goto("/")
-                rec.wait_for("#kpi-rev")
-                # Before the bloat. Its evidence must come back *un*truncated —
-                # a recorder that marked every field truncated would otherwise
-                # satisfy everything below.
-                rec.pause(0.2)
+            with Recorder(
+                out_dir,
+                base_url=base_url,
+                speech=False,
+                segment=EVIDENCE_SEGMENT,
+            ) as rec:
+                rec.redact(*EVIDENCE_REDACT)
+                rec.register_secret(*EVIDENCE_REGISTER, EVIDENCE_STRADDLE)
+                rec.goto("/?evidence=1")
+                rec.wait_for("#ev-ws-key")
+                # Two beats while #ev-tick-card is still rewriting itself every
+                # 25 ms. The capture reads the page three times (harvest,
+                # snapshot, harvest) and that window is wider than the interval,
+                # so the mask cannot be built from what the snapshot saw — and
+                # the right answer is to write no page text, not to write text
+                # masked against a value that is already stale.
+                rec.pause(0.3)
+                rec.pause(0.3)
+                # ...and with the rotating value gone, everything else is
+                # gradable. The interval keeps running; it just has nothing to
+                # write into.
+                rec.page.evaluate(
+                    "() => document.getElementById('ev-tick-card').remove()"
+                )
+                rec.pause(0.4)
+                # A caption naming a redacted card's value. Nothing refuses it
+                # — it was never registered — and it is sticky, so it stamps
+                # itself onto every beat that follows in timeline.json and
+                # timeline.md, the two files this skill says to commit.
+                rec.caption(EVIDENCE_BLEED_CAPTION)
+
+                # Markup, three times. A registered value split across elements
+                # must withhold the markup outright; attributes nothing renders
+                # must not be in it at all; and a spotlight on a *redacted*
+                # element must come back elided rather than withheld.
+                rec.spotlight(EVIDENCE_SPLIT_TARGET)
+                rec.pause(0.3)
+                rec.spotlight(EVIDENCE_ATTR_TARGET)
+                rec.pause(0.3)
+                rec.spotlight(EVIDENCE_REDACTED_TARGET)
+                rec.pause(0.3)
+                rec.spotlight()
+
+                # The caps. Bloat the page, spotlight the bloat, and place a
+                # registered secret so the markup budget cuts through it.
                 rec.page.evaluate(EVIDENCE_BLOAT_JS, EVIDENCE_BLOAT_ITEMS)
                 rec.spotlight(f"#{EVIDENCE_BLOAT_ID}")
-                rec.pause(0.2)
+                straddle = rec.page.evaluate(
+                    EVIDENCE_STRADDLE_JS,
+                    [
+                        EVIDENCE_BLOAT_ID,
+                        EVIDENCE_STRADDLE,
+                        EVIDENCE_LIMITS_EXPECTED["html"],
+                    ],
+                )
+                rec.pause(0.3)
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
-            return failures + [
-                f"evidence-caps: Recorder raised {type(exc).__name__}: {exc}"
-            ]
+            return failures + [f"{label}: Recorder raised {type(exc).__name__}: {exc}"]
+        # Inside the same server, and after the take above rather than instead
+        # of it: this one records nothing worth grading and exists only to
+        # prove the capture's refusal is fatal.
+        failures += check_evidence_leak_is_fatal(out_root, base_url)
 
-    beats, docs, problems = evidence_docs("evidence-caps", out_dir)
+    if stale.exists():
+        failures.append(
+            f"{label}: {stale.name} survived a re-record into the same "
+            f"directory. It is a previous take's evidence, holding a value "
+            f"this take was told to redact — and re-recording into the same "
+            f"folder is how this skill is meant to be used."
+        )
+    if not other.exists():
+        failures.append(
+            f"{label}: {other.name} was deleted. It belongs to another segment "
+            f"of the same demo, which a re-record of *this* segment must "
+            f"leave alone — otherwise re-recording one segment throws away the "
+            f"evidence for all the others."
+        )
+
+    beats, docs, problems = evidence_docs(label, out_dir, segment=EVIDENCE_SEGMENT)
     failures += problems
     if not docs:
         return failures
@@ -7705,69 +8183,264 @@ def run_evidence_caps(out_root: Path) -> list[str]:
         for i, (beat, doc) in enumerate(zip(beats, docs, strict=False))
         if beat.get("verb") == "pause"
     ]
-    if len(pauses) != 2:
+    if len(pauses) != 7:
         return failures + [
-            f"evidence-caps: {len(pauses)} pause beats, expected 2 (one before "
-            f"the bloat, one after) — the take is not the take this grades"
+            f"{label}: {len(pauses)} pause beats, expected 7 — the take is not "
+            f"the take this grades"
         ]
-    (before_i, before), (after_i, after) = pauses
+    ticking = pauses[:2]
+    settled_i, settled = pauses[2]
+    split_i, split = pauses[3]
+    attrs_i, attrs = pauses[4]
+    elided_i, elided = pauses[5]
+    capped_i, capped = pauses[6]
 
-    if before.get("truncated"):
+    # -- the leak shapes -----------------------------------------------------
+    #
+    # A byte sweep, like redaction's, over every evidence file the take wrote.
+    # The `keep` half is what stops it from passing on a recorder that masked
+    # everything, or captured nothing.
+    written = sorted((out_dir / EVIDENCE_DIR_NAME).glob("*.json"))
+    blob = "\n".join(p.read_text() for p in written)
+    # Every file the take wrote, not only the evidence — `timeline.json` and
+    # `timeline.md` are the ones this skill tells people to *commit*, and the
+    # harvest that keeps a redacted value out of the evidence has to reach them
+    # too. The storyboard captions one of these values on purpose.
+    everything = sorted(p for p in out_dir.rglob("*") if p.is_file())
+    for what, literal in EVIDENCE_SECRETS.items():
+        holding = sorted(
+            str(p.relative_to(out_dir))
+            for p in everything
+            if literal.encode() in p.read_bytes()
+        )
+        if holding:
+            failures.append(
+                f"{label}: {what} ({literal}) is readable in {holding!r}. "
+                f"redact() covers where a value renders; a text dump of the "
+                f"DOM — and the beat log beside it — is not protected by "
+                f"anything about a picture."
+            )
+    for what, literal in EVIDENCE_KEEP.items():
+        if literal not in blob:
+            failures.append(
+                f"{label}: {what} ({literal!r}) is in none of the evidence "
+                f"files. It renders outside everything redact() covers, so "
+                f"either the capture wrote no page text — which makes every "
+                f"assertion above a statement about an empty file — or the "
+                f"mask went wide enough to eat the app it was documenting."
+            )
+
+    # -- the rotating value: refuse, do not guess ----------------------------
+    refused = [i for i, doc in ticking if doc.get("omitted")]
+    if not refused:
         failures.append(
-            f"evidence-caps: beat {before_i} ran before anything was appended "
-            f"to the page and its evidence is already marked truncated "
-            f"{before.get('truncated')!r} — the marker means nothing if it is "
+            f"{label}: neither beat {ticking[0][0]} nor {ticking[1][0]} refused "
+            f"to capture, and both ran while a redacted card was being "
+            f"rewritten every 25 ms — faster than the three round trips a "
+            f"capture takes. One of them has to come back `omitted`, or the "
+            f"mask is being built from a value the snapshot did not see."
+        )
+    for i, doc in ticking:
+        if not doc.get("omitted"):
+            continue
+        for field in ("aria", "scope_aria", "html"):
+            if doc.get(field):
+                failures.append(
+                    f"{label}: beat {i} says it omitted its page text and "
+                    f"still carries `{field}` — the refusal is cosmetic"
+                )
+    if settled.get("omitted"):
+        failures.append(
+            f"{label}: beat {settled_i} refused too ({settled['omitted']!r}), "
+            f"and it ran after the rotating card was removed. If every beat "
+            f"refuses, nothing below is being graded."
+        )
+
+    # -- markup: withheld when split, stripped of what never rendered --------
+    if split.get("scope") != EVIDENCE_SPLIT_TARGET:
+        failures.append(
+            f"{label}: beat {split_i} scopes to {split.get('scope')!r}, "
+            f"expected {EVIDENCE_SPLIT_TARGET!r}"
+        )
+    if EVIDENCE_HTML_WITHHELD_MARKER not in str(split.get("html")):
+        failures.append(
+            f"{label}: beat {split_i} spotlights an element holding a "
+            f"registered secret written across two tags, and its `html` is "
+            f"{str(split.get('html'))[:160]!r}. A substring mask cannot reach a "
+            f"value interleaved with elements, so the markup has to be withheld "
+            f"and say so — publishing it half-cleaned is the leak."
+        )
+    if attrs.get("scope") != EVIDENCE_ATTR_TARGET:
+        failures.append(
+            f"{label}: beat {attrs_i} scopes to {attrs.get('scope')!r}, "
+            f"expected {EVIDENCE_ATTR_TARGET!r}"
+        )
+    markup = str(attrs.get("html") or "")
+    if "nothing rendered here" not in markup:
+        failures.append(
+            f"{label}: beat {attrs_i}'s `html` is {markup[:160]!r}, which does "
+            f"not contain the text the element actually renders — the markup "
+            f"was not captured, so the attribute assertions below prove nothing"
+        )
+    for attr in ("data-token", "data-cfg"):
+        if attr in markup:
+            failures.append(
+                f"{label}: beat {attrs_i}'s `html` still carries {attr!r}. "
+                f"Nothing renders it, so it was in no frame, no still, no "
+                f"caption and no narration clip — serializing it here makes "
+                f"evidence the only place it exists."
+            )
+
+    # -- markup: elided, not withheld, when the target is itself redacted -----
+    #
+    # Redacting and spotlighting the same element is the ordinary call, and
+    # `querySelectorAll('*')` never returns the element it was called on — so a
+    # serializer that elides only *descendants* misses exactly that case. The
+    # value inside this one is split across tags, so what it falls back to is
+    # visible: the substring mask cannot reach the markup either, the withhold
+    # path catches it, and the beat comes back with no markup at all instead of
+    # markup a reader can use. Both outcomes are safe; only one is evidence.
+    if elided.get("scope") != EVIDENCE_REDACTED_TARGET:
+        failures.append(
+            f"{label}: beat {elided_i} scopes to {elided.get('scope')!r}, "
+            f"expected {EVIDENCE_REDACTED_TARGET!r}"
+        )
+    elided_html = str(elided.get("html") or "")
+    if EVIDENCE_HTML_WITHHELD_MARKER in elided_html:
+        failures.append(
+            f"{label}: beat {elided_i} spotlights an element that redact() "
+            f"covers, and its markup was withheld rather than elided. A "
+            f"redacted subtree can be replaced wholesale — the withhold path "
+            f"is the last resort for a value the mask cannot reach, and "
+            f"reaching for it here costs the beat its markup for nothing."
+        )
+    elif SECRET_MASK_EXPECTED not in elided_html:
+        failures.append(
+            f"{label}: beat {elided_i}'s `html` is {elided_html[:160]!r}, with "
+            f"no {SECRET_MASK_EXPECTED!r} in it — the spotlight target is "
+            f"redacted, so its contents have to be elided in the markup and "
+            f"visibly so"
+        )
+    elif EVIDENCE_REDACTED_TARGET.lstrip("#") not in elided_html:
+        failures.append(
+            f"{label}: beat {elided_i}'s `html` is {elided_html[:160]!r}, which "
+            f"does not name the element it is the markup of — an elision that "
+            f"took the structure with it leaves nothing to read"
+        )
+    # ...and the subtree goes with it. Eliding a redacted element means
+    # replacing its `textContent`, which takes every descendant — so the
+    # markup is the target's own tag and nothing else. Without this the
+    # descendants survive and only the *strings* in them are masked, which
+    # publishes `sk-<i>live</i>[redacted]`: a value elided in the halves the
+    # substring mask happened to reach, in markup a reader would take at face
+    # value. Measured — that is exactly what a serializer that elides only
+    # descendants writes here, and every other assertion above is satisfied
+    # by it.
+    tags = re.findall(r"<[a-zA-Z/][^>]*>", elided_html)
+    if elided_html and len(tags) != 2:
+        failures.append(
+            f"{label}: beat {elided_i}'s `html` holds {len(tags)} tags "
+            f"({tags[:6]!r}), expected the redacted target's own open and "
+            f"close and nothing between them. redact() covers a whole "
+            f"subtree; markup that kept the subtree and masked only the "
+            f"strings in it is elided wherever the mask happened to reach and "
+            f"in the clear everywhere else."
+        )
+
+    # -- the caps ------------------------------------------------------------
+    if settled.get("truncated"):
+        failures.append(
+            f"{label}: beat {settled_i} ran before anything was appended to the "
+            f"page and its evidence is already marked truncated "
+            f"{settled.get('truncated')!r} — the marker means nothing if it is "
             f"always there"
         )
-    if len(before.get("aria") or "") >= EVIDENCE_LIMITS_EXPECTED["aria"]:
+    if len(settled.get("aria") or "") >= EVIDENCE_LIMITS_EXPECTED["aria"]:
         failures.append(
-            f"evidence-caps: beat {before_i}'s aria is "
-            f"{len(before.get('aria') or '')} characters before the page was "
+            f"{label}: beat {settled_i}'s aria is "
+            f"{len(settled.get('aria') or '')} characters before the page was "
             f"bloated, so the untruncated case is not being exercised"
         )
-
-    for field in ("aria", "html"):
+    if capped.get("scope") != f"#{EVIDENCE_BLOAT_ID}":
+        failures.append(
+            f"{label}: beat {capped_i} scopes to {capped.get('scope')!r}, "
+            f"expected the bloated element — its markup is what the html cap is "
+            f"being graded on"
+        )
+    # All three text fields, not the two that were easiest to reach: a cap
+    # applied to `aria` and not to `scope_aria` is a cap on a third of what a
+    # spotlight beat writes.
+    for field in ("aria", "scope_aria", "html"):
         limit = EVIDENCE_LIMITS_EXPECTED[field]
-        text = after.get(field)
+        text = capped.get(field)
         if not isinstance(text, str):
             failures.append(
-                f"evidence-caps: beat {after_i} captured no `{field}` at all, "
-                f"so the cap on it is untested"
+                f"{label}: beat {capped_i} captured no `{field}` at all, so the "
+                f"cap on it is untested"
             )
             continue
-        if field not in (after.get("truncated") or []):
+        if field not in (capped.get("truncated") or []):
             failures.append(
-                f"evidence-caps: beat {after_i}'s `{field}` is {len(text)} "
+                f"{label}: beat {capped_i}'s `{field}` is {len(text)} "
                 f"characters against a {limit} cap, and `truncated` is "
-                f"{after.get('truncated')!r} — it was cut and does not say so"
+                f"{capped.get('truncated')!r} — it was cut and does not say so"
             )
         if EVIDENCE_MARKER not in text:
             failures.append(
-                f"evidence-caps: beat {after_i}'s `{field}` was cut with no "
-                f"marker where it stops. It ends {text[-80:]!r}, which reads "
-                f"as a page that simply ended there."
+                f"{label}: beat {capped_i}'s `{field}` was cut with no marker "
+                f"where it stops. It ends {text[-80:]!r}, which reads as a page "
+                f"that simply ended there."
             )
         # Cut *to* the budget, not merely somewhere under a ceiling: the marker
         # is the only thing allowed past it.
         allowed = limit + EVIDENCE_TRUNCATED_MAX
         if not limit < len(text) <= allowed:
             failures.append(
-                f"evidence-caps: beat {after_i}'s `{field}` is {len(text)} "
+                f"{label}: beat {capped_i}'s `{field}` is {len(text)} "
                 f"characters, expected the {limit}-character budget plus a "
                 f"marker (at most {allowed})"
             )
-    if after.get("scope") != f"#{EVIDENCE_BLOAT_ID}":
+
+    # -- masking runs before capping, which only matters where they meet -----
+    #
+    # The premise is arranged and asserted rather than hoped for: the take
+    # re-pads a list item until a registered secret's characters span the
+    # markup budget, and reports where it landed. Cap first and the value's
+    # head survives as the last thing in the file, which no later substring
+    # search for the whole literal finds.
+    if straddle is None:
         failures.append(
-            f"evidence-caps: beat {after_i} scopes to {after.get('scope')!r}, "
-            f"expected the bloated element — its markup is what the html cap "
-            f"is being graded on"
+            f"{label}: could not place a registered secret across the "
+            f"{EVIDENCE_LIMITS_EXPECTED['html']}-character markup budget, so "
+            f"the mask-then-cap ordering is not being exercised at all"
         )
+    else:
+        print(
+            f"smoke: {label} a registered secret spans the markup budget "
+            f"(chars {straddle['at']}-{straddle['at'] + len(EVIDENCE_STRADDLE)} "
+            f"of {straddle['length']}, budget "
+            f"{EVIDENCE_LIMITS_EXPECTED['html']})"
+        )
+        # Any run of the value long enough to identify it, not only the whole
+        # thing: a cut leaves a head, and a head is exactly what a search for
+        # the literal misses.
+        for size in (len(EVIDENCE_STRADDLE), 20, 12):
+            head = EVIDENCE_STRADDLE[:size]
+            if head in blob:
+                failures.append(
+                    f"{label}: {head!r} — {size} characters of a registered "
+                    f"secret that straddles the markup budget — survives in the "
+                    f"evidence. The value was cut before it was masked, so what "
+                    f"is left is a head no substring search finds."
+                )
+                break
+
     if not failures:
         print(
-            f"smoke: evidence-caps aria cut to "
-            f"{EVIDENCE_LIMITS_EXPECTED['aria']} and html to "
-            f"{EVIDENCE_LIMITS_EXPECTED['html']} characters, both marked "
-            f"(untruncated beat {before_i} left alone)"
+            f"smoke: {label} ok ({len(docs)} beats as "
+            f"{EVIDENCE_SEGMENT}.seg.beat-NN.json, {len(EVIDENCE_SECRETS)} leak "
+            f"shapes clean, {len(EVIDENCE_KEEP)} controls intact, "
+            f"{len(refused)} beat(s) refused a moving target)"
         )
     return failures
 
@@ -7846,6 +8519,11 @@ def main() -> int:
         help="record only the two-segment take and its stitch (issue #7)",
     )
     parser.add_argument(
+        "--evidence-only",
+        action="store_true",
+        help="record only the per-beat evidence take (issue #9)",
+    )
+    parser.add_argument(
         "--out-dir",
         type=Path,
         help="where recordings land (default: a fresh temp dir). The web/ and "
@@ -7867,6 +8545,7 @@ def main() -> int:
             ("--determinism-only", args.determinism_only),
             ("--redaction-only", args.redaction_only),
             ("--segments-only", args.segments_only),
+            ("--evidence-only", args.evidence_only),
         )
         if on
     ]
@@ -7914,7 +8593,8 @@ def main() -> int:
         if only in (None, "--web-only"):
             failures += run_web_problems(out_root)
             failures += run_strict_web(out_root)
-            failures += run_evidence_caps(out_root)
+        if only in (None, "--web-only", "--evidence-only"):
+            failures += run_evidence(out_root)
         if only in (None, "--terminal-only"):
             failures += run_terminal_problems(out_root)
             failures += run_terminal_race(out_root)

--- a/tests/smoke
+++ b/tests/smoke
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
-# dependencies = ["playwright>=1.40"]
+# dependencies = ["playwright>=1.49"]
 # ///
 """End-to-end smoke test for the demo-video recorders.
 
@@ -37,6 +37,13 @@ and grades each take on separate axes:
    the same frame, and on a byte search of everything the take wrote. The
    terminal half (issue #5) grades the PTY scrubber the same way, against a
    value split across `os.read()` boundaries on purpose.
+6. **Evidence** — every beat left a text account of what was on screen, capped
+   and explicitly truncated, from which a reader can state what the frame
+   showed without decoding one. Its own leak path, because it is the only
+   artifact here that is *plain text* and `redact()` only covers pixels.
+
+Playwright 1.49 or newer: evidence uses `locator.aria_snapshot()`, and the
+`page.accessibility` API that predates it has since been removed.
 
     tests/smoke                 # every take
     tests/smoke --web-only
@@ -767,6 +774,123 @@ MAX_MERGE_OFFSET_ERROR_S = 0.1
 # by the boundary, and neither is satisfied by a constant shift of any
 # segment's beats — which is what this bar, at any width, cannot say.
 MAX_CROSS_SEGMENT_DRIFT_S = MAX_CAPTURE_LOSS_S
+
+# -- per-beat evidence (issue #9) ---------------------------------------------
+#
+# Every beat writes evidence/beat-NN.json: what was on screen when the verb
+# returned, in text. The acceptance criterion is that a reviewer given only
+# those files can say what the frame showed — so the assertions below are not
+# "the file exists and parses" but *facts about the fixture app*, hand-written
+# here and looked for in the page text the recorder captured.
+EVIDENCE_DIR_NAME = "evidence"
+
+# The recorder's caps and its truncation marker, written out by hand for the
+# same reason WEB_BEATS is: a bound read off the code being graded agrees with
+# that code whatever it says. check_evidence_caps() asserts the package's own
+# constants equal these, so widening a cap has to be done on purpose.
+EVIDENCE_SCHEMA_EXPECTED = 1
+EVIDENCE_LIMITS_EXPECTED = {
+    "aria": 12_000,
+    "scope_aria": 12_000,
+    "html": 8_000,
+    "screen": 12_000,
+}
+EVIDENCE_MARKER = "[demo-video: truncated here,"
+# The most a marker can add past a field's budget, so "cut to the cap" can be
+# asserted as a range rather than as "under some ceiling".
+EVIDENCE_TRUNCATED_MAX = len(
+    "\n…[demo-video: truncated here, 999999999 more characters]"
+)
+
+# One file's ceiling: the three text fields at their caps (32 000 characters)
+# plus JSON escaping of a newline-dense YAML tree, plus the beat block. Well
+# clear of the ~3.3 kB a healthy fixture beat writes, and it exists to catch a
+# cap that stopped being applied rather than to tune anything.
+MAX_EVIDENCE_FILE_BYTES = 64_000
+# ...and the directory's, which is the "do not bloat the evidence folder" half.
+# Observed: 76 kB for the 23-beat web take, 40 kB for the 18-beat terminal one.
+MAX_EVIDENCE_DIR_BYTES = 512_000
+
+# What a reviewer must be able to read out of one beat's evidence, and what
+# must *not* be in it. The second list is what makes this more than a
+# spell-check of a static dump: `03-refreshed` holding `$134,950` and *not*
+# `$128,400` says the evidence tracks the page beat by beat, which is the whole
+# claim. Every string is a fact about tests/fixture/index.html, written here,
+# never read back off the recorder.
+#
+#   (verb, target, must appear, must not appear)
+WEB_EVIDENCE = [
+    (
+        "shot",
+        "01-dashboard",
+        [
+            "$128,400",
+            "snapshot 1 of 3",
+            "Refresh",
+            "Harbor Supply Co.",
+            "Ferrari Logistics",
+            "A small dashboard.",
+        ],
+        ["$134,950", "snapshot 2 of 3"],
+    ),
+    (
+        # The filter really filtered: one row left, and the four it dropped are
+        # gone from the account of the screen as well as from the screen.
+        "shot",
+        "02-filtered",
+        ["Harbor Supply Co.", "Seattle", "Filter by city."],
+        ["Ferrari Logistics", "Cascade Outfitters", "Pine & Poplar"],
+    ),
+    (
+        "shot",
+        "03-refreshed",
+        ["$134,950", "snapshot 2 of 3", "Refresh reloads it."],
+        ["$128,400", "snapshot 1 of 3"],
+    ),
+]
+
+# The spotlight is what issue #9 says the capture is scoped to, so it is graded
+# on its own: the beat that sets one names it and carries that element's own
+# tree and markup, and the beat that clears one carries neither.
+WEB_EVIDENCE_SCOPE = ("#kpi-rev", "$128,400", 'id="kpi-rev"')
+
+TERMINAL_EVIDENCE = [
+    (
+        "shot",
+        "01-echo",
+        # The command as typed *and* its output, which is the pair that says
+        # the PTY ran what run() sent rather than echoing it.
+        ["echo hello from demo-video", "hello from demo-video"],
+        ["ls -1", "AGENTS.md"],
+    ),
+    (
+        "shot",
+        "02-listing",
+        ["ls -1", "skills", "tests", "hello from demo-video"],
+        [],
+    ),
+]
+
+# -- the evidence cap take ----------------------------------------------------
+#
+# Truncation cannot be provoked on the fixture as it stands — its whole ARIA
+# tree is 2.3 kB against a 12 kB cap — and slackening the cap to meet it would
+# be grading the wrong number. So one short take bloats the page on purpose,
+# and is graded on nothing else. Its own take rather than a hook in a graded
+# one: 900 list items would change what the reference recording shows.
+EVIDENCE_BLOAT_ID = "smoke-bloat"
+EVIDENCE_BLOAT_ITEMS = 900
+EVIDENCE_BLOAT_JS = """(n) => {
+  const box = document.createElement('ul');
+  box.id = '__ID__';
+  for (let i = 0; i < n; i++) {
+    const li = document.createElement('li');
+    li.textContent = 'bloat row ' + i + ' — filler so the evidence cap has '
+      + 'something to cut';
+    box.appendChild(li);
+  }
+  document.body.appendChild(box);
+}""".replace("__ID__", EVIDENCE_BLOAT_ID)
 
 # -- redaction (issue #4) ----------------------------------------------------
 #
@@ -4962,9 +5086,56 @@ def check_redaction(out_dir: Path, info: dict, started_at: float) -> list[str]:
             f"lines, and nothing for the refused one"
         )
 
+    # -- leak path 5: the evidence files -------------------------------------
+    #
+    # `evidence/beat-NN.json` is the one artifact this recorder writes that is
+    # plain text, and `redact()` is a *pixel* control — it covers where a value
+    # renders and leaves the value in the DOM, which is exactly what an
+    # evidence file is a dump of. So the sweep below has to actually reach
+    # these files, and they have to have something in them.
+    #
+    # Both halves are needed and neither alone is worth anything. An empty
+    # `evidence/`, or files holding nothing but a beat record, satisfy "no
+    # secret appears" perfectly — so the *controls*, which are never redacted
+    # and sit in the same panel as the keys, must be found in there. That pair
+    # is what makes the absence of the keys mean something.
+    evidence_dir = out_dir / EVIDENCE_DIR_NAME
+    evidence_files = sorted(evidence_dir.glob("*.json"))
+    beat_count = 0
+    if timeline.is_file():
+        beat_count = len(json.loads(timeline.read_text()).get("beats") or [])
+    if len(evidence_files) != beat_count or not evidence_files:
+        failures.append(
+            f"redaction: {EVIDENCE_DIR_NAME}/ holds {len(evidence_files)} files "
+            f"for {beat_count} beats. The byte sweep below is only a statement "
+            f"about the files that are there, so a take that wrote no evidence "
+            f"would pass it by writing nothing."
+        )
+    evidence_text = "\n".join(p.read_text() for p in evidence_files)
+    for what, control in (
+        ("the unredacted control key", REDACT_CONTROL),
+        ("the unredacted hero control", REDACT_HERO_CONTROL),
+    ):
+        if control not in evidence_text:
+            failures.append(
+                f"redaction: {what} ({control}) is not in any evidence file. It "
+                f"is rendered beside the redacted keys and is never registered, "
+                f"so its absence means the evidence captured nothing — and "
+                f"'no secret appears in it' is then a statement about an empty "
+                f"file."
+            )
+    for what, literal in REDACT_LITERALS.items():
+        holding = [p.name for p in evidence_files if literal in p.read_text()]
+        if holding:
+            failures.append(
+                f"redaction: {what} appears verbatim in the evidence files "
+                f"{holding!r}. redact() hides where a value *renders*; the DOM "
+                f"still holds it, and evidence is a text dump of the DOM."
+            )
+
     # Everything the take wrote, byte for byte: timeline.json, timeline.md,
-    # the stills, the mp4, the narration clips, the marker. No exemptions —
-    # a leak path nobody thought of is exactly what this catches.
+    # the stills, the mp4, the narration clips, the evidence, the marker. No
+    # exemptions — a leak path nobody thought of is exactly what this catches.
     swept = 0
     for path in sorted(out_dir.rglob("*")):
         if not path.is_file():
@@ -4979,7 +5150,227 @@ def check_redaction(out_dir: Path, info: dict, started_at: float) -> list[str]:
     if not failures:
         print(
             f"smoke: redaction none of the {len(REDACT_LITERALS)} secrets "
-            f"appears verbatim in any of the {swept} files the take wrote"
+            f"appears verbatim in any of the {swept} files the take wrote "
+            f"({len(evidence_files)} of them per-beat evidence, which the "
+            f"controls prove is not empty)"
+        )
+    return failures
+
+
+def evidence_docs(
+    label: str, out_dir: Path
+) -> tuple[list[dict], list[dict], list[str]]:
+    """(beats, evidence documents, failures) for one take, paired by index.
+
+    The pairing is the structural half of this axis: every beat in
+    timeline.json must name an evidence file, that file must exist, and
+    `evidence/` must hold nothing the log does not name — the same
+    both-directions check the stills already get, and for the same reason. A
+    dangling pointer sends a reviewer to a file that was never written; an
+    orphan file is a beat the log forgot.
+    """
+    failures: list[str] = []
+    timeline = out_dir / "timeline.json"
+    if not timeline.is_file():
+        return [], [], [f"{label}: timeline.json was never written"]
+    beats = json.loads(timeline.read_text()).get("beats") or []
+    directory = out_dir / EVIDENCE_DIR_NAME
+    if not directory.is_dir():
+        return (
+            beats,
+            [],
+            [
+                f"{label}: no {EVIDENCE_DIR_NAME}/ directory — the take recorded "
+                f"{len(beats)} beats and wrote an account of none of them"
+            ],
+        )
+    docs: list[dict] = []
+    for position, beat in enumerate(beats):
+        # Computed here rather than imported, so a change to how evidence is
+        # named fails loudly instead of being agreed with.
+        wanted = f"{EVIDENCE_DIR_NAME}/beat-{position:02d}.json"
+        if beat.get("evidence") != wanted:
+            failures.append(
+                f"{label}: beat {position} ({beat.get('verb')!r}) points at "
+                f"evidence {beat.get('evidence')!r}, expected {wanted!r}"
+            )
+        path = out_dir / (beat.get("evidence") or wanted)
+        if not path.is_file():
+            failures.append(
+                f"{label}: beat {position} ({beat.get('verb')!r}) names "
+                f"evidence {path.name!r}, which was never written"
+            )
+            continue
+        size = path.stat().st_size
+        if size > MAX_EVIDENCE_FILE_BYTES:
+            failures.append(
+                f"{label}: {path.name} is {size} bytes, over the "
+                f"{MAX_EVIDENCE_FILE_BYTES}-byte ceiling — the per-field caps "
+                f"are not being applied"
+            )
+        try:
+            docs.append(json.loads(path.read_text()))
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            failures.append(f"{label}: {path.name} is not valid JSON: {exc}")
+    on_disk = sorted(p.name for p in directory.glob("*.json"))
+    named = sorted(Path(b["evidence"]).name for b in beats if b.get("evidence"))
+    if on_disk != named:
+        failures.append(
+            f"{label}: {EVIDENCE_DIR_NAME}/ holds {on_disk!r} but the beats "
+            f"name {named!r} — a beat captured nothing, or something was "
+            f"captured that no beat owns"
+        )
+    total = sum(p.stat().st_size for p in directory.glob("*.json"))
+    if total > MAX_EVIDENCE_DIR_BYTES:
+        failures.append(
+            f"{label}: {EVIDENCE_DIR_NAME}/ is {total // 1024} kB over "
+            f"{len(named)} beats, past the {MAX_EVIDENCE_DIR_BYTES // 1024} kB "
+            f"bar — evidence is meant to be capped, not to outgrow the mp4"
+        )
+    return beats, docs, failures
+
+
+def evidence_screen_text(doc: dict) -> str:
+    """Only the part of an evidence document that describes the *screen*.
+
+    Deliberately excludes the embedded beat record. Every caption is in
+    `beat.caption` already, so searching the whole file for one would pass on a
+    recorder that captured no page text at all — the assertion has to be about
+    what the page said, not about the log quoting itself.
+    """
+    return "\n".join(
+        str(doc.get(field) or "") for field in ("aria", "scope_aria", "html", "screen")
+    )
+
+
+def check_evidence(
+    label: str,
+    out_dir: Path,
+    expected: list[tuple[str, str, list[str], list[str]]],
+    scope: tuple[str, str, str] | None = None,
+) -> list[str]:
+    """Issue #9's acceptance criterion, made concrete.
+
+    "A reviewer given only the evidence files can state what was on screen
+    without seeing an image" is not something a test can assert as written, so
+    it is asserted as its consequence: named facts about the fixture app —
+    values, labels, table rows, command output — have to be readable in the
+    evidence for the beat that showed them, and the values the *previous*
+    screen showed have to be gone.
+    """
+    beats, docs, failures = evidence_docs(label, out_dir)
+    if not docs:
+        return failures
+
+    for position, (beat, doc) in enumerate(zip(beats, docs, strict=False)):
+        where = f"{label}: {EVIDENCE_DIR_NAME}/beat-{position:02d}.json"
+        if doc.get("schema") != EVIDENCE_SCHEMA_EXPECTED:
+            failures.append(
+                f"{where} says schema {doc.get('schema')!r}, expected "
+                f"{EVIDENCE_SCHEMA_EXPECTED!r}"
+            )
+        if doc.get("segment") is not None:
+            failures.append(f"{where} claims segment {doc.get('segment')!r}")
+        if doc.get("media") != "demo.mp4":
+            failures.append(f"{where} describes media {doc.get('media')!r}")
+        # The embedded beat has to be *this* beat. Without it every file could
+        # hold the same screen and every fact below would still be found
+        # somewhere.
+        stamped = doc.get("beat") or {}
+        for field in ("index", "verb", "selector", "caption", "t_start", "t_end"):
+            if stamped.get(field) != beat.get(field):
+                failures.append(
+                    f"{where} stamps beat {field}={stamped.get(field)!r}, but "
+                    f"timeline.json says {beat.get(field)!r}"
+                )
+        if not isinstance(doc.get("truncated"), list):
+            failures.append(
+                f"{where} has no `truncated` list — a reader cannot tell a "
+                f"short page from a cut-off one"
+            )
+
+    def find(verb: str, target: str) -> tuple[int, dict] | None:
+        hits = [
+            (i, doc)
+            for i, (beat, doc) in enumerate(zip(beats, docs, strict=False))
+            if beat.get("verb") == verb and beat.get("selector") == target
+        ]
+        if len(hits) != 1:
+            failures.append(
+                f"{label}: {len(hits)} beats are ({verb!r}, {target!r}), so the "
+                f"evidence facts written for it cannot be checked against one"
+            )
+            return None
+        return hits[0]
+
+    for verb, target, present, absent in expected:
+        hit = find(verb, target)
+        if hit is None:
+            continue
+        position, doc = hit
+        text = evidence_screen_text(doc)
+        if not text.strip():
+            failures.append(
+                f"{label}: beat {position} ({verb} {target!r}) captured no page "
+                f"text at all — `aria`/`screen` are empty, so nothing about "
+                f"what was on screen survived"
+            )
+            continue
+        missing = [s for s in present if s not in text]
+        if missing:
+            failures.append(
+                f"{label}: the evidence for beat {position} ({verb} {target!r}) "
+                f"does not say {missing!r} was on screen. A reviewer holding "
+                f"only this file cannot state what the frame showed, which is "
+                f"issue #9's acceptance criterion. Captured "
+                f"{len(text)} characters."
+            )
+        leaked = [s for s in absent if s in text]
+        if leaked:
+            failures.append(
+                f"{label}: the evidence for beat {position} ({verb} {target!r}) "
+                f"still says {leaked!r} was on screen, which belongs to an "
+                f"earlier state of the page — the capture is not per-beat, it "
+                f"is a stale dump reused across beats"
+            )
+
+    if scope is not None:
+        selector, inside, markup = scope
+        hit = find("spotlight", selector)
+        if hit is not None:
+            position, doc = hit
+            if doc.get("scope") != selector:
+                failures.append(
+                    f"{label}: beat {position} spotlights {selector!r} and its "
+                    f"evidence scopes to {doc.get('scope')!r} — issue #9 asks "
+                    f"for the capture to be scoped to the spotlight target"
+                )
+            for field, wanted in (("scope_aria", inside), ("html", markup)):
+                got = doc.get(field)
+                if not isinstance(got, str) or wanted not in got:
+                    failures.append(
+                        f"{label}: beat {position}'s evidence `{field}` is "
+                        f"{str(got)[:120]!r}, which does not contain {wanted!r} "
+                        f"— the spotlight target's own tree and markup are "
+                        f"what the scope is for"
+                    )
+        cleared = find("spotlight", None)  # type: ignore[arg-type]
+        if cleared is not None:
+            position, doc = cleared
+            if doc.get("scope") is not None or doc.get("html") is not None:
+                failures.append(
+                    f"{label}: beat {position} clears the spotlight, but its "
+                    f"evidence still scopes to {doc.get('scope')!r} with "
+                    f"markup attached — the scope outlives the highlight"
+                )
+
+    if not failures:
+        sizes = [
+            (out_dir / b["evidence"]).stat().st_size for b in beats if b.get("evidence")
+        ]
+        print(
+            f"smoke: {label} evidence ok ({len(docs)} beats, "
+            f"{sum(sizes) // 1024} kB, largest {max(sizes)} bytes)"
         )
     return failures
 
@@ -5136,6 +5527,7 @@ def run_web(out_root: Path) -> list[str]:
         )
         + check_timeline("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
         + check_beat_frames("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
+        + check_evidence("web", out_dir, WEB_EVIDENCE, WEB_EVIDENCE_SCOPE)
         + check_healthy("web", out_dir)
     )
 
@@ -7257,6 +7649,129 @@ def run_terminal_redaction(out_root: Path) -> list[str]:
     return problems + check_terminal_redaction(out_dir, info, started)
 
 
+def run_evidence_caps(out_root: Path) -> list[str]:
+    """A four-second take whose only job is the evidence size cap.
+
+    The fixture's whole ARIA tree is 2.3 kB against a 12 kB cap, so truncation
+    has to be provoked: 900 list items put both the page tree and the
+    spotlight target's markup well past their budgets. Graded on nothing else
+    — no video, no stills, no timeline beyond the evidence pointers.
+    """
+    from demo_recording import EVIDENCE_LIMITS, EVIDENCE_SCHEMA
+
+    failures: list[str] = []
+    # The package's own constants against the ones written above. Everything
+    # below is a statement about those numbers, so a cap quietly widened by ten
+    # has to fail here rather than pass by agreeing with itself.
+    if dict(EVIDENCE_LIMITS) != EVIDENCE_LIMITS_EXPECTED:
+        failures.append(
+            f"evidence-caps: the package caps evidence at {dict(EVIDENCE_LIMITS)!r}, "
+            f"this harness grades {EVIDENCE_LIMITS_EXPECTED!r} — one of them "
+            f"moved without the other"
+        )
+    if EVIDENCE_SCHEMA != EVIDENCE_SCHEMA_EXPECTED:
+        failures.append(
+            f"evidence-caps: the package exports EVIDENCE_SCHEMA "
+            f"{EVIDENCE_SCHEMA!r}, this harness grades "
+            f"{EVIDENCE_SCHEMA_EXPECTED!r}"
+        )
+
+    from demo_recording import Recorder
+
+    out_dir = fresh_take_dir(out_root, "evidence-caps")
+    with fixture_server() as base_url:
+        try:
+            with Recorder(out_dir, base_url=base_url, speech=False) as rec:
+                rec.goto("/")
+                rec.wait_for("#kpi-rev")
+                # Before the bloat. Its evidence must come back *un*truncated —
+                # a recorder that marked every field truncated would otherwise
+                # satisfy everything below.
+                rec.pause(0.2)
+                rec.page.evaluate(EVIDENCE_BLOAT_JS, EVIDENCE_BLOAT_ITEMS)
+                rec.spotlight(f"#{EVIDENCE_BLOAT_ID}")
+                rec.pause(0.2)
+        except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+            return failures + [
+                f"evidence-caps: Recorder raised {type(exc).__name__}: {exc}"
+            ]
+
+    beats, docs, problems = evidence_docs("evidence-caps", out_dir)
+    failures += problems
+    if not docs:
+        return failures
+    pauses = [
+        (i, doc)
+        for i, (beat, doc) in enumerate(zip(beats, docs, strict=False))
+        if beat.get("verb") == "pause"
+    ]
+    if len(pauses) != 2:
+        return failures + [
+            f"evidence-caps: {len(pauses)} pause beats, expected 2 (one before "
+            f"the bloat, one after) — the take is not the take this grades"
+        ]
+    (before_i, before), (after_i, after) = pauses
+
+    if before.get("truncated"):
+        failures.append(
+            f"evidence-caps: beat {before_i} ran before anything was appended "
+            f"to the page and its evidence is already marked truncated "
+            f"{before.get('truncated')!r} — the marker means nothing if it is "
+            f"always there"
+        )
+    if len(before.get("aria") or "") >= EVIDENCE_LIMITS_EXPECTED["aria"]:
+        failures.append(
+            f"evidence-caps: beat {before_i}'s aria is "
+            f"{len(before.get('aria') or '')} characters before the page was "
+            f"bloated, so the untruncated case is not being exercised"
+        )
+
+    for field in ("aria", "html"):
+        limit = EVIDENCE_LIMITS_EXPECTED[field]
+        text = after.get(field)
+        if not isinstance(text, str):
+            failures.append(
+                f"evidence-caps: beat {after_i} captured no `{field}` at all, "
+                f"so the cap on it is untested"
+            )
+            continue
+        if field not in (after.get("truncated") or []):
+            failures.append(
+                f"evidence-caps: beat {after_i}'s `{field}` is {len(text)} "
+                f"characters against a {limit} cap, and `truncated` is "
+                f"{after.get('truncated')!r} — it was cut and does not say so"
+            )
+        if EVIDENCE_MARKER not in text:
+            failures.append(
+                f"evidence-caps: beat {after_i}'s `{field}` was cut with no "
+                f"marker where it stops. It ends {text[-80:]!r}, which reads "
+                f"as a page that simply ended there."
+            )
+        # Cut *to* the budget, not merely somewhere under a ceiling: the marker
+        # is the only thing allowed past it.
+        allowed = limit + EVIDENCE_TRUNCATED_MAX
+        if not limit < len(text) <= allowed:
+            failures.append(
+                f"evidence-caps: beat {after_i}'s `{field}` is {len(text)} "
+                f"characters, expected the {limit}-character budget plus a "
+                f"marker (at most {allowed})"
+            )
+    if after.get("scope") != f"#{EVIDENCE_BLOAT_ID}":
+        failures.append(
+            f"evidence-caps: beat {after_i} scopes to {after.get('scope')!r}, "
+            f"expected the bloated element — its markup is what the html cap "
+            f"is being graded on"
+        )
+    if not failures:
+        print(
+            f"smoke: evidence-caps aria cut to "
+            f"{EVIDENCE_LIMITS_EXPECTED['aria']} and html to "
+            f"{EVIDENCE_LIMITS_EXPECTED['html']} characters, both marked "
+            f"(untruncated beat {before_i} left alone)"
+        )
+    return failures
+
+
 def run_terminal(out_root: Path) -> list[str]:
     if os.name != "posix":
         print(
@@ -7295,6 +7810,7 @@ def run_terminal(out_root: Path) -> list[str]:
         + check_beat_frames(
             "terminal", out_dir, started, TERMINAL_BEATS, TERMINAL_CAPTIONS, size
         )
+        + check_evidence("terminal", out_dir, TERMINAL_EVIDENCE)
         + check_healthy("terminal", out_dir)
     )
 
@@ -7398,6 +7914,7 @@ def main() -> int:
         if only in (None, "--web-only"):
             failures += run_web_problems(out_root)
             failures += run_strict_web(out_root)
+            failures += run_evidence_caps(out_root)
         if only in (None, "--terminal-only"):
             failures += run_terminal_problems(out_root)
             failures += run_terminal_race(out_root)

--- a/tests/smoke
+++ b/tests/smoke
@@ -84,6 +84,7 @@ import urllib.parse
 import urllib.request
 from collections.abc import Iterator
 from contextlib import contextmanager
+from html import unescape as html_unescape
 from pathlib import Path
 from typing import NamedTuple
 
@@ -295,6 +296,26 @@ TERMINAL_FAILING_COMMAND = "(exit 3)"
 # absent" from being a statement about an empty screen dump.
 TERMINAL_PRINTED_MARKER = "printed-below"
 TERMINAL_PRINTED_SECRET = "sk-live-PRNT00000000"
+
+# ...and the same, printed on a line long enough to **wrap**. `__termText()`
+# emits one xterm.js buffer row per line joined with newlines and never consults
+# `isWrapped`, so a credential that crosses the last column arrives split:
+# `"…sk-live-WRAP0000\n000000000000 wrapped-marker…"` — fully legible, and
+# recovered by anyone who pipes the file through `tr -d '\n'`. The mask missed
+# it, and so did the end-of-document backstop, which is the failure a backstop
+# exists to not have.
+#
+# The take before this one could never provoke it: `echo printed-below` plus a
+# 20-character secret is ~60 columns against a ~120-column terminal. A real
+# `env`, `aws configure get` or `curl -v` wraps every time. So this one is
+# padded to the measured width of the terminal, deliberately, and the padding
+# is computed at record time from `term.cols` rather than guessed.
+TERMINAL_WRAP_MARKER = "wrapped-marker"
+TERMINAL_WRAP_SECRET = "sk-live-WRAP0000000000000000"
+# How many characters of the secret land on the first row. Any value strictly
+# between 1 and len(secret) exercises the split; 8 keeps both halves long enough
+# to be obviously a fragment of one string in the failure message.
+TERMINAL_WRAP_HEAD = 8
 
 # The regression from the first round of review: two run()s with no wait
 # between them. The shell buffers the second command and runs it after the
@@ -939,11 +960,26 @@ EVIDENCE_BLOAT_JS = """(n) => {
 #   SLOT  light DOM slotted into a redacted shadow host — assigned into the
 #         subtree, not a descendant of it.
 #   VALU  an input value, which lives on the property and not the attribute.
-#   TICK  rewritten every 25 ms, so the harvest and the ARIA snapshot see
+#   TICK  rewritten every 5 ms, so the harvest and the ARIA snapshot see
 #         different values unless the capture refuses to straddle a repaint.
 #   ATTR  a data-* attribute nothing renders, reached only because the markup
 #         dump is a new surface this feature created.
 #   JSON  the same, inside a JSON blob in another attribute.
+#   HATT  mirrored into `title`, `data-value`, `aria-label` and an input value
+#         on siblings the take does not redact. The harvest read those when
+#         deciding what "renders in the clear", so any one of them exempted the
+#         key from masking everywhere — including timeline.json.
+#   HIDE  the same trick in CSS: an .sr-only clip, `opacity:0`,
+#         `visibility:hidden` and `left:-9999px`. `checkVisibility()` called
+#         with no arguments reports every one of them visible.
+#   AMPS  a registered secret containing `&`, which `outerHTML` writes as
+#         `&amp;`. The mask, the withhold fallback and the end-of-document
+#         backstop were all raw substring tests and all three missed it.
+#
+# HATT and HIDE are one literal per *family* rather than per channel, and that
+# is deliberate: every element in a family holds the same value, so a single
+# channel regressing puts that value back into `outside` and un-masks it
+# everywhere. One assertion covers four shapes and names the family it broke.
 EVIDENCE_SECRETS = {
     "the whitespace-padded key": "sk-live-WSPC00000000",
     "the key whose label also renders outside it": "sk-live-BLED00000000",
@@ -951,9 +987,12 @@ EVIDENCE_SECRETS = {
     "the accessible name sourced from outside the subtree": "sk-live-LBLD00000000",
     "the key slotted into a redacted shadow host": "sk-live-SLOT00000000",
     "the input value that lives on the property": "sk-live-VALU00000000",
-    "the key rewritten every 25 ms": "sk-live-TICK",
+    "the key rewritten every 5 ms": "sk-live-TICK",
     "the data-* attribute nothing renders": "sk-live-ATTR00000000",
     "the key inside a JSON attribute": "sk-live-JSON00000000",
+    "the key mirrored into attributes nothing paints": "sk-live-HATT00000000",
+    "the key mirrored into elements CSS hides": "sk-live-HIDE00000000",
+    "the registered secret an ampersand escapes": "sk-live-AMPS0000&sig=0000000000",
 }
 # The elements the take redacts, and the two it registers as text instead.
 # `#ev-spot-*` are deliberately **not** redacted: their values are registered
@@ -970,8 +1009,17 @@ EVIDENCE_REDACT = [
     "#ev-slot-inner",
     "#ev-value-card",
     "#ev-tick-card",
+    # The two whose values are mirrored *outside* them — into attributes on one
+    # hand, into CSS-hidden elements on the other. Neither mirror is redacted,
+    # which is the whole shape: `redact()` covers where a value renders, and
+    # the question is whether the recorder agrees with the browser about where
+    # that is.
+    "#ev-attr-card",
+    "#ev-hide-card",
 ]
-EVIDENCE_REGISTER = ["harborzenith7725"]
+# `harborzenith7725` is split across tags; the second contains an `&`, which
+# only exists in the markup as `&amp;`.
+EVIDENCE_REGISTER = ["harborzenith7725", "sk-live-AMPS0000&sig=0000000000"]
 
 # A caption naming a value that `redact()` covers and nobody registered. It is
 # not refused — correctly: `register_secret()` was never told about it, and the
@@ -980,7 +1028,22 @@ EVIDENCE_REGISTER = ["harborzenith7725"]
 # `timeline.md` are the two this skill tells people to commit. Without the
 # harvest reaching them, the same string is `[redacted]` in the evidence and in
 # the clear in the log beside it.
-EVIDENCE_BLEED_CAPTION = "The card shows sk-live-BLED00000000 today."
+#
+# It names *two* values, one from each family of leak, because the caption is
+# the only path by which a redacted value reaches the two committed files —
+# and B1's measured leak landed in both of them, not just in evidence/.
+#
+# It also quotes one of the EVIDENCE_KEEP sentences verbatim, which is not
+# decoration. A sticky caption is copied into `beat.caption` in every evidence
+# file that follows, so a `keep` assertion that searched whole files would find
+# that sentence in all of them with **zero** page text captured — the same
+# hollow shape found in `check_terminal_evidence_secret` last round. With the
+# sentence here, "the mask did not eat the app" and "the log quoted itself" are
+# distinguishable, and the assertion searches page text only.
+EVIDENCE_BLEED_CAPTION = (
+    "The card shows sk-live-BLED00000000, mirrored at sk-live-HIDE00000000. "
+    "Revenue for the quarter was steady, and the feed is live."
+)
 # Planted in evidence/ *before* the take, as if a previous recording into the
 # same folder had left it there. It must not survive.
 EVIDENCE_STALE_SECRET = "sk-live-STAL00000000"
@@ -1024,7 +1087,15 @@ EVIDENCE_KEEP = {
 #                   in the clear, and then withholds the markup as a
 #                   consolation. Elided markup is worth reading and withheld
 #                   markup is not, so the difference is graded.
+#   #ev-spot-amp    renders a registered secret containing an `&`. `outerHTML`
+#                   writes that as `&amp;`, so the markup holds the value in
+#                   full and matches no raw search — measured as a clean `aria`
+#                   reading `token=[redacted]` and a dirty `html` in the same
+#                   file. Nothing here asserts *which* way it comes out safe
+#                   (masked or withheld); the byte sweep asserts the value is
+#                   gone, which is the claim.
 EVIDENCE_SPLIT_TARGET = "#ev-spot-split"
+EVIDENCE_AMP_TARGET = "#ev-spot-amp"
 EVIDENCE_ATTR_TARGET = "#ev-spot-attrs"
 EVIDENCE_REDACTED_TARGET = "#ev-child-card"
 EVIDENCE_HTML_WITHHELD_MARKER = "[demo-video: markup withheld"
@@ -5338,7 +5409,7 @@ def check_redaction(out_dir: Path, info: dict, started_at: float) -> list[str]:
                 f"file."
             )
     for what, literal in REDACT_LITERALS.items():
-        holding = [p.name for p in evidence_files if literal in p.read_text()]
+        holding = [p.name for p in evidence_files if leaked_in(p.read_bytes(), literal)]
         if holding:
             failures.append(
                 f"redaction: {what} appears verbatim in the evidence files "
@@ -5356,7 +5427,7 @@ def check_redaction(out_dir: Path, info: dict, started_at: float) -> list[str]:
         swept += 1
         data = path.read_bytes()
         for what, literal in REDACT_LITERALS.items():
-            if literal.encode() in data:
+            if leaked_in(data, literal):
                 failures.append(
                     f"redaction: {what} appears verbatim in {path.relative_to(out_dir)}"
                 )
@@ -5456,6 +5527,38 @@ def evidence_docs(
             f"bar — evidence is meant to be capped, not to outgrow the mp4"
         )
     return beats, docs, failures
+
+
+def leaked_in(data: bytes, literal: str) -> bool:
+    """Is `literal` recoverable from these bytes by anyone who opens the file?
+
+    A byte search for the literal is not enough, and every extra form below is
+    a leak that walked past exactly such a search during review:
+
+      * **HTML entities.** `outerHTML` writes a registered
+        `sk-live-AMPS0000&sig=…` as `…&amp;sig=…`. The value is in the file
+        whole, and `literal.encode() in data` says it is not there.
+      * **Whitespace that is not in the value.** A terminal wraps a credential
+        at the last column and `__termText()` puts a newline through it;
+        `json.dumps` then writes that newline as the two characters `\\n`. Both
+        halves are legible and `tr -d '\\n'` reassembles them.
+
+    Deliberately *not* imported from `demo_recording`: a sweep that normalized
+    the same way the code under test normalizes would agree with it whatever it
+    did, which is the failure this whole file is arranged to avoid. These are
+    written out from what a reader can actually do to the file.
+    """
+    text = data.decode("utf-8", "replace")
+    recovered = html_unescape(
+        text.replace("\\n", "\n").replace("\\t", "\t").replace("\\r", "\r")
+    )
+    return (
+        literal in text
+        or literal in recovered
+        # Whitespace deleted, on both sides: the wrap put whitespace inside the
+        # value, so the value has to be squeezed too or the two never meet.
+        or re.sub(r"\s+", "", literal) in re.sub(r"\s+", "", recovered)
+    )
 
 
 def evidence_screen_text(doc: dict) -> str:
@@ -5818,7 +5921,9 @@ def check_terminal_evidence_secret(out_dir: Path) -> list[str]:
     files = sorted(directory.glob("*.json"))
     if not files:
         return ["terminal-problems: the take wrote no evidence at all"]
-    holding = sorted(p.name for p in files if TERMINAL_PRINTED_SECRET in p.read_text())
+    holding = sorted(
+        p.name for p in files if leaked_in(p.read_bytes(), TERMINAL_PRINTED_SECRET)
+    )
     if holding:
         failures.append(
             f"terminal-problems: a registered secret a command printed is "
@@ -5843,6 +5948,110 @@ def check_terminal_evidence_secret(out_dir: Path) -> list[str]:
         print(
             "smoke: terminal-problems a printed secret is masked out of the "
             "screen dump, and the line around it survives"
+        )
+    return failures
+
+
+def run_terminal_wrap(out_root: Path) -> list[str]:
+    """A registered secret printed across a terminal line wrap.
+
+    Its own take rather than another command in `terminal-problems/`, because
+    the line has to be as wide as the terminal and the terminal's width is
+    measured at record time — a beat whose `selector` is a command of
+    unpredictable length cannot be an entry in that take's hand-written
+    exit-code table.
+
+    **The transformation is the point.** `__termText()` walks the xterm.js
+    buffer a row at a time and joins with newlines, without consulting
+    `isWrapped`, so a credential crossing the last column is two rows and a
+    newline goes through the middle of it. `_evidence_re` used to be
+    `r"\\s+".join(tokens)` — elastic about whitespace the *literal* has and
+    exact about whitespace the *text* has — so it matched neither half, and the
+    end-of-document backstop was a plain `in` over `json.dumps` output, where
+    the newline is the two characters `\\n`, so it missed in the same
+    direction. Measured: the value legible in the file, recoverable with
+    `tr -d '\\n'`, and a second unwrapped occurrence on the same screen masked
+    to `[redacted]` right beside it.
+
+    Graded as a matched pair, and a third assertion for the premise: the take
+    computes where the secret lands and refuses to grade a line that did not
+    actually wrap, so this cannot quietly become a test of an ordinary echo.
+    """
+    if os.name != "posix":
+        return []
+    from demo_recording import TerminalRecorder
+
+    label = "terminal-wrap"
+    out_dir = fresh_take_dir(out_root, label)
+    failures: list[str] = []
+    geometry: dict = {}
+    try:
+        with TerminalRecorder(out_dir, speech=False) as rec:
+            rec.register_secret(TERMINAL_WRAP_SECRET)
+            cols = int(rec.page.evaluate("() => window.__term.cols"))
+            # The shell prints "<pad> <secret> <marker>" starting at column 0,
+            # so the secret starts at len(pad) + 1. Solve for the padding that
+            # puts TERMINAL_WRAP_HEAD of its characters before the boundary.
+            pad = "x" * max(0, cols - TERMINAL_WRAP_HEAD - 1)
+            line = f"{pad} {TERMINAL_WRAP_SECRET} {TERMINAL_WRAP_MARKER}"
+            geometry = {
+                "cols": cols,
+                "starts_at": len(pad) + 1,
+                "ends_at": len(pad) + 1 + len(TERMINAL_WRAP_SECRET),
+            }
+            rec.caption("A long line wraps.")
+            rec.run(f"echo {line}")
+            rec.wait_for_prompt(timeout_s=15)
+            rec.pause(0.4)
+    except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+        return [f"{label}: TerminalRecorder raised {type(exc).__name__}: {exc}"]
+
+    # The premise, arithmetic rather than hoped for.
+    if not (geometry["starts_at"] < geometry["cols"] < geometry["ends_at"]):
+        failures.append(
+            f"{label}: the secret occupies columns {geometry['starts_at']}-"
+            f"{geometry['ends_at']} of a {geometry['cols']}-column terminal, so "
+            f"the line did not wrap through it and nothing below is being "
+            f"exercised"
+        )
+
+    files = sorted((out_dir / EVIDENCE_DIR_NAME).glob("*.json"))
+    if not files:
+        return failures + [f"{label}: the take wrote no evidence at all"]
+    everything = sorted(p for p in out_dir.rglob("*") if p.is_file())
+    holding = sorted(
+        str(p.relative_to(out_dir))
+        for p in everything
+        if leaked_in(p.read_bytes(), TERMINAL_WRAP_SECRET)
+    )
+    if holding:
+        failures.append(
+            f"{label}: the registered secret is recoverable from {holding!r} — "
+            f"in one piece, or in the two the wrap left once the whitespace "
+            f"between them is deleted"
+        )
+    # ...and the half that catches the wrap. The literal is *not* in the file
+    # as written — a newline is sitting in the middle of it — so a search for
+    # it says nothing. Delete the whitespace and look again.
+    screens = "\n".join(evidence_screen_text(json.loads(p.read_text())) for p in files)
+    if TERMINAL_WRAP_SECRET in re.sub(r"\s+", "", screens):
+        failures.append(
+            f"{label}: the registered secret is recoverable from the screen "
+            f"dump by deleting whitespace — the terminal wrapped it and the "
+            f"mask compared against the unwrapped form. It is one `tr -d` from "
+            f"plaintext, in a file whose whole purpose is to be grepped."
+        )
+    if TERMINAL_WRAP_MARKER not in screens:
+        failures.append(
+            f"{label}: {TERMINAL_WRAP_MARKER!r} is in no evidence file's "
+            f"`screen`, so the line holding the secret was never captured and "
+            f"its absence proves nothing"
+        )
+    if not failures:
+        print(
+            f"smoke: {label} a registered secret split by a line wrap at column "
+            f"{geometry['cols']} (chars {geometry['starts_at']}-"
+            f"{geometry['ends_at']}) is masked in both halves"
         )
     return failures
 
@@ -8107,7 +8316,7 @@ def run_evidence(out_root: Path) -> list[str]:
                 rec.goto("/?evidence=1")
                 rec.wait_for("#ev-ws-key")
                 # Two beats while #ev-tick-card is still rewriting itself every
-                # 25 ms. The capture reads the page three times (harvest,
+                # 5 ms. The capture reads the page three times (harvest,
                 # snapshot, harvest) and that window is wider than the interval,
                 # so the mask cannot be built from what the snapshot saw — and
                 # the right answer is to write no page text, not to write text
@@ -8136,6 +8345,11 @@ def run_evidence(out_root: Path) -> list[str]:
                 rec.spotlight(EVIDENCE_ATTR_TARGET)
                 rec.pause(0.3)
                 rec.spotlight(EVIDENCE_REDACTED_TARGET)
+                rec.pause(0.3)
+                # ...and a registered value the serializer escapes on its way
+                # into `html`. Nothing else on this page puts a character with
+                # an entity form inside a secret.
+                rec.spotlight(EVIDENCE_AMP_TARGET)
                 rec.pause(0.3)
                 rec.spotlight()
 
@@ -8183,9 +8397,9 @@ def run_evidence(out_root: Path) -> list[str]:
         for i, (beat, doc) in enumerate(zip(beats, docs, strict=False))
         if beat.get("verb") == "pause"
     ]
-    if len(pauses) != 7:
+    if len(pauses) != 8:
         return failures + [
-            f"{label}: {len(pauses)} pause beats, expected 7 — the take is not "
+            f"{label}: {len(pauses)} pause beats, expected 8 — the take is not "
             f"the take this grades"
         ]
     ticking = pauses[:2]
@@ -8193,7 +8407,8 @@ def run_evidence(out_root: Path) -> list[str]:
     split_i, split = pauses[3]
     attrs_i, attrs = pauses[4]
     elided_i, elided = pauses[5]
-    capped_i, capped = pauses[6]
+    amp_i, amp = pauses[6]
+    capped_i, capped = pauses[7]
 
     # -- the leak shapes -----------------------------------------------------
     #
@@ -8202,6 +8417,16 @@ def run_evidence(out_root: Path) -> list[str]:
     # everything, or captured nothing.
     written = sorted((out_dir / EVIDENCE_DIR_NAME).glob("*.json"))
     blob = "\n".join(p.read_text() for p in written)
+    # The `keep` half is searched in the **page text only**, the same way
+    # `check_evidence` and `check_terminal_evidence_secret` search theirs, and
+    # for the same reason: every one of these strings is also in a caption or a
+    # selector somewhere in the embedded beat record, so searching the whole
+    # file would find them whether or not a character of the page was captured.
+    # Sound over the whole file today by luck. The absence half stays broad —
+    # "this credential is in none of these bytes" is a claim about every byte.
+    screens = "\n".join(
+        evidence_screen_text(json.loads(p.read_text())) for p in written
+    )
     # Every file the take wrote, not only the evidence — `timeline.json` and
     # `timeline.md` are the ones this skill tells people to *commit*, and the
     # harvest that keeps a redacted value out of the evidence has to reach them
@@ -8211,7 +8436,7 @@ def run_evidence(out_root: Path) -> list[str]:
         holding = sorted(
             str(p.relative_to(out_dir))
             for p in everything
-            if literal.encode() in p.read_bytes()
+            if leaked_in(p.read_bytes(), literal)
         )
         if holding:
             failures.append(
@@ -8221,10 +8446,10 @@ def run_evidence(out_root: Path) -> list[str]:
                 f"anything about a picture."
             )
     for what, literal in EVIDENCE_KEEP.items():
-        if literal not in blob:
+        if literal not in screens:
             failures.append(
-                f"{label}: {what} ({literal!r}) is in none of the evidence "
-                f"files. It renders outside everything redact() covers, so "
+                f"{label}: {what} ({literal!r}) is in no evidence file's page "
+                f"text. It renders outside everything redact() covers, so "
                 f"either the capture wrote no page text — which makes every "
                 f"assertion above a statement about an empty file — or the "
                 f"mask went wide enough to eat the app it was documenting."
@@ -8236,7 +8461,7 @@ def run_evidence(out_root: Path) -> list[str]:
         failures.append(
             f"{label}: neither beat {ticking[0][0]} nor {ticking[1][0]} refused "
             f"to capture, and both ran while a redacted card was being "
-            f"rewritten every 25 ms — faster than the three round trips a "
+            f"rewritten every 5 ms — faster than the three round trips a "
             f"capture takes. One of them has to come back `omitted`, or the "
             f"mask is being built from a value the snapshot did not see."
         )
@@ -8345,6 +8570,34 @@ def run_evidence(out_root: Path) -> list[str]:
             f"subtree; markup that kept the subtree and masked only the "
             f"strings in it is elided wherever the mask happened to reach and "
             f"in the clear everywhere else."
+        )
+
+    # -- markup: an entity form is still the value ---------------------------
+    #
+    # The byte sweep above is what grades the leak; this grades the *premise*,
+    # which the sweep cannot. `sk-live-AMPS0000&sig=…` is absent from a file
+    # that never captured the element at all, so without this the whole shape
+    # is satisfied by a null `html`.
+    if amp.get("scope") != EVIDENCE_AMP_TARGET:
+        failures.append(
+            f"{label}: beat {amp_i} scopes to {amp.get('scope')!r}, expected "
+            f"{EVIDENCE_AMP_TARGET!r} — the entity-escaping shape is not being "
+            f"captured, so the sweep's silence about it says nothing"
+        )
+    amp_html = str(amp.get("html") or "")
+    if not amp_html:
+        failures.append(
+            f"{label}: beat {amp_i} captured no `html` at all, so the value "
+            f"`outerHTML` escapes was never serialized and nothing about entity "
+            f"forms is being graded"
+        )
+    elif EVIDENCE_HTML_WITHHELD_MARKER not in amp_html and "&amp;" in amp_html:
+        failures.append(
+            f"{label}: beat {amp_i}'s `html` is {amp_html[:160]!r} — it still "
+            f"carries an escaped ampersand, so a registered secret spelled with "
+            f"one is being published in a form no raw search finds. The mask, "
+            f"the withhold fallback and the backstop must all resolve entities "
+            f"before deciding."
         )
 
     # -- the caps ------------------------------------------------------------
@@ -8597,6 +8850,7 @@ def main() -> int:
             failures += run_evidence(out_root)
         if only in (None, "--terminal-only"):
             failures += run_terminal_problems(out_root)
+            failures += run_terminal_wrap(out_root)
             failures += run_terminal_race(out_root)
             failures += run_strict_terminal(out_root)
         # Both flags reach it: it is a terminal take and a redaction take, and

--- a/tests/smoke
+++ b/tests/smoke
@@ -290,13 +290,6 @@ BETWEEN_BEATS_JS = "() => console.error('__M__')".replace("__M__", BETWEEN_BEATS
 # went wrong" inferred from any other signal.
 TERMINAL_FAILING_COMMAND = "(exit 3)"
 
-# A secret a *command prints*, and a plain marker printed beside it. The
-# terminal has no redact() (issue #5), so `register_secret()` is the whole
-# defence for its evidence — and the marker is what keeps "the secret is
-# absent" from being a statement about an empty screen dump.
-TERMINAL_PRINTED_MARKER = "printed-below"
-TERMINAL_PRINTED_SECRET = "sk-live-PRNT00000000"
-
 # ...and the same, printed on a line long enough to **wrap**. `__termText()`
 # emits one xterm.js buffer row per line joined with newlines and never consults
 # `isWrapped`, so a credential that crosses the last column arrives split:
@@ -311,7 +304,14 @@ TERMINAL_PRINTED_SECRET = "sk-live-PRNT00000000"
 # padded to the measured width of the terminal, deliberately, and the padding
 # is computed at record time from `term.cols` rather than guessed.
 TERMINAL_WRAP_MARKER = "wrapped-marker"
-TERMINAL_WRAP_SECRET = "sk-live-WRAP0000000000000000"
+# `zz-wrap-`, not `sk-live-`, and that is forced rather than stylistic. The
+# stream scrubber (#5) carries a shape net — `sk-[A-Za-z0-9_-]{16,}` among
+# others — which masks an `sk-live-` value on its way past whether or not
+# anyone registered it, so such a value can never reach the xterm buffer and
+# this shape cannot exist with one. `zz-` matches no shape, exactly as #58's
+# own `TCTL` control does, which is what lets it render and then wrap.
+# Twenty-eight characters, so the geometry below is the same arithmetic.
+TERMINAL_WRAP_SECRET = "zz-wrap-00000000000000000000"
 # How many characters of the secret land on the first row. Any value strictly
 # between 1 and len(secret) exercises the split; 8 keeps both halves long enough
 # to be obviously a fragment of one string in the failure message.
@@ -341,14 +341,6 @@ TERMINAL_RACE_SHELL = '#!/bin/sh\nsleep __DELAY__\nexec /bin/bash "$@"\n'
 # beat. Hand-written, like the beat lists: derived from the log it grades, it
 # would agree with the log no matter what the log said.
 TERMINAL_PROBLEM_EXIT_CODES = {
-    # The beat's `selector` is the command as *logged*, and the secret in it
-    # was registered before it was typed — so the timeline records the mask,
-    # not the value. `[redacted]` is core.py's SECRET_MASK, written out by hand
-    # for the same reason every other expectation in this file is: a value read
-    # off the code being graded agrees with it whatever it says. That this beat
-    # is here at all is a second assertion — the command a run() logs has to
-    # survive being scrubbed.
-    f"echo {TERMINAL_PRINTED_MARKER} [redacted]": 0,
     "echo ok": 0,
     TERMINAL_FAILING_COMMAND: 3,
     TERMINAL_UNWAITED[0]: 0,
@@ -969,14 +961,14 @@ EVIDENCE_BLOAT_JS = """(n) => {
 #         on siblings the take does not redact. The harvest read those when
 #         deciding what "renders in the clear", so any one of them exempted the
 #         key from masking everywhere — including timeline.json.
-#   HIDE  the same trick in CSS: an .sr-only clip, `opacity:0`,
+#   VEIL  the same trick in CSS: an .sr-only clip, `opacity:0`,
 #         `visibility:hidden` and `left:-9999px`. `checkVisibility()` called
 #         with no arguments reports every one of them visible.
 #   AMPS  a registered secret containing `&`, which `outerHTML` writes as
 #         `&amp;`. The mask, the withhold fallback and the end-of-document
 #         backstop were all raw substring tests and all three missed it.
 #
-# HATT and HIDE are one literal per *family* rather than per channel, and that
+# HATT and VEIL are one literal per *family* rather than per channel, and that
 # is deliberate: every element in a family holds the same value, so a single
 # channel regressing puts that value back into `outside` and un-masks it
 # everywhere. One assertion covers four shapes and names the family it broke.
@@ -991,7 +983,7 @@ EVIDENCE_SECRETS = {
     "the data-* attribute nothing renders": "sk-live-ATTR00000000",
     "the key inside a JSON attribute": "sk-live-JSON00000000",
     "the key mirrored into attributes nothing paints": "sk-live-HATT00000000",
-    "the key mirrored into elements CSS hides": "sk-live-HIDE00000000",
+    "the key mirrored into elements CSS hides": "sk-live-VEIL00000000",
     "the registered secret an ampersand escapes": "sk-live-AMPS0000&sig=0000000000",
 }
 # The elements the take redacts, and the two it registers as text instead.
@@ -1015,7 +1007,7 @@ EVIDENCE_REDACT = [
     # the question is whether the recorder agrees with the browser about where
     # that is.
     "#ev-attr-card",
-    "#ev-hide-card",
+    "#ev-veil-card",
 ]
 # `harborzenith7725` is split across tags; the second contains an `&`, which
 # only exists in the markup as `&amp;`.
@@ -1037,11 +1029,11 @@ EVIDENCE_REGISTER = ["harborzenith7725", "sk-live-AMPS0000&sig=0000000000"]
 # decoration. A sticky caption is copied into `beat.caption` in every evidence
 # file that follows, so a `keep` assertion that searched whole files would find
 # that sentence in all of them with **zero** page text captured — the same
-# hollow shape found in `check_terminal_evidence_secret` last round. With the
+# hollow shape found in the terminal's own screen assertion last round. With the
 # sentence here, "the mask did not eat the app" and "the log quoted itself" are
 # distinguishable, and the assertion searches page text only.
 EVIDENCE_BLEED_CAPTION = (
-    "The card shows sk-live-BLED00000000, mirrored at sk-live-HIDE00000000. "
+    "The card shows sk-live-BLED00000000, mirrored at sk-live-VEIL00000000. "
     "Revenue for the quarter was steady, and the feed is live."
 )
 # Planted in evidence/ *before* the take, as if a previous recording into the
@@ -5895,163 +5887,129 @@ def run_web_problems(out_root: Path) -> list[str]:
     return check_issues("web-problems", out_dir, WEB_PROBLEM_ISSUES)
 
 
-def check_terminal_evidence_secret(out_dir: Path) -> list[str]:
-    """A registered secret a command *printed* must not survive in `screen`.
-
-    The terminal's evidence is the whole rendered buffer, and it is the only
-    medium here with no `redact()` at all (issue #5) — so `register_secret()`
-    is the entire defence, and it has to be shown reaching the screen dump.
-    The word printed beside the secret is the anti-vacuity half: it is on the
-    same screen, it is not a secret, and a capture that wrote nothing satisfies
-    "the secret is absent" perfectly.
-
-    That half is looked for in **`screen` only**, never in the whole file. The
-    beat record embedded alongside carries the command as logged, and the
-    marker is a word in that command — so searching the file finds it whether
-    or not a single character of the terminal was captured. Written the easy
-    way first, and an injected `{"screen": ""}` payload was measured passing
-    it.
-
-    The secret is searched the other way round, over the whole file: the
-    absence of a credential is a claim about every byte written, not about one
-    field.
-    """
-    failures: list[str] = []
-    directory = out_dir / EVIDENCE_DIR_NAME
-    files = sorted(directory.glob("*.json"))
-    if not files:
-        return ["terminal-problems: the take wrote no evidence at all"]
-    holding = sorted(
-        p.name for p in files if leaked_in(p.read_bytes(), TERMINAL_PRINTED_SECRET)
-    )
-    if holding:
-        failures.append(
-            f"terminal-problems: a registered secret a command printed is "
-            f"readable in {holding!r}. TerminalRecorder has no redact(), so "
-            f"register_secret() is the only thing between a printed credential "
-            f"and this file."
-        )
-    screens = []
-    for path in files:
-        try:
-            screens.append(evidence_screen_text(json.loads(path.read_text())))
-        except (json.JSONDecodeError, UnicodeDecodeError):
-            failures.append(f"terminal-problems: {path.name} is not valid JSON")
-    if TERMINAL_PRINTED_MARKER not in "\n".join(screens):
-        failures.append(
-            f"terminal-problems: {TERMINAL_PRINTED_MARKER!r} is in no evidence "
-            f"file's `screen`, so the terminal holding the secret was never "
-            f"captured and its absence proves nothing. It is printed on the "
-            f"same line as the secret, so a screen dump that has one has both."
-        )
-    if not failures:
-        print(
-            "smoke: terminal-problems a printed secret is masked out of the "
-            "screen dump, and the line around it survives"
-        )
-    return failures
-
-
 def run_terminal_wrap(out_root: Path) -> list[str]:
-    """A registered secret printed across a terminal line wrap.
+    """A registered secret split by a line wrap must still be refused.
 
-    Its own take rather than another command in `terminal-problems/`, because
-    the line has to be as wide as the terminal and the terminal's width is
-    measured at record time — a beat whose `selector` is a command of
-    unpredictable length cannot be an entry in that take's hand-written
-    exit-code table.
+    Two mechanisms miss the same value for the same reason, and this take is
+    what makes them agree. `_screen()` walks the xterm.js buffer a row at a
+    time and joins with newlines without consulting `isWrapped`, so a
+    credential crossing the last column is two rows with a newline through the
+    middle: contiguous to a viewer, contiguous in the frames, and a substring
+    of nothing. `_verify_redaction_final()` — the check that decides whether
+    the mp4 may be written at all — asked `secret in screen`, and the evidence
+    mask asked the same question the same way. Both said no.
 
-    **The transformation is the point.** `__termText()` walks the xterm.js
-    buffer a row at a time and joins with newlines, without consulting
-    `isWrapped`, so a credential crossing the last column is two rows and a
-    newline goes through the middle of it. `_evidence_re` used to be
-    `r"\\s+".join(tokens)` — elastic about whitespace the *literal* has and
-    exact about whitespace the *text* has — so it matched neither half, and the
-    end-of-document backstop was a plain `in` over `json.dumps` output, where
-    the newline is the two characters `\\n`, so it missed in the same
-    direction. Measured: the value legible in the file, recoverable with
-    `tr -d '\\n'`, and a second unwrapped occurrence on the same screen masked
-    to `[redacted]` right beside it.
+    **Late registration is how the value gets onto the screen at all**, and it
+    is not a contrivance. The stream scrubber (#5) masks what it knows about
+    while the bytes go past, so a value registered up front never reaches the
+    buffer and this shape cannot exist. Registering *after* the command has
+    printed is the ordinary shape of the mistake: a token rotates into output
+    before the storyboard names it, or the author adds `register_secret()` on
+    the second run-through. What is on screen at the end of the take is what
+    is in the frames, whenever it was registered — which is exactly what the
+    final check is for.
 
-    Graded as a matched pair, and a third assertion for the premise: the take
-    computes where the secret lands and refuses to grade a line that did not
-    actually wrap, so this cannot quietly become a test of an ordinary echo.
+    Printed from a **script**, not a `run()` argument: a command line is
+    echoed, and typing the value into one trips `run()`'s own guard (#5) and
+    puts it in the frames by a path this take is not about. Same reasoning as
+    `term_printer_script()`.
+
+    Graded on the refusal and on what it kept: `SKILL.md` promises a
+    `SecretLeak` keeps nothing, and the geometry is asserted first so a take
+    that quietly stopped wrapping fails loudly rather than passing as a test
+    of an ordinary echo.
     """
     if os.name != "posix":
         return []
-    from demo_recording import TerminalRecorder
+    from demo_recording import SecretLeak, TerminalRecorder
 
     label = "terminal-wrap"
     out_dir = fresh_take_dir(out_root, label)
     failures: list[str] = []
     geometry: dict = {}
+    raised: BaseException | None = None
+    # Outside the take directory, so the "nothing was kept" sweep below grades
+    # what the recorder wrote and not what this harness did. The shell starts
+    # in the process cwd, so this is a chdir, the same way
+    # `run_terminal_redaction` reaches `./print-secrets`.
+    work_dir = Path(tempfile.mkdtemp(prefix="smoke-wrap-"))
+    script = work_dir / "print-wrapped"
+    previous = Path.cwd()
+    os.chdir(work_dir)
     try:
         with TerminalRecorder(out_dir, speech=False) as rec:
-            rec.register_secret(TERMINAL_WRAP_SECRET)
             cols = int(rec.page.evaluate("() => window.__term.cols"))
-            # The shell prints "<pad> <secret> <marker>" starting at column 0,
-            # so the secret starts at len(pad) + 1. Solve for the padding that
-            # puts TERMINAL_WRAP_HEAD of its characters before the boundary.
+            # The script prints "<pad> <secret> <marker>" from column 0, so the
+            # secret starts at len(pad) + 1. Solve for the padding that puts
+            # TERMINAL_WRAP_HEAD of its characters before the boundary.
             pad = "x" * max(0, cols - TERMINAL_WRAP_HEAD - 1)
-            line = f"{pad} {TERMINAL_WRAP_SECRET} {TERMINAL_WRAP_MARKER}"
             geometry = {
                 "cols": cols,
                 "starts_at": len(pad) + 1,
                 "ends_at": len(pad) + 1 + len(TERMINAL_WRAP_SECRET),
             }
+            script.write_text(
+                f"#!/bin/sh\nprintf '%s %s %s\\n' "
+                f"'{pad}' '{TERMINAL_WRAP_SECRET}' '{TERMINAL_WRAP_MARKER}'\n"
+            )
+            script.chmod(0o755)
             rec.caption("A long line wraps.")
-            rec.run(f"echo {line}")
+            rec.run("./print-wrapped")
             rec.wait_for_prompt(timeout_s=15)
             rec.pause(0.4)
-    except Exception as exc:  # noqa: BLE001 - a raising take is a failure
-        return [f"{label}: TerminalRecorder raised {type(exc).__name__}: {exc}"]
+            # ...and only now is it a secret. The scrubber never saw it, so it
+            # is on the screen, wrapped, and the final check is the only thing
+            # left between it and a written mp4.
+            rec.register_secret(TERMINAL_WRAP_SECRET)
+    except SecretLeak as leak:
+        raised = leak
+    except Exception as exc:  # noqa: BLE001 - any other verdict is a failure
+        return [f"{label}: expected SecretLeak, got {type(exc).__name__}: {exc}"]
+    finally:
+        os.chdir(previous)
+        shutil.rmtree(work_dir, ignore_errors=True)
 
     # The premise, arithmetic rather than hoped for.
-    if not (geometry["starts_at"] < geometry["cols"] < geometry["ends_at"]):
+    if not geometry or not (
+        geometry["starts_at"] < geometry["cols"] < geometry["ends_at"]
+    ):
         failures.append(
-            f"{label}: the secret occupies columns {geometry['starts_at']}-"
-            f"{geometry['ends_at']} of a {geometry['cols']}-column terminal, so "
-            f"the line did not wrap through it and nothing below is being "
-            f"exercised"
+            f"{label}: the secret occupies columns {geometry.get('starts_at')}-"
+            f"{geometry.get('ends_at')} of a {geometry.get('cols')}-column "
+            f"terminal, so the line did not wrap through it and nothing below "
+            f"is being exercised"
         )
-
-    files = sorted((out_dir / EVIDENCE_DIR_NAME).glob("*.json"))
-    if not files:
-        return failures + [f"{label}: the take wrote no evidence at all"]
-    everything = sorted(p for p in out_dir.rglob("*") if p.is_file())
-    holding = sorted(
-        str(p.relative_to(out_dir))
-        for p in everything
-        if leaked_in(p.read_bytes(), TERMINAL_WRAP_SECRET)
+    if raised is None:
+        failures.append(
+            f"{label}: a registered secret was on the terminal screen at the "
+            f"end of the take, split across a line wrap, and the take finished "
+            f"cleanly. `_screen()` joins buffer rows with newlines and does not "
+            f"consult isWrapped, so `secret in screen` sees neither half — and "
+            f"the value is in the frames whole."
+        )
+    elif str(len(TERMINAL_WRAP_SECRET)) not in str(raised):
+        failures.append(
+            f"{label}: the take was refused with {str(raised)[:120]!r}, which "
+            f"does not name the {len(TERMINAL_WRAP_SECRET)}-character value "
+            f"this take planted — something else refused it and the wrap was "
+            f"never reached"
+        )
+    left = sorted(
+        str(q.relative_to(out_dir))
+        for q in out_dir.rglob("*")
+        if q.is_file() and q.name != MARKER_NAME
     )
-    if holding:
+    if left:
         failures.append(
-            f"{label}: the registered secret is recoverable from {holding!r} — "
-            f"in one piece, or in the two the wrap left once the whitespace "
-            f"between them is deleted"
-        )
-    # ...and the half that catches the wrap. The literal is *not* in the file
-    # as written — a newline is sitting in the middle of it — so a search for
-    # it says nothing. Delete the whitespace and look again.
-    screens = "\n".join(evidence_screen_text(json.loads(p.read_text())) for p in files)
-    if TERMINAL_WRAP_SECRET in re.sub(r"\s+", "", screens):
-        failures.append(
-            f"{label}: the registered secret is recoverable from the screen "
-            f"dump by deleting whitespace — the terminal wrapped it and the "
-            f"mask compared against the unwrapped form. It is one `tr -d` from "
-            f"plaintext, in a file whose whole purpose is to be grepped."
-        )
-    if TERMINAL_WRAP_MARKER not in screens:
-        failures.append(
-            f"{label}: {TERMINAL_WRAP_MARKER!r} is in no evidence file's "
-            f"`screen`, so the line holding the secret was never captured and "
-            f"its absence proves nothing"
+            f"{label}: {left!r} survived a take refused for a secret on screen. "
+            f"SKILL.md says a SecretLeak keeps nothing, and a terminal still is "
+            f"the raw screen."
         )
     if not failures:
         print(
             f"smoke: {label} a registered secret split by a line wrap at column "
             f"{geometry['cols']} (chars {geometry['starts_at']}-"
-            f"{geometry['ends_at']}) is masked in both halves"
+            f"{geometry['ends_at']}) is still refused, and keeps nothing"
         )
     return failures
 
@@ -6066,12 +6024,6 @@ def run_terminal_problems(out_root: Path) -> list[str]:
     try:
         with TerminalRecorder(out_dir, speech=False) as rec:
             rec.caption("Exit codes are recorded.")
-            # A secret a *command prints*. Registered before it is echoed, so
-            # the only thing that can keep it out of the screen dump is the
-            # writer applying `register_secret()` to the terminal payload.
-            rec.register_secret(TERMINAL_PRINTED_SECRET)
-            rec.run(f"echo {TERMINAL_PRINTED_MARKER} {TERMINAL_PRINTED_SECRET}")
-            rec.wait_for_prompt(timeout_s=15)
             rec.run("echo ok")
             rec.wait_for_prompt(timeout_s=15)
             rec.run(TERMINAL_FAILING_COMMAND)
@@ -6091,7 +6043,7 @@ def run_terminal_problems(out_root: Path) -> list[str]:
         out_dir,
         TERMINAL_PROBLEM_ISSUES,
         exit_codes=TERMINAL_PROBLEM_EXIT_CODES,
-    ) + check_terminal_evidence_secret(out_dir)
+    )
 
 
 def run_terminal_race(out_root: Path) -> list[str]:
@@ -7848,11 +7800,11 @@ def check_terminal_redaction(out_dir: Path, info: dict, started_at: float) -> li
         # positively: "no beat holds the secret" is equally true of a log that
         # dropped the beats.
         masked = [b for b in beats if SECRET_MASK in (b.get("selector") or "")]
-        if len(masked) != 2:
+        if len(masked) != 3:
             failures.append(
                 f"terminal-redaction: {len(masked)} beats carry a scrubbed "
-                f"selector, expected 2 — the refused run() and the refused "
-                f"send() each held a registered value. Selectors logged: "
+                f"selector, expected 3 — the refused run(), the refused send(), "
+                f"and the refused key(). Selectors logged: "
                 f"{[b.get('selector') for b in beats]!r}"
             )
         sent = [b for b in beats if b.get("verb") == "send"]
@@ -8418,7 +8370,7 @@ def run_evidence(out_root: Path) -> list[str]:
     written = sorted((out_dir / EVIDENCE_DIR_NAME).glob("*.json"))
     blob = "\n".join(p.read_text() for p in written)
     # The `keep` half is searched in the **page text only**, the same way
-    # `check_evidence` and `check_terminal_evidence_secret` search theirs, and
+    # `check_evidence` and `run_terminal_wrap` search theirs, and
     # for the same reason: every one of these strings is also in a caption or a
     # selector somewhere in the embedded beat record, so searching the whole
     # file would find them whether or not a character of the page was captured.


### PR DESCRIPTION
Fixes #9.

A reviewing agent infers DOM state from pixels. The recorder is driving the
page — it has the real thing, and the round trip through images is lossy and
expensive.

Writes `evidence/beat-NN.json` per beat: an ARIA snapshot, the spotlight
target's `outerHTML`, and for `TerminalRecorder` the ANSI-stripped screen.

## Spec correction

The issue names `page.accessibility.snapshot()`. **That API no longer exists**
— removed from Playwright (verified: `Accessibility` is not importable from
`playwright.sync_api` at 1.61). Uses `locator.aria_snapshot()`, its successor,
which is what the issue actually asked for ("semantic, compact, stable across
restyling"). No fallback branch — an older Playwright gets `aria: null` and an
`aria_format` saying why, rather than a second code path nothing can exercise.
`tests/smoke` pins `playwright>=1.49`.

`outerHTML` is only ever the spotlight target's, never the page's: body markup
measured 24 kB against 2.3 kB of ARIA, and carried inline `<script>` text and
`srcdoc` attributes — source code and whole embedded documents nobody put on
screen.

## Evidence is a fifth leak path, and it needed its own mechanism

`redact()` covers *pixels*. The value stays in the DOM. Evidence dumps the DOM.
`register_secret()` does not help, because `redact()` never tells the recorder
what the element says.

So `_redacted_rendered_text()` reads it out of the page at every capture —
everything matching a registered selector or the mask's marker, walking every
node in the subtree, shadow roots at every depth, `::before`/`::after` computed
content, input values and value-bearing attributes, across every frame. That
union is applied to all beats on the way out, so a value first seen at beat 20
is masked out of beat 3.

Harvesting only the element the selector matched **left 3 of the fixture's 8
keys in the clear** — a value in a redacted *wrapper*, one in a `::after`, and
one two shadow roots down. Markup also needs structural elision:
`sk-live-<b>FAKE</b>` has a `textContent` a string mask finds and an
`outerHTML` it does not.

Masking runs **before** capping, deliberately: capping first can cut a secret
in half and leave a prefix no substring search finds.

## Proof

The byte sweep requires all 13 secrets absent **and both unredacted controls
present** — otherwise "no secret appears" is a statement about an empty
directory:

```
smoke: redaction none of the 13 secrets appears verbatim in any of the 45 files
the take wrote (31 of them per-beat evidence, which the controls prove is not empty)
```

With the harvest disabled, exactly the seven values that only `redact()` covers
leak into 26 files each while the two *registered* ones stay masked — the
asymmetry, demonstrated.

Twelve fault injections, each watched fail.

## Not committed

`evidence/` is gitignored: greppable plaintext of a real app's DOM, regenerated
wholesale per take, and git cannot be made to forget it. `timeline.json`/`.md`
remain the committed record.

## #22

Settled at no cost to #7: the segment goes in the filename and the path is
written **onto the beat** as `evidence` rather than derived from `index`.
SKILL.md says "read the pointer, never rebuild it". #7 renumbers freely.

Filed: #47, #48, #49, #50.