### PR TITLE
stitch() merges per-segment timelines with corrected offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ __pycache__/
 .tts/
 *.seg.mp4
 # Per-segment beat logs. The merged timeline.json/timeline.md next to
-# demo.mp4 is committed; these are the parts it is built from.
+# demo.mp4 is committed; these are the parts it is built from, and stitch()
+# deletes them with their .seg.mp4 unless it was passed keep_parts=True.
 *.seg.timeline.json
 *.seg.timeline.md
 # Left behind only when a take crashes before the recorder cleans up.

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ tests/out/
 
 # Best practice
 .env
+
+# ffmpeg concat listing, written and removed by stitch()
+.concat.txt

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -550,6 +550,16 @@ at the top level carry the value every segment agrees on — `"mixed"`, and
 `null` per key, where they do not; the per-segment truth is in `segments`. A
 timeline a single take wrote has no `segments` key at all.
 
+`stitch()` refuses before it encodes anything if the parts cannot honestly be
+joined: a missing or unreadable `.seg.mp4`, a beat log of the wrong schema or
+one written for a *different recording* of that segment, or parts that
+disagree on codec, resolution, frame rate or having an audio track.
+`concat -c copy` accepts all of those and exits 0, and the damage is invisible
+afterwards — a frame-rate mismatch moves every later beat away from its frame,
+a resolution mismatch keeps the first part's dimensions, and one silent part
+makes concat drop every later part's narration. Recording every segment with
+the same `Recorder` settings is what keeps you clear of it.
+
 ## Failing the take on a broken app
 
 **A demo that looks perfect while the app throws `TypeError` on every render

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -35,7 +35,7 @@ Each demo gets one folder (suggested: `docs/guides/<YYYY-MM-DD>-<slug>/`):
 |---|---|---|
 | `record.py` | The storyboard that produced the media (re-runnable) | yes |
 | `images/*.png` | Stills captured at key moments | yes |
-| `timeline.json` | The beat log — every verb, when it ran, what caption was up | yes |
+| `timeline.json` | The beat log — every verb, when it ran, what caption was up. For a segmented demo, the merged one `stitch()` writes | yes |
 | `timeline.md` | The same log rendered for humans, stills embedded | yes |
 | `guide.md` | Optional written guide embedding the stills | yes |
 | `demo.mp4` | The recording (mp4 only — gifs get too big) | **no** — regenerate it, or attach it to the PR |
@@ -311,7 +311,7 @@ that recorded a console error, an uncaught exception, or a non-zero exit — see
 | `redact(*selectors)` | Blur these elements for the whole take — frames and stills. **Plain CSS selectors only.** Call it **before** the first `goto()`. See **Redacting secrets**. |
 | `register_secret(*values)` | Register literal text that must never be captioned, spoken, or logged. A caption containing it raises `SecretLeak`. |
 | `interlude(text, style=…)` | Bridge a jump. `style="card"` (default) is a full-screen title card, for real time-skips; `style="light"` is a centered label over a soft scrim with the scene still visible, for short transitions. `""` fades it out. |
-| `stitch(out_dir, [segments])` | Lossless concat of segment recordings into demo.mp4 |
+| `stitch(out_dir, [segments])` | Lossless concat of segment recordings into demo.mp4, **and** merge their beat logs into one `timeline.json` / `timeline.md` beside it. `keep_parts=True` leaves each `.seg.mp4` and its `.seg.timeline.*` on disk for a re-stitch |
 | `rec.page` | The live Playwright page — the escape hatch for anything the verbs don't cover (iframes, keyboard shortcuts, drag) |
 
 ## Redacting secrets
@@ -479,9 +479,17 @@ to the media. No storyboard changes are needed; it is a byproduct of recording.
 embedded under the caption it was taken during. **Commit both.** They are
 small, diffable, and unlike `demo.mp4` they survive as a record of what the
 demo showed after the video has been regenerated or thrown away — which is
-what makes them worth reviewing in a PR. Segments write
-`<segment>.seg.timeline.json` alongside `<segment>.seg.mp4`; gitignore those
-with the segment media.
+what makes them worth reviewing in a PR.
+
+**A segmented demo gets exactly the same pair, written by `stitch()`.** Each
+segment records `<segment>.seg.timeline.json` beside its `<segment>.seg.mp4`,
+with timestamps relative to that segment's own start; `stitch()` merges them
+into one `timeline.json` / `timeline.md` next to `demo.mp4`, moving each
+segment's beats by the **real duration** (ffprobe) of the parts before it.
+Commit the merged pair; gitignore the `*.seg.timeline.*` parts with the
+segment media, exactly as you gitignore `*.seg.mp4`. `stitch()` deletes them
+along with the `.seg.mp4` files unless you pass `keep_parts=True`, which keeps
+both so one expensive segment can be re-recorded and re-stitched.
 
 `timeline.json` is the machine-readable one, and a stable contract — adding a
 key is fine, renaming one is not:
@@ -493,7 +501,7 @@ key is fine, renaming one is not:
   "beats": [
     { "index": 4, "t_start": 3.02, "t_end": 3.06, "caption": "A small dashboard.",
       "verb": "shot", "selector": "01-dashboard",
-      "still": "images/01-dashboard.png", "segment": null }
+      "still": "images/01-dashboard.png", "segment": null, "segment_index": 4 }
   ],
   "issues": [
     { "kind": "console_error", "t": 0.47, "beat": 0, "verb": "goto",
@@ -518,6 +526,29 @@ key is fine, renaming one is not:
 - `issues` is what the recorder saw *behind* the pixels; `issue_count` is how
   many it saw, and is larger than `len(issues)` only when a take blew past the
   200-issue cap.
+- `index` is the beat's position **in this file**, so `stitch()` renumbers it
+  across a merged demo. `segment` and `segment_index` (its position within its
+  own segment) survive the merge untouched — use that pair, not `index`, to
+  name a beat in anything that has to line up across a re-stitch.
+
+A merged timeline says so, and says what it was built from:
+
+```json
+{ "segment": null, "media": "demo.mp4", "duration": 15.2,
+  "recorder": "Recorder",
+  "segments": [
+    { "segment": "part1", "media": "part1.seg.mp4", "duration": 6.6,
+      "offset": 0.0, "beats": 6, "recorder": "Recorder", "determinism": {…} },
+    { "segment": "part2", "media": "part2.seg.mp4", "duration": 8.6,
+      "offset": 6.6, "beats": 9, "recorder": "Recorder", "determinism": {…} }
+  ] }
+```
+
+`offset` is where each part starts inside `demo.mp4`, which is what maps a
+merged timestamp back to the file it came from. `recorder` and `determinism`
+at the top level carry the value every segment agrees on — `"mixed"`, and
+`null` per key, where they do not; the per-segment truth is in `segments`. A
+timeline a single take wrote has no `segments` key at all.
 
 ## Failing the take on a broken app
 
@@ -744,7 +775,9 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    `Recorder(out_dir, segment="part1")`, poll between segments until the
    work is done, open the next segment with `rec.interlude("…a few minutes
    later…")` on `about:blank` before navigating, and `stitch()` into
-   demo.mp4.
+   demo.mp4. `stitch()` also merges the segments' beat logs into one
+   `timeline.json` / `timeline.md`, so a segmented demo commits the same two
+   files as any other — you do not have to do anything for that.
 2. **Write `record.py`** in the demo folder as a short storyboard. Capture
    a still (`rec.shot("NN-name")`) at each moment a written guide would
    narrate. Make retakes idempotent — clean up state earlier takes created,
@@ -815,7 +848,11 @@ with TerminalRecorder(Path(__file__).parent) as rec:
 8. **Commit the storyboard, not the media.** `record.py`, `guide.md`, the
    `images/*.png` stills, and `timeline.json` / `timeline.md` go into git —
    they are small, diffable, and between them they say what the demo showed
-   without anyone having to watch it. **`demo.mp4` does not.** A video is
+   without anyone having to watch it. For a **segmented** demo those two are
+   the merged pair `stitch()` wrote next to `demo.mp4`; the per-segment
+   `*.seg.timeline.*` are working files that go with `*.seg.mp4`, and
+   `stitch()` removes them for you unless you asked to keep the parts.
+   **`demo.mp4` does not.** A video is
    stale by the next change to the feature and bloats history permanently,
    and anyone with the skill installed can regenerate it with
    `uv run <demo folder>/record.py`. Gitignore `demo.mp4`, `*.seg.mp4`

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -512,21 +512,32 @@ def tts_clip(
 # Envelope
 #   schema        int    — TIMELINE_SCHEMA, bumped on any breaking change
 #   generated_by  str    — always "demo-video"
-#   recorder      str    — "Recorder" | "TerminalRecorder" (which medium)
+#   recorder      str    — "Recorder" | "TerminalRecorder" (which medium), or
+#                          "mixed" on a merged demo whose segments differ
 #   segment       str?   — the segment name, or null for a whole demo
 #   media         str    — the mp4 this timeline describes, e.g. "demo.mp4"
 #   duration      float? — that mp4's real duration (ffprobe), null if absent
 #   determinism   dict   — the conditions the take was recorded under:
 #                          `deterministic` (was the clock frozen and motion
 #                          flattened), `clock` (the frozen instant, null when
-#                          the page's clock ran), `timezone_id`, `locale`
+#                          the page's clock ran), `timezone_id`, `locale`.
+#                          On a merged demo each value is the one every segment
+#                          agrees on, or null where they disagree — the
+#                          per-segment truth is in `segments`.
+#   segments      list?   — merged demos only (`stitch`): one record per part,
+#                          in order, each `segment`, `media`, `duration`
+#                          (ffprobe), `offset` (where it starts in `media`),
+#                          `beats`, `recorder`, `determinism`. Absent from a
+#                          timeline a single take wrote.
 #   beats         list   — the beats, in the order they ran
-#   strict        bool   — whether strict mode was on for this take
+#   strict        bool   — whether strict mode was on for this take (on a
+#                          merged demo: only if it was on for every segment)
 #   issues        list   — the problems the take recorded (see "take issues")
 #   issue_count   int    — how many were seen; > len(issues) only if capped
 #
 # Beat
-#   index     int    — position in `beats`, 0-based
+#   index     int    — position in `beats`, 0-based. Renumbered by `stitch`, so
+#                      it is always the beat's position *in this file*.
 #   t_start   float  — seconds from the start of `media` to the verb starting
 #   t_end     float  — seconds from the start of `media` to the verb returning
 #   caption   str    — the caption text on screen during the beat (the new
@@ -540,6 +551,12 @@ def tts_clip(
 #   still     str?   — for `shot` beats, the still's path relative to the
 #                      timeline file ("images/01-dashboard.png"); else null
 #   segment   str?   — the segment this beat was recorded in, or null
+#   segment_index
+#             int    — the beat's position within its own segment. Equal to
+#                      `index` in a take's own timeline, and *unchanged* by a
+#                      merge — so `(segment, segment_index)` names a beat the
+#                      same way before and after `stitch`, which `index` alone
+#                      cannot (see issue #22).
 #   exit_code int?   — TerminalRecorder `run` beats only: the shell's status
 #                      for that command, or null if it could not be read
 #
@@ -675,15 +692,36 @@ def render_timeline_md(doc: dict) -> str:
     if doc.get("duration") is not None:
         head.append(f"{float(doc['duration']):.1f}s")
     head.append(f"{len(beats)} beats")
+    # Where the seams are. A merged demo's beat times are continuous across
+    # them, so nothing in the table below says a segment boundary happened —
+    # and a reviewer wondering why the scene jumps at 8.4s deserves an answer.
+    # It also changes what "do not edit this, regenerate it" means: a merged
+    # document comes back from stitch(), not from re-recording.
+    segments = doc.get("segments") or []
     out = [
         "# Demo timeline",
         "",
         " · ".join(head),
         "",
-        "Written by the demo-video recorder on every clean exit — do not edit "
-        "it by hand, re-record instead.",
+        "Written by the demo-video recorder when it stitched the segments "
+        "below — do not edit it by hand, re-stitch instead."
+        if segments
+        else "Written by the demo-video recorder on every clean exit — do not "
+        "edit it by hand, re-record instead.",
         "",
     ]
+    if segments:
+        spans = ", ".join(
+            f"`{s.get('segment')}` "
+            f"({_fmt_t(s.get('offset'))}–"
+            f"{_fmt_t((s.get('offset') or 0) + (s.get('duration') or 0))}s)"
+            for s in segments
+        )
+        out += [
+            f"Stitched from {len(segments)} segments, in order: {spans}. Beat "
+            f"times below are on the stitched video's clock.",
+            "",
+        ]
     # The exit column only exists when something in this take has one — a web
     # timeline would otherwise carry an empty column on every row. A `run` beat
     # whose status could not be read shows "?" rather than blank, so the
@@ -1516,6 +1554,12 @@ class _DemoBase:
             "selector": self.scrub(selector) if selector else selector,
             "still": self.scrub(still) if still else still,
             "segment": self.segment,
+            # Equal to `index` here, and deliberately written anyway: `stitch`
+            # renumbers `index` across a merged demo and leaves this one alone,
+            # so `(segment, segment_index)` is the beat's identity before and
+            # after a merge. A consumer naming files after a beat (issue #9)
+            # can use it without knowing which kind of timeline it is reading.
+            "segment_index": len(self._beats),
         }
         record.update(extra)
         self._beats.append(record)
@@ -1803,23 +1847,194 @@ class _DemoBase:
         print(f"wrote {mp4} ({mp4.stat().st_size // 1024} kB{spoken})")
 
 
+def _shift(value: object, offset: float) -> float | None:
+    """A timestamp moved `offset` seconds later, or None if there wasn't one."""
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        return None
+    return round(float(value) + offset, 3)
+
+
+def _common(values: list, mixed: object = None) -> object:
+    """The value every segment agrees on, or `mixed` when they do not."""
+    if not values:
+        return mixed
+    first = values[0]
+    return first if all(v == first for v in values[1:]) else mixed
+
+
+def _merge_determinism(records: list[dict]) -> dict:
+    """The determinism record of a merged demo, key by key.
+
+    A value every segment agrees on is that value; anything they disagree on
+    becomes null, because there is no honest single answer and the per-segment
+    records are right there in `segments`. Silently taking the first segment's
+    would say a demo was recorded on a frozen clock when half of it was not.
+    """
+    order: list[str] = []
+    for record in records:
+        for key in record or {}:
+            if key not in order:
+                order.append(key)
+    return {
+        key: _common([(record or {}).get(key) for record in records])
+        for key in order
+    }
+
+
+def _segment_timeline(out_dir: Path, segment: str, media: Path) -> dict:
+    """One segment's timeline document, checked against the media it names.
+
+    Refuses rather than guesses. A segment timeline that is missing, written
+    to a different schema, or describing some other file is not something a
+    merge can quietly work around: the result would be a demo-wide timeline
+    silently missing a segment's worth of beats, which is exactly the failure
+    #7 exists to remove.
+    """
+    json_path, _ = timeline_paths(out_dir, segment)
+    if not json_path.is_file():
+        raise FileNotFoundError(
+            f"{json_path} — segment {segment!r} has an mp4 but no beat log, so "
+            f"its beats cannot be merged into the demo's timeline. Re-record "
+            f"the segment (a clean take always writes one); note that a "
+            f"previous stitch() deletes the segment logs unless it was passed "
+            f"keep_parts=True."
+        )
+    doc = json.loads(json_path.read_text())
+    if doc.get("schema") != TIMELINE_SCHEMA:
+        raise ValueError(
+            f"{json_path} is schema {doc.get('schema')!r}, but this package "
+            f"writes and merges schema {TIMELINE_SCHEMA!r} — re-record the "
+            f"segment rather than merging a document this code does not know "
+            f"the shape of"
+        )
+    if doc.get("media") != media.name:
+        raise ValueError(
+            f"{json_path} describes {doc.get('media')!r}, not {media.name!r} — "
+            f"it is a leftover from a different take, and merging it would "
+            f"date-stamp somebody else's beats onto this demo"
+        )
+    return doc
+
+
+def _merged_timeline(
+    segments: list[str], parts: list[Path], docs: list[dict], demo: Path
+) -> dict:
+    """One timeline for a stitched demo, built from its segments'.
+
+    Each segment's beats are offset by the **real duration of the segments
+    before it**, read off the encoded `.seg.mp4` with ffprobe rather than
+    summed from the storyboard's nominal pacing. The encoder's answer is the
+    only one that matches the file a reviewer scrubs: Chromium's screencast
+    drops wall time during idle stretches (issue #18), so a segment's video is
+    routinely shorter than the time its beats say it took. Nominal timing would
+    put every beat of every later segment progressively past its frame.
+
+    The consequence worth knowing: a stall *inside* a segment still skews that
+    segment's own late beats against its own video, and the merge inherits it —
+    but it cannot leak across a boundary, because the next segment's offset is
+    measured, not accumulated from beats.
+    """
+    beats: list[dict] = []
+    issues: list[dict] = []
+    records: list[dict] = []
+    offset = 0.0
+    issue_count = 0
+    strict = True
+    for segment, part, doc in zip(segments, parts, docs, strict=True):
+        duration = round(media_duration(part), 3)
+        base = len(beats)
+        for beat in doc.get("beats") or []:
+            merged = dict(beat)
+            # `index` is documented as the position in *this* file, and
+            # timeline.md's table, every "beat N" message and any positional
+            # consumer read it that way — so it is renumbered. What that would
+            # destroy, `segment_index` keeps: the pair (segment, segment_index)
+            # names the same beat before and after the merge. See issue #22.
+            merged["segment_index"] = beat.get("segment_index", beat.get("index"))
+            merged["index"] = len(beats)
+            merged["t_start"] = _shift(beat.get("t_start"), offset)
+            merged["t_end"] = _shift(beat.get("t_end"), offset)
+            beats.append(merged)
+        for issue in doc.get("issues") or []:
+            moved = dict(issue)
+            moved["t"] = _shift(issue.get("t"), offset)
+            # `beat` indexes the segment's own beat list; re-point it at the
+            # merged one, or an issue arrives attributed to whatever beat of
+            # segment one happens to sit at that index.
+            if isinstance(issue.get("beat"), int) and not isinstance(
+                issue.get("beat"), bool
+            ):
+                moved["beat"] = base + int(issue["beat"])
+            issues.append(moved)
+        issue_count += int(doc.get("issue_count") or 0)
+        strict = strict and bool(doc.get("strict"))
+        records.append(
+            {
+                "segment": segment,
+                "media": part.name,
+                "duration": duration,
+                "offset": round(offset, 3),
+                "beats": len(doc.get("beats") or []),
+                "recorder": doc.get("recorder"),
+                "determinism": doc.get("determinism"),
+            }
+        )
+        offset = round(offset + duration, 3)
+    total = None
+    if demo.exists():
+        try:
+            total = round(media_duration(demo), 3)
+        except (subprocess.CalledProcessError, ValueError, OSError):
+            total = None  # a timeline without it still beats none
+    return {
+        "schema": TIMELINE_SCHEMA,
+        "generated_by": "demo-video",
+        "recorder": _common([r["recorder"] for r in records], "mixed"),
+        "segment": None,  # this document is the whole demo, not a part of one
+        "media": demo.name,
+        "duration": total,
+        "determinism": _merge_determinism([r["determinism"] for r in records]),
+        "segments": records,
+        "beats": beats,
+        "strict": strict,
+        # Same cap as a single take's, for the same reason: timeline.json has
+        # to stay a file somebody can open. `issue_count` is the honest total.
+        "issues": issues[:MAX_ISSUES],
+        "issue_count": issue_count,
+    }
+
+
 def stitch(out_dir: Path, segments: list[str], keep_parts: bool = False) -> None:
-    """Concatenate segment recordings into demo.mp4.
+    """Concatenate segment recordings into demo.mp4 and merge their beat logs.
+
+    Each segment records its own <segment>.seg.mp4 and, beside it,
+    <segment>.seg.timeline.json with timestamps relative to that segment's own
+    start. This writes one demo.mp4 and one timeline.json / timeline.md next to
+    it, with every beat moved onto the stitched video's clock — see
+    `_merged_timeline` for how the offsets are derived and why they come from
+    ffprobe rather than from the storyboard.
 
     keep_parts=True leaves the .seg.mp4 files on disk so a single segment
     can be re-recorded and re-stitched without redoing the expensive ones
-    (segments are untracked; only demo.mp4 is committed).
-
-    Note: each segment writes its own <segment>.seg.timeline.json, with
-    timestamps relative to that segment's own start. Merging them into one
-    timeline.json next to demo.mp4 — offsetting each by the real duration of
-    the segments before it — is issue #7, and belongs here.
+    (segments are untracked; only demo.mp4 is committed). The per-segment
+    timelines follow their media exactly: kept when the .seg.mp4 is kept —
+    a re-stitch needs them — and deleted with it otherwise. Leaving them
+    behind would leave a timeline naming a file that no longer exists, and
+    the next stitch could not tell that stale log from a fresh one (#21).
     """
     out_dir = Path(out_dir)
     parts = [out_dir / f"{s}.seg.mp4" for s in segments]
     for p in parts:
         if not p.exists():
             raise FileNotFoundError(p)
+    # Every segment's beat log is read and checked *before* a frame is
+    # encoded. Failing here costs nothing; failing after the concat would
+    # leave a fresh demo.mp4 with no timeline beside it, which is the one
+    # state a reader cannot tell from a demo that never had beats.
+    docs = [
+        _segment_timeline(out_dir, s, p)
+        for s, p in zip(segments, parts, strict=True)
+    ]
     listing = out_dir / ".concat.txt"
     listing.write_text(
         "".join(
@@ -1836,6 +2051,14 @@ def stitch(out_dir: Path, segments: list[str], keep_parts: bool = False) -> None
         check=True,
     )
     listing.unlink()
+    # Merged before the parts can be removed: the offsets are the parts' own
+    # encoded durations, and ffprobe cannot read a file that has been unlinked.
+    merged = _merged_timeline(segments, parts, docs, demo)
+    json_path, _ = write_timeline(out_dir, merged)
+    print(f"wrote {demo} and {json_path.name} from {len(segments)} segments")
     if not keep_parts:
         for p in parts:
             p.unlink()
+        for s in segments:
+            for path in timeline_paths(out_dir, s):
+                path.unlink(missing_ok=True)

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1881,14 +1881,29 @@ def _merge_determinism(records: list[dict]) -> dict:
     }
 
 
-def _segment_timeline(out_dir: Path, segment: str, media: Path) -> dict:
-    """One segment's timeline document, checked against the media it names.
+# How far a segment's recorded `duration` may sit from what its .seg.mp4
+# measures now. The recorder probed the same file with the same tool moments
+# after writing it, so anything past this is not rounding — it is a log paired
+# with a *different* recording of that segment (see _segment_timeline).
+SEGMENT_STALE_S = 0.25
+
+
+def _segment_timeline(out_dir: Path, segment: str, media: Path, probed: float) -> dict:
+    """One segment's timeline document, checked against the media beside it.
 
     Refuses rather than guesses. A segment timeline that is missing, written
-    to a different schema, or describing some other file is not something a
-    merge can quietly work around: the result would be a demo-wide timeline
-    silently missing a segment's worth of beats, which is exactly the failure
-    #7 exists to remove.
+    to a different schema, or describing a different recording is not
+    something a merge can quietly work around: the result would be a demo-wide
+    timeline whose beats belong to a video nobody has, which is exactly the
+    failure #7 exists to remove.
+
+    The check that does the work here is the **duration** one. The `media`
+    name is derived from the same segment string as the path this was loaded
+    from, so those two can only disagree if somebody hand-edited the file —
+    whereas re-recording one segment and merging it against the previous
+    take's log is an ordinary Tuesday, produces a name that matches perfectly,
+    and is precisely the stale pairing that would date-stamp the wrong beats
+    onto this demo.
     """
     json_path, _ = timeline_paths(out_dir, segment)
     if not json_path.is_file():
@@ -1911,13 +1926,85 @@ def _segment_timeline(out_dir: Path, segment: str, media: Path) -> dict:
         raise ValueError(
             f"{json_path} describes {doc.get('media')!r}, not {media.name!r} — "
             f"it is a leftover from a different take, and merging it would "
-            f"date-stamp somebody else's beats onto this demo"
+            f"stamp somebody else's beats onto this demo"
+        )
+    logged = doc.get("duration")
+    if isinstance(logged, (int, float)) and abs(float(logged) - probed) > SEGMENT_STALE_S:
+        raise ValueError(
+            f"{json_path} was written for a {float(logged):.2f}s recording, but "
+            f"{media.name} is {probed:.2f}s — the log and the video are from "
+            f"different takes of segment {segment!r}. Re-record the segment, or "
+            f"delete the stale log: merging them would put this demo's beats at "
+            f"timestamps belonging to a video that no longer exists."
         )
     return doc
 
 
+# What every part must agree on before `concat -c copy` may join them. All of
+# these are silent failures rather than loud ones, which is why they are
+# checked here instead of being left to ffmpeg:
+#
+#   frame rate  a mismatch is accepted, ffmpeg exits 0, and the joined video
+#               runs at one part's rate — measured putting a beat 1.92 s from
+#               its frame, which is the merge's whole subject matter;
+#   geometry    accepted silently, and the output keeps the first part's
+#               dimensions, so the second is stretched or cropped. Reachable
+#               through the very demo the merged envelope's "mixed" recorder
+#               value exists for: a web segment and a terminal one;
+#   audio       a silent part followed by a narrated one makes concat drop the
+#               narration *entirely*. The recorders give every segment a track
+#               (silence when there are no lines) for this reason, so a part
+#               without one did not come from here.
+#
+# None of it is reachable through the shipped recorders, which pin -r 25, one
+# viewport and an audio track per segment. Nothing enforced that at the join.
+_STREAM_FIELDS = ("codec", "width", "height", "frame rate", "audio track")
+
+
+def _stream_shape(path: Path) -> tuple:
+    """(codec, width, height, r_frame_rate, has audio) for one part."""
+    out = subprocess.run(
+        ["ffprobe", "-v", "quiet", "-select_streams", "v:0", "-show_entries",
+         "stream=codec_name,width,height,r_frame_rate", "-of", "csv=p=0", str(path)],
+        check=True, capture_output=True, text=True,
+    )
+    video = tuple(out.stdout.strip().split(","))
+    audio = subprocess.run(
+        ["ffprobe", "-v", "quiet", "-select_streams", "a", "-show_entries",
+         "stream=codec_name", "-of", "csv=p=0", str(path)],
+        check=True, capture_output=True, text=True,
+    )
+    return (*video, bool(audio.stdout.strip()))
+
+
+def _check_stream_shapes(parts: list[Path]) -> None:
+    """Refuse to concat parts that differ in anything concat cannot fix."""
+    shapes = [_stream_shape(p) for p in parts]
+    for shape, part in zip(shapes[1:], parts[1:], strict=True):
+        if shape == shapes[0]:
+            continue
+        differing = ", ".join(
+            f"{name} {a!r} vs {b!r}"
+            for name, a, b in zip(_STREAM_FIELDS, shapes[0], shape, strict=False)
+            if a != b
+        )
+        raise ValueError(
+            f"{part.name} does not match {parts[0].name}: {differing}. "
+            f"`concat -c copy` joins these without complaint and the result is "
+            f"wrong in a way nothing downstream can see — a frame-rate mismatch "
+            f"moves every beat of the later segments away from its frame, a "
+            f"geometry mismatch keeps the first part's dimensions, and a part "
+            f"with no audio track makes concat drop every later part's "
+            f"narration. Re-record the segments with the same recorder settings."
+        )
+
+
 def _merged_timeline(
-    segments: list[str], parts: list[Path], docs: list[dict], demo: Path
+    segments: list[str],
+    parts: list[Path],
+    docs: list[dict],
+    durations: list[float],
+    demo: Path,
 ) -> dict:
     """One timeline for a stitched demo, built from its segments'.
 
@@ -1940,8 +2027,10 @@ def _merged_timeline(
     offset = 0.0
     issue_count = 0
     strict = True
-    for segment, part, doc in zip(segments, parts, docs, strict=True):
-        duration = round(media_duration(part), 3)
+    for segment, part, doc, probed in zip(
+        segments, parts, docs, durations, strict=True
+    ):
+        duration = round(probed, 3)
         base = len(beats)
         for beat in doc.get("beats") or []:
             merged = dict(beat)
@@ -2014,6 +2103,10 @@ def stitch(out_dir: Path, segments: list[str], keep_parts: bool = False) -> None
     `_merged_timeline` for how the offsets are derived and why they come from
     ffprobe rather than from the storyboard.
 
+    Refuses before it encodes anything: every part must exist, be probeable,
+    carry a beat log of this schema written for *this* recording of it, and
+    agree with the other parts on everything `concat -c copy` cannot fix.
+
     keep_parts=True leaves the .seg.mp4 files on disk so a single segment
     can be re-recorded and re-stitched without redoing the expensive ones
     (segments are untracked; only demo.mp4 is committed). The per-segment
@@ -2027,38 +2120,47 @@ def stitch(out_dir: Path, segments: list[str], keep_parts: bool = False) -> None
     for p in parts:
         if not p.exists():
             raise FileNotFoundError(p)
-    # Every segment's beat log is read and checked *before* a frame is
-    # encoded. Failing here costs nothing; failing after the concat would
-    # leave a fresh demo.mp4 with no timeline beside it, which is the one
-    # state a reader cannot tell from a demo that never had beats.
+    # Everything the merge needs is read and checked *before* a frame is
+    # encoded — the durations included, not just the beat logs. Failing here
+    # costs nothing; failing after the concat leaves a fresh demo.mp4 with no
+    # timeline beside it, which is the one state a reader cannot tell from a
+    # demo that never had beats. That is reachable without anyone's help: a
+    # truncated .seg.mp4 makes concat exit 0 and ffprobe raise afterwards.
+    durations = [media_duration(p) for p in parts]
+    _check_stream_shapes(parts)
     docs = [
-        _segment_timeline(out_dir, s, p)
-        for s, p in zip(segments, parts, strict=True)
+        _segment_timeline(out_dir, s, p, d)
+        for s, p, d in zip(segments, parts, durations, strict=True)
     ]
     listing = out_dir / ".concat.txt"
-    listing.write_text(
-        "".join(
-            # concat-demuxer quoting: a literal ' inside single quotes
-            # is written as '\'' (paths like ".../Rógvi's Mac/..." occur).
-            "file '{}'\n".format(str(p.resolve()).replace("'", "'\\''"))
-            for p in parts
-        )
-    )
     demo = out_dir / "demo.mp4"
-    subprocess.run(
-        ["ffmpeg", "-y", "-loglevel", "error", "-f", "concat", "-safe", "0",
-         "-i", str(listing), "-c", "copy", "-movflags", "+faststart", str(demo)],
-        check=True,
-    )
-    listing.unlink()
-    # Merged before the parts can be removed: the offsets are the parts' own
-    # encoded durations, and ffprobe cannot read a file that has been unlinked.
-    merged = _merged_timeline(segments, parts, docs, demo)
+    try:
+        listing.write_text(
+            "".join(
+                # concat-demuxer quoting: a literal ' inside single quotes
+                # is written as '\'' (paths like ".../Rógvi's Mac/..." occur).
+                "file '{}'\n".format(str(p.resolve()).replace("'", "'\\''"))
+                for p in parts
+            )
+        )
+        subprocess.run(
+            ["ffmpeg", "-y", "-loglevel", "error", "-f", "concat", "-safe", "0",
+             "-i", str(listing), "-c", "copy", "-movflags", "+faststart",
+             str(demo)],
+            check=True,
+        )
+    finally:
+        # Even when ffmpeg failed: a stray .concat.txt in a demo folder is
+        # untracked litter that outlives the run that made it.
+        listing.unlink(missing_ok=True)
+    merged = _merged_timeline(segments, parts, docs, durations, demo)
     json_path, _ = write_timeline(out_dir, merged)
     print(f"wrote {demo} and {json_path.name} from {len(segments)} segments")
     if not keep_parts:
-        for p in parts:
-            p.unlink()
-        for s in segments:
+        # missing_ok throughout, and the media and its log in one pass: a
+        # segment named twice, or a part something else already removed, must
+        # not abort this loop half-done and leave the orphans of #21 behind.
+        for s, p in zip(segments, parts, strict=True):
+            p.unlink(missing_ok=True)
             for path in timeline_paths(out_dir, s):
                 path.unlink(missing_ok=True)

--- a/tests/README.md
+++ b/tests/README.md
@@ -57,7 +57,8 @@ smoke: redaction still 01-key-blurred.png ok (key 1.0, token 2.9, control 39.3)
 smoke: redaction .tts/ holds 2 clips — the narrated lines, and nothing for the refused one
 smoke: redaction no artifact holds either secret verbatim
 smoke: segments recorded 2 parts, each with its own beat log (part1 6.8s, part2 7.8s)
-smoke: segments the merge puts the second segment's closing caption +0 ms from where its own segment does (-80 ms in part2.seg.mp4, -80 ms in demo.mp4)
+smoke: segments part1's probe caption is +0 ms from where its own segment puts it (-120 ms in part1.seg.mp4, -120 ms in demo.mp4)
+smoke: segments part2's probe caption is +0 ms from where its own segment puts it (-80 ms in part2.seg.mp4, -80 ms in demo.mp4)
 smoke: segments stitched 2 parts into a 14.6s demo.mp4 and merged their beat logs (15 beats); keep_parts=True kept every part and its log, the default removed them
 smoke: segments closing caption 'Recorded end to end.' logged at 11.43s, on screen at 11.35s (-80 ms)
 smoke: segments timeline.json ok (15 beats)
@@ -694,24 +695,42 @@ shorter than its beats say it took. Injecting nominal timing here moves the
 second segment's beats 2.1 s off their frames.
 
 **How the acceptance criterion is measured, and why it can be stated at
-100 ms.** The closing caption is timed *twice* — once in `part2.seg.mp4`
-against that segment's own beat log, and once in the stitched `demo.mp4`
-against the merged one. `stitch()` copies the streams, so those are literally
-the same frames carrying the same capture loss, and the **difference** between
-the two skews is the merge's offset error with issue #18 cancelled out.
-Measured across six takes: **+0 ms**, every time, against a 100 ms bar; the
-absolute skews behind it ranged -200 to +0 ms. A bar on the absolute skew
-could not be set anywhere near that, because a segment whose capture stalled
-shows every caption early in its own video too.
+100 ms.** Every segment carries a probe caption with a quiet run-up, and each
+is timed *twice* — once in that segment's own `.seg.mp4` against that
+segment's own beat log, and once in the stitched `demo.mp4` against the merged
+one. `stitch()` copies the streams, so those are literally the same frames
+carrying the same capture loss, and the **difference** between the two skews
+is that segment's offset error with issue #18 cancelled out. Measured across
+several takes: **+0 ms** for both segments, against a 100 ms bar; the absolute
+skews behind them ranged -200 to +0 ms. A bar on the absolute skew could not
+be set anywhere near that, because a segment whose capture stalled shows every
+caption early in its own video too.
 
-That cancellation is also why the sharp `MAX_SKEW_DRIFT_S` (250 ms) does *not*
-apply between the take's two probes here: they sit in different segments, so
-they rode different screencasts, each with its own ~0.7 s of untickerable
-recorder setup, and a stall in the second moves only the second. Measured
-across four takes: -80, +80, +80, and one at **-520** — a real segment-two
-stall, which would have made this axis flake. Across a boundary the bound is
-therefore one capture-loss window, and the tight claim is made by the
-differential measurement instead.
+**One probe per segment, and that is load-bearing rather than thorough.** The
+differential at segment *k* measures `offset_true - offset_recorded` for that
+segment and nothing else. Timing only the last segment therefore checks only
+the last cumulative offset: a constant shift applied to segment one's beats
+leaves it exact, and with three or more segments every intermediate offset
+would have no pixel measurement at all. That is not hypothetical — an earlier
+round of this file timed one beat, and injecting +350 ms onto segment one
+passed, printing `beat clock holds across the take (+400 ms)`.
+
+The other half is each segment's *own* skew, graded against the same
+directional bars a single take gets (250 ms log-ahead, 750 ms video-ahead) but
+read out of that segment's own mp4. The differential cancels capture loss on
+purpose, so it is blind by construction to a segment whose own video has slid
+away from its own beat log; this is where that shows up, per capture.
+
+Between them, `MAX_SKEW_DRIFT_S` across a boundary has nothing left to say,
+and it is explicitly **a flake guard rather than a check**: the take's two
+probes sit in different segments, so they rode different screencasts, each
+with its own ~0.7 s of untickerable recorder setup, and a stall in the second
+moves only the second. Measured across four takes: -80, +80, +80, and one at
+**-520** — a real segment-two capture stall, not a merge error, which a 250 ms
+bar here would fail on about one run in four. It is widened to one capture-loss
+window for that reason alone, and the file says so where the number is set. A
+constant shift of any segment's beats is caught by the two measurements above,
+at 100 ms, not by this one at any width.
 
 The rest is what is true of a merge and of nothing else:
 
@@ -722,7 +741,11 @@ The rest is what is true of a merge and of nothing else:
 | `stitch(keep_parts=True)` leaves every part **and its beat log** | re-recording one expensive segment and re-stitching is the whole reason that flag exists, and it needs the logs as much as the mp4s |
 | stitching twice produces the same beats | the merge has to be a function of what is on disk |
 | the default `stitch()` leaves **no** `*.seg.*` at all | [#21](https://github.com/rogvid/skills/issues/21): a `.seg.timeline.json` outliving its `.seg.mp4` names a file that is gone, and the next stitch cannot tell it from a fresh one |
-| the merged envelope's `segments` records match ffprobe, in order, and tile `demo.mp4` | it is what maps a merged timestamp back to the file it came from |
+| the merged envelope's `segments` records, **all six fields**: `segment` / `media` in order, `duration` / `offset` against ffprobe and tiling `demo.mp4`, and `beats` / `recorder` / `determinism` against the segment's own log | it is what maps a merged timestamp back to the file it came from, and `SKILL.md` points a reader at the last three for the per-segment truth the envelope cannot carry once segments disagree. Checking only the first four was measured passing with `beats` hardcoded to 0 and `recorder` to `"Bogus"` |
+| `segments[].beats` also equals how many merged beats carry that segment | the two can only differ if the merge dropped or duplicated some |
+| `stitch()` refuses parts that disagree on codec, geometry, frame rate, or having an audio track | `concat -c copy` joins them and exits 0. A frame-rate mismatch was measured putting a beat **1.92 s** from its frame; a geometry mismatch silently keeps part one's dimensions; a silent part followed by a narrated one makes concat drop the narration entirely. None is reachable through the shipped recorders — nothing enforced it at the join |
+| `stitch()` refuses a segment log written for a different recording of that segment | the `media`-name check cannot see it: both sides derive from the same segment string. Re-recording one part and merging it against the previous take's log is the ordinary way to get here, and it was accepted silently (6.6 s log against a 2.0 s part) |
+| every part is probed *before* ffmpeg runs, and `.concat.txt` is removed even when it fails | a truncated part makes concat exit 0 and `media_duration` raise afterwards, leaving `demo.mp4` with no `timeline.json` — the one state a reader cannot tell from a demo that never had beats |
 | `index` is renumbered to the position in the merged file, `segment_index` is **not** | [#22](https://github.com/rogvid/skills/issues/22): `(segment, segment_index)` names a beat the same way before and after a merge, which `index` alone cannot. Asserted in every take, not just this one — for a single take it is 0, 1, 2, … |
 | a take recorded in one piece carries no `segments` key | that key means "assembled by stitch()", and a reader would otherwise be told a single recording has parts |
 
@@ -882,18 +905,34 @@ knows is missing is worse than one that is openly absent.
   exercised only as "stitch the same parts twice". A demo mixing a web and a
   terminal segment, which the merged envelope's `"mixed"` recorder value is
   for, is recorded nowhere.
+- **The differential measurement dies before its own bar does.** Each reading
+  goes through `caption_appearance_s`, whose search window is `ALIGN_PRE_S`
+  (1.2 s) — so once a segment's *in-segment* skew passes about -0.72 s the
+  measurement cannot be made at all, and the failure it produces blames a
+  screencast stall (#18) rather than saying the merge was not graded. That
+  cliff sits *inside* the 750 ms absolute bar, and the one segment-two stall
+  measured here (-520 ms) was ~200 ms from it. The same limit makes a large
+  offset error unmeasurable rather than measured: an injected nominal-timing
+  merge (-2.12 s) degraded to "the caption band did not move… almost certainly
+  a screencast stall", and what actually named the cause was the
+  `segments`-record-vs-ffprobe check, not the acceptance criterion.
+- **The merged envelope's disagreement paths are never taken.** Both segments
+  are recorded by the same recorder with the same settings, so `recorder`
+  resolves to `"Recorder"` and every `determinism` key agrees. The `"mixed"`
+  value and `_merge_determinism`'s null-on-disagreement branch — both
+  documented in `SKILL.md` as what a reader gets from a mixed demo — are
+  produced by nothing here and asserted by nothing.
 - **The merge's `issues` path is unexercised.** `stitch()` also offsets each
   issue's `t` and re-points its `beat` at the merged beat list, and the
   segmented take is a recording of a *healthy* app under `strict=True` — so it
   records no issues at all and none of that runs. An issue attributed to the
   wrong beat of the wrong segment would pass this suite. Tracked in
   [#51](https://github.com/rogvid/skills/issues/51).
-- **The merge's error is measured at one beat, not all of them.** The
-  differential measurement below reads the *closing caption* out of two
-  videos. Every other beat in the second segment is carried by the same single
-  offset, so one being right makes the rest right — but a merge that moved
-  some beats and not others would be caught only by the ordering and coverage
-  checks, which are much coarser.
+- **The merge's error is measured at one beat per segment, not all of them.**
+  Every other beat in a segment is carried by that segment's single offset, so
+  one being right makes the rest right — but a merge that moved some of a
+  segment's beats and not others would be caught only by the ordering and
+  coverage checks, which are much coarser.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,8 +18,9 @@ tests/
 ```
 
 Takes: `web/` and `terminal/` (the two media), the determinism pair, the
-problem takes, and `redaction/` — the web recorder against a page that renders
-a secret, plus a second few-second take that must *fail*.
+problem takes, `redaction/` — the web recorder against a page that renders
+a secret, plus a second few-second take that must *fail* — and `segments/`,
+one demo recorded in two parts and joined with `stitch()`.
 
 ## Running it
 
@@ -32,6 +33,7 @@ tests/smoke                       # all three takes, output to a temp dir
 tests/smoke --web-only            # just the Playwright take
 tests/smoke --terminal-only       # just the PTY/xterm.js take
 tests/smoke --redaction-only      # just the secret-redaction take
+tests/smoke --segments-only       # just the two-segment take and its stitch
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -54,6 +56,11 @@ smoke: redaction #api-key is blurred in every frame of demo.mp4 (worst 1.5 vs co
 smoke: redaction still 01-key-blurred.png ok (key 1.0, token 2.9, control 39.3)
 smoke: redaction .tts/ holds 2 clips — the narrated lines, and nothing for the refused one
 smoke: redaction no artifact holds either secret verbatim
+smoke: segments recorded 2 parts, each with its own beat log (part1 6.8s, part2 7.8s)
+smoke: segments the merge puts the second segment's closing caption +0 ms from where its own segment does (-80 ms in part2.seg.mp4, -80 ms in demo.mp4)
+smoke: segments stitched 2 parts into a 14.6s demo.mp4 and merged their beat logs (15 beats); keep_parts=True kept every part and its log, the default removed them
+smoke: segments closing caption 'Recorded end to end.' logged at 11.43s, on screen at 11.35s (-80 ms)
+smoke: segments timeline.json ok (15 beats)
 …
 smoke: web-problems timeline.json records 8 problem(s), 6 of them fatal under strict — take still passed
 smoke: web-strict strict=True refused the take, naming beat 0 (goto) (4 fatal issues, artifacts kept)
@@ -75,10 +82,10 @@ smoke: determinism ok (3 takes)
 smoke: PASSED
 ```
 
-Re-running into the same `--out-dir` is safe: the ten take subdirectories
-(`web/`, `terminal/`, `web-problems/`, `terminal-problems/`, `terminal-race/`,
-`web-strict/`, `terminal-strict/`, `determinism-a/`, `determinism-b/`,
-`determinism-off/`) are deleted before each take. Only the first two are graded
+Re-running into the same `--out-dir` is safe: the take subdirectories
+(`web/`, `terminal/`, `segments/`, `web-problems/`, `terminal-problems/`,
+`terminal-race/`, `web-strict/`, `terminal-strict/`, `determinism-a/`,
+`determinism-b/`, `determinism-off/`) are deleted before each take. Only the first two are graded
 on their video; the rest are short and exist to break, or to reproduce, in one
 specific way each. That is not tidiness — every artifact assertion works by
 path, so without it a leftover `demo.mp4` from the previous run would grade a
@@ -663,6 +670,62 @@ if the fixture ever stopped putting those elements behind a real boundary the
 take would go on passing while proving nothing: `page.locator("#sd-key")` must
 find exactly one, and `document.querySelectorAll("#sd-key")` exactly none.
 
+**Segments and the merge** — a demo recorded in two parts and joined by
+`stitch()` ([#7](https://github.com/rogvid/skills/issues/7)). `segments/`
+records the storyboard `SKILL.md` prescribes for a real time-skip: part one,
+then a second `Recorder(segment=…)` that opens with an `interlude()` on the
+blank page before navigating back. Each part writes its own `.seg.mp4` and its
+own beat log; the demo-wide `timeline.json` is assembled from them.
+
+**The merged timeline is graded by `check_timeline()` — the same function, and
+the same assertions, that grade a single take.** That is the point rather than
+an economy: the beats, the captions, the per-beat caption context, the
+monotonicity and coverage of the timestamps, `timeline.md`'s table, the stills
+on disk, and the measured "does this timestamp point at that frame" check all
+apply unchanged. A segmented demo graded more softly than a recorded one is a
+segmented demo nobody can trust. What the merge adds is a hand-written
+*segment* column — a stitch that merged part one twice produces a perfectly
+monotonic timeline of the right length, and only that column notices.
+
+The offsets are the parts' **ffprobe durations**, never the storyboard's
+nominal timing, and that distinction is load-bearing: the screencast drops
+wall time during idle stretches, so a segment's video routinely runs ~0.9 s
+shorter than its beats say it took. Injecting nominal timing here moves the
+second segment's beats 2.1 s off their frames.
+
+**How the acceptance criterion is measured, and why it can be stated at
+100 ms.** The closing caption is timed *twice* — once in `part2.seg.mp4`
+against that segment's own beat log, and once in the stitched `demo.mp4`
+against the merged one. `stitch()` copies the streams, so those are literally
+the same frames carrying the same capture loss, and the **difference** between
+the two skews is the merge's offset error with issue #18 cancelled out.
+Measured across six takes: **+0 ms**, every time, against a 100 ms bar; the
+absolute skews behind it ranged -200 to +0 ms. A bar on the absolute skew
+could not be set anywhere near that, because a segment whose capture stalled
+shows every caption early in its own video too.
+
+That cancellation is also why the sharp `MAX_SKEW_DRIFT_S` (250 ms) does *not*
+apply between the take's two probes here: they sit in different segments, so
+they rode different screencasts, each with its own ~0.7 s of untickerable
+recorder setup, and a stall in the second moves only the second. Measured
+across four takes: -80, +80, +80, and one at **-520** — a real segment-two
+stall, which would have made this axis flake. Across a boundary the bound is
+therefore one capture-loss window, and the tight claim is made by the
+differential measurement instead.
+
+The rest is what is true of a merge and of nothing else:
+
+| Checked | Why |
+|---|---|
+| before any stitch, each part has an `.seg.mp4` *and* an `.seg.timeline.json`/`.md`, and no `demo.mp4`/`timeline.json` exists yet | the cleanup assertion below is otherwise satisfied by a recorder that never wrote them, and every path assertion by a leftover |
+| each part's own log starts within `MAX_UNMERGED_FIRST_BEAT_S` of zero | "the merged timestamps are large" proves nothing if they were large before the merge |
+| `stitch(keep_parts=True)` leaves every part **and its beat log** | re-recording one expensive segment and re-stitching is the whole reason that flag exists, and it needs the logs as much as the mp4s |
+| stitching twice produces the same beats | the merge has to be a function of what is on disk |
+| the default `stitch()` leaves **no** `*.seg.*` at all | [#21](https://github.com/rogvid/skills/issues/21): a `.seg.timeline.json` outliving its `.seg.mp4` names a file that is gone, and the next stitch cannot tell it from a fresh one |
+| the merged envelope's `segments` records match ffprobe, in order, and tile `demo.mp4` | it is what maps a merged timestamp back to the file it came from |
+| `index` is renumbered to the position in the merged file, `segment_index` is **not** | [#22](https://github.com/rogvid/skills/issues/22): `(segment, segment_index)` names a beat the same way before and after a merge, which `index` alone cannot. Asserted in every take, not just this one — for a single take it is 0, 1, 2, … |
+| a take recorded in one piece carries no `segments` key | that key means "assembled by stitch()", and a reader would otherwise be told a single recording has parts |
+
 ## Known gaps
 
 Things a pass does **not** prove. They are listed because an assertion nobody
@@ -812,10 +875,25 @@ knows is missing is worse than one that is openly absent.
     version of this file presented the first as tested and the second as the
     redundant one; that was wrong in a way worth stating, because it claimed
     coverage that does not exist.
-- **Nothing checks `stitch()`, segments, or `interlude()`.** Single-segment
-  takes only — so `<segment>.seg.timeline.json`, and the merge
-  [#7](https://github.com/rogvid/skills/issues/7) will build on it, are
-  unexercised.
+- **The segmented take records two parts of one storyboard, not a real
+  time-skip.** Nothing waits between them, both are the web recorder against
+  the same fixture, and no segment is re-recorded on its own — so the flow
+  `keep_parts=True` exists for (re-record one expensive part, re-stitch) is
+  exercised only as "stitch the same parts twice". A demo mixing a web and a
+  terminal segment, which the merged envelope's `"mixed"` recorder value is
+  for, is recorded nowhere.
+- **The merge's `issues` path is unexercised.** `stitch()` also offsets each
+  issue's `t` and re-points its `beat` at the merged beat list, and the
+  segmented take is a recording of a *healthy* app under `strict=True` — so it
+  records no issues at all and none of that runs. An issue attributed to the
+  wrong beat of the wrong segment would pass this suite. Tracked in
+  [#51](https://github.com/rogvid/skills/issues/51).
+- **The merge's error is measured at one beat, not all of them.** The
+  differential measurement below reads the *closing caption* out of two
+  videos. Every other beat in the second segment is carried by the same single
+  offset, so one being right makes the rest right — but a merge that moved
+  some beats and not others would be caught only by the ordering and coverage
+  checks, which are much coarser.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.
@@ -899,7 +977,9 @@ the crop and looking at it before it was believed.
   `tests/smoke`, add its `shot()` name to `WEB_SHOTS` / `TERMINAL_SHOTS` so the
   still is actually checked, and add its `(verb, target)` to `WEB_BEATS` /
   `TERMINAL_BEATS` (and its text to `WEB_CAPTIONS` / `TERMINAL_CAPTIONS` if it
-  is a caption) so the timeline check knows to expect it. Those lists are
+  is a caption) so the timeline check knows to expect it. `record_segments`
+  works the same way, except that its list is `SEGMENT_BEATS_FULL` and carries
+  a third column, the segment the beat belongs to. Those lists are
   deliberately hand-maintained; see **Timeline** above for why. Adding a beat
   lengthens the take; keep it inside the duration window, or widen the window
   deliberately. **Every interaction gets a `b.expect(...)` naming what it

--- a/tests/smoke
+++ b/tests/smoke
@@ -106,7 +106,9 @@ MIN_PNG_BYTES = 5_000
 # strongest blank one. See tests/README.md for what this metric cannot
 # resolve — notably a total stylesheet failure, which scores ~10 and is
 # therefore checked separately via getComputedStyle rather than by pixels.
-MIN_CONTENT_STDDEV = {"web": 6.0, "terminal": 2.0}
+# "segments" is the web recorder against the same fixture, composited the same
+# way, so it takes the web numbers here and in the two dicts below.
+MIN_CONTENT_STDDEV = {"web": 6.0, "terminal": 2.0, "segments": 6.0}
 
 # Pixel proof that the caption bar reached the screen, as the mean absolute
 # luma change in the caption band between two stills taken back to back — one
@@ -125,7 +127,7 @@ MIN_CONTENT_STDDEV = {"web": 6.0, "terminal": 2.0}
 # The terminal margin is the thinnest number in this file — 2.7x over its
 # floor, against 4x or better for everything else. tests/README.md calls that
 # out under "Known gaps".
-MIN_CAPTION_BAND_DIFF = {"web": 8.0, "terminal": 1.0}
+MIN_CAPTION_BAND_DIFF = {"web": 8.0, "terminal": 1.0, "segments": 8.0}
 
 # Consecutive stills must differ by at least this mean absolute luma, on the
 # 160x90 grayscale reduction. This detects a *duplicate* — a stale or copied
@@ -529,11 +531,124 @@ ALIGN_ARRIVAL_FRACTION = 0.25
 # anything. Below this the probe caption was never drawn in the video, and the
 # right answer is a failure, not a timestamp. Same per-medium reasoning (and
 # the same numbers) as MIN_CAPTION_BAND_DIFF above.
-MIN_ALIGN_BAND_DELTA = {"web": 6.0, "terminal": 1.0}
+MIN_ALIGN_BAND_DELTA = {"web": 6.0, "terminal": 1.0, "segments": 6.0}
 
 # Written into each take directory so a later run can tell "a directory this
 # harness owns and may delete" from "somebody's source tree".
 MARKER_NAME = ".demo-video-smoke"
+
+# -- the segmented take (issue #7) -------------------------------------------
+#
+# One demo recorded as two `Recorder(segment=...)` takes and joined with
+# `stitch()`. This is the shape a demo takes whenever the story contains real
+# waiting — minutes of background work nobody wants on video — and until now
+# nothing here recorded a segment at all.
+#
+# What it is for is the *merge*. Each segment writes its own beat log with
+# timestamps relative to its own start, and `stitch()` has to move them onto
+# the stitched video's clock by the real duration of the parts before them.
+# Getting that wrong is invisible in every other axis: the video is fine, the
+# beats are all present, and only the timestamps of the second half lie —
+# which is precisely what beat-aligned frame extraction and per-beat evidence
+# read. So the merged log is graded by `check_timeline()`, the *same* function
+# that grades a single take, including its measured
+# does-this-timestamp-point-at-that-frame check against the stitched mp4.
+SEGMENT_NAMES = ["part1", "part2"]
+
+# Kept deliberately small: two more browser launches and two more encodes are
+# the expensive part, and everything this take proves it proves in 15 seconds.
+SEGMENT_OPENING = "One demo, in two parts."
+SEGMENT_INTERLUDE = "A few minutes later."
+
+# Short for a title card, and the reason is the compositor. TICKER_JS is what
+# keeps the screencast from losing wall time (see issue #18), and the interlude
+# card is full-screen at the same z-index — appended after the ticker, so it
+# covers it for exactly as long as it is up. Everything else in this take has
+# the ticker painting on top, so this hold is the one window where a stall
+# could still land, and a stall between the two probes is what the
+# MAX_SKEW_DRIFT_S bar would (correctly) fail on.
+SEGMENT_INTERLUDE_HOLD_S = 1.2
+
+# One storyboard still, in the first segment: enough to prove both segments
+# write into the same images/ and that the merged log still names it. A second
+# would have to differ from the first by MIN_STILL_DIFF, and the two segments
+# open on the same dashboard.
+SEGMENT_SHOTS = ["01-part1"]
+SEGMENT_DURATION_S = (10.0, 45.0)
+
+# Every beat of both segments, in order, as (verb, target, segment). Hand
+# written for the same reason as WEB_BEATS — a list derived from the log being
+# graded agrees with it no matter what it says — and carrying the segment
+# because that is the column a merge can get wrong on its own: a stitch that
+# merged segment one twice produces a perfectly monotonic timeline of the
+# right length.
+SEGMENT_BEATS_FULL = [
+    ("goto", "/", "part1"),
+    ("wait_for", "#kpi-rev", "part1"),
+    ("pause", None, "part1"),
+    ("caption", None, "part1"),
+    ("shot", "01-part1", "part1"),
+    ("caption", None, "part1"),
+    # `interlude`'s target is its style, not its text — see core.interlude().
+    ("interlude", "card", "part2"),
+    ("goto", "/", "part2"),
+    ("wait_for", "#kpi-rev", "part2"),
+    ("caption", None, "part2"),
+    ("shot", "90-caption-off", "part2"),
+    ("pause", None, "part2"),
+    ("caption", None, "part2"),
+    ("shot", "91-caption-on", "part2"),
+    ("caption", None, "part2"),
+]
+SEGMENT_BEATS = [(verb, target) for verb, target, _ in SEGMENT_BEATS_FULL]
+SEGMENT_BEAT_SEGMENTS = [segment for _, _, segment in SEGMENT_BEATS_FULL]
+SEGMENT_CAPTIONS = [SEGMENT_OPENING, "", "", PROBE_CAPTION, ""]
+SEGMENT_INTERLUDES = [SEGMENT_INTERLUDE]
+
+# How far the segment offsets recorded in the merged envelope may sit from what
+# ffprobe says about the parts, and from the stitched demo.mp4's own duration.
+# They are the same measurement — this is concat's frame quantisation and the
+# recorder's 3-decimal rounding, not tolerance for a different answer.
+SEGMENT_OFFSET_TOLERANCE_S = 0.2
+
+# A segment's own beat log is relative to that segment's start, so the second
+# segment's first beat sits within a second or two of zero *before* the merge.
+# Asserted, because "the merged timestamps are large" proves nothing if they
+# were large to begin with — that is what makes the merge visible at all.
+MAX_UNMERGED_FIRST_BEAT_S = 3.0
+
+# How far the merge itself may be wrong, in seconds. This is #7's acceptance
+# criterion, and it is measured **differentially**, which is the only way to
+# state it this tightly:
+#
+#   the closing caption is timed once in `part2.seg.mp4` against that
+#   segment's own beat log, and once in the stitched `demo.mp4` against the
+#   merged one. Both readings carry the same screencast capture loss — the
+#   frames are literally the same frames, `stitch()` copies the streams — so
+#   the *difference* between the two skews is the merge's offset error and
+#   nothing else.
+#
+# What that removes is issue #18, which would otherwise dominate: a segment
+# whose capture stalled shows every caption early in its own video too, and a
+# bar on the absolute skew could never tell that apart from an offset the
+# merge got wrong. Residual noise is the 40 ms sampling grid in each of the
+# two measurements, which do not share a sampling phase.
+MAX_MERGE_OFFSET_ERROR_S = 0.1
+
+# Bound on how far the *two* timing probes may drift apart when they sit in
+# different segments. MAX_SKEW_DRIFT_S (250 ms) is the sharp one and it works
+# because whatever a capture loses it loses for every later frame equally — so
+# a stall moves both probes together and cancels. That argument holds inside
+# one screencast and stops at a segment boundary: each segment is its own
+# capture, with its own ~0.7 s of untickerable recorder setup, and a stall in
+# the second shifts only the second probe. Measured across four two-segment
+# takes: -80, +80, +80, and one at -520 (the segment-two stall of #18).
+#
+# So across a boundary the bound is a whole capture-loss window, and the
+# merge's own accuracy is asserted separately and far more tightly by
+# MAX_MERGE_OFFSET_ERROR_S. Nothing is given up: an offset error shows up
+# there, at 100 ms, with the capture loss cancelled out.
+MAX_CROSS_SEGMENT_DRIFT_S = MAX_CAPTURE_LOSS_S
 
 # -- redaction (issue #4) ----------------------------------------------------
 #
@@ -1778,6 +1893,77 @@ def record_terminal(
     return b.problems, rect, rect, size
 
 
+def record_segments(
+    out_dir: Path, base_url: str
+) -> tuple[list[str], Rect, Rect, tuple[int, int]]:
+    """One demo, recorded as two segments — the shape a real time-skip takes.
+
+    Deliberately the storyboard SKILL.md tells people to write: record part
+    one, do the slow thing (here, nothing at all), then open part two with an
+    `interlude()` on the blank page before navigating back. Both segments
+    write their own `.seg.mp4` and their own beat log; `stitch()` joins them.
+
+    Nothing is stitched here — the caller does it, so that what the parts look
+    like *before* the merge can be asserted. Without that, "the merged
+    timestamps are large" would prove nothing.
+    """
+    from demo_recording import Recorder
+
+    b = Beats("segments")
+    settings = {
+        "base_url": base_url,
+        "speech": False,
+        # Same reasoning as record_web(): deterministic=True is what makes
+        # start_ticker()'s control-element assertion mean anything, and
+        # strict=True keeps this a recording of a working app.
+        "strict": True,
+        "deterministic": True,
+    }
+
+    with Recorder(out_dir, segment=SEGMENT_NAMES[0], **settings) as rec:
+        rec.goto("/")
+        rec.wait_for("#kpi-rev")
+        start_ticker(b, rec.page)
+        # The run-up for the early timing probe: the page has finished painting
+        # and nothing moves in the caption band until the caption does.
+        rec.pause(PROBE_QUIET_S)
+        rec.caption(SEGMENT_OPENING)
+        check_caption(b, rec.page, SEGMENT_OPENING)
+        rec.shot(SEGMENT_SHOTS[0])
+        rec.caption("")
+
+        g = rec._geom
+        video_rect: Rect = (g["appx"], g["appy"], g["appw"], g["apph"])
+        size = (rec._size["width"], rec._size["height"])
+        still_rect: Rect = (0, 0, size[0], size[1])
+
+    with Recorder(out_dir, segment=SEGMENT_NAMES[1], **settings) as rec:
+        # On about:blank, before anything else: the second segment's opening
+        # seconds are the ones most likely to go idle, and idle is what makes
+        # the screencast lose wall time (TICKER_JS, issue #18). The interlude
+        # card covers it while it is up — see SEGMENT_INTERLUDE_HOLD_S.
+        start_ticker(b, rec.page)
+        rec.interlude(SEGMENT_INTERLUDE, hold=SEGMENT_INTERLUDE_HOLD_S)
+        rec.goto("/")
+        rec.wait_for("#kpi-rev")
+        # The navigation took the first one with it.
+        start_ticker(b, rec.page)
+
+        # The closing probe, in the *second* segment on purpose: its beat
+        # timestamps are the ones the merge has to move, and this is where the
+        # acceptance criterion of #7 is actually measured.
+        rec.caption("")
+        check_caption(b, rec.page, "")
+        rec.shot(CAPTION_PROBE[0])
+        rec.pause(PROBE_QUIET_S)
+        rec.caption(PROBE_CAPTION)
+        check_caption(b, rec.page, PROBE_CAPTION)
+        rec.shot(CAPTION_PROBE[1])
+        rec.caption("")
+
+    return b.problems, video_rect, still_rect, size
+
+
 class EntropyTake(NamedTuple):
     """One recording of the entropy storyboard, and what it rendered."""
 
@@ -2689,6 +2875,8 @@ def check_timeline(
     expected_beats: list[tuple[str, str | None]],
     expected_captions: list[str],
     frame_size: tuple[int, int],
+    expected_segments: list[str | None] | None = None,
+    expected_interludes: list[str] | None = None,
 ) -> list[str]:
     """The beat log the take left behind: timeline.json and timeline.md.
 
@@ -2696,12 +2884,25 @@ def check_timeline(
     parses is the cheap part; that its beats are the beats the storyboard
     actually performed, and that its timestamps point at the right frames of
     demo.mp4, is the part worth having.
+
+    Used unchanged for a *merged* timeline — the one `stitch()` writes from
+    several segments' — which is the point: a demo assembled from parts has to
+    be graded by the same assertions as one recorded in a single take, or the
+    segmented path is a second, softer standard. `expected_segments` names the
+    segment each beat was recorded in (all None for a single take), and
+    `expected_interludes` the lines any `interlude` beats show.
     """
     from demo_recording import TIMELINE_SCHEMA, media_duration
 
     failures: list[str] = []
     json_path = out_dir / "timeline.json"
     md_path = out_dir / "timeline.md"
+    segments_of: list[str | None] = list(
+        expected_segments
+        if expected_segments is not None
+        else [None] * len(expected_beats)
+    )
+    segment_indices = _expected_segment_indices(segments_of)
 
     if not json_path.is_file():
         return [f"{label}: {json_path} was never written"]
@@ -2724,8 +2925,18 @@ def check_timeline(
         )
     if doc.get("segment") is not None:
         failures.append(
-            f"{label}: timeline.json says segment {doc.get('segment')!r}; these "
-            f"takes are single-segment, so it should be null"
+            f"{label}: timeline.json says segment {doc.get('segment')!r}; this "
+            f"file describes a whole demo, so it should be null"
+        )
+    # `segments` is the merge's own record of what it joined and where. A take
+    # that recorded in one go must not carry it: a consumer reading it would be
+    # told a single recording has parts, and the offsets it lists are exactly
+    # what a later reader would trust to map a timestamp back to a file.
+    if not any(segments_of) and "segments" in doc:
+        failures.append(
+            f"{label}: timeline.json carries a `segments` list "
+            f"({doc.get('segments')!r}), but this take was recorded in one "
+            f"piece — that key means the file was assembled by stitch()"
         )
 
     # Which clock produced the take. A still committed to a repo is otherwise a
@@ -2783,7 +2994,7 @@ def check_timeline(
     # the recorder's `self._caption = text` and the caption beats stay perfect
     # while every other beat goes blank. Derived from the two hand-written
     # lists above, never from the log being graded.
-    context = _expected_context(expected_beats, expected_captions)
+    context = _expected_context(expected_beats, expected_captions, expected_interludes)
     if context is not None:
         logged = [b.get("caption") for b in beats]
         if logged != context:
@@ -2837,8 +3048,27 @@ def check_timeline(
                 f"this verb for at least {MIN_HELD_BEAT_SPAN_S}s — `t_end` is "
                 f"not being recorded when the verb returned"
             )
-        if beat.get("segment") is not None:
-            failures.append(f"{where} claims segment {beat.get('segment')!r}")
+        # Which segment recorded this beat, and where it sat in that segment's
+        # own log. `index` is renumbered by the merge, so it cannot answer
+        # "which beat is this" across a stitch; `(segment, segment_index)` is
+        # the pair that can, and #9 will name per-beat evidence from it. Both
+        # expectations are derived from the hand-written list above.
+        want_segment = segments_of[position] if position < len(segments_of) else None
+        if beat.get("segment") != want_segment:
+            failures.append(
+                f"{where} says it was recorded in segment "
+                f"{beat.get('segment')!r}, expected {want_segment!r}"
+            )
+        want_segment_index = (
+            segment_indices[position] if position < len(segment_indices) else None
+        )
+        if beat.get("segment_index") != want_segment_index:
+            failures.append(
+                f"{where} carries segment_index {beat.get('segment_index')!r}, "
+                f"expected {want_segment_index!r} — it is the beat's position "
+                f"within its own segment, and unlike `index` a merge must not "
+                f"renumber it (issue #22)"
+            )
 
     # Beats run back to back, so their spans should account for essentially
     # all of the time between the first starting and the last ending. This is
@@ -3004,15 +3234,27 @@ def check_timeline(
     # not cancel.
     if len(measured) == 2:
         drift = measured[1][1] - measured[0][1]
-        if abs(drift) > MAX_SKEW_DRIFT_S:
+        # ...as long as both probes rode the same capture. Across a segment
+        # boundary they did not, and the cancellation argument goes with it —
+        # see MAX_CROSS_SEGMENT_DRIFT_S.
+        same_capture = probes[0][1].get("segment") == probes[1][1].get("segment")
+        bound = MAX_SKEW_DRIFT_S if same_capture else MAX_CROSS_SEGMENT_DRIFT_S
+        why = (
+            "A capture that dropped time would have moved both equally, so "
+            "this is the beat log's clock: time between beats is not being "
+            "measured monotonically."
+            if same_capture
+            else "These two probes are in different segments, so this is a "
+            "whole capture-loss window on top of anything the merge got "
+            "wrong — the merge's own error is bounded separately."
+        )
+        if abs(drift) > bound:
             failures.append(
                 f"{label}: the {measured[0][0]} is {measured[0][1] * 1000:+.0f} ms "
                 f"off the video and the {measured[1][0]} is "
                 f"{measured[1][1] * 1000:+.0f} ms — they have drifted "
                 f"{drift * 1000:+.0f} ms apart, over the "
-                f"{MAX_SKEW_DRIFT_S * 1000:.0f} ms bar. A capture that dropped "
-                f"time would have moved both equally, so this is the beat log's "
-                f"clock: time between beats is not being measured monotonically."
+                f"{bound * 1000:.0f} ms bar. {why}"
             )
         else:
             print(
@@ -3024,26 +3266,51 @@ def check_timeline(
 
 
 def _expected_context(
-    expected_beats: list[tuple[str, str | None]], expected_captions: list[str]
+    expected_beats: list[tuple[str, str | None]],
+    expected_captions: list[str],
+    expected_interludes: list[str] | None = None,
 ) -> list[str] | None:
     """The caption in force during each expected beat.
 
     A `caption` beat carries the text it sets; everything after it carries that
-    text until the next one. Returns None if the two lists disagree about how
-    many captions there are, in which case the checks above already say so and
-    this one has nothing to add.
+    text until the next one. An `interlude` beat carries its own line — it is a
+    title card, not a caption — and leaves the running caption alone, which is
+    also what the recorder does. Returns None if the lists disagree about how
+    many captions or interludes there are, in which case the checks above
+    already say so and this one has nothing to add.
     """
-    wanted = [verb for verb, _ in expected_beats].count("caption")
-    if wanted != len(expected_captions):
+    verbs = [verb for verb, _ in expected_beats]
+    if verbs.count("caption") != len(expected_captions):
+        return None
+    interludes = list(expected_interludes or [])
+    if verbs.count("interlude") != len(interludes):
         return None
     context: list[str] = []
     current = ""
     pending = list(expected_captions)
-    for verb, _ in expected_beats:
+    for verb in verbs:
         if verb == "caption":
             current = pending.pop(0)
+        elif verb == "interlude":
+            context.append(interludes.pop(0))
+            continue
         context.append(current)
     return context
+
+
+def _expected_segment_indices(segments: list[str | None]) -> list[int]:
+    """Each beat's position within its own segment, from the segment column.
+
+    For a single take (every entry None) this is just 0, 1, 2, … — so the
+    assertion that `segment_index` matches it holds for every take here, not
+    only the segmented one.
+    """
+    seen: dict[str | None, int] = {}
+    indices: list[int] = []
+    for name in segments:
+        indices.append(seen.get(name, 0))
+        seen[name] = seen.get(name, 0) + 1
+    return indices
 
 
 def _first_difference(actual: list, expected: list) -> object:
@@ -4469,6 +4736,317 @@ def run_redaction(out_root: Path) -> list[str]:
     return problems + check_redaction(out_dir, info, started)
 
 
+def _segment_parts(out_dir: Path) -> list[str]:
+    """Everything on disk a segment owns, by name."""
+    return sorted(p.name for p in out_dir.glob("*.seg.*"))
+
+
+def _probe_beat(doc: dict, segment: str | None = None) -> dict | None:
+    """The beat that set PROBE_CAPTION, in a segment's log or the merged one."""
+    for beat in doc.get("beats") or []:
+        if beat.get("verb") != "caption" or beat.get("caption") != PROBE_CAPTION:
+            continue
+        if segment is None or beat.get("segment") == segment:
+            return beat
+    return None
+
+
+def check_merge_offset(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
+    """#7's acceptance criterion, with the screencast's own error cancelled.
+
+    The closing caption lives in the *second* segment, so its merged timestamp
+    is entirely the merge's arithmetic. Time it twice — once in
+    `part2.seg.mp4` against that segment's own beat log, once in `demo.mp4`
+    against the merged one — and the two readings differ by the offset error
+    and nothing else: `stitch()` copies the streams, so those are the same
+    frames, carrying the same capture loss, in both files.
+
+    Deliberately *not* computed from the durations the merge wrote down. That
+    would be the harness re-doing the recorder's arithmetic and agreeing with
+    it. This reads pixels out of two videos and compares where the caption
+    actually is.
+    """
+    band = caption_band(frame_size)
+    part = out_dir / f"{SEGMENT_NAMES[-1]}.seg.mp4"
+    demo = out_dir / "demo.mp4"
+    segment_json = out_dir / f"{SEGMENT_NAMES[-1]}.seg.timeline.json"
+    merged_json = out_dir / "timeline.json"
+    # Reported rather than raised: this runs after a keep_parts=True stitch,
+    # so a file missing here is one that stitch already failed to keep, and
+    # crashing on it would bury the failure that explains why.
+    missing = [
+        p.name for p in (part, demo, segment_json, merged_json) if not p.is_file()
+    ]
+    if missing:
+        return [
+            f"segments: {missing!r} is not on disk after stitch(keep_parts=True), "
+            f"so the merge cannot be measured against the segment it came from"
+        ]
+    segment_doc = json.loads(segment_json.read_text())
+    merged_doc = json.loads(merged_json.read_text())
+
+    alone = _probe_beat(segment_doc)
+    stitched = _probe_beat(merged_doc, SEGMENT_NAMES[-1])
+    if alone is None or stitched is None:
+        return [
+            f"segments: the closing caption {PROBE_CAPTION!r} is logged in "
+            f"{SEGMENT_NAMES[-1]}.seg.timeline.json={alone is not None} / the "
+            f"merged timeline (as a {SEGMENT_NAMES[-1]} beat)="
+            f"{stitched is not None} — it has to be in both for the merge to "
+            f"be measurable at all"
+        ]
+    if alone.get("segment_index") != stitched.get("segment_index"):
+        return [
+            f"segments: the closing caption is beat {alone.get('segment_index')!r} "
+            f"of {SEGMENT_NAMES[-1]} in that segment's own log but "
+            f"{stitched.get('segment_index')!r} in the merged one — the two "
+            f"files disagree about which beat this is"
+        ]
+
+    readings: dict[str, float] = {}
+    for what, media, t_start in (
+        ("in its own segment", part, alone.get("t_start")),
+        ("in the stitched demo", demo, stitched.get("t_start")),
+    ):
+        if not isinstance(t_start, (int, float)):
+            return [f"segments: the closing caption has no t_start {what}"]
+        seen_at, note = caption_appearance_s("segments", media, band, float(t_start))
+        if seen_at is None:
+            return [
+                f"segments: the closing caption could not be timed {what} "
+                f"({media.name}) — {note}"
+            ]
+        readings[what] = seen_at - float(t_start)
+
+    error = readings["in the stitched demo"] - readings["in its own segment"]
+    if abs(error) > MAX_MERGE_OFFSET_ERROR_S:
+        return [
+            f"segments: the closing caption sits "
+            f"{readings['in its own segment'] * 1000:+.0f} ms off its beat in "
+            f"{part.name} but {readings['in the stitched demo'] * 1000:+.0f} ms "
+            f"off it in demo.mp4 — the merge moved that beat "
+            f"{error * 1000:+.0f} ms away from the frame it names, past the "
+            f"{MAX_MERGE_OFFSET_ERROR_S * 1000:.0f} ms bar. Both readings are "
+            f"of the same frames, so capture loss (issue #18) cancels here and "
+            f"this is stitch()'s offset arithmetic: it must be the parts' real "
+            f"ffprobe durations, in order."
+        ]
+    print(
+        f"smoke: segments the merge puts the second segment's closing caption "
+        f"{error * 1000:+.0f} ms from where its own segment does "
+        f"({readings['in its own segment'] * 1000:+.0f} ms in {part.name}, "
+        f"{readings['in the stitched demo'] * 1000:+.0f} ms in demo.mp4)"
+    )
+    return []
+
+
+def stitch_segments(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
+    """Stitch the recorded segments, twice, and grade what that produced.
+
+    Twice because `keep_parts` has two directions and both are load-bearing:
+    the first stitch must leave every part *and its beat log* behind, since
+    re-stitching after re-recording one expensive segment is the entire reason
+    that flag exists — and the second, at the default, must take them away
+    together. A `.seg.timeline.json` outliving its `.seg.mp4` is issue #21: it
+    names a file that no longer exists, and the next stitch cannot tell that
+    stale log from a fresh one.
+
+    The merged timeline itself is graded by `check_timeline()`, the same
+    function that grades a single take. What is here is only what is true of a
+    merge and of nothing else.
+    """
+    from demo_recording import media_duration, stitch
+
+    failures: list[str] = []
+    demo = out_dir / "demo.mp4"
+    merged_json = out_dir / "timeline.json"
+
+    # -- what the segments left behind, before any of it is merged -----------
+    before = _segment_parts(out_dir)
+    wanted = sorted(
+        f"{name}.seg.{suffix}"
+        for name in SEGMENT_NAMES
+        for suffix in ("mp4", "timeline.json", "timeline.md")
+    )
+    if before != wanted:
+        return [
+            f"segments: after recording, the take directory holds {before!r}, "
+            f"expected {wanted!r} — each segment writes its own mp4 and its own "
+            f"beat log beside it, and the merge below has nothing to read "
+            f"otherwise"
+        ]
+    if demo.exists() or merged_json.exists():
+        failures.append(
+            f"segments: {demo.name}/{merged_json.name} exist before stitch() "
+            f"was called — every assertion below would be grading a file this "
+            f"run did not produce"
+        )
+
+    # A segment's beats are relative to that segment's own start. Asserted
+    # before the merge so that the merged timestamps being large means
+    # something: if the second segment's log already started at 8 s, a stitch
+    # that offset nothing at all would look exactly like a correct one.
+    durations: list[float] = []
+    for name in SEGMENT_NAMES:
+        part = out_dir / f"{name}.seg.mp4"
+        durations.append(media_duration(part))
+        doc = json.loads((out_dir / f"{name}.seg.timeline.json").read_text())
+        if doc.get("segment") != name or doc.get("media") != part.name:
+            failures.append(
+                f"segments: {name}.seg.timeline.json says segment "
+                f"{doc.get('segment')!r} / media {doc.get('media')!r}, expected "
+                f"{name!r} / {part.name!r}"
+            )
+        first = (doc.get("beats") or [{}])[0].get("t_start")
+        if not isinstance(first, (int, float)) or first > MAX_UNMERGED_FIRST_BEAT_S:
+            failures.append(
+                f"segments: {name}.seg.timeline.json's first beat starts at "
+                f"{first!r}s, which is not a timestamp relative to that "
+                f"segment's own start — the merge below is then unmeasurable"
+            )
+    print(
+        f"smoke: segments recorded {len(SEGMENT_NAMES)} parts, each with its "
+        f"own beat log ("
+        + ", ".join(
+            f"{n} {d:.1f}s" for n, d in zip(SEGMENT_NAMES, durations, strict=True)
+        )
+        + ")"
+    )
+
+    # -- keep_parts=True: the parts and their logs both survive ---------------
+    stitch(out_dir, SEGMENT_NAMES, keep_parts=True)
+    kept = _segment_parts(out_dir)
+    if kept != wanted:
+        # A hard stop: everything below re-reads the parts, and "they were
+        # deleted" is the answer, not a second failure about their contents.
+        return failures + [
+            f"segments: stitch(keep_parts=True) left {kept!r}, expected the "
+            f"parts untouched ({wanted!r}) — re-recording one segment and "
+            f"re-stitching is what that flag is for, and it needs the beat logs "
+            f"as much as the mp4s"
+        ]
+    if not merged_json.is_file():
+        return failures + [
+            "segments: stitch() wrote no timeline.json next to demo.mp4 — the "
+            "segments' beat logs were not merged at all"
+        ]
+    first_merge = json.loads(merged_json.read_text())
+
+    # While the parts are still here: the acceptance criterion, measured
+    # against both videos so the screencast's own error cancels.
+    failures += check_merge_offset(out_dir, frame_size)
+
+    # -- the default: parts and logs go together (issue #21) ------------------
+    stitch(out_dir, SEGMENT_NAMES)
+    left = _segment_parts(out_dir)
+    if left:
+        failures.append(
+            f"segments: after stitch() at the default keep_parts=False, "
+            f"{left!r} are still on disk. A .seg.timeline.json whose .seg.mp4 "
+            f"has been deleted names a file that no longer exists, and the next "
+            f"stitch cannot tell it from a fresh one (issue #21)"
+        )
+    second_merge = json.loads(merged_json.read_text())
+    if second_merge.get("beats") != first_merge.get("beats"):
+        failures.append(
+            "segments: re-stitching the same parts produced different beats — "
+            "the merge is not a function of what is on disk, so a re-stitch "
+            "after re-recording one segment cannot be trusted"
+        )
+
+    # -- the offsets the merge recorded, against ffprobe ----------------------
+    records = second_merge.get("segments")
+    if not isinstance(records, list) or len(records) != len(SEGMENT_NAMES):
+        failures.append(
+            f"segments: the merged timeline's `segments` is {records!r}, "
+            f"expected one record per part in order — it is what maps a "
+            f"merged timestamp back to the file it came from"
+        )
+        return failures
+    offset = 0.0
+    for record, name, probed in zip(records, SEGMENT_NAMES, durations, strict=True):
+        if record.get("segment") != name or record.get("media") != f"{name}.seg.mp4":
+            failures.append(
+                f"segments: merged `segments` record {record!r} is not part "
+                f"{name!r} — the parts are listed out of order, or renamed"
+            )
+        for field, wanted_value in (("duration", probed), ("offset", offset)):
+            value = record.get(field)
+            if (
+                not isinstance(value, (int, float))
+                or abs(value - wanted_value) > SEGMENT_OFFSET_TOLERANCE_S
+            ):
+                failures.append(
+                    f"segments: merged `segments` says {name} {field} "
+                    f"{value!r}s; ffprobe makes it {wanted_value:.3f}s. The "
+                    f"offsets have to be the encoder's own durations — nominal "
+                    f"storyboard timing puts every later beat past its frame "
+                    f"(issue #18)"
+                )
+        offset += probed
+
+    total = media_duration(demo) if demo.is_file() else 0.0
+    if abs(total - offset) > SEGMENT_OFFSET_TOLERANCE_S:
+        failures.append(
+            f"segments: the parts are {offset:.2f}s of video between them but "
+            f"demo.mp4 is {total:.2f}s — the offsets do not tile the stitched "
+            f"video, so beats in the last segment cannot line up with it"
+        )
+    if not failures:
+        print(
+            f"smoke: segments stitched {len(SEGMENT_NAMES)} parts into a "
+            f"{total:.1f}s demo.mp4 and merged their beat logs "
+            f"({len(second_merge.get('beats') or [])} beats); keep_parts=True "
+            f"kept every part and its log, the default removed them"
+        )
+    return failures
+
+
+def run_segments(out_root: Path) -> list[str]:
+    """Record a demo in two parts, stitch it, and grade the merged log.
+
+    The merged timeline is handed to `check_timeline()` — the same function,
+    the same assertions, including the measured one — because a segmented demo
+    that is graded more softly than a single take is a segmented demo nobody
+    can trust. What is extra here is `stitch_segments()`.
+    """
+    out_dir = fresh_take_dir(out_root, "segments")
+    started = time.time()
+    with fixture_server() as base_url:
+        try:
+            problems, video_rect, still_rect, size = record_segments(out_dir, base_url)
+        except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+            return [f"segments: Recorder raised {type(exc).__name__}: {exc}"]
+        try:
+            problems += stitch_segments(out_dir, size)
+        except Exception as exc:  # noqa: BLE001 - a raising stitch is a failure
+            problems.append(f"segments: stitch() raised {type(exc).__name__}: {exc}")
+    return (
+        problems
+        + check_take(
+            "segments",
+            out_dir,
+            SEGMENT_SHOTS,
+            SEGMENT_DURATION_S,
+            started,
+            video_rect,
+            still_rect,
+            size,
+        )
+        + check_timeline(
+            "segments",
+            out_dir,
+            started,
+            SEGMENT_BEATS,
+            SEGMENT_CAPTIONS,
+            size,
+            expected_segments=SEGMENT_BEAT_SEGMENTS,
+            expected_interludes=SEGMENT_INTERLUDES,
+        )
+        + check_healthy("segments", out_dir)
+    )
+
+
 def run_terminal(out_root: Path) -> list[str]:
     if os.name != "posix":
         print(
@@ -4534,6 +5112,11 @@ def main() -> int:
         help="record only the redaction take (issue #4)",
     )
     parser.add_argument(
+        "--segments-only",
+        action="store_true",
+        help="record only the two-segment take and its stitch (issue #7)",
+    )
+    parser.add_argument(
         "--out-dir",
         type=Path,
         help="where recordings land (default: a fresh temp dir). The web/ and "
@@ -4554,6 +5137,7 @@ def main() -> int:
             ("--terminal-only", args.terminal_only),
             ("--determinism-only", args.determinism_only),
             ("--redaction-only", args.redaction_only),
+            ("--segments-only", args.segments_only),
         )
         if on
     ]
@@ -4593,6 +5177,8 @@ def main() -> int:
             failures += run_redaction(out_root)
         if only in (None, "--terminal-only"):
             failures += run_terminal(out_root)
+        if only in (None, "--segments-only"):
+            failures += run_segments(out_root)
         # After the graded takes, never instead of them: these five record
         # nothing worth looking at, and if a recorder is broken the messages
         # above are the ones that say how.

--- a/tests/smoke
+++ b/tests/smoke
@@ -605,6 +605,14 @@ SEGMENT_BEAT_SEGMENTS = [segment for _, _, segment in SEGMENT_BEATS_FULL]
 SEGMENT_CAPTIONS = [SEGMENT_OPENING, "", "", PROBE_CAPTION, ""]
 SEGMENT_INTERLUDES = [SEGMENT_INTERLUDE]
 
+# The caption each segment is timed on, in segment order — every one preceded
+# by PROBE_QUIET_S of caption-band quiet, so each can be found in its own
+# `.seg.mp4` as well as in the stitched demo. **One per segment, and that is
+# the point**: a probe only in the last segment measures only the last
+# cumulative offset, and a constant shift applied to an earlier segment's
+# beats leaves that offset exact. See check_merge_offset().
+SEGMENT_PROBES = [SEGMENT_OPENING, PROBE_CAPTION]
+
 # How far the segment offsets recorded in the merged envelope may sit from what
 # ffprobe says about the parts, and from the stitched demo.mp4's own duration.
 # They are the same measurement — this is concat's frame quantisation and the
@@ -617,37 +625,46 @@ SEGMENT_OFFSET_TOLERANCE_S = 0.2
 # were large to begin with — that is what makes the merge visible at all.
 MAX_UNMERGED_FIRST_BEAT_S = 3.0
 
-# How far the merge itself may be wrong, in seconds. This is #7's acceptance
-# criterion, and it is measured **differentially**, which is the only way to
-# state it this tightly:
+# How far the merge itself may be wrong, in seconds — **per segment**. This is
+# #7's acceptance criterion, and it is measured differentially, which is the
+# only way to state it this tightly:
 #
-#   the closing caption is timed once in `part2.seg.mp4` against that
-#   segment's own beat log, and once in the stitched `demo.mp4` against the
-#   merged one. Both readings carry the same screencast capture loss — the
-#   frames are literally the same frames, `stitch()` copies the streams — so
-#   the *difference* between the two skews is the merge's offset error and
-#   nothing else.
+#   each segment's probe caption is timed once in that segment's own
+#   `.seg.mp4` against that segment's own beat log, and once in the stitched
+#   `demo.mp4` against the merged one. Both readings carry the same screencast
+#   capture loss — the frames are literally the same frames, `stitch()` copies
+#   the streams — so the *difference* between the two skews is that segment's
+#   offset error and nothing else.
 #
 # What that removes is issue #18, which would otherwise dominate: a segment
 # whose capture stalled shows every caption early in its own video too, and a
 # bar on the absolute skew could never tell that apart from an offset the
 # merge got wrong. Residual noise is the 40 ms sampling grid in each of the
 # two measurements, which do not share a sampling phase.
+#
+# One probe per segment rather than one per demo, because the differential at
+# the *last* segment measures only the last cumulative offset: a constant
+# shift of an earlier segment's beats leaves it exact and passes. Measured —
+# +350 ms onto segment one read as +0 ms here while this timed one beat.
 MAX_MERGE_OFFSET_ERROR_S = 0.1
 
 # Bound on how far the *two* timing probes may drift apart when they sit in
-# different segments. MAX_SKEW_DRIFT_S (250 ms) is the sharp one and it works
-# because whatever a capture loses it loses for every later frame equally — so
-# a stall moves both probes together and cancels. That argument holds inside
-# one screencast and stops at a segment boundary: each segment is its own
-# capture, with its own ~0.7 s of untickerable recorder setup, and a stall in
-# the second shifts only the second probe. Measured across four two-segment
-# takes: -80, +80, +80, and one at -520 (the segment-two stall of #18).
+# different segments. MAX_SKEW_DRIFT_S (250 ms) is sharp because whatever a
+# capture loses it loses for every later frame equally, so a stall moves both
+# probes together and cancels. That argument holds inside one screencast and
+# stops at a segment boundary: each segment is its own capture, with its own
+# ~0.7 s of untickerable recorder setup, and a stall in the second shifts only
+# the second probe. Measured across four two-segment takes: -80, +80, +80, and
+# one at -520 — a real capture stall in segment two, not a merge error, which
+# a 250 ms bar here would fail on about one run in four.
 #
-# So across a boundary the bound is a whole capture-loss window, and the
-# merge's own accuracy is asserted separately and far more tightly by
-# MAX_MERGE_OFFSET_ERROR_S. Nothing is given up: an offset error shows up
-# there, at 100 ms, with the capture loss cancelled out.
+# **This is a flake guard, not a check.** It is loose because the mechanism it
+# would otherwise catch is measured properly elsewhere, per segment and per
+# capture, by check_merge_offset(): the merge's own error at 100 ms with
+# capture loss cancelled, and each segment's own skew against the same 250 /
+# 750 ms directional bars a single take gets. Neither of those is confounded
+# by the boundary, and neither is satisfied by a constant shift of any
+# segment's beats — which is what this bar, at any width, cannot say.
 MAX_CROSS_SEGMENT_DRIFT_S = MAX_CAPTURE_LOSS_S
 
 # -- redaction (issue #4) ----------------------------------------------------
@@ -3244,9 +3261,9 @@ def check_timeline(
             "this is the beat log's clock: time between beats is not being "
             "measured monotonically."
             if same_capture
-            else "These two probes are in different segments, so this is a "
-            "whole capture-loss window on top of anything the merge got "
-            "wrong — the merge's own error is bounded separately."
+            else "These two probes are in different segments, so they rode "
+            "different captures and this bar is only a flake guard — the "
+            "sharp per-segment ones are in check_merge_offset()."
         )
         if abs(drift) > bound:
             failures.append(
@@ -4741,10 +4758,10 @@ def _segment_parts(out_dir: Path) -> list[str]:
     return sorted(p.name for p in out_dir.glob("*.seg.*"))
 
 
-def _probe_beat(doc: dict, segment: str | None = None) -> dict | None:
-    """The beat that set PROBE_CAPTION, in a segment's log or the merged one."""
+def _probe_beat(doc: dict, text: str, segment: str | None = None) -> dict | None:
+    """The beat that set `text`, in a segment's own log or the merged one."""
     for beat in doc.get("beats") or []:
-        if beat.get("verb") != "caption" or beat.get("caption") != PROBE_CAPTION:
+        if beat.get("verb") != "caption" or beat.get("caption") != text:
             continue
         if segment is None or beat.get("segment") == segment:
             return beat
@@ -4752,92 +4769,130 @@ def _probe_beat(doc: dict, segment: str | None = None) -> dict | None:
 
 
 def check_merge_offset(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
-    """#7's acceptance criterion, with the screencast's own error cancelled.
+    """#7's acceptance criterion, per segment, with capture loss cancelled.
 
-    The closing caption lives in the *second* segment, so its merged timestamp
-    is entirely the merge's arithmetic. Time it twice — once in
-    `part2.seg.mp4` against that segment's own beat log, once in `demo.mp4`
-    against the merged one — and the two readings differ by the offset error
-    and nothing else: `stitch()` copies the streams, so those are the same
-    frames, carrying the same capture loss, in both files.
+    Every segment carries a caption with a quiet run-up (`SEGMENT_PROBES`), and
+    each one is timed **twice**: in that segment's own `.seg.mp4` against that
+    segment's own beat log, and in the stitched `demo.mp4` against the merged
+    one. `stitch()` copies the streams, so those are literally the same frames
+    carrying the same screencast capture loss — the *difference* between the
+    two skews is `offset_true - offset_recorded` for that segment, and nothing
+    else.
 
-    Deliberately *not* computed from the durations the merge wrote down. That
+    **One probe per segment, not one per demo.** Timing only the last
+    segment's caption measures only the last cumulative offset: a constant
+    shift applied to segment one's beats leaves the final offset exact and
+    goes unseen, and with three or more segments every intermediate offset has
+    no pixel measurement at all. Injecting +350 ms onto segment one passed
+    this file when it timed one beat.
+
+    Each segment's own skew is graded too, against the same directional bars a
+    single take gets. That is the half the differential cannot see: it cancels
+    capture loss on purpose, so a segment whose *own* video has slid away from
+    its *own* beat log — a stall, or a bad clock — divides out of it exactly.
+    Together they say where the merge put a beat and where the recording put
+    it, separately, per capture.
+
+    Deliberately *not* computed from the durations the merge wrote down: that
     would be the harness re-doing the recorder's arithmetic and agreeing with
-    it. This reads pixels out of two videos and compares where the caption
-    actually is.
+    it. This reads pixels out of two videos.
     """
     band = caption_band(frame_size)
-    part = out_dir / f"{SEGMENT_NAMES[-1]}.seg.mp4"
     demo = out_dir / "demo.mp4"
-    segment_json = out_dir / f"{SEGMENT_NAMES[-1]}.seg.timeline.json"
     merged_json = out_dir / "timeline.json"
-    # Reported rather than raised: this runs after a keep_parts=True stitch,
-    # so a file missing here is one that stitch already failed to keep, and
-    # crashing on it would bury the failure that explains why.
-    missing = [
-        p.name for p in (part, demo, segment_json, merged_json) if not p.is_file()
-    ]
-    if missing:
-        return [
-            f"segments: {missing!r} is not on disk after stitch(keep_parts=True), "
-            f"so the merge cannot be measured against the segment it came from"
-        ]
-    segment_doc = json.loads(segment_json.read_text())
-    merged_doc = json.loads(merged_json.read_text())
+    failures: list[str] = []
 
-    alone = _probe_beat(segment_doc)
-    stitched = _probe_beat(merged_doc, SEGMENT_NAMES[-1])
-    if alone is None or stitched is None:
-        return [
-            f"segments: the closing caption {PROBE_CAPTION!r} is logged in "
-            f"{SEGMENT_NAMES[-1]}.seg.timeline.json={alone is not None} / the "
-            f"merged timeline (as a {SEGMENT_NAMES[-1]} beat)="
-            f"{stitched is not None} — it has to be in both for the merge to "
-            f"be measurable at all"
+    for name, text in zip(SEGMENT_NAMES, SEGMENT_PROBES, strict=True):
+        part = out_dir / f"{name}.seg.mp4"
+        segment_json = out_dir / f"{name}.seg.timeline.json"
+        # Reported rather than raised: this runs after a keep_parts=True
+        # stitch, so a file missing here is one that stitch already failed to
+        # keep, and crashing on it would bury the failure that explains why.
+        missing = [
+            p.name for p in (part, demo, segment_json, merged_json) if not p.is_file()
         ]
-    if alone.get("segment_index") != stitched.get("segment_index"):
-        return [
-            f"segments: the closing caption is beat {alone.get('segment_index')!r} "
-            f"of {SEGMENT_NAMES[-1]} in that segment's own log but "
-            f"{stitched.get('segment_index')!r} in the merged one — the two "
-            f"files disagree about which beat this is"
-        ]
+        if missing:
+            failures.append(
+                f"segments: {missing!r} is not on disk after "
+                f"stitch(keep_parts=True), so {name}'s beats cannot be measured "
+                f"against the segment they came from"
+            )
+            continue
+        alone = _probe_beat(json.loads(segment_json.read_text()), text)
+        stitched = _probe_beat(json.loads(merged_json.read_text()), text, name)
+        if alone is None or stitched is None:
+            failures.append(
+                f"segments: {name}'s probe caption {text!r} is logged in "
+                f"{segment_json.name}={alone is not None} / the merged timeline "
+                f"(as a {name} beat)={stitched is not None} — it has to be in "
+                f"both for that segment's offset to be measurable at all"
+            )
+            continue
+        if alone.get("segment_index") != stitched.get("segment_index"):
+            failures.append(
+                f"segments: {name}'s probe caption is beat "
+                f"{alone.get('segment_index')!r} of {name} in that segment's own "
+                f"log but {stitched.get('segment_index')!r} in the merged one — "
+                f"the two files disagree about which beat this is"
+            )
+            continue
 
-    readings: dict[str, float] = {}
-    for what, media, t_start in (
-        ("in its own segment", part, alone.get("t_start")),
-        ("in the stitched demo", demo, stitched.get("t_start")),
-    ):
-        if not isinstance(t_start, (int, float)):
-            return [f"segments: the closing caption has no t_start {what}"]
-        seen_at, note = caption_appearance_s("segments", media, band, float(t_start))
-        if seen_at is None:
-            return [
-                f"segments: the closing caption could not be timed {what} "
-                f"({media.name}) — {note}"
-            ]
-        readings[what] = seen_at - float(t_start)
+        readings: dict[str, float] = {}
+        for what, media, t_start in (
+            ("in its own segment", part, alone.get("t_start")),
+            ("in the stitched demo", demo, stitched.get("t_start")),
+        ):
+            if not isinstance(t_start, (int, float)):
+                readings.clear()
+                failures.append(f"segments: {name}'s probe has no t_start {what}")
+                break
+            seen_at, note = caption_appearance_s(
+                "segments", media, band, float(t_start)
+            )
+            if seen_at is None:
+                readings.clear()
+                failures.append(
+                    f"segments: {name}'s probe caption could not be timed {what} "
+                    f"({media.name}) — {note}"
+                )
+                break
+            readings[what] = seen_at - float(t_start)
+        if len(readings) != 2:
+            continue
 
-    error = readings["in the stitched demo"] - readings["in its own segment"]
-    if abs(error) > MAX_MERGE_OFFSET_ERROR_S:
-        return [
-            f"segments: the closing caption sits "
-            f"{readings['in its own segment'] * 1000:+.0f} ms off its beat in "
-            f"{part.name} but {readings['in the stitched demo'] * 1000:+.0f} ms "
-            f"off it in demo.mp4 — the merge moved that beat "
-            f"{error * 1000:+.0f} ms away from the frame it names, past the "
-            f"{MAX_MERGE_OFFSET_ERROR_S * 1000:.0f} ms bar. Both readings are "
-            f"of the same frames, so capture loss (issue #18) cancels here and "
-            f"this is stitch()'s offset arithmetic: it must be the parts' real "
-            f"ffprobe durations, in order."
-        ]
-    print(
-        f"smoke: segments the merge puts the second segment's closing caption "
-        f"{error * 1000:+.0f} ms from where its own segment does "
-        f"({readings['in its own segment'] * 1000:+.0f} ms in {part.name}, "
-        f"{readings['in the stitched demo'] * 1000:+.0f} ms in demo.mp4)"
-    )
-    return []
+        own, joined = readings["in its own segment"], readings["in the stitched demo"]
+        error = joined - own
+        if abs(error) > MAX_MERGE_OFFSET_ERROR_S:
+            failures.append(
+                f"segments: {name}'s probe caption sits {own * 1000:+.0f} ms off "
+                f"its beat in {part.name} but {joined * 1000:+.0f} ms off it in "
+                f"demo.mp4 — the merge moved that beat {error * 1000:+.0f} ms "
+                f"away from the frame it names, past the "
+                f"{MAX_MERGE_OFFSET_ERROR_S * 1000:.0f} ms bar. Both readings are "
+                f"of the same frames, so capture loss (issue #18) cancels here "
+                f"and this is stitch()'s offset arithmetic for {name}: it must "
+                f"be the parts' real ffprobe durations, in order."
+            )
+            continue
+        # The other half, per capture: this segment's own video against this
+        # segment's own log, on the same directional bars a single take gets.
+        # The differential above divides this out by construction.
+        if own > MAX_LOG_EARLY_S or own < -MAX_CAPTURE_LOSS_S:
+            failures.append(
+                f"segments: {name}'s probe caption is {own * 1000:+.0f} ms off "
+                f"its beat *within {part.name}*, outside the "
+                f"{-MAX_CAPTURE_LOSS_S * 1000:.0f}…{MAX_LOG_EARLY_S * 1000:+.0f} ms "
+                f"a single capture is allowed. The merge is not involved — this "
+                f"segment's own beat log and its own video disagree (a positive "
+                f"skew is the log's; a negative one is capture loss, issue #18)."
+            )
+            continue
+        print(
+            f"smoke: segments {name}'s probe caption is {error * 1000:+.0f} ms "
+            f"from where its own segment puts it ({own * 1000:+.0f} ms in "
+            f"{part.name}, {joined * 1000:+.0f} ms in demo.mp4)"
+        )
+    return failures
 
 
 def stitch_segments(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
@@ -4887,10 +4942,12 @@ def stitch_segments(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
     # something: if the second segment's log already started at 8 s, a stitch
     # that offset nothing at all would look exactly like a correct one.
     durations: list[float] = []
+    segment_docs: list[dict] = []
     for name in SEGMENT_NAMES:
         part = out_dir / f"{name}.seg.mp4"
         durations.append(media_duration(part))
         doc = json.loads((out_dir / f"{name}.seg.timeline.json").read_text())
+        segment_docs.append(doc)
         if doc.get("segment") != name or doc.get("media") != part.name:
             failures.append(
                 f"segments: {name}.seg.timeline.json says segment "
@@ -4954,7 +5011,13 @@ def stitch_segments(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
             "after re-recording one segment cannot be trusted"
         )
 
-    # -- the offsets the merge recorded, against ffprobe ----------------------
+    # -- every field of the records the merge wrote, against its sources ------
+    #
+    # All six, not the two that are interesting. `beats`, `recorder` and
+    # `determinism` are what SKILL.md tells a reader to fall back to when the
+    # top level says "mixed" or null, so an unasserted one is a documented
+    # source of truth that nothing checks: both were injected — `beats`
+    # hardcoded to 0, `recorder` to "Bogus" — and the suite passed.
     records = second_merge.get("segments")
     if not isinstance(records, list) or len(records) != len(SEGMENT_NAMES):
         failures.append(
@@ -4964,7 +5027,9 @@ def stitch_segments(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
         )
         return failures
     offset = 0.0
-    for record, name, probed in zip(records, SEGMENT_NAMES, durations, strict=True):
+    for record, name, probed, doc in zip(
+        records, SEGMENT_NAMES, durations, segment_docs, strict=True
+    ):
         if record.get("segment") != name or record.get("media") != f"{name}.seg.mp4":
             failures.append(
                 f"segments: merged `segments` record {record!r} is not part "
@@ -4983,6 +5048,33 @@ def stitch_segments(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
                     f"storyboard timing puts every later beat past its frame "
                     f"(issue #18)"
                 )
+        # Carried over from the segment's own log, so it is graded against that
+        # log rather than against a number this file made up. `beats` is
+        # checked against the segment's beat count *and* against how many of
+        # that segment's beats actually reached the merged list — the two can
+        # only differ if the merge dropped or duplicated some.
+        merged_from_segment = sum(
+            1 for b in (second_merge.get("beats") or []) if b.get("segment") == name
+        )
+        for field, wanted_value in (
+            ("beats", len(doc.get("beats") or [])),
+            ("recorder", doc.get("recorder")),
+            ("determinism", doc.get("determinism")),
+        ):
+            if record.get(field) != wanted_value:
+                failures.append(
+                    f"segments: merged `segments` says {name} {field} "
+                    f"{record.get(field)!r}, but {name}.seg.timeline.json says "
+                    f"{wanted_value!r} — SKILL.md points a reader at these "
+                    f"records for exactly the per-segment truth the top-level "
+                    f"envelope cannot carry once segments disagree"
+                )
+        if record.get("beats") != merged_from_segment:
+            failures.append(
+                f"segments: merged `segments` says {name} contributed "
+                f"{record.get('beats')!r} beats, but {merged_from_segment} beats "
+                f"in the merged list carry that segment"
+            )
         offset += probed
 
     total = media_duration(demo) if demo.is_file() else 0.0


### PR DESCRIPTION
Fixes #7. Fixes #21.

Each segment produced its own `timeline.json` with timestamps relative to its
own start, so a multi-segment demo had no coherent timeline — and every
consumer of the manifest broke on exactly the demos hardest to review by hand.

`stitch()` now loads and validates every segment's timeline **before** ffmpeg
runs (a post-concat failure would leave a fresh `demo.mp4` with no timeline),
then concatenates, merges, and cleans up. Offsets come from
`media_duration()` on each `.seg.mp4` — the encoder's answer, never nominal
beat timing.

#21: `.seg.timeline.json`/`.md` are now deleted exactly when their `.seg.mp4`
is, and kept under `keep_parts=True` since a re-stitch needs them.

## Segments were completely untested before this

`tests/README.md` listed them under Known gaps: no take recorded a segment and
`interlude` beats were unexercised. Coverage came first, merge logic second.

## The acceptance criterion, measured differentially

**+0 ms on all six takes.** The closing caption lives in segment two and is
timed twice — in `part2.seg.mp4` against that segment's own log, and in the
stitched `demo.mp4` against the merged log. `stitch` copies streams, so those
are the same frames carrying the same capture loss; the *difference* is merge
error alone, with #18 cancelled.

That cancellation forced an honest change: the harness's sharp 250ms
probes-drifting-apart bound assumes both probes rode one capture. Across a
segment boundary they do not — each segment has its own screencast and its own
~0.7s untickerable setup window, and one of four early takes lost a whole one
(−520ms). The cross-boundary bound is now one capture-loss window (750ms),
documented, with the tight claim made by the differential measurement instead
of by a bar.

## #22

Fixed by **stable identity**, not renumbering. `index` keeps meaning "position
in this file" and is renumbered on merge (timeline.md's table, "beat N (verb)"
messages and `issues[].beat` all read it that way). Every beat also carries
`segment_index`, written for every take and untouched by the merge, so
`(segment, segment_index)` names a beat identically before and after a stitch.

Renumbering was rejected because #9 writes evidence *during* a take, when
nothing knows how many segments there will be — it would make #9 depend on #7
having run, and make a re-stitch rewrite files for segments that did not
change. #22 stays open until #9 names files from that pair.

17 fault injections, each watched fail — including `nominal_timing`, the exact
bug the issue warns about (parts off by ~0.9s each, caption 2.08s from its
frame), and two anti-vacuity checks.

Filed #51: `stitch()`'s issue-merging path is untested, because the segmented
take is healthy by design.