### PR TITLE
Redact secrets on the terminal PTY output path

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -57,6 +57,23 @@ The words, and what each fixture element they belong to is for:
   TKCT  #token-control     a field's control — same chrome, never redacted
   SDCT  #sd-token-control  the same, inside the shadow root
   LATE  a caption          set before the value in it was registered
+
+The terminal half of redaction (issue #5) needs four more, and they are not
+all `sk-live-` shaped because the shapes themselves are what is being tested:
+
+  PTYK  sk-live-…   registered, printed by a command under a PTY
+  ANSI  sk-live-…   the same, printed with a colour escape inside it
+  SHAP  ghp_…       registered by nobody — the shape net is all that hides it
+  SEND  pw-live-…   sent as Secret(...); deliberately matches no shape, so
+                    that what masks it can only be the registration
+  TCTL  zz-live-…   never registered and matching no shape, on purpose: it is
+                    the legible reference every masked row is measured against
+
+Same convention as above — a four-letter word and a run of zeroes — and the
+same reasoning: the default ruleset flags none of them (the GitHub rule wants
+exactly 36 characters after `ghp_`; this one has 24), and these entries exist
+so a future release that does start flagging them cannot turn the job red for
+strings that were never credentials.
 """
 paths = ['''^skills/demo-video/helpers/assets/''']
 regexes = [

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -58,22 +58,40 @@ The words, and what each fixture element they belong to is for:
   SDCT  #sd-token-control  the same, inside the shadow root
   LATE  a caption          set before the value in it was registered
 
-The terminal half of redaction (issue #5) needs four more, and they are not
-all `sk-live-` shaped because the shapes themselves are what is being tested:
+The terminal half of redaction (issue #5) adds a family of its own, and they
+are not all `sk-live-` shaped because the shapes themselves are what is being
+tested. **No allowlist entry was added for any of them, and none is needed** —
+the `regexes` list below covers the web literals only. They are described here
+because this file's comments are the audit trail for every fake credential in
+the repo, and a value nobody wrote down is a value the next person has to
+re-derive:
 
   PTYK  sk-live-…   registered, printed by a command under a PTY
   ANSI  sk-live-…   the same, printed with a colour escape inside it
+  HIDE  sk-live-…   the same, cut by a cursor-hide escape
+  OSCT  sk-live-…   the same, cut by a window-title escape
+  PAUS  sk-live-…   the same shape, paused mid-value inside the hold window
   SHAP  ghp_…       registered by nobody — the shape net is all that hides it
+  STRM  ghp_…       the same, written one character at a time
+  ANCH  ghp_…       the same, paused after its first character
+  SLOW  ghp_…       the same, paused *past* the hold window — the one value in
+                    the take that is supposed to render in the clear, because
+                    it grades a documented limit
+  CURS  sk-live-…   written at two cursor positions, which must kill the take
+  KEYD  sk-live-…   spelled out through key(), which must be refused
+  AKIA…             an AWS-shaped id nobody registered
+  eyJ….eyJ….        a JWT-shaped token nobody registered
   SEND  pw-live-…   sent as Secret(...); deliberately matches no shape, so
                     that what masks it can only be the registration
   TCTL  zz-live-…   never registered and matching no shape, on purpose: it is
                     the legible reference every masked row is measured against
 
 Same convention as above — a four-letter word and a run of zeroes — and the
-same reasoning: the default ruleset flags none of them (the GitHub rule wants
-exactly 36 characters after `ghp_`; this one has 24), and these entries exist
-so a future release that does start flagging them cannot turn the job red for
-strings that were never credentials.
+same reasoning: the default ruleset flags none of them. The GitHub rule wants
+exactly 36 characters after `ghp_` and these have 24; the AWS rule wants
+exactly 16 after `AKIA` and this has 24; the JWT rule wants 17 or more in each
+of the first two segments and needs the second to begin `ey`, and this one has
+neither. Verified by running gitleaks over the whole tree, not assumed.
 """
 paths = ['''^skills/demo-video/helpers/assets/''']
 regexes = [

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -382,8 +382,8 @@ with Recorder(Path(__file__).parent) as rec:
     it had already taken. A redacted take also withholds the first paint of
     each navigation until that check has passed.
 - **`register_secret(*values)`** is about *text*, not pixels. A `caption()`,
-  `interlude()`, `terminal()` or `terminal_close()` line containing a
-  registered value raises `SecretLeak` and **fails the take** — deliberately,
+  `interlude()`, `terminal()`, `terminal_close()`, `run()` or `send()` line
+  containing a registered value raises `SecretLeak` and **fails the take** — deliberately,
   rather than masking the line: captions are burned in *and* spoken *and*
   cached as audio in `.tts/`, and a secret in one is an authoring bug that
   wants rewording, not blurring. Text you did not author is scrubbed to
@@ -396,10 +396,82 @@ with Recorder(Path(__file__).parent) as rec:
   yields `[redacted]`, and it can never be logged as a beat's target by
   accident.
 
+### Redaction in a terminal demo
+
+`TerminalRecorder` has no `redact()`, and that is not an omission: a CSS
+selector means nothing to a PTY. What it has instead is a **scrubber on the
+output path**, between `os.read()` and the terminal, so a secret a program
+prints never reaches the buffer the frames are drawn from.
+
+```python
+from demo_recording import TerminalRecorder, Secret
+
+with TerminalRecorder(Path(__file__).parent) as rec:
+    rec.register_secret(os.environ["DEMO_TOKEN"])   # exact text: the guarantee
+    rec.run("./deploy --show-config")               # its output comes back masked
+    rec.run("ssh-add -l")                           # wait_for_prompt() sees the mask too
+    rec.send(Secret(os.environ["DEMO_PW"]))         # a password, at a prompt
+```
+
+- **Registered values are the guarantee.** Every occurrence in a program's
+  output becomes `[redacted]` — in the video, in the stills, and in the screen
+  text `wait_for_text()` and `wait_for_prompt()` match against. It holds when
+  the value is chopped across `os.read()` boundaries (the recorder holds back
+  any trailing fragment that could still complete one, with no time limit) and
+  when an escape sequence is printed *inside* it, as long as that sequence
+  does not move the cursor — see below.
+- **…and what the stream cannot express, the recorder refuses.** Before it
+  writes anything, the take reads the finished terminal — visible screen and
+  scrollback — and raises `SecretLeak` if a registered value is in it: no mp4,
+  no timeline, no stills. That is the backstop for the case the scrubber
+  cannot see (a value written in two pieces at two cursor positions), and it
+  is why "not covered" below means "the take dies", not "it records the key".
+- **Shape detection is a safety net under that, not a substitute for it.**
+  Four patterns are masked whether or not anyone registered them:
+
+  | | what it matches |
+  |---|---|
+  | `sk-…` | `sk-` + 16 or more of `A-Za-z0-9_-` |
+  | `ghp_…` | `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_` + 16 or more alphanumerics |
+  | `AKIA…` | `AKIA` or `ASIA` + 12 or more of `0-9A-Z` |
+  | JWT | `eyJ` + base64url, a `.`, base64url, optionally `.` and more |
+
+  They are deliberately narrow. Anything looser starts masking ordinary
+  output, and a demo with holes punched in it at random is worse than one that
+  shows a fake key. **Do not plan a demo around them**: a value that does not
+  match one of those four shapes — a database URL with a password in it, a
+  session cookie, an internal token format, a licence key — is not touched
+  unless you register it. They are also the *only* thing the final screen
+  check ignores: a registered value on screen kills the take, a shape-matched
+  one does not, because failing a recording on a heuristic is worse than the
+  heuristic missing.
+- **`run()` and `send()` refuse authored secrets.** A command line is text the
+  storyboard wrote and the PTY echoes on camera, so it is treated like a
+  caption: `run("curl -H 'x-api-key: sk-live-…'")` raises `SecretLeak` and
+  fails the take rather than typing a command the viewer cannot read. Pass the
+  value through the environment instead (`run('curl -H "x-api-key: $KEY"')`),
+  or type it with `send(Secret(...))`.
+- **`send(Secret(v))` is the password case.** It registers the value, types
+  the real thing, and the terminal's own echo of it comes back masked — one
+  character per read, which is exactly the split the carry buffer exists for.
+  Programs that turn echo off (a real `getpass`) show nothing either way.
+- **`key()` refuses one too.** `key(*value)` spells a value out one keystroke
+  at a time, and the beat it records is those keys joined by spaces — which no
+  scrub of the value can match, in a file this skill tells you to commit. So
+  the call raises rather than the log leaking.
+- **A held fragment can make the screen lag.** The recorder cannot know that
+  `sk-live-de` is the start of a registered value until the rest arrives, so
+  it withholds it. If the program then goes quiet — a prompt waiting for
+  input — those characters stay off screen, and a `wait_for_text()` looking
+  for them waits with them. After two seconds the recorder says so on stderr,
+  naming the count. Shape fragments are not held indefinitely: they go out
+  after three seconds, or immediately if they sit in the middle of a word
+  rather than where a token would start.
+
 ### What redaction does NOT cover
 
-Read this before trusting a recording to it. It closes four specific paths, and
-nothing else:
+Read this before trusting a recording to it. It closes a specific, countable
+set of paths — four on the web, one in the terminal — and nothing else:
 
 - **The cover is erasure; `style="blur"` is not.** An opaque rectangle
   removes the pixels. A blur destroys legibility, not information — a
@@ -419,10 +491,13 @@ nothing else:
   text, so the value stays *unregistered* — write it into a caption yourself
   and it will be captioned, spoken and cached without complaint. Register the
   text separately, or type it as a `Secret`.
-- **Only exact substrings match.** No shape detection, no `sk-`/`ghp_`/`AKIA`
-  patterns, no normalisation — a secret rendered with different whitespace, a
-  soft hyphen, or split across two elements is not caught. (Shape matching for
-  the terminal path is [issue #5](https://github.com/rogvid/skills/issues/5).)
+- **Only exact substrings match, on every path but one.** No normalisation —
+  a secret rendered with different whitespace, a soft hyphen, or split across
+  two elements is not caught, and a caption or a beat field is checked
+  literally. The single exception is the terminal recorder's PTY output, which
+  also runs four shape patterns over what a program prints; those are listed
+  under **Redaction in a terminal demo**, they apply nowhere else, and they
+  are a net rather than a promise.
 - **Registering late does not un-record anything.** A caption set before its
   value was registered is already burned into the frames and already spoken;
   what registration afterwards buys is only that the files the recorder writes
@@ -444,10 +519,55 @@ nothing else:
 - **Canvas: the picture is covered, the bitmap is not.** The cover is over
   the canvas element's rect, so nothing it draws is visible. Anything reading
   the bitmap back (`toDataURL`, `getImageData`) still sees the original.
-- **`TerminalRecorder` has no redaction yet.** `register_secret()` and
-  `scrub()` exist on it (it shares the base), but nothing scrubs the PTY→xterm
-  path, so a command that *prints* a secret still records it. That is
-  [issue #5](https://github.com/rogvid/skills/issues/5).
+- **The terminal scrubber has its own list, and it is not short.** Everything
+  under **Redaction in a terminal demo** above holds; here is what it does not
+  reach.
+  - **A value split by something that moves the cursor is not masked — and it
+    can be perfectly legible.** Matching runs against a copy with the *inert*
+    sequences removed: colour and style (SGR), mode set/reset (`\x1b[?25l`,
+    which every spinner emits), erase-to-end-of-line, window-title OSC,
+    charset and keypad selection. None of those moves the cursor, so a token
+    broken by one is contiguous on screen and is caught.
+
+    Cursor movement is different. `\x1b[3;1Hsk-live-` followed by
+    `\x1b[3;15HKEY…` puts the value on screen as one word while no substring
+    of the stream contains it, and masking across the jump would delete the
+    movement and corrupt the redraw. **Do not read this as "the secret comes
+    out scrambled anyway" — it comes out readable.** What saves the recording
+    is the final screen check: the take raises `SecretLeak` and keeps nothing.
+    A recording you wanted, refused. Keep such values off the screen.
+
+    (A line the *terminal* wraps at the right margin is not this case and is
+    caught: wrapping puts no escape in the stream.)
+  - **The final screen check covers registered values only.** A shape-matched
+    token written the same way is not refused and not masked. Register.
+  - **Half a secret still renders.** The recorder cannot know a run of
+    characters is the start of a key until the rest arrives, so a program
+    killed part-way through printing one leaves what it printed on screen.
+    (At teardown a dangling fragment of a registered value, or one that had
+    reached a credential anchor, is masked; up to that point it is on screen
+    because it might have been anything.)
+  - **Shape detection has a clock, and a registered value does not.** A
+    fragment that could still grow into a shape match is held across quiet
+    moments — measured, a token written at 5, 20, 100 or 400 ms per character
+    is masked — but not forever: three seconds where a token would start,
+    and not at all in the middle of a word, because a screen permanently
+    missing its last character is a `wait_for_text()` that never returns. So a
+    program that pauses **longer than three seconds inside a token** defeats
+    shape matching. Registered values have no such limit.
+  - **A shape-matched token longer than 4096 characters may have its head
+    rendered** — the fragment ceiling. A *registered* value of any length is
+    held whole.
+  - **Registering late is worse here than on the web.** The scrubber runs as
+    output arrives, so anything already on screen when you call
+    `register_secret()` stays on screen. Register before the command runs.
+  - **Scrollback is the recording.** A secret masked on screen was never in
+    the buffer at all, so scrollback holds the mask too — but anything the
+    *program* writes elsewhere (a log file, a `tee`, its own history) is
+    untouched. This hides values from the recording, not from the machine.
+  - **The PTY child is a real process.** It sees your real environment; the
+    recorder does not sanitize it. A screen recording of a shell is a
+    recording of a shell.
 - **What CSS cannot reach, the mask cannot hide**: a cross-origin iframe's
   contents, an OS-level dialog, anything drawn outside the page. A `<canvas>`
   *is* covered — `filter` on the element blurs its rendered pixels like any
@@ -732,7 +852,7 @@ with TerminalRecorder(Path(__file__).parent) as rec:
 | Verb | Use |
 |---|---|
 | `run(command)` | Type a shell command visibly, press Enter. Pair with `wait_for_prompt()`. |
-| `send(text, enter=True)` | Type a response to the running program (answer a prompt, a REPL expression). |
+| `send(text, enter=True)` | Type a response to the running program (answer a prompt, a REPL expression). Takes a `Secret(v)` for a password: the value is registered, typed for real, and the terminal's echo of it comes back masked. |
 | `key(*names)` | Send keys: `"Up" "Down" "Left" "Right" "Enter" "Tab" "Escape" "Home" "End" "PageUp" "PageDown" "Backspace" "Delete" "Space"`, `"C-<letter>"` (e.g. `"C-c"`), or any single literal char (`"q"`, `"/"`). |
 | `wait_for_prompt(timeout_s=60)` | Wait until the shell prompt returns — i.e. the command finished. |
 | `wait_for_text(pattern, timeout_s=60)` | **The universal sync.** Wait until the rendered screen (visible text + scrollback, ANSI-stripped) matches `pattern`; `^`/`$` anchor to screen lines. |
@@ -762,6 +882,12 @@ with TerminalRecorder(Path(__file__).parent) as rec:
 - **Typing is real echo.** `run`/`send` write to the PTY; the terminal
   echoes each key, so it appears typed. Programs that turn echo off
   (password prompts, raw-mode TUIs) correctly show nothing.
+- **A secret a command prints is masked on the way in.** `register_secret()`
+  before the command runs, and its output — plus the screen text
+  `wait_for_text()` reads — comes back `[redacted]`. `run()` and `send()`
+  refuse a command line holding a registered value outright. Read
+  **Redacting secrets → Redaction in a terminal demo**, and the list of what
+  it does not cover, before trusting it.
 - **Keep the prompt distinctive.** The default `❯ ` rarely collides with
   output. If you theme it via `terminal_prompt`, keep it a string unlikely
   to appear as the last line of a command's output.

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -418,14 +418,27 @@ with TerminalRecorder(Path(__file__).parent) as rec:
   text `wait_for_text()` and `wait_for_prompt()` match against. It holds when
   the value is chopped across `os.read()` boundaries (the recorder holds back
   any trailing fragment that could still complete one, with no time limit) and
-  when an escape sequence is printed *inside* it, as long as that sequence
-  does not move the cursor — see below.
+  when one of a **listed set** of escape sequences is printed *inside* it —
+  colour and style, cursor show/hide, erase-to-end-of-line, window-title OSC,
+  charset and keypad selection. Not "any sequence that does not move the
+  cursor": that is the shape of the rule, not its reach, and sequences outside
+  the list are where it stops. See below for both halves.
 - **…and what the stream cannot express, the recorder refuses.** Before it
   writes anything, the take reads the finished terminal — visible screen and
   scrollback — and raises `SecretLeak` if a registered value is in it: no mp4,
   no timeline, no stills. That is the backstop for the case the scrubber
   cannot see (a value written in two pieces at two cursor positions), and it
   is why "not covered" below means "the take dies", not "it records the key".
+
+  "Finished" and "no stills" both mean it. The check runs after the narration
+  tail and after the recorder has flushed whatever it was still holding, so
+  it reads the screen the recording actually ends on — and it runs on every
+  way out of the `with`, including a storyboard that raised. A
+  `wait_for_text()` that timed out still gets its stills taken back, because
+  a still is written long before a take ends and a terminal still is the raw
+  screen. When that happens the timeout is what gets raised, not the leak:
+  the leak is printed, and the message that says what to fix is the one you
+  wanted.
 - **Shape detection is a safety net under that, not a substitute for it.**
   Four patterns are masked whether or not anyone registered them:
 
@@ -522,12 +535,22 @@ set of paths — four on the web, one in the terminal — and nothing else:
 - **The terminal scrubber has its own list, and it is not short.** Everything
   under **Redaction in a terminal demo** above holds; here is what it does not
   reach.
-  - **A value split by something that moves the cursor is not masked — and it
-    can be perfectly legible.** Matching runs against a copy with the *inert*
-    sequences removed: colour and style (SGR), mode set/reset (`\x1b[?25l`,
-    which every spinner emits), erase-to-end-of-line, window-title OSC,
-    charset and keypad selection. None of those moves the cursor, so a token
-    broken by one is contiguous on screen and is caught.
+  - **A value split by an escape the scrubber does not know is not masked —
+    and it can be perfectly legible.** Matching runs against a copy with the
+    *inert* sequences removed, and that is a **fixed list**: colour and style
+    (SGR), mode set/reset (`\x1b[?25l`, which every spinner emits),
+    erase-to-end-of-line, window-title OSC, charset and keypad selection. A
+    token broken by one of those is contiguous on screen and is caught.
+
+    A token broken by a non-cursor-moving sequence that is *not* on the list
+    is not. Measured, each of these renders the value as one word on screen
+    while the scrubber writes it in the clear: a CSI with an intermediate byte
+    (`\x1b[1 q`, the cursor-style escape), a DCS string (`\x1bPxx\x1b\\`), and
+    an OSC aborted by an ESC rather than a BEL (`\x1b]0;t\x1b[0m`). For a
+    *registered* value the final screen check below still kills the take, so
+    the guarantee holds — the recording is refused rather than leaked. For a
+    value that only shape detection was hiding, nothing catches it and it is
+    in the frames.
 
     Cursor movement is different. `\x1b[3;1Hsk-live-` followed by
     `\x1b[3;15HKEY…` puts the value on screen as one word while no substring

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1239,16 +1239,44 @@ class _DemoBase:
         # browser and the Playwright driver still get torn down — then
         # re-raised at the end, having skipped conversion. A take that cannot
         # prove it masked what it was told to writes no mp4.
+        #
+        # The order of the next three statements is the whole guarantee, and
+        # every one of them was wrong once:
+        #
+        #   * the narration tail runs **first**. It holds the frame open so a
+        #     take does not end mid-sentence, and it pumps — a terminal take's
+        #     child process is still running and still writing. Verifying
+        #     before it vouched for frames that were not the frames recorded.
+        #   * `_stop()` runs **second**, because a medium can be sitting on
+        #     output: the terminal's stream scrubber withholds any trailing
+        #     fragment that might still grow into a secret, and flushes it
+        #     here. Verifying before that read a screen the recording does not
+        #     end on.
+        #   * the check runs **last, on every path out of the `with`**, not
+        #     only the clean one. A storyboard that raises — a wait_for_text()
+        #     timeout, a Ctrl-C on a hung demo — used to skip it altogether
+        #     and keep its stills, and a terminal still is the raw screen.
         unmasked: BaseException | None = None
         if exc_type is None:
-            try:
-                self._verify_redaction_final()
-            except SecretLeak as leak:
-                unmasked = leak
-            else:
-                self._finish_line(tail=0.5)  # don't end mid-sentence
-        clean = exc_type is None and unmasked is None
+            self._finish_line(tail=0.5)  # don't end mid-sentence
         self._stop()
+        try:
+            self._verify_redaction_final()
+        except SecretLeak as leak:
+            unmasked = leak
+        except Exception as exc_check:  # noqa: BLE001 - unverifiable is not clean
+            # The check itself broke — a dead page, a closed context. On a
+            # clean take that is a leak by another name: nothing can vouch for
+            # the frames, so nothing is kept. On a take that had already
+            # failed it is almost certainly a consequence of *that* failure,
+            # so the artifacts still go, but the original exception is what
+            # the author gets to read.
+            unmasked = SecretLeak(
+                f"the take's redaction could not be verified at the end "
+                f"({type(exc_check).__name__}: {exc_check}), so nothing can "
+                f"vouch for what is in the frames. This take wrote no mp4."
+            )
+        clean = exc_type is None and unmasked is None
         video = self.page.video
         self._context.close()
         webm = Path(video.path()) if video else None
@@ -1301,7 +1329,16 @@ class _DemoBase:
         #
         # So the leak is raised first and suppresses everything, and the strict
         # verdict is only reached when there was no leak to suppress it.
+        #
+        # Except over a storyboard that had already raised. Replacing a
+        # wait_for_text() timeout with a leak report costs the author the one
+        # message that says what to fix, and the leak has already cost the
+        # artifacts — which is the part that matters. So it is said loudly and
+        # the original exception is left to propagate.
         if unmasked is not None:
+            if exc_type is not None:
+                print(f"demo-video: {unmasked}", file=sys.stderr)
+                return
             raise unmasked
         if exc_type is None and self._strict and self._fatal_count:
             raise StrictTakeFailed(self._strict_message())

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -201,15 +201,26 @@ _EXIT_RE = re.compile(re.escape(_EXIT_OSC) + r"(-?\d+);(\d+)\x07")
 #      *inert* sequences removed, and a match found there is mapped back to raw
 #      offsets, because the text written to xterm has to be the raw one.
 #
-#      Inert means "does not move the cursor", and that is the whole test —
-#      text either side of such a sequence lands in adjacent cells, so a token
-#      broken by one is one token on screen. Colour and style (SGR), mode
-#      set/reset (`\x1b[?25l` — every spinner library hides the cursor
+#      Inert is a **fixed list**, not a predicate, and the difference is the
+#      whole honesty of this comment. What it lists: colour and style (SGR),
+#      mode set/reset (`\x1b[?25l` — every spinner library hides the cursor
 #      mid-line), erase-to-end-of-line, window-title OSC, charset and keypad
-#      selection. Two of those (`\x1b[1K`, `\x1b[2K`) do wipe cells the token
-#      already occupied, so joining across them can mask a value the viewer
-#      would never have seen whole. That direction is deliberate: over-masking
-#      costs a demo a redacted word, under-masking costs it the key.
+#      selection. Text either side of one of those lands in adjacent cells, so
+#      a token broken by one is one token on screen and is caught.
+#
+#      It is *not* "every sequence that does not move the cursor", and reading
+#      it that way is how this ends up over-trusted. Measured leaks, each of
+#      them inert on screen and none of them matched here: a CSI with an
+#      intermediate byte (`\x1b[1 q`), a DCS string (`\x1bPxx\x1b\\`), and an
+#      OSC aborted by ESC instead of BEL (`\x1b]0;t\x1b[0m`). A registered
+#      value split by one of those still dies at `_verify_redaction_final`; a
+#      shape-matched one goes into the frames. Issue #71.
+#
+#      In the other direction two members of the list (`\x1b[1K`, `\x1b[2K`)
+#      wipe cells the token already occupied, so joining across them can mask
+#      a value the viewer would never have seen whole. That trade is
+#      deliberate — over-masking costs a demo a redacted word, under-masking
+#      costs it the key — but it is a trade, not a proof. Issue #66.
 #
 #      What is **not** stripped is anything that moves the cursor: `\r`,
 #      `\x1b[H`, `\x1b[3;15H`, and `\x1b[2J` (which homes it). Masking
@@ -864,6 +875,14 @@ class TerminalRecorder(_DemoBase):
         scrollback — and refuses the take if a registered value is in it: no
         mp4, no timeline, and the stills discarded, exactly as an unverifiable
         CSS mask does.
+
+        "Finished" is load-bearing and is `__exit__`'s job, not this one's:
+        by the time this runs the narration tail has been held (which pumps a
+        child that is still writing) and `_stop()` has flushed whatever the
+        scrubber was withholding. Called any earlier, it vouches for a screen
+        the recording does not end on. It also runs on the paths *out* of a
+        storyboard that raised — a still is written long before a take ends,
+        and here a still is the raw screen.
 
         Registered values only. A shape match is a heuristic, and failing a
         take on a heuristic would mean an innocent-looking token nobody

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -28,12 +28,14 @@ import re
 import select
 import struct
 import subprocess
+import sys
 import termios
 import time
 from collections import deque
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
-from .core import _beat_verb, _DemoBase, _env
+from .core import SECRET_MASK, Secret, SecretLeak, _beat_verb, _DemoBase, _env
 
 _ASSETS = Path(__file__).parent.parent / "assets" / "xterm"
 
@@ -172,6 +174,422 @@ _EXIT_OSC = "\x1b]777;demo-video-exit;"
 _EXIT_RE = re.compile(re.escape(_EXIT_OSC) + r"(-?\d+);(\d+)\x07")
 
 
+# -- scrubbing the PTY output path (issue #5) --------------------------------
+#
+# The web recorder hides a secret with CSS, over the element that renders it.
+# There is no element here: the terminal's contents are whatever a real program
+# wrote to a real PTY, so the only place to intervene is between `os.read()`
+# and `term.write()`. Everything downstream — the frames, the stills, the
+# xterm buffer `wait_for_text()` and `wait_for_prompt()` read, the tail quoted
+# in their timeout messages — sees only what that path lets through.
+#
+# `scrub()` on each chunk does not do it, and the three reasons are the whole
+# design of _StreamRedactor below:
+#
+#   1. **`os.read()` chops the stream anywhere.** A secret split across two
+#      reads is a substring of neither, so a per-chunk scrub misses it and
+#      misses it silently. It needs a carry buffer, exactly as `self._decoder`
+#      already holds back a UTF-8 sequence split across reads — and *after*
+#      the decoder, or a multi-byte character straddling the boundary is
+#      corrupted. The carry is the shortest suffix that could still grow into
+#      a match, not a fixed `max(len) - 1` window: holding a fixed window back
+#      would leave the last characters of a finished screen unrendered, and
+#      `wait_for_prompt()` reads that screen.
+#   2. **Escape sequences can interleave inside a token.** `sk-live-` printed
+#      plain and `FAKE0000` printed green is one token on screen and two
+#      substrings in the stream. So matching happens against a copy with the
+#      *inert* sequences removed, and a match found there is mapped back to raw
+#      offsets, because the text written to xterm has to be the raw one.
+#
+#      Inert means "does not move the cursor", and that is the whole test —
+#      text either side of such a sequence lands in adjacent cells, so a token
+#      broken by one is one token on screen. Colour and style (SGR), mode
+#      set/reset (`\x1b[?25l` — every spinner library hides the cursor
+#      mid-line), erase-to-end-of-line, window-title OSC, charset and keypad
+#      selection. Two of those (`\x1b[1K`, `\x1b[2K`) do wipe cells the token
+#      already occupied, so joining across them can mask a value the viewer
+#      would never have seen whole. That direction is deliberate: over-masking
+#      costs a demo a redacted word, under-masking costs it the key.
+#
+#      What is **not** stripped is anything that moves the cursor: `\r`,
+#      `\x1b[H`, `\x1b[3;15H`, and `\x1b[2J` (which homes it). Masking
+#      across one would delete the movement and corrupt the redraw, so the
+#      recorder does not. **That leaves a real hole rather than a harmless
+#      one**: `\x1b[3;1Hsk-live-` then `\x1b[3;15HKEY…` puts the value on
+#      screen contiguously and no substring of the stream contains it. Nothing
+#      on this path can catch that, which is exactly why
+#      `_verify_redaction_final` below reads the finished *screen* and fails
+#      the take. Scrub what the stream can express; refuse what it cannot.
+#   3. **"The burst ended" is not "the take ended", and neither is a pause.**
+#      A fragment that could still grow into a match has to be held across
+#      quiet moments, because ordinary streaming output *is* quiet moments:
+#      measured on this recorder, a token written at 5 ms per character sees
+#      `select()` go idle between every character. Releasing on the first idle
+#      poll meant a per-chunk scrub with extra steps.
+#
+#      But holding forever is not available either. Every sync verb here reads
+#      the rendered screen, so a program whose last character is `e` — the
+#      start of a possible JWT — would render one character short until it
+#      wrote again, and `wait_for_text("done")` would hang on text the
+#      recorder was sitting on. So the hold is *timed*, and the two cases get
+#      very different clocks:
+#
+#        * a fragment that has not reached a full anchor yet (`g`, `gh`,
+#          `ghp`, `e`, `ey`, `A`, `AK`) is decided by *what precedes it*. At
+#          the end of a word — the `e` of `done`, the `s` of `builds` — it is
+#          ordinary text and is written the moment the PTY goes quiet, so a
+#          finished screen is never short. At a token boundary (after a space,
+#          a quote, an `=`) it is where a key would start, and it is held on
+#          the anchored clock below.
+#        * a fragment that *has* reached an anchor (`ghp_…`, `sk-…`, `AKIA…`,
+#          `eyJ…`) is a credential prefix, and holding it only costs a screen
+#          that genuinely ends in one — so it gets _ANCHORED_HOLD_S, which no
+#          streaming program comes near (measured: 5, 20, 100 and 400 ms per
+#          character all masked).
+#
+#      That split is what makes the timer generous enough to be safe. A flat
+#      quarter-second grace for every fragment leaked a token typed at 400 ms
+#      per character — a typewriter-effect demo — and holding every fragment
+#      for three seconds would leave `wait_for_text("done")` staring at `don`.
+#
+#      A fragment that could still complete a *registered* secret is held with
+#      no clock at all: that one is a guarantee rather than a heuristic, and it
+#      is what keeps the PTY's character-at-a-time echo of a typed password
+#      (see `send`) from appearing one character at a time. `_pump` says so
+#      out loud when it has been holding for a while — see
+#      `_warn_if_withholding`, because a screen quietly missing its last four
+#      characters is worse than a slow one.
+
+# Escape sequences that neither move the cursor nor erase what is already on
+# screen, and a trailing fragment of anything that could still become one.
+_INERT_ESC_RE = re.compile(
+    r"\x1b\[[0-9;:?]*[mhlK]"  # SGR, mode set/reset (cursor hide), erase to EOL
+    r"|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)"  # OSC: window title, hyperlinks
+    r"|\x1b[()*+][A-Za-z0-9]"  # charset selection (ncurses emits \x1b(B)
+    r"|\x1b[=>]"  # keypad application mode
+)
+_PARTIAL_ESC_RE = re.compile(r"\x1b(?:\[[0-9;:?]*|\][^\x07\x1b]*|[()*+])?\Z")
+
+# Shape detection: the safety net, for values nobody registered. Each entry is
+# (what it is, the whole token, an *anchored* fragment, a *partial* fragment).
+#
+# The last two are what the carry buffer holds back at a boundary, and they are
+# separate because they are held for very different lengths of time (see note 3
+# above). Their union is every prefix of a possible match, and a gap between
+# them is a gap a split token slips through.
+#
+# Deliberately conservative. Every one of these is a documented, unambiguous
+# credential prefix followed by a run of token characters; a shorter or
+# fuzzier pattern would mask ordinary output, and output masked by accident is
+# a demo nobody can follow. This is a net under explicit registration, never a
+# substitute for it — see SKILL.md.
+SECRET_SHAPES: tuple[
+    tuple[str, re.Pattern[str], re.Pattern[str], re.Pattern[str]], ...
+] = (
+    (
+        "an sk- API key",
+        re.compile(r"sk-[A-Za-z0-9_-]{16,}"),
+        re.compile(r"sk-[A-Za-z0-9_-]*\Z"),
+        re.compile(r"sk?\Z"),
+    ),
+    (
+        "a GitHub token",
+        re.compile(r"gh[pousr]_[A-Za-z0-9]{16,}"),
+        re.compile(r"gh[pousr]_[A-Za-z0-9]*\Z"),
+        re.compile(r"g(?:h[pousr]?)?\Z"),
+    ),
+    (
+        "an AWS access key id",
+        re.compile(r"(?:AKIA|ASIA)[0-9A-Z]{12,}"),
+        re.compile(r"(?:AKIA|ASIA)[0-9A-Z]*\Z"),
+        re.compile(r"A(?:[KS]I?)?\Z"),
+    ),
+    (
+        "a JWT",
+        re.compile(r"eyJ[A-Za-z0-9_=-]{6,}\.[A-Za-z0-9_=-]{6,}(?:\.[A-Za-z0-9_=-]*)?"),
+        re.compile(r"eyJ[A-Za-z0-9_=.-]*\Z"),
+        re.compile(r"ey?\Z"),
+    ),
+)
+
+# How long a shape fragment survives a silent PTY. Bounded, because an
+# unbounded hold is a screen that renders short of what the program wrote and
+# every sync verb in this file reads that screen — and generous, because
+# ordinary streaming output goes quiet between characters and anything shorter
+# turns shape detection back into a per-chunk scrub.
+#
+# It applies to a fragment that has reached a credential anchor, and to one
+# that has not but sits where a token would start. A fragment in the middle of
+# a word is not held past the first quiet poll at all; see _hold_from.
+_ANCHORED_HOLD_S = 3.0
+
+# How long the PTY may be silent while a *registered* secret's fragment is
+# withheld before the recorder says so on stderr. That hold has no timeout —
+# see note 3 — so the failure mode is a screen missing its last few characters
+# with no explanation, which is exactly the kind of thing that costs an
+# afternoon.
+_WITHHOLD_WARN_S = 2.0
+
+# Ceiling on what a *shape* fragment rule may hold back. A shape's anchored
+# pattern can match arbitrarily far ("eyJ" followed by 60 KB of base64 is one
+# fragment), and holding a whole read back would stop the recording rendering.
+#
+# It deliberately does **not** bound the registered-secret hold, which is
+# already bounded by the secret's own length: clamping that one would release
+# the head of a long registered value, which is the precise leak this file
+# exists to prevent. It does not cut a completed match in half either — see the
+# last few lines of `_hold_from`.
+_MAX_HOLD = 4096
+
+# At teardown, a fragment left in the carry that is a proper prefix of a
+# registered secret — or an anchored shape fragment that never completed — is
+# replaced by the mask rather than written out. The take is over, so it will
+# never be resolved either way, and half a key is still half a key. Short
+# fragments are written as they are: one or two characters carry nothing, and
+# masking them would rewrite innocent output.
+_MIN_DANGLING_PREFIX = 4
+
+
+def _strip_inert(text: str) -> tuple[str, list[int] | None]:
+    """`text` without inert escapes, plus the raw offset of every character.
+
+    The returned list is one longer than the stripped text: `offsets[i]` is
+    where `stripped[i]` starts in `text`, and `offsets[len(stripped)]` is
+    `len(text)`, so a half-open match range maps back with no special case.
+    `None` means the two are the same string and every offset is itself —
+    the common case, and a 65 KB read is not worth a 65 KB list to say so.
+    """
+    if "\x1b" not in text:
+        return text, None
+    parts: list[str] = []
+    offsets: list[int] = []
+    pos = 0
+    for match in _INERT_ESC_RE.finditer(text):
+        parts.append(text[pos:match.start()])
+        offsets.extend(range(pos, match.start()))
+        pos = match.end()
+    parts.append(text[pos:])
+    offsets.extend(range(pos, len(text)))
+    offsets.append(len(text))
+    return "".join(parts), offsets
+
+
+def _merged_spans(spans: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Overlapping and touching ranges, unioned, in order.
+
+    Two secrets that overlap (a token and the header line holding it) must
+    become one mask, not two nested ones — and the writer below walks the list
+    once, so it needs them disjoint and sorted.
+    """
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+class _StreamRedactor:
+    """Masks registered secrets and shape-matched tokens in a chopped stream.
+
+    One instance per recorder, fed every fragment `_pump()` reads, in order.
+    `feed()` returns what may be written to the terminal now; whatever could
+    still turn out to be part of a secret stays here until the next call.
+
+    `secrets` is read on every call rather than copied: `register_secret()`
+    can be called mid-storyboard, and a value registered at 4 s has to mask
+    the output printed at 5 s.
+    """
+
+    def __init__(self, secrets: Callable[[], Sequence[str]]) -> None:
+        self._secrets = secrets
+        self._carry = ""
+        # The last character actually written to the terminal. A fragment at
+        # the very start of a buffer has no predecessor *in that buffer*, and
+        # whether it sits at a token boundary is exactly what decides how long
+        # it is held.
+        self._last_emitted = ""
+
+    def feed(self, text: str) -> str:
+        """A fragment straight off the PTY."""
+        return self._process(text, mode="read")
+
+    def quiet(self, idle_for: float) -> str:
+        """The PTY has nothing ready, and has had nothing for `idle_for`.
+
+        Not "the burst ended, release everything": a program writing a token
+        one character at a time goes idle between every character, and this
+        used to hand shape detection a per-chunk scrub. Only fragments whose
+        hold has actually expired are released — see _ANCHORED_HOLD_S.
+        """
+        return self._process("", mode="quiet", idle_for=idle_for)
+
+    def _token_start(self, plain: str, index: int) -> bool:
+        """True when `plain[index]` could be the first character of a token.
+
+        Reads across the buffer boundary via `_last_emitted`, because the
+        boundary is wherever `os.read()` happened to land and a rule that
+        forgot that would answer differently for the same output depending on
+        how it was chopped.
+        """
+        before = plain[index - 1] if index > 0 else self._last_emitted[-1:]
+        return not before.isalnum()
+
+    def flush(self, text: str = "") -> str:
+        """The take is over: release everything, masking what is left."""
+        return self._process(text, mode="final")
+
+    @property
+    def held(self) -> int:
+        """How many characters are being withheld (for diagnostics)."""
+        return len(self._carry)
+
+    def _process(self, text: str, *, mode: str, idle_for: float = 0.0) -> str:
+        text = self._carry + text
+        self._carry = ""
+        if not text:
+            return ""
+        secrets = tuple(self._secrets())
+        # A half-arrived escape sequence is held in every mode but the last:
+        # stripping depends on seeing it whole, and it is two or three bytes.
+        held = ""
+        if mode != "final":
+            partial = _PARTIAL_ESC_RE.search(text)
+            if partial is not None:
+                held, text = text[partial.start():], text[:partial.start()]
+        plain, offsets = _strip_inert(text)
+        spans = self._spans(plain, secrets)
+        cut = self._hold_from(plain, secrets, spans, mode, idle_for)
+        emitted_before = self._last_emitted
+        out: list[str] = []
+        raw_pos = 0
+        for start, end in spans:
+            if end > cut:
+                break
+            raw_start = start if offsets is None else offsets[start]
+            raw_end = end if offsets is None else offsets[end]
+            out.append(text[raw_pos:raw_start])
+            out.append(SECRET_MASK)
+            # Every colour change that was *inside* the masked run, re-emitted
+            # after the mask. Dropping them would leave the rest of the line
+            # painted in whatever colour preceded the secret.
+            out.append("".join(_INERT_ESC_RE.findall(text[raw_start:raw_end])))
+            raw_pos = raw_end
+        raw_cut = cut if offsets is None else offsets[cut]
+        out.append(text[raw_pos:raw_cut])
+        self._carry = text[raw_cut:] + held
+        written = "".join(out)
+        if mode == "final":
+            written = self._mask_dangling(written, secrets)
+        # What the boundary rule reads next time. Unchanged when nothing was
+        # written, so a run of empty quiet polls does not lose it.
+        self._last_emitted = written[-1:] or emitted_before
+        return written
+
+    @staticmethod
+    def _mask_dangling(text: str, secrets: Sequence[str]) -> str:
+        """`text` with a trailing *incomplete* secret replaced by the mask.
+
+        Only at teardown, where "incomplete" is final: the stream is over, so
+        a run of characters that was on its way to being a key never becomes
+        one — and half a key is still half a key. Both kinds count: a prefix
+        of a registered value, and a fragment that had reached a credential
+        anchor (`ghp_…`) without ever completing a match.
+        """
+        for secret in secrets:
+            longest = min(len(secret) - 1, len(text))
+            for size in range(longest, _MIN_DANGLING_PREFIX - 1, -1):
+                if text[-size:] == secret[:size]:
+                    return text[:-size] + SECRET_MASK
+        for _, _, anchored, _ in SECRET_SHAPES:
+            fragment = anchored.search(text)
+            if fragment is not None and (
+                len(text) - fragment.start() >= _MIN_DANGLING_PREFIX
+            ):
+                return text[: fragment.start()] + SECRET_MASK
+        return text
+
+    def _spans(self, plain: str, secrets: Sequence[str]) -> list[tuple[int, int]]:
+        """Every range of `plain` that must not be rendered."""
+        spans: list[tuple[int, int]] = []
+        for secret in secrets:
+            at = plain.find(secret)
+            while at >= 0:
+                spans.append((at, at + len(secret)))
+                at = plain.find(secret, at + 1)
+        for _, whole, _, _ in SECRET_SHAPES:
+            for match in whole.finditer(plain):
+                spans.append(match.span())
+        return _merged_spans(spans)
+
+    def _hold_from(
+        self,
+        plain: str,
+        secrets: Sequence[str],
+        spans: list[tuple[int, int]],
+        mode: str,
+        idle_for: float,
+    ) -> int:
+        """The offset in `plain` from which nothing may be written yet."""
+        if mode == "final":
+            return len(plain)
+        # A suffix that is a proper prefix of a registered secret. Held with no
+        # clock: this is the path the guarantee rests on, and the value is one
+        # the storyboard named, so a demo that stalls on it stalls on something
+        # its author wrote down. It cannot run away with the screen either —
+        # the hold is at most `len(secret) - 1` characters by construction,
+        # which is why _MAX_HOLD below does not apply to it.
+        literal_cut = len(plain)
+        for secret in secrets:
+            for size in range(min(len(secret) - 1, len(plain)), 0, -1):
+                if plain[-size:] == secret[:size]:
+                    literal_cut = min(literal_cut, len(plain) - size)
+                    break
+        # ...and a suffix that could still grow into a shape match. Two
+        # clocks, because one to three characters of ordinary text and a
+        # credential prefix are not the same bet — see _ANCHORED_HOLD_S.
+        hold_anchored = mode == "read" or idle_for < _ANCHORED_HOLD_S
+        shape_cut = len(plain)
+        for _, _, anchored, partial in SECRET_SHAPES:
+            if hold_anchored:
+                fragment = anchored.search(plain)
+                if fragment is not None:
+                    shape_cut = min(shape_cut, fragment.start())
+            fragment = partial.search(plain)
+            if fragment is not None:
+                # Where a token would start, this is a credential prefix in
+                # the making and waits on the anchored clock. In the middle of
+                # a word it is the tail of an ordinary one — `don|e` — and
+                # goes out as soon as the PTY stops, so no finished screen is
+                # ever missing a character.
+                held_until = (
+                    hold_anchored
+                    if self._token_start(plain, fragment.start())
+                    else mode == "read"
+                )
+                if held_until:
+                    shape_cut = min(shape_cut, fragment.start())
+        if hold_anchored:
+            # A complete shape match that runs to the end of the fragment may
+            # still be growing; masking it now would leave its continuation
+            # to be written unmasked on the next read. Held on the anchored
+            # clock, not the read boundary: a token written character by
+            # character goes idle between every character.
+            for start, end in spans:
+                if end == len(plain):
+                    shape_cut = min(shape_cut, start)
+        shape_cut = max(shape_cut, len(plain) - _MAX_HOLD)
+        cut = max(min(literal_cut, shape_cut), 0)
+        # The clamp above, and a fragment rule that fires mid-match, can both
+        # land the cut inside a span. Writing half a masked run is worse than
+        # holding all of it.
+        for start, end in spans:
+            if start < cut < end:
+                cut = start
+        return cut
+
+
 class TerminalRecorder(_DemoBase):
     """Records a terminal session (CLI, REPL, or full-screen TUI).
 
@@ -241,6 +659,16 @@ class TerminalRecorder(_DemoBase):
         self._pending_runs: deque[dict] = deque()
         self._exit_seq: int | None = None
         self._exit_tail = ""
+        # Nothing reaches xterm.js without passing through this. Reads the
+        # live registry, so a register_secret() call halfway through a
+        # storyboard masks the output that follows it.
+        self._redactor = _StreamRedactor(lambda: self.secrets)
+        # When the PTY last produced a byte, and whether the operator has been
+        # told that output is being withheld. The redactor's holds are timed
+        # off this clock rather than off read boundaries — a program writing a
+        # token one character at a time goes idle between every character.
+        self._last_data_at = time.monotonic()
+        self._withheld_warned = False
 
     # -- setup / teardown ---------------------------------------------------
 
@@ -313,10 +741,13 @@ class TerminalRecorder(_DemoBase):
         # Whatever _take_exit_markers held back as a possible half-marker was
         # withheld from the terminal, not dropped — flush it before the page
         # goes away, or the last frame is missing bytes the program did write.
+        # ...and it goes through the redactor on its way out like everything
+        # else, together with whatever the redactor itself was holding.
         tail, self._exit_tail = self._exit_tail, ""
-        if tail:
+        last = self._redactor.flush(tail)
+        if last:
             try:
-                self.page.evaluate("d => window.__termWrite(d)", tail)
+                self._write_out(last)
             except Exception:  # noqa: BLE001 - teardown, the page may be gone
                 pass
         proc = getattr(self, "_proc", None)
@@ -357,6 +788,14 @@ class TerminalRecorder(_DemoBase):
                 self._child_done = True
                 return
             if not r:
+                # Nothing ready. Fragments whose hold has *expired* are
+                # written now — not every held fragment: a program writing a
+                # token character by character is idle between characters, and
+                # releasing on the first idle poll is a per-chunk scrub with
+                # extra steps. See _ANCHORED_HOLD_S.
+                idle_for = time.monotonic() - self._last_data_at
+                self._write_out(self._redactor.quiet(idle_for))
+                self._warn_if_withholding(idle_for)
                 return
             try:
                 data = os.read(self._fd, 65536)
@@ -367,9 +806,92 @@ class TerminalRecorder(_DemoBase):
             if not data:
                 self._child_done = True
                 return
-            text = self._take_exit_markers(self._decoder.decode(data))
-            if text:
-                self.page.evaluate("d => window.__termWrite(d)", text)
+            # Decoder first (a UTF-8 sequence can straddle a read), exit
+            # markers second (the recorder's own side channel, never rendered),
+            # redactor last — it is the only one of the three whose output is
+            # what xterm.js is given.
+            self._last_data_at = time.monotonic()
+            self._write_out(
+                self._redactor.feed(
+                    self._take_exit_markers(self._decoder.decode(data))
+                )
+            )
+
+    def _write_out(self, text: str) -> None:
+        """The one door into the terminal. Everything on screen came through
+        here, so everything on screen has been through the redactor."""
+        if text:
+            self.page.evaluate("d => window.__termWrite(d)", text)
+
+    def _warn_if_withholding(self, idle_for: float) -> None:
+        """Say so when the screen is missing characters the program wrote.
+
+        A fragment that could still complete a *registered* secret is held
+        with no timeout, which is what keeps a typed password from appearing
+        one character at a time. The cost is a screen that renders short with
+        no explanation — and a `wait_for_text()` waiting for text the recorder
+        is sitting on. Once per episode, on stderr, naming the count.
+        """
+        held = self._redactor.held
+        if not held:
+            self._withheld_warned = False
+            return
+        if self._withheld_warned or idle_for < _WITHHOLD_WARN_S:
+            return
+        self._withheld_warned = True
+        print(
+            f"demo-video: holding back the last {held} character(s) of "
+            f"terminal output — they are the start of a registered secret, "
+            f"and the recorder cannot know whether the rest is coming. The "
+            f"screen will look that many characters short until the program "
+            f"writes again. If a wait_for_text() is stuck here, what it is "
+            f"waiting for begins with a registered value.",
+            file=sys.stderr,
+        )
+
+    def _verify_redaction_final(self) -> None:
+        """Last word before conversion: nothing registered may be on screen.
+
+        The scrubber works on the *stream*, and a stream is not a screen. A
+        program that positions the cursor and writes a value in two places —
+        `\x1b[3;1H` then `\x1b[3;15H` — renders it contiguously without it
+        ever being contiguous in the bytes, and no substring match on the way
+        past can see that. Neither can any later masking: by then the pixels
+        are recorded.
+
+        So this is the backstop the web recorder has and this one did not.
+        It reads the finished terminal buffer — visible screen *and*
+        scrollback — and refuses the take if a registered value is in it: no
+        mp4, no timeline, and the stills discarded, exactly as an unverifiable
+        CSS mask does.
+
+        Registered values only. A shape match is a heuristic, and failing a
+        take on a heuristic would mean an innocent-looking token nobody
+        registered could destroy a recording.
+        """
+        if not self.secrets:
+            return
+        try:
+            screen = self._screen()
+        except Exception as exc:  # noqa: BLE001 - unverifiable is not clean
+            raise SecretLeak(
+                f"the terminal's contents could not be read at the end of the "
+                f"take ({type(exc).__name__}), so nothing can vouch for what "
+                f"is in the frames. This take wrote no mp4."
+            ) from exc
+        for secret in self.secrets:
+            if secret in screen:
+                raise SecretLeak(
+                    f"a registered secret ({len(secret)} chars) is on the "
+                    f"terminal screen at the end of the take, so it is in the "
+                    f"frames. The output scrubber masks what it can see in the "
+                    f"byte stream; a value written in two pieces at different "
+                    f"cursor positions is contiguous on screen and in no "
+                    f"substring of the stream, and nothing can mask that after "
+                    f"the fact. This take wrote no mp4, no timeline, and kept "
+                    f"no stills. Keep the value off the screen: print a "
+                    f"placeholder, or do not run the command that shows it."
+                )
 
     def _take_exit_markers(self, text: str) -> str:
         """Strip the PS1 exit-status markers out of `text`, recording each.
@@ -487,7 +1009,14 @@ class TerminalRecorder(_DemoBase):
         comes back — usually during the following wait_for_prompt(), which is
         why the pairing is not merely a suggestion. A command that exits
         non-zero also logs a `nonzero_exit` issue, and fails the take under
-        strict=True."""
+        strict=True.
+
+        A command line holding a registered secret raises SecretLeak. It is
+        authored text, like a caption: the storyboard wrote it, the PTY echoes
+        it, and the honest answer is to make the author reword the line rather
+        than to mask a command nobody could then read. To type a secret *into*
+        a program that asks for one, use `send(Secret(...))`."""
+        self._no_secrets(command, "run()")
         self._type(command)
         beat = self._beats[-1] if self._beats else None
         if beat is not None:
@@ -501,9 +1030,23 @@ class TerminalRecorder(_DemoBase):
         self._idle(0.2)
 
     @_beat_verb("send")
-    def send(self, text: str, enter: bool = True) -> None:
+    def send(self, text: str | Secret, enter: bool = True) -> None:
         """Type a response to the running program (an answer to a prompt, a
-        REPL expression). enter=False to send the keystrokes without Return."""
+        REPL expression). enter=False to send the keystrokes without Return.
+
+        `send(Secret(v))` is the password case, and the terminal analogue of
+        `type_into(sel, Secret(v))`: it registers the value, types the real
+        thing, and the PTY's echo of it comes back masked — character by
+        character, which is precisely the split the redactor's carry buffer
+        exists for. Plain text containing an already-registered secret raises
+        SecretLeak instead, because a plain string is authored text."""
+        if isinstance(text, Secret):
+            # Registered before a single character is written, so the echo of
+            # the first keystroke is already covered.
+            self.register_secret(text)
+            text = text.reveal()
+        else:
+            self._no_secrets(text, "send()")
         self._type(text)
         if enter:
             self._write("\r")
@@ -514,7 +1057,13 @@ class TerminalRecorder(_DemoBase):
         """Send keys to a TUI. Each argument is one of: a named key ("Up"
         "Down" "Left" "Right" "Enter" "Tab" "Escape" "Home" "End" "PageUp"
         "PageDown" "Backspace" "Delete" "Space"); a Ctrl combo "C-<letter>"
-        (e.g. "C-c"); or a single literal character ("q", "j", "/")."""
+        (e.g. "C-c"); or a single literal character ("q", "j", "/").
+
+        Refuses a registered secret spelled out one keystroke at a time. That
+        is authored text like `run()`'s, and it is the one call whose beat log
+        entry a scrub cannot clean: the beat records the keys joined by
+        spaces, which no literal match on the value can see."""
+        self._no_secrets("".join(names), "key()")
         for name in names:
             seq = _KEYMAP.get(name)
             if seq is None:

--- a/tests/README.md
+++ b/tests/README.md
@@ -19,8 +19,9 @@ tests/
 
 Takes: `web/` and `terminal/` (the two media), the determinism pair, the
 problem takes, `redaction/` — the web recorder against a page that renders
-a secret, plus a second few-second take that must *fail* — and `segments/`,
-one demo recorded in two parts and joined with `stitch()`.
+a secret, plus a second few-second take that must *fail* — `segments/`,
+one demo recorded in two parts and joined with `stitch()`, and
+`terminal-redaction/`, the redaction question asked of the PTY output path.
 
 ## Running it
 
@@ -29,10 +30,7 @@ tests/smoke                       # every take, output to a temp dir
 tests/smoke --web-only            # just the Playwright takes
 tests/smoke --terminal-only       # just the PTY/xterm.js takes
 tests/smoke --determinism-only    # just the three re-recording takes
-tests/smoke                       # all three takes, output to a temp dir
-tests/smoke --web-only            # just the Playwright take
-tests/smoke --terminal-only       # just the PTY/xterm.js take
-tests/smoke --redaction-only      # just the secret-redaction take
+tests/smoke --redaction-only      # just the secret-redaction takes
 tests/smoke --segments-only       # just the two-segment take and its stitch
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
@@ -84,27 +82,19 @@ smoke: PASSED
 ```
 
 Re-running into the same `--out-dir` is safe: the take subdirectories
-(`web/`, `terminal/`, `segments/`, `web-problems/`, `terminal-problems/`,
-`terminal-race/`, `web-strict/`, `terminal-strict/`, `determinism-a/`,
-`determinism-b/`, `determinism-off/`) are deleted before each take. Only the first two are graded
+(`web/`, `terminal/`, `segments/`, `redaction/`, `terminal-redaction/`,
+`web-problems/`, `terminal-problems/`, `terminal-race/`, `web-strict/`,
+`terminal-strict/`, `determinism-a/`, `determinism-b/`, `determinism-off/`)
+are deleted before each take. Only the first two are graded
 on their video; the rest are short and exist to break, or to reproduce, in one
 specific way each. That is not tidiness — every artifact assertion works by
 path, so without it a leftover `demo.mp4` from the previous run would grade a
 recorder that produced nothing at all as a pass, and recording repeatedly into
 one directory is exactly how a change to the recorder gets verified.
-Re-running into the same `--out-dir` is safe: the `web/`, `redaction/` and
-`terminal/` subdirectories are deleted before each take. That is not tidiness — every
-artifact assertion works by path, so without it a leftover `demo.mp4` from the
-previous run would grade a recorder that produced nothing at all as a pass, and
-recording repeatedly into one directory is exactly how a change to the recorder
-gets verified.
 
 Deleting is bounded. Only those named subdirectories are ever
 removed, and only when each is absent, empty, or carries the
 `.demo-video-smoke` marker file a previous run wrote there. `--out-dir .` in a
-Deleting is bounded. Only `<out-dir>/web/`, `<out-dir>/redaction/` and
-`<out-dir>/terminal/` are ever removed, and only when each is absent, empty, or
-carries the `.demo-video-smoke` marker file a previous run wrote there. `--out-dir .` in a
 project that has its own `web/` directory gets a refusal naming the path, not a
 deleted source tree.
 
@@ -749,6 +739,154 @@ The rest is what is true of a merge and of nothing else:
 | `index` is renumbered to the position in the merged file, `segment_index` is **not** | [#22](https://github.com/rogvid/skills/issues/22): `(segment, segment_index)` names a beat the same way before and after a merge, which `index` alone cannot. Asserted in every take, not just this one — for a single take it is 0, 1, 2, … |
 | a take recorded in one piece carries no `segments` key | that key means "assembled by stitch()", and a reader would otherwise be told a single recording has parts |
 
+
+**Terminal redaction** — `terminal-redaction/`, the PTY half
+([#5](https://github.com/rogvid/skills/issues/5)). Different mechanism,
+different failure mode: there is no DOM to cover, so the only intervention is
+a scrubber between `os.read()` and `term.write()`, and everything downstream —
+the frames, the stills, and the xterm buffer `wait_for_text()` matches
+against — is drawn from what that scrubber let through.
+
+A shell script prints one tagged value per line, all 28 characters wide so
+they share a column, and the take is graded on the pixels of those rows:
+
+| row | what it is | what hides it |
+|---|---|---|
+| `key` | a registered value printed by a command | the registry |
+| `ans` | a registered value with a **colour escape inside it** | matching an escape-stripped copy |
+| `hid` | the same, cut by `ESC[?25l` — what every spinner emits mid-line | the same, once "inert" means more than SGR |
+| `osc` | the same, cut by a window-title OSC | the same |
+| `shp` | a `ghp_`-shaped token **nobody registered**, printed in one burst | shape detection alone |
+| `str` | a `ghp_`-shaped token written **one character at a time** | shape detection *across quiet boundaries* |
+| `pau` | an `sk-`-shaped token **paused 0.4 s mid-value** | the same |
+| `anc` | a `ghp_`-shaped token paused after its **first character** | the same, plus the token-boundary rule |
+| `aws` | an `AKIA`-shaped token nobody registered | shape detection alone |
+| `jwt` | a JWT nobody registered | shape detection alone |
+| `pwd` | `send(Secret(...))`, echoed back by the PTY | the registry, one character per read |
+| `ctl` | never registered, matches no shape | nothing — it is the reference |
+| `ref` | the literal string `[redacted]` | nothing — it is the reference |
+
+The `str`, `pau` and `anc` rows are the ones a scrubber that flushes on an
+idle poll gets wrong, and they are why the printer is a shell script rather
+than a `printf`.
+Capping `os.read()` cannot manufacture a *time* boundary: capped reads come
+back-to-back off a full buffer and the scrubber never sees the PTY go idle
+mid-value. `str` writes at 5 ms per character, which is slower than the
+recorder drains, so `select()` reports nothing ready between every character.
+`pau` and `anc` stop dead in the middle of a token — `anc` after one
+character, where nothing yet says "credential" and only *where it sits* does.
+
+**The split across `os.read()` boundaries is forced, not hoped for**, and that
+is the assertion the acceptance criterion turns on. `capped_pty_reads()`
+replaces the `os` module *in `demo_recording.terminal` only* with one whose
+`read()` returns at most 7 bytes and keeps every fragment. The take then
+asserts, from those fragments, that the printed key was reassembled from more
+than one of them — measured 5 — and prints the number. Without the cap this
+box hands the whole value over in a single read: injected, the assertion fires
+and says so, which is the difference between testing a carry buffer and
+hoping one was needed. The `pwd` row needs no help; the PTY echoes a typed
+character as it is typed, so it arrives in 28 fragments on any box.
+
+The ANSI case is asserted at the byte level too, over the printer's output
+only: the raw stream must contain `value-head`, `ESC[32m`, `value-tail` and
+must **not** contain the value whole — otherwise a literal substring match
+would have found it and the row proves nothing.
+
+**The pixels are graded three ways, and the second is what makes the first
+mean anything.** Every crop is the same 28 cells of one row at native
+resolution:
+
+- a masked row against the `ref` row must be **the same picture** — mean
+  absolute luma difference 0.0 in the stills, 1.2-2.4 in the mp4 (codec noise
+  on identical glyphs), bar 3.0 / 6.0;
+- the `ctl` row against the same `ref` row must **not** be: 40.6 in the
+  stills, 42.7 in the mp4, bar 12.0. That row is a 28-character key in the
+  same font at the same size in the same frame — exactly what a leak looks
+  like — so this says the comparison can tell a key from `[redacted]` at all.
+  With the scrubber taught to swallow the control too, it collapses to 0.0-1.4
+  and the take says every reading below it is vacuous;
+- the `ctl` row must be **sharp** (edge energy 28-31, floor 6.0 / 5.0). With
+  the terminal's foreground colour set to its background it scores 0.0-0.2 and
+  the take refuses to grade anything, which is the answer a blank recording
+  needs: every "these two crops match" reading is also true of two crops of
+  nothing.
+
+Not OCR, and not a claim to be. It says the pixels at that row are the mask
+and not a key; it cannot say *which* mask, and no assertion here reads text
+back out of a frame (the same gap the web half has).
+
+**Two more paths, checked without pixels.** The rendered screen — what
+`wait_for_text()` and `wait_for_prompt()` read, and the buffer every frame is
+drawn from — must hold none of the thirteen values and must hold the control
+intact. And every byte the take writes is swept for all thirteen, with no
+exemptions; the printer script lives in a temp directory of its own precisely
+so the sweep grades what the *recorder* wrote.
+
+**Two values are longer than the recorder's 4096-character fragment ceiling**,
+and they pull in opposite directions. A 4208-character JWT says a hold clamped
+mid-match must not write the head of a credential and mask the tail; a
+4208-character *registered* value says the ceiling must not bound the registry
+at all, whose hold is already bounded by the value's own length. Neither is
+graded on pixels — 4 kB of base64 wraps over fifty rows and scrolls every
+measured row away — so they go last, the video is graded only up to that
+point, and both are checked on the screen text and the byte sweep against a
+64-character witness. The whole value is the wrong needle: a clamped hold
+leaks a *prefix*, and a take rendering the first 111 characters in the clear
+was measured passing a check for the token itself.
+
+**`key()` must refuse too.** It is the one verb whose beat log a scrub cannot
+clean: the beat records the keys joined by spaces, and no literal match on the
+value can see `'s k - l i v e - …'` in `timeline.json`. So the call raises
+rather than the log leaking, and the take asserts nothing reached the screen
+first.
+
+**`run()` and `send()` must refuse.** Both are authored text echoed on camera,
+the terminal's `caption()`. Each is called with a registered value, must raise
+`SecretLeak`, must not type a character before doing so (asserted on the
+screen afterwards), and must not quote the value in the exception. The two
+refused beats are asserted to carry a `[redacted]` selector — positively,
+because "no beat holds the secret" is equally true of a log that lost the
+beats — and exactly one `send` beat must carry **no** target at all, which is
+the `Secret`: it is deliberately not a `str` so that `_verb_target` cannot
+write it into `timeline.json`, and teaching `_verb_target` to stringify it
+fails this.
+
+**The `hld` row is the other half of the carry rule, and it is timed.** The
+scrubber holds back any trailing fragment that could still complete a secret —
+which means a program whose last characters could begin a token renders short
+until it writes again, and every sync verb reads that screen. So the printer
+ends with `hld xe` and no newline, then parks on a `read`.
+
+`xe` and not `gh`, and that is the case. Both are shape fragments — `e` could
+begin a JWT — but this one sits *in the middle of a word*, where a credential
+never starts, so it must go out on the first quiet poll. The take measures how
+long it takes to appear and fails past 1.5 s. A rule that cannot tell `hld xe`
+from `hld gh` puts it on the three-second anchored clock: injected, it arrives
+at 3.9 s and this fails, which no assertion about the *final* screen can see.
+Remove the release altogether and it never arrives at all.
+
+The three arms are asserted separately and injected separately: this row (a
+fragment mid-word, released at once), the `str`/`pau`/`anc` rows (a fragment
+where a token would start, held for seconds), and the `pwd` row (a fragment of
+a *registered* value, held with no clock — the echo arrives one character per
+read with an idle pump between each, so releasing those would print a password
+one character at a time).
+
+**And a value the stream can never show contiguous must kill the take.**
+`terminal-cursor-leak/` is its own recording because it has to *die*. A
+program that writes `ESC[6;1Hcup <head>` and then `ESC[6;13H<tail>` puts the
+registered value on screen as one word while no substring of the byte stream
+contains it — the premise is asserted, not assumed, by requiring the value to
+be on the finished screen. The scrubber cannot see that; documented as
+uncovered, and uncovered has to mean *refused*, so `_verify_redaction_final()`
+reads the finished terminal buffer (visible screen *and* scrollback) before
+anything is converted and raises `SecretLeak`. The take must leave no
+`demo.mp4`, no `timeline.json`, no still and nothing in `.video/`, and the
+message must say the value was found *on screen* without quoting it. With that
+check removed the take records a normal mp4 with the key legible in every
+frame, `issues: []` and `strict=True` satisfied — the quietest failure in this
+harness, and the injection prints exactly that.
+
 ## Known gaps
 
 Things a pass does **not** prove. They are listed because an assertion nobody
@@ -822,11 +960,28 @@ knows is missing is worse than one that is openly absent.
   only — so the path where a fatal issue arrives past the cap and is counted
   but not recorded is unexercised, as is a `run()` whose prompt never comes
   back and therefore ends `exit_code: null`.
-- **Nothing checks that the withheld half-marker is flushed.** `_pump` holds
-  back trailing bytes that could still become an exit-status escape, and
-  `_stop` writes them to the terminal on teardown. No assertion reads the final
+- **Nothing checks what teardown flushes.** `_pump` holds back trailing bytes
+  that could still become an exit-status escape *or* the start of a secret,
+  and `_stop` writes both to the terminal on teardown — masking a dangling
+  fragment of a registered value as it goes. No assertion reads the final
   frame, so a regression there would lose the last few bytes of a program's
-  output silently.
+  output silently, and `_StreamRedactor._mask_dangling` is unexercised. Making
+  it fail needs a take that ends mid-secret and an assertion on the last
+  frames of the mp4, which is a race with the screencast.
+- **The terminal scrubber's colour bookkeeping is unasserted.** A masked run
+  swallows any SGR sequence inside it and re-emits it after the mask, so the
+  rest of the line keeps its colour. In this fixture the colour is reset
+  inside the same run, so removing that re-emission changes no pixel here.
+  It is cosmetic either way — nothing about *what* is hidden depends on it.
+- **Only SGR-interleaved secrets are caught, and only that is tested.** A
+  value broken up by a cursor movement — a redrawn progress line, a TUI
+  painting in two passes, a terminal-wrapped line — is not contiguous on
+  screen and is deliberately not matched (see SKILL.md). Nothing here records
+  such a program, so the harness does not measure how common that is.
+- **Shape detection is graded on one shape.** `ghp_` is the only one of the
+  four patterns a take actually prints; `sk-`, `AKIA` and the JWT shape are
+  exercised only as tail fragments and by the pattern list being read at all.
+  A regression in one of the other three passes.
 - **Nothing checks a non-bash shell.** The exit status arrives through `$?` and
   `\#` expanded in `PS1`, which is bash behaviour; zsh needs `PROMPT_SUBST` and
   would leave every `exit_code` null. Only `/bin/bash` is recorded here — the
@@ -1061,6 +1216,13 @@ the crop and looking at it before it was believed.
   `.gitleaks.toml`, and give it *both* a masked and an unmasked measurement.
   A redaction assertion with nothing sharp to compare against is the most
   dangerous kind of vacuous test: it passes on a black frame.
+- **A new thing the *terminal* scrubber must hide** — add a line to
+  `term_printer_script()`, a literal to the `TERM_*` constants, a row to
+  `TERM_MASKED_ROWS`, and allowlist the shape in `.gitleaks.toml`. Keep it 28
+  characters so it lands in the same columns as the `ctl` and `ref` rows,
+  which are what it is measured against. If it is meant to be caught by shape
+  rather than registration, do not register it — that separation is the only
+  thing that says the two mechanisms work apart.
 
 **Prove any new assertion can fail.** Break the thing it watches — stub the verb
 out in `skills/demo-video/helpers/`, or blank the fixture — run `tests/smoke`,

--- a/tests/README.md
+++ b/tests/README.md
@@ -83,9 +83,11 @@ smoke: PASSED
 
 Re-running into the same `--out-dir` is safe: the take subdirectories
 (`web/`, `terminal/`, `segments/`, `redaction/`, `terminal-redaction/`,
-`web-problems/`, `terminal-problems/`, `terminal-race/`, `web-strict/`,
-`terminal-strict/`, `determinism-a/`, `determinism-b/`, `determinism-off/`)
-are deleted before each take. Only the first two are graded
+`terminal-cursor-leak-clean/`, `terminal-cursor-leak-crash/`,
+`terminal-cursor-leak-tail/`, `web-problems/`, `terminal-problems/`,
+`terminal-race/`, `web-strict/`, `terminal-strict/`, `determinism-a/`,
+`determinism-b/`, `determinism-off/`) are deleted before each take. Only the
+first two are graded
 on their video; the rest are short and exist to break, or to reproduce, in one
 specific way each. That is not tidiness — every artifact assertion works by
 path, so without it a leftover `demo.mp4` from the previous run would grade a
@@ -760,14 +762,15 @@ they share a column, and the take is graded on the pixels of those rows:
 | `str` | a `ghp_`-shaped token written **one character at a time** | shape detection *across quiet boundaries* |
 | `pau` | an `sk-`-shaped token **paused 0.4 s mid-value** | the same |
 | `anc` | a `ghp_`-shaped token paused after its **first character** | the same, plus the token-boundary rule |
+| `slw` | a `ghp_`-shaped token paused **past** the hold window | nothing — it is the documented limit, graded as one |
 | `aws` | an `AKIA`-shaped token nobody registered | shape detection alone |
 | `jwt` | a JWT nobody registered | shape detection alone |
 | `pwd` | `send(Secret(...))`, echoed back by the PTY | the registry, one character per read |
 | `ctl` | never registered, matches no shape | nothing — it is the reference |
 | `ref` | the literal string `[redacted]` | nothing — it is the reference |
 
-The `str`, `pau` and `anc` rows are the ones a scrubber that flushes on an
-idle poll gets wrong, and they are why the printer is a shell script rather
+The `str`, `pau`, `anc` and `slw` rows are the ones a scrubber that flushes on
+an idle poll gets wrong, and they are why the printer is a shell script rather
 than a `printf`.
 Capping `os.read()` cannot manufacture a *time* boundary: capped reads come
 back-to-back off a full buffer and the scrubber never sees the PTY go idle
@@ -775,6 +778,18 @@ mid-value. `str` writes at 5 ms per character, which is slower than the
 recorder drains, so `select()` reports nothing ready between every character.
 `pau` and `anc` stop dead in the middle of a token — `anc` after one
 character, where nothing yet says "credential" and only *where it sits* does.
+
+`slw` stops for longer than the recorder will hold, and is the only row that
+must come out **legible**. That is not a gap in the take, it is the take
+grading a gap: `SKILL.md` says shape detection has a clock, and the clock has
+to be measurable from outside as well as inside. `pau` pauses 2.0 s and must be
+masked, `slw` pauses 4.0 s and must not; together they pin `_ANCHORED_HOLD_S`
+(3.0 s) from both sides, with a second of margin either way because the
+quantity the recorder measures is wall-clock idle time on a loaded CI box.
+Injected at 5.0 s, `slw` comes out masked and the take says the documented
+limit moved; injected at 1.0 s, `pau` and `anc` come out legible at 41-45
+against the mask. Before this pair, `_ANCHORED_HOLD_S` could be set to any
+value above ~0.45 s and the whole suite still passed.
 
 **The split across `os.read()` boundaries is forced, not hoped for**, and that
 is the assertion the acceptance criterion turns on. `capped_pty_reads()`
@@ -872,20 +887,34 @@ a *registered* value, held with no clock — the echo arrives one character per
 read with an idle pump between each, so releasing those would print a password
 one character at a time).
 
-**And a value the stream can never show contiguous must kill the take.**
-`terminal-cursor-leak/` is its own recording because it has to *die*. A
-program that writes `ESC[6;1Hcup <head>` and then `ESC[6;13H<tail>` puts the
-registered value on screen as one word while no substring of the byte stream
-contains it — the premise is asserted, not assumed, by requiring the value to
-be on the finished screen. The scrubber cannot see that; documented as
-uncovered, and uncovered has to mean *refused*, so `_verify_redaction_final()`
-reads the finished terminal buffer (visible screen *and* scrollback) before
-anything is converted and raises `SecretLeak`. The take must leave no
-`demo.mp4`, no `timeline.json`, no still and nothing in `.video/`, and the
-message must say the value was found *on screen* without quoting it. With that
-check removed the take records a normal mp4 with the key legible in every
-frame, `issues: []` and `strict=True` satisfied — the quietest failure in this
-harness, and the injection prints exactly that.
+**And a value the stream can never show contiguous must kill the take — on
+every way out of the `with`.** A program that writes `ESC[6;1Hcup <head>` and
+then `ESC[6;13H<tail>` puts the registered value on screen as one word while
+no substring of the byte stream contains it; the premise is asserted, not
+assumed, by requiring the value to be on the finished screen. The scrubber
+cannot see that. Documented as uncovered, and uncovered has to mean *refused*,
+so `_verify_redaction_final()` reads the finished terminal buffer (visible
+screen *and* scrollback) and raises `SecretLeak`. No `demo.mp4`, no
+`timeline.json`, no still, nothing in `.video/`, and a message that says the
+value was found *on screen* without quoting it.
+
+Three recordings, because "every way out" is three different bugs and the
+first version of this check only covered the first:
+
+| arm | how the `with` ends | what it caught |
+|---|---|---|
+| `clean` | the storyboard finishes | with the check removed: a normal mp4, the key legible in every frame, `issues: []`, `strict=True` satisfied — the quietest failure in this harness |
+| `crash` | the storyboard raises after the value is on screen | the check was gated on `exc_type is None`, so a `wait_for_text()` timeout or a Ctrl-C skipped it entirely and **kept the still** — 129 kB of PNG with the key on it. On the web side the same structure is harmless because a still is CSS-masked when it is taken; here a still is the raw screen |
+| `tail` | the value lands *after* the last verb, inside the window a narrated take holds open so it does not end mid-sentence | the check ran before that window and before the scrubber's final flush, so it vouched for a screen the recording does not end on. Injected, it writes an 82 kB mp4 and a timeline and reports nothing wrong |
+
+The `crash` arm asserts the recorder re-raises what the *storyboard* threw
+rather than a leak report: the timeout is the message that says what to fix,
+and the leak has already cost the artifacts, which is the part that matters.
+
+The `tail` arm needs a narration tail and the smoke run has no
+`ELEVENLABS_API_KEY`, so it sets `_line_end` directly — the one field
+`_finish_line()` reads, and the one `_start_line()` sets from
+`media_duration(clip)`. Same code path, no key required.
 
 ## Known gaps
 
@@ -978,10 +1007,13 @@ knows is missing is worse than one that is openly absent.
   painting in two passes, a terminal-wrapped line — is not contiguous on
   screen and is deliberately not matched (see SKILL.md). Nothing here records
   such a program, so the harness does not measure how common that is.
-- **Shape detection is graded on one shape.** `ghp_` is the only one of the
-  four patterns a take actually prints; `sk-`, `AKIA` and the JWT shape are
-  exercised only as tail fragments and by the pattern list being read at all.
-  A regression in one of the other three passes.
+- **Shape detection is graded on how a token is *split*, not on the pattern
+  list.** All four patterns are printed unregistered and pixel-graded — `ghp_`
+  on the `shp`, `str` and `anc` rows, `sk-` on `pau`, `AKIA` on `aws`, a JWT
+  on `jwt` — so removing any one of them fails the take. What is not covered
+  is the *inside* of each pattern: one spelling of each shape is printed, so a
+  regression that narrowed `gh[pousr]_` to `ghp_`, or dropped `ASIA` from the
+  AWS pattern, still passes.
 - **Nothing checks a non-bash shell.** The exit status arrives through `$?` and
   `\#` expanded in `PS1`, which is bash behaviour; zsh needs `PROMPT_SUBST` and
   would leave every `exit_code` null. Only `/bin/bash` is recorded here — the

--- a/tests/smoke
+++ b/tests/smoke
@@ -917,6 +917,12 @@ TERM_SHAPE = "ghp_SHAP00000000000000000000"
 TERM_STREAMED = "ghp_STRM00000000000000000000"
 TERM_PAUSED = "sk-live-PAUS0000000000000000"
 TERM_ANCHOR_SPLIT = "ghp_ANCH00000000000000000000"
+# Paused past _ANCHORED_HOLD_S, and therefore **expected on screen in the
+# clear**. It is the only value in this take that is, apart from the two
+# references — deliberately, because "shape detection has a clock" is a
+# documented limit and a limit nobody grades is a limit that quietly moves.
+# Absent from TERM_LITERALS and from TERM_MASKED_ROWS for the same reason.
+TERM_SLOW = "ghp_SLOW00000000000000000000"
 TERM_AWS = "AKIAAWSK00000000000000000000"
 TERM_JWT = "eyJKV0TAAA.eyJzdWJBQUE.SIGN0"
 TERM_TYPED = "pw-live-SEND0000000000000000"
@@ -1020,11 +1026,23 @@ TERM_REFERENCE_ROW = "ref"
 # password one character at a time. The three arms are asserted separately:
 # this row, the `str`/`pau` rows, and the `pwd` row.
 TERM_HELD_LINE = "hld xe"
-# ...and how long the screen may lag behind the program for it. A fragment in
-# the middle of a word goes out on the first quiet poll, so this is the pump
-# interval plus slack. Held on the *anchored* clock instead — which is what a
-# rule that could not tell `hld xe` from `hld gh` would do — it arrives at
-# three seconds and this fails. Without the release it never arrives at all.
+# ...and how long the release may take, measured from the `ref` row — the
+# printf immediately before it — rather than from the start of the script.
+#
+# That framing is the fix for a bar that used to be quietly meaningless. The
+# comment here claimed "the pump interval plus slack", but the timer started
+# before the printer ran, so what it actually measured was the printer's own
+# runtime: every `sleep` in the script plus the recorder's frame holds, with
+# the release somewhere in the noise. Measured 0.835 s idle and 1.053 s under
+# 16-way saturation against a 1.5 s bar — 1.4x headroom on a 2-core GitHub
+# runner recording video through Chromium, which is a flake waiting to happen,
+# and it got worse the moment the `slw` row added a four-second sleep (8.2 s
+# against the same bar).
+#
+# Timed from the previous `printf` there is nothing in between, so the
+# quantity is the release itself: measured 0.1-0.3 s. The failure it has to
+# catch adds a whole _ANCHORED_HOLD_S (3.0 s) on top. The bar sits between
+# them with room on both sides.
 TERM_HELD_MAX_WAIT_S = 1.5
 
 # The pwd row only exists once send() has typed into `read`; the other five
@@ -1055,9 +1073,23 @@ MAX_TERM_MASK_DELTA = {"still": 3.0, "video": 6.0}
 # mid-token — the exact condition that made shape detection a no-op, and one
 # the read cap cannot manufacture. 5 ms is the fastest rate measured leaking.
 TERM_STREAM_MS = 5
-# ...and a single long pause mid-token, past any grace a fragment could be
-# given, for the case where a program computes between two writes.
-TERM_PAUSE_S = 0.4
+# A single long pause mid-token, for the case where a program computes between
+# two writes — and one of the two values that pin the recorder's
+# `_ANCHORED_HOLD_S` (3.0 s) from either side.
+#
+# This one sits *inside* the window and must come out masked; TERM_SLOW_PAUSE_S
+# below sits outside it and must come out legible. Both are needed. With only
+# this one, `_ANCHORED_HOLD_S` could be raised to any value at all and nothing
+# would notice; with only the other, it could be lowered to ~0.5. A full second
+# of margin either side of 3.0, because the quantity the recorder actually
+# measures is wall-clock idle time on a CI box recording video through
+# Chromium, not the sleep the printer asked for.
+TERM_PAUSE_S = 2.0
+# ...and the same pause past the far edge of that window. This one is a
+# *documented leak*: SKILL.md says a program that pauses longer than three
+# seconds inside a token defeats shape matching, and this is the arm that
+# holds that sentence to its word. See TERM_SLOW.
+TERM_SLOW_PAUSE_S = 4.0
 MIN_TERM_DISTINCT_DELTA = {"still": 12.0, "video": 12.0}
 MIN_TERM_CONTROL_EDGE = {"still": 6.0, "video": 5.0}
 TERM_REDACT_SAMPLE_FPS = 2
@@ -5441,6 +5473,12 @@ def term_printer_script(mask: str) -> str:
     first three characters of `str` is a coin flip, and the run where it does
     not is a run where nothing tested that rule.
 
+    `slw` is the same cut, TERM_SLOW_PAUSE_S long, and it is the only row here
+    that must come out **legible**. The recorder's hold on a shape fragment is
+    bounded — it has to be, or a screen ending in `e` renders short forever —
+    and `slw` measures that bound from the outside while `pau` measures it
+    from the inside. Neither alone says where three seconds is.
+
     The last two lines are the other half of the scrubber's contract — see
     TERM_HELD_LINE. `read` keeps the program alive so the PTY stays silent
     with an unterminated line on screen.
@@ -5465,6 +5503,9 @@ def term_printer_script(mask: str) -> str:
             f"printf 'anc %s'\n"
             f"sleep {TERM_PAUSE_S}\n"
             f"printf '%s\\n' '{TERM_ANCHOR_SPLIT[1:]}'\n"
+            f"printf 'slw %s'\n"
+            f"sleep {TERM_SLOW_PAUSE_S}\n"
+            f"printf '%s\\n' '{TERM_SLOW[TERM_ANSI_CUT:]}'\n"
             f"printf 'aws %s\\n' '{TERM_AWS}'\n"
             f"printf 'jwt %s\\n' '{TERM_JWT}'\n"
             f"printf 'ctl %s\\n' '{TERM_CONTROL}'\n"
@@ -5474,6 +5515,7 @@ def term_printer_script(mask: str) -> str:
         )
         .replace("printf 'pau %s'", f"printf 'pau %s' '{pause_head}'")
         .replace("printf 'anc %s'", f"printf 'anc %s' '{TERM_ANCHOR_SPLIT[:1]}'")
+        .replace("printf 'slw %s'", f"printf 'slw %s' '{TERM_SLOW[:TERM_ANSI_CUT]}'")
     )
 
 
@@ -5585,6 +5627,19 @@ def record_terminal_redaction(out_dir: Path, work_dir: Path) -> tuple[list[str],
                     r"^key \[redacted\]$",
                     "the screen never showed a masked `key` row",
                 ),
+                # The last *complete* line the printer writes, and the one
+                # immediately before the held fragment. Waiting for it here is
+                # what makes the number below mean something: the printer
+                # sleeps for seconds on the `pau`, `anc` and `slw` rows, and a
+                # timer started before all that measures the script's runtime
+                # with the release buried in its noise. From here to the next
+                # pattern there is nothing between the two `printf`s.
+                (
+                    f"^{re.escape(TERM_REFERENCE_ROW)} {re.escape(SECRET_MASK)}$",
+                    "the screen never showed the `ref` row, so the release "
+                    "timed below could not be isolated from the printer's own "
+                    "runtime",
+                ),
                 (
                     f"^{re.escape(TERM_HELD_LINE)}$",
                     f"the screen never showed {TERM_HELD_LINE!r}, which the "
@@ -5596,7 +5651,7 @@ def record_terminal_redaction(out_dir: Path, work_dir: Path) -> tuple[list[str],
             ):
                 began = time.monotonic()
                 try:
-                    rec.wait_for_text(pattern, timeout_s=10)
+                    rec.wait_for_text(pattern, timeout_s=20)
                 except RuntimeError as exc:
                     b.fail_if(True, f"{why} — {' '.join(str(exc).split())[:200]}")
                 waited[pattern] = time.monotonic() - began
@@ -5605,6 +5660,9 @@ def record_terminal_redaction(out_dir: Path, work_dir: Path) -> tuple[list[str],
             # quiet poll and the screen is never behind the program. Held on
             # the clock the token-boundary fragments get, it would arrive three
             # seconds late — which no assertion about the final screen can see.
+            #
+            # Measured from the `ref` row, one `printf` earlier, so this is the
+            # release and nothing else.
             lag = waited[f"^{re.escape(TERM_HELD_LINE)}$"]
             b.fail_if(
                 lag > TERM_HELD_MAX_WAIT_S,
@@ -5627,6 +5685,25 @@ def record_terminal_redaction(out_dir: Path, work_dir: Path) -> tuple[list[str],
                     f"let it through, so it is in every frame drawn from that "
                     f"buffer and in what wait_for_text() reads",
                 )
+            # The documented limit, asserted as a limit. SKILL.md says a
+            # program that pauses longer than three seconds inside a token
+            # defeats shape matching; this row is that program. Graded
+            # positively — it must be on screen *in the clear* — because a
+            # "not covered" paragraph nobody grades is a paragraph that goes
+            # quietly out of date the first time somebody tunes the constant.
+            # Together with the `pau` row, which pauses TERM_PAUSE_S and must
+            # be masked, it pins _ANCHORED_HOLD_S from both sides: raise it and
+            # this fails, lower it and `pau` does.
+            b.fail_if(
+                f"slw {TERM_SLOW}" not in screen,
+                f"the token paused {TERM_SLOW_PAUSE_S}s mid-value is not on "
+                f"screen in the clear. That is the documented limit of shape "
+                f"detection — the hold is bounded, or a screen ending in `e` "
+                f"renders short forever — and it is graded here so the bound "
+                f"cannot move without somebody deciding to move it. Either "
+                f"the recorder now holds longer than SKILL.md says, or the "
+                f"row never rendered at all",
+            )
             b.fail_if(
                 f"{TERM_CONTROL_ROW} {TERM_CONTROL}" not in screen,
                 "the unregistered control value is not on screen intact. It is "
@@ -6110,39 +6187,68 @@ TERM_CURSOR_SCRIPT = (
     "printf '\\033[6;__COL__H%s\\n' '__TAIL__'\n"
 )
 
+# The same two writes, backgrounded behind a sleep, so they land *after* the
+# storyboard's last verb has returned — inside the window `_finish_line()`
+# holds open at the end of a narrated take. See the `tail` arm below.
+TERM_CURSOR_LATE_SCRIPT = (
+    "#!/bin/sh\n"
+    "(sleep __DELAY__\n"
+    " printf '\\033[6;1Hcup %s' '__HEAD__'\n"
+    " printf '\\033[6;__COL__H%s\\n' '__TAIL__') &\n"
+)
 
-def check_cursor_screen_leak(out_root: Path, work_dir: Path) -> list[str]:
-    """A value the stream cannot show is contiguous must fail the take.
+# How long the late writer waits, and how long the simulated narration tail
+# runs. The write has to land strictly inside the tail: after the storyboard's
+# last verb, before the recorder stops pumping.
+TERM_LATE_WRITE_S = 1.2
+TERM_LATE_TAIL_S = 3.0
 
-    Its own take because it has to *die*. The scrubber matches substrings of
-    the byte stream, and a program that positions the cursor twice puts a
-    value on screen without ever putting it in one substring — measured, and
-    documented in SKILL.md as uncovered. Uncovered has to mean *refused*: the
-    recorder reads the finished terminal buffer before it converts anything,
-    and a registered value found there kills the take the way an unverifiable
-    CSS mask does on the web side.
 
-    Without that check this take records a normal mp4, with the key legible in
-    every frame, `issues: []`, and `strict=True` satisfied — which is the
-    quietest failure in this whole harness.
+class _StoryboardFailed(RuntimeError):
+    """What a storyboard raises when a sync verb gives up.
+
+    Its own class only so the `crash` arm below can tell "the take re-raised
+    what the storyboard threw" from "something else went wrong", which a bare
+    RuntimeError cannot.
     """
-    if os.name != "posix":
-        return []
+
+
+def _cursor_leak_take(
+    out_root: Path, work_dir: Path, arm: str
+) -> tuple[list[str], BaseException | None, str, Path]:
+    """Record one cursor-leak take. Returns (failures, raised, screen, dir).
+
+    Three arms, one body, because the guarantee SKILL.md states is
+    unconditional and each arm is a different way out of the `with`:
+
+      `clean`  the storyboard finishes. The historical case.
+      `crash`  the storyboard raises after the value is on screen — a
+               wait_for_text() timeout, a Ctrl-C on a hung demo. `__exit__`
+               used to skip the screen check entirely on this path and keep
+               the still, which on the terminal side is the raw screen with
+               the key legible on it.
+      `tail`   the value lands *after* the last verb, in the window a narrated
+               take holds open to avoid ending mid-sentence. The check used to
+               run before that window, so the frames it vouched for were not
+               the frames that got recorded.
+    """
     from demo_recording import SecretLeak, TerminalRecorder
 
-    label = "terminal-cursor-leak"
+    label = f"terminal-cursor-leak-{arm}"
     out_dir = fresh_take_dir(out_root, label)
-    script = work_dir / "cursor-write"
     head, tail = TERM_CURSOR[:TERM_ANSI_CUT], TERM_CURSOR[TERM_ANSI_CUT:]
     # The column the second write starts at: "cup " plus the head, one-based.
     # Off by one and the two pieces overlap, the value on screen is not the
     # registered one, and the take proves nothing while looking fine — which
     # is what the premise assertion below is for.
     column = len("cup ") + len(head) + 1
+    template = TERM_CURSOR_LATE_SCRIPT if arm == "tail" else TERM_CURSOR_SCRIPT
+    script = work_dir / "cursor-write"
     script.write_text(
-        TERM_CURSOR_SCRIPT.replace("__HEAD__", head)
+        template.replace("__HEAD__", head)
         .replace("__TAIL__", tail)
         .replace("__COL__", str(column))
+        .replace("__DELAY__", f"{TERM_LATE_WRITE_S}")
     )
     script.chmod(0o755)
 
@@ -6154,50 +6260,48 @@ def check_cursor_screen_leak(out_root: Path, work_dir: Path) -> list[str]:
             rec.register_secret(TERM_CURSOR)
             rec.run("./cursor-write")
             rec.wait_for_prompt(timeout_s=20)
-            # Taken on purpose, and required to be gone afterwards: a still is
-            # written long before the take ends, and the web half shipped a
-            # round where a refused take left its stills on disk holding the
-            # value it had refused to write an mp4 for.
-            rec.shot("01-cursor")
-            screen = rec._screen()
+            if arm == "tail":
+                # Nothing is on screen yet — the writer is still sleeping —
+                # so a check that ran here would pass, which is the point.
+                if TERM_CURSOR in rec._screen():
+                    failures.append(
+                        f"{label}: the late writer had already written by the "
+                        f"time the storyboard ended, so this arm is the "
+                        f"`clean` arm with extra steps. Raise "
+                        f"TERM_LATE_WRITE_S above the take's own runtime."
+                    )
+                # The narration tail, without narration. `_finish_line()`
+                # reads exactly one field — `_line_end`, which `_start_line()`
+                # sets from `media_duration(clip)` — and idles until it
+                # passes, pumping the PTY the whole way. Setting it directly
+                # is the same code path a spoken line takes, and it is the
+                # only way to reach it here: the smoke run has no
+                # ELEVENLABS_API_KEY, so `speech=True` records silently and
+                # the tail is zero.
+                rec._line_end = time.monotonic() + TERM_LATE_TAIL_S
+            else:
+                # Taken on purpose, and required to be gone afterwards: a still
+                # is written long before the take ends, and the web half
+                # shipped a round where a refused take left its stills on disk
+                # holding the value it had refused to write an mp4 for.
+                rec.shot("01-cursor")
+                screen = rec._screen()
+            if arm == "crash":
+                raise _StoryboardFailed(
+                    "the storyboard gave up after the value reached the screen"
+                )
     except SecretLeak as exc:
         raised = exc
+    except _StoryboardFailed as exc:
+        raised = exc
     except Exception as exc:  # noqa: BLE001 - any other failure is a failure
-        return [f"{label}: expected SecretLeak, got {type(exc).__name__}: {exc}"]
+        failures.append(f"{label}: unexpected {type(exc).__name__}: {exc}")
+    return failures, raised, screen, out_dir
 
-    if raised is None:
-        failures.append(
-            f"{label}: a registered value written at two cursor positions is "
-            f"contiguous on screen and in no substring of the stream. The "
-            f"scrubber cannot see it — that is documented — so the recorder "
-            f"has to refuse the take at teardown instead. It returned "
-            f"normally, which means it wrote an mp4 with the key legible in "
-            f"every frame and reported nothing wrong."
-        )
-    else:
-        if TERM_CURSOR in str(raised):
-            failures.append(
-                f"{label}: the SecretLeak quotes the value it caught, which "
-                f"puts it in every log that reports the failure"
-            )
-        if "screen" not in str(raised):
-            failures.append(
-                f"{label}: the failure does not say the value was found on "
-                f"screen, so a reader cannot tell it from a mask that failed "
-                f"to apply: {str(raised)[:120]!r}"
-            )
-    # The premise, asserted rather than assumed. If the two halves ever ended
-    # up adjacent in the byte stream the scrubber would have masked them, the
-    # screen would be clean, nothing would raise — and the failure above would
-    # be reported against a take that never contained a leak to catch.
-    if TERM_CURSOR not in screen:
-        failures.append(
-            f"{label}: the value never reached the terminal screen, so this "
-            f"take exercised nothing. It is supposed to be written in two "
-            f"pieces at two cursor positions and land contiguously; check "
-            f"TERM_CURSOR_SCRIPT against the terminal's width and the row it "
-            f"writes to."
-        )
+
+def _cursor_leak_artifacts(label: str, out_dir: Path) -> list[str]:
+    """Nothing this take wrote may survive it."""
+    failures = []
     for name, path in (
         ("demo.mp4", out_dir / "demo.mp4"),
         ("timeline.json", out_dir / "timeline.json"),
@@ -6219,10 +6323,88 @@ def check_cursor_screen_leak(out_root: Path, work_dir: Path) -> list[str]:
             f"{label}: raw capture left behind in .video/: {leftovers!r} — it "
             f"holds the frames the mp4 was refused for"
         )
+    return failures
+
+
+def check_cursor_screen_leak(out_root: Path, work_dir: Path) -> list[str]:
+    """A value the stream cannot show is contiguous must fail the take.
+
+    Its own takes because they have to *die*. The scrubber matches substrings
+    of the byte stream, and a program that positions the cursor twice puts a
+    value on screen without ever putting it in one substring — measured, and
+    documented in SKILL.md as uncovered. Uncovered has to mean *refused*: the
+    recorder reads the finished terminal buffer before it converts anything,
+    and a registered value found there kills the take the way an unverifiable
+    CSS mask does on the web side.
+
+    Without that check the `clean` arm records a normal mp4, with the key
+    legible in every frame, `issues: []`, and `strict=True` satisfied — which
+    is the quietest failure in this whole harness. The other two arms are the
+    ways out of the `with` that the check used to miss entirely; see
+    `_cursor_leak_take`.
+    """
+    if os.name != "posix":
+        return []
+    from demo_recording import SecretLeak
+
+    failures: list[str] = []
+    for arm in ("clean", "crash", "tail"):
+        label = f"terminal-cursor-leak-{arm}"
+        problems, raised, screen, out_dir = _cursor_leak_take(out_root, work_dir, arm)
+        failures += problems
+        # `crash` re-raises what the storyboard threw — the recorder must not
+        # bury a wait_for_text() timeout under a leak report, because the
+        # timeout is what tells the author what to fix. The leak still has to
+        # cost the artifacts, which is what _cursor_leak_artifacts grades.
+        want = _StoryboardFailed if arm == "crash" else SecretLeak
+        if raised is None:
+            failures.append(
+                f"{label}: a registered value written at two cursor positions "
+                f"is contiguous on screen and in no substring of the stream. "
+                f"The scrubber cannot see it — that is documented — so the "
+                f"recorder has to refuse the take at teardown instead. It "
+                f"returned normally, which means it wrote an mp4 with the key "
+                f"legible in every frame and reported nothing wrong."
+            )
+        elif not isinstance(raised, want):
+            failures.append(
+                f"{label}: expected {want.__name__}, got "
+                f"{type(raised).__name__}: {str(raised)[:160]!r}"
+            )
+        elif isinstance(raised, SecretLeak):
+            if TERM_CURSOR in str(raised):
+                failures.append(
+                    f"{label}: the SecretLeak quotes the value it caught, "
+                    f"which puts it in every log that reports the failure"
+                )
+            if "screen" not in str(raised):
+                failures.append(
+                    f"{label}: the failure does not say the value was found "
+                    f"on screen, so a reader cannot tell it from a mask that "
+                    f"failed to apply: {str(raised)[:120]!r}"
+                )
+        # The premise, asserted rather than assumed. If the two halves ever
+        # ended up adjacent in the byte stream the scrubber would have masked
+        # them, the screen would be clean, nothing would raise — and the
+        # failure above would be reported against a take that never contained
+        # a leak to catch. Only the arms that read the screen mid-take can say
+        # this; `tail` writes after the last verb, and its evidence that the
+        # value reached the screen *is* the refusal.
+        if arm == "clean" and TERM_CURSOR not in screen:
+            failures.append(
+                f"{label}: the value never reached the terminal screen, so "
+                f"this take exercised nothing. It is supposed to be written "
+                f"in two pieces at two cursor positions and land "
+                f"contiguously; check TERM_CURSOR_SCRIPT against the "
+                f"terminal's width and the row it writes to."
+            )
+        failures += _cursor_leak_artifacts(label, out_dir)
     if not failures:
         print(
             "smoke: terminal-redaction a value the stream never carried whole "
-            "is caught on the finished screen and fails the take"
+            "is caught on the finished screen and fails the take — on a clean "
+            "exit, on a storyboard that raised, and on a write that lands in "
+            "the narration tail"
         )
     return failures
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -34,7 +34,9 @@ and grades each take on separate axes:
    for byte, and the one recorded with the recorder's *defaults* must not.
 5. **Redaction** — a registered secret reaches no frame, still, caption or TTS
    cache entry. Graded on pixel sharpness against an unredacted control key in
-   the same frame, and on a byte search of everything the take wrote.
+   the same frame, and on a byte search of everything the take wrote. The
+   terminal half (issue #5) grades the PTY scrubber the same way, against a
+   value split across `os.read()` boundaries on purpose.
 
     tests/smoke                 # every take
     tests/smoke --web-only
@@ -872,6 +874,198 @@ MAX_REDACTED_EDGE_RATIO = {"text": 0.07, "field": 0.25}
 # is scored and the *worst* one is graded, because one frame showing the key is
 # a leak: a paused video is a screenshot.
 REDACT_SAMPLE_FPS = 2
+
+# -- terminal redaction (issue #5) -------------------------------------------
+#
+# The terminal half of redaction is a different mechanism with a different
+# failure mode. There is no DOM to cover: the frames show whatever a real
+# program wrote to a real PTY, so the only intervention is a scrubber between
+# `os.read()` and `term.write()`. What that buys, and what this take grades:
+#
+#   * a *registered* secret printed by a command never reaches the terminal
+#     buffer, and therefore never reaches a frame, a still, or the screen text
+#     `wait_for_text()` reads;
+#   * neither does one **split across `os.read()` boundaries**, which is the
+#     acceptance criterion of #5 and is *forced* here rather than hoped for —
+#     see capped_pty_reads();
+#   * nor one with an ANSI colour escape **inside** it, which is what
+#     colourised output looks like;
+#   * a token nobody registered, matched only by its shape, is masked too;
+#   * `run()` and `send()` refuse authored text holding a registered secret,
+#     the way `caption()` and `terminal()` already do.
+#
+# Six values, all 28 characters wide so every one of them occupies the same
+# columns of the terminal grid and can be compared crop against crop. Spelled
+# like the web literals — a four-letter word and a run of zeroes, allowlisted
+# in .gitleaks.toml — because none of them is a credential.
+#
+#   TERM_PRINTED  registered, printed by a command
+#   TERM_ANSI     registered, printed with a colour escape inside it
+#   TERM_SHAPE    never registered. The `ghp_` shape net is all that hides it,
+#                 which is the point: it proves the net exists, separately
+#                 from the registry
+#   TERM_TYPED    sent as Secret(...) and echoed back by the PTY one character
+#                 per read — deliberately not shape-matching, so what masks it
+#                 can only be the registration `send()` did
+#   TERM_CONTROL  never registered, and matches no shape. The reference for
+#                 "there is legible text in this frame at all"
+TERM_PRINTED = "sk-live-PTYK0000000000000000"
+TERM_ANSI = "sk-live-ANSI0000000000000000"
+TERM_HIDE = "sk-live-HIDE0000000000000000"
+TERM_OSC = "sk-live-OSCT0000000000000000"
+TERM_SHAPE = "ghp_SHAP00000000000000000000"
+TERM_STREAMED = "ghp_STRM00000000000000000000"
+TERM_PAUSED = "sk-live-PAUS0000000000000000"
+TERM_ANCHOR_SPLIT = "ghp_ANCH00000000000000000000"
+TERM_AWS = "AKIAAWSK00000000000000000000"
+TERM_JWT = "eyJKV0TAAA.eyJzdWJBQUE.SIGN0"
+TERM_TYPED = "pw-live-SEND0000000000000000"
+TERM_CONTROL = "zz-live-TCTL0000000000000000"
+
+# Two more, each for a take of its own further down.
+#
+#   TERM_CURSOR  written in two pieces at two cursor positions. Contiguous on
+#                screen, contiguous in no substring of the stream — the case
+#                the scrubber cannot see and `_verify_redaction_final` must
+#                refuse.
+#   TERM_KEYED   spelled out through key(), one keystroke per character. The
+#                beat log records the keys joined by spaces, which no literal
+#                scrub can match, so the guard has to refuse the call.
+TERM_CURSOR = "sk-live-CURS0000000000000000"
+TERM_KEYED = "sk-live-KEYD0000000000000000"
+
+# Longer than the recorder's _MAX_HOLD (4096), so the fragment rule that holds
+# a growing token hits its ceiling mid-match. Graded on the screen text and
+# the byte sweep rather than on pixels: 4 kB of base64 wraps over fifty rows
+# and would scroll every measured row off screen.
+TERM_LONG_JWT = "eyJ" + "L" * 2100 + "." + "J" * 2100 + ".SIG"
+# ...and the needle to look for it with. A hold that hits its ceiling does not
+# leak the *whole* value — it writes out the leading characters, seven per
+# read, and keeps holding the last 4096. So the whole value is the wrong thing
+# to search for: measured, a take rendering the first 111 characters of this
+# token in the clear passes a check for the token itself.
+TERM_LONG_WITNESS = TERM_LONG_JWT[:64]
+
+# The same ceiling from the other side: a *registered* value longer than it.
+# Deliberately matching no shape, so the only thing that can hide it is the
+# registry — and the registry's hold is the one the ceiling must never clamp.
+# Clamping it (measured, by injection) writes all 4200 characters to the
+# screen seven at a time while the recorder reports nothing wrong.
+TERM_LONG_REGISTERED = "zz-long-" + "R" * 4200
+TERM_LONG_REG_WITNESS = TERM_LONG_REGISTERED[:64]
+
+# Where TERM_ANSI is cut in two by a colour escape. A literal substring match
+# on the byte stream sees `sk-live-ANSI` and `0000000000000000`, and neither
+# is the secret; only matching against an escape-stripped copy finds it.
+TERM_ANSI_CUT = 12
+
+# Every value that must not survive anywhere the take writes, and where it
+# came from. TERM_CONTROL is deliberately absent — it is *supposed* to be in
+# the frames, and a sweep that flagged it would be measuring nothing.
+TERM_LITERALS = {
+    "the key a command printed": TERM_PRINTED,
+    "the key printed with a colour escape inside it": TERM_ANSI,
+    "the key printed with a cursor-hide escape inside it": TERM_HIDE,
+    "the key printed with a window-title escape inside it": TERM_OSC,
+    "the ghp_-shaped token nobody registered": TERM_SHAPE,
+    "the ghp_-shaped token written one character at a time": TERM_STREAMED,
+    "the sk--shaped token paused in the middle": TERM_PAUSED,
+    "the ghp_-shaped token paused inside its anchor": TERM_ANCHOR_SPLIT,
+    "the AKIA-shaped token nobody registered": TERM_AWS,
+    "the JWT nobody registered": TERM_JWT,
+    "the leading characters of the over-long JWT": TERM_LONG_WITNESS,
+    "the leading characters of the over-long registered value": (TERM_LONG_REG_WITNESS),
+    "the password sent as Secret(...)": TERM_TYPED,
+}
+
+# Each line the take puts on screen is `<tag> <value>`, one tag per row, all
+# tags the same width so every value starts in the same column. `ref` renders
+# the mask itself, literally, and is the reference every masked row is
+# compared against: it is what `[redacted]` looks like in this font at this
+# size in this frame, measured rather than assumed.
+TERM_TAG_W = 4  # "key " and friends
+TERM_VALUE_CELLS = 28
+TERM_MASKED_ROWS = {
+    "key": "the key a command printed",
+    "ans": "the key with a colour escape inside it",
+    "hid": "the key with a cursor-hide escape inside it",
+    "osc": "the key with a window-title escape inside it",
+    "shp": "the shape-matched token, printed in one burst",
+    "str": "the shape-matched token, written one character at a time",
+    "pau": "the shape-matched token, paused mid-value",
+    "anc": "the shape-matched token, paused after its first character",
+    "aws": "the AKIA-shaped token",
+    "jwt": "the JWT-shaped token",
+    "pwd": "the password sent as Secret(...)",
+}
+TERM_CONTROL_ROW = "ctl"
+TERM_REFERENCE_ROW = "ref"
+
+# Printed with no trailing newline, by a program that then waits for input —
+# so the PTY goes silent with `gh` at the end of the stream. Those two
+# characters could still become a `ghp_` token, so the scrubber holds them,
+# and it has to let them go once the burst is over. Otherwise the screen
+# renders short of what the program wrote and every verb that syncs on the
+# screen — wait_for_text, wait_for_prompt — waits for text the recorder is
+# sitting on.
+#
+# `xe` and not `gh`, and that is the whole point of the case. Both are shape
+# fragments — `e` could begin a JWT — but this one sits *in the middle of a
+# word*, where a credential never starts, so the recorder writes it the moment
+# the PTY goes quiet and the screen is never short. A fragment at a token
+# boundary (`hld gh`) is where a key would start and is held for seconds
+# instead; a fragment that could complete a *registered* value is held with no
+# timeout at all, which is what stops the echo of send(Secret(...)) — one
+# character per read, with an idle pump between each — from printing a
+# password one character at a time. The three arms are asserted separately:
+# this row, the `str`/`pau` rows, and the `pwd` row.
+TERM_HELD_LINE = "hld xe"
+# ...and how long the screen may lag behind the program for it. A fragment in
+# the middle of a word goes out on the first quiet poll, so this is the pump
+# interval plus slack. Held on the *anchored* clock instead — which is what a
+# rule that could not tell `hld xe` from `hld gh` would do — it arrives at
+# three seconds and this fails. Without the release it never arrives at all.
+TERM_HELD_MAX_WAIT_S = 1.5
+
+# The pwd row only exists once send() has typed into `read`; the other five
+# are on screen from the moment the printer ran.
+TERM_REDACT_SHOTS = ["01-printed", "02-typed"]
+TERM_REDACT_DURATION_S = (4.0, 40.0)
+
+# How the three-way pixel comparison is graded. Every crop is the same 28
+# cells of the same row height, taken at native resolution, and compared by
+# mean absolute luma difference:
+#
+#   * a masked row against the `ref` row must be *the same picture* — the
+#     terminal is rendering `[redacted]`, not a key. Measured 0.0-0.4 in the
+#     lossless stills and 0.3-1.6 in the mp4 (codec noise on identical text).
+#   * the `ctl` row against the same `ref` row must *not* be, and that is the
+#     calibration: it is a 28-character key in the same font at the same size
+#     in the same frame — exactly what a leak would look like — so it says the
+#     comparison can tell the two apart at all. Measured 30-40.
+#   * and the `ctl` row must be sharp, which is what stops every number above
+#     from passing on a blank recording or a terminal that rendered nothing.
+#
+# The bars sit in the gap between those bands, an order of magnitude from
+# either side.
+MAX_TERM_MASK_DELTA = {"still": 3.0, "video": 6.0}
+# Milliseconds between characters when the printer writes a token one at a
+# time. The recorder drains the PTY faster than that, so `select()` reports
+# nothing ready between every character and the scrubber sees a quiet boundary
+# mid-token — the exact condition that made shape detection a no-op, and one
+# the read cap cannot manufacture. 5 ms is the fastest rate measured leaking.
+TERM_STREAM_MS = 5
+# ...and a single long pause mid-token, past any grace a fragment could be
+# given, for the case where a program computes between two writes.
+TERM_PAUSE_S = 0.4
+MIN_TERM_DISTINCT_DELTA = {"still": 12.0, "video": 12.0}
+MIN_TERM_CONTROL_EDGE = {"still": 6.0, "video": 5.0}
+TERM_REDACT_SAMPLE_FPS = 2
+
+# Bytes per `os.read()` while the take records. Small enough that no 28-byte
+# value can arrive whole, so "split across two reads" is a fact of every run
+# rather than a race the harness hopes to win. See capped_pty_reads().
+TERM_READ_CAP = 7
 
 
 class SmokeFailure(Exception):
@@ -5139,6 +5333,927 @@ def run_segments(out_root: Path) -> list[str]:
     )
 
 
+# -- the terminal redaction take (issue #5) ----------------------------------
+
+
+class _CappedReads:
+    """`os` for demo_recording.terminal, with every read capped and recorded.
+
+    Issue #5's acceptance criterion is a secret **split across two `os.read()`
+    boundaries**, and it says to force that rather than hope for it. A PTY
+    hands back whatever happens to be in the buffer, so on a quiet box a
+    `printf` usually arrives whole and a take that merely printed a key would
+    prove nothing about the carry buffer at all.
+
+    Capping every read at a handful of bytes makes the split a property of
+    every run, and keeping the fragments turns "it was split" from an
+    assumption into something the harness checks and prints. Only the module
+    global in demo_recording.terminal is replaced — patching `os.read` itself
+    would reach Playwright, ffmpeg and the harness's own file reads.
+    """
+
+    def __init__(self, cap: int) -> None:
+        self._cap = cap
+        self.fragments: list[bytes] = []
+
+    def __getattr__(self, name: str):
+        return getattr(os, name)
+
+    def read(self, fd: int, size: int) -> bytes:
+        data = os.read(fd, min(size, self._cap))
+        self.fragments.append(data)
+        return data
+
+
+@contextmanager
+def capped_pty_reads(cap: int) -> Iterator[_CappedReads]:
+    import demo_recording.terminal as terminal_module
+
+    shim = _CappedReads(cap)
+    real = terminal_module.os
+    terminal_module.os = shim
+    try:
+        yield shim
+    finally:
+        terminal_module.os = real
+
+
+def fragments_spanned(fragments: list[bytes], needle: bytes) -> int:
+    """How many reads `needle` had to be reassembled from.
+
+    1 means a single read carried it whole — the case a per-chunk `scrub()`
+    already handles, and therefore the case that proves nothing. 0 means it is
+    not in the raw stream at all, which for a value a command printed means
+    the test is measuring the wrong thing.
+    """
+    joined = b"".join(fragments)
+    at = joined.find(needle)
+    if at < 0:
+        return 0
+    end, span, pos = at + len(needle), 0, 0
+    for fragment in fragments:
+        if pos < end and pos + len(fragment) > at:
+            span += 1
+        pos += len(fragment)
+    return span
+
+
+def _sh_char_by_char(tag: str, value: str, gap_ms: int) -> str:
+    """Shell that writes `<tag> <value>` one character at a time.
+
+    The reason this exists rather than a `printf`: the recorder drains the PTY
+    faster than a program this slow writes, so `select()` reports nothing
+    ready between every character. That quiet-boundary-inside-a-token is the
+    condition that turned shape detection into a no-op, and capping `os.read()`
+    cannot manufacture it — capped reads still come back-to-back off a full
+    buffer, and the scrubber never sees the PTY go idle mid-value.
+    """
+    chars = " ".join(f"'{c}'" for c in value)
+    return (
+        f"printf '{tag} '\n"
+        f'for c in {chars}; do printf %s "$c"; sleep {gap_ms / 1000:.3f}; done\n'
+        "printf '\\n'\n"
+    )
+
+
+def term_printer_script(mask: str) -> str:
+    """A shell script that prints one tagged value per line.
+
+    A script rather than a `run()` per value, for one reason that matters: a
+    command line is echoed on screen, and typing the values into one would
+    both trip `run()`'s own guard and put them in the frames by a path this
+    take is not about. It is written outside the take directory, so the byte
+    sweep grades what the *recorder* wrote and not what the harness did.
+
+    Four of the rows are a value cut in half by something. `ans` by a colour
+    escape, `hid` by a cursor-hide (`\x1b[?25l` — what every spinner library
+    emits mid-line), `osc` by a window-title escape. None of those moves the
+    cursor, so all three are one token on screen and none is a substring of
+    the stream.
+
+    Three more are cut in half by *time*, which is a boundary the read cap
+    cannot produce and which a scrubber that flushes on idle walks straight
+    through. `str` writes a token one character at a time; `pau` stops in the
+    middle of one for TERM_PAUSE_S; `anc` stops after its *first character*,
+    which is the harder half — one character is not yet a credential prefix,
+    and what keeps it is where it sits, not what it says. Leaving `anc` to
+    chance does not work: whether an ordinary pump boundary lands inside the
+    first three characters of `str` is a coin flip, and the run where it does
+    not is a run where nothing tested that rule.
+
+    The last two lines are the other half of the scrubber's contract — see
+    TERM_HELD_LINE. `read` keeps the program alive so the PTY stays silent
+    with an unterminated line on screen.
+    """
+    head, tail = TERM_ANSI[:TERM_ANSI_CUT], TERM_ANSI[TERM_ANSI_CUT:]
+    hide_head, hide_tail = TERM_HIDE[:TERM_ANSI_CUT], TERM_HIDE[TERM_ANSI_CUT:]
+    osc_head, osc_tail = TERM_OSC[:TERM_ANSI_CUT], TERM_OSC[TERM_ANSI_CUT:]
+    pause_head = TERM_PAUSED[:TERM_ANSI_CUT]
+    pause_tail = TERM_PAUSED[TERM_ANSI_CUT:]
+    return (
+        (
+            "#!/bin/sh\n"
+            f"printf 'key %s\\n' '{TERM_PRINTED}'\n"
+            f"printf 'ans %s\\033[32m%s\\033[0m\\n' '{head}' '{tail}'\n"
+            f"printf 'hid %s\\033[?25l%s\\033[?25h\\n' '{hide_head}' '{hide_tail}'\n"
+            f"printf 'osc %s\\033]0;demo\\007%s\\n' '{osc_head}' '{osc_tail}'\n"
+            f"printf 'shp %s\\n' '{TERM_SHAPE}'\n"
+            + _sh_char_by_char("str", TERM_STREAMED, TERM_STREAM_MS)
+            + f"printf 'pau %s'\n"
+            f"sleep {TERM_PAUSE_S}\n"
+            f"printf '%s\\n' '{pause_tail}'\n"
+            f"printf 'anc %s'\n"
+            f"sleep {TERM_PAUSE_S}\n"
+            f"printf '%s\\n' '{TERM_ANCHOR_SPLIT[1:]}'\n"
+            f"printf 'aws %s\\n' '{TERM_AWS}'\n"
+            f"printf 'jwt %s\\n' '{TERM_JWT}'\n"
+            f"printf 'ctl %s\\n' '{TERM_CONTROL}'\n"
+            f"printf 'ref %s\\n' '{mask}'\n"
+            f"printf '{TERM_HELD_LINE}'\n"
+            "read -r _release\n"
+        )
+        .replace("printf 'pau %s'", f"printf 'pau %s' '{pause_head}'")
+        .replace("printf 'anc %s'", f"printf 'anc %s' '{TERM_ANCHOR_SPLIT[:1]}'")
+    )
+
+
+# The terminal grid, read off the live xterm.js instance: where the character
+# cells are on screen, and what is in each row of the viewport. Both are read
+# from the terminal itself rather than computed from the font size, so a
+# change to the window chrome or the font moves the measurement with it.
+_TERM_GRID_JS = """() => {
+  const term = window.__term;
+  const screen = document.querySelector('#__term_host .xterm-screen');
+  if (!term || !screen) return null;
+  const box = screen.getBoundingClientRect();
+  const buf = term.buffer.active;
+  const lines = [];
+  for (let y = 0; y < term.rows; y++) {
+    const line = buf.getLine(buf.viewportY + y);
+    lines.push(line ? line.translateToString(true) : '');
+  }
+  return {x: box.x, y: box.y, w: box.width, h: box.height,
+          cols: term.cols, rows: term.rows, lines: lines};
+}"""
+
+
+def term_row_rect(grid: dict, tag: str) -> Rect | None:
+    """Where the value on the `<tag> …` row is, in frame pixels.
+
+    Every row is measured over the same 28 cells starting at the same column,
+    so the crops are directly comparable: same size, same font, same frame.
+    """
+    row = next(
+        (i for i, line in enumerate(grid["lines"]) if line.startswith(f"{tag} ")),
+        None,
+    )
+    if row is None:
+        return None
+    cell_w = grid["w"] / grid["cols"]
+    cell_h = grid["h"] / grid["rows"]
+    return (
+        int(grid["x"] + TERM_TAG_W * cell_w),
+        int(grid["y"] + row * cell_h),
+        max(2, int(TERM_VALUE_CELLS * cell_w)),
+        max(2, int(cell_h)),
+    )
+
+
+def record_terminal_redaction(out_dir: Path, work_dir: Path) -> tuple[list[str], dict]:
+    """A terminal take whose program prints secrets four different ways.
+
+    Returns the post-condition failures plus what check_terminal_redaction
+    needs afterwards: where each row sits in the frame, when each value
+    reached the screen, and the evidence that the PTY really did chop the
+    values across reads.
+    """
+    from demo_recording import SECRET_MASK, Secret, SecretLeak, TerminalRecorder
+
+    b = Beats("terminal-redaction")
+
+    # Collected, never raised — the same reason record_terminal() does it: a
+    # take that aborts on a sync writes no mp4, and the mp4 is most of what is
+    # being graded here.
+    def expect_prompt(after: str) -> None:
+        try:
+            rec.wait_for_prompt(timeout_s=20)
+        except RuntimeError as exc:
+            b.fail_if(
+                True,
+                f"after {after}, the shell prompt never came back — "
+                f"{' '.join(str(exc).split())[:200]}",
+            )
+
+    printer = work_dir / "print-secrets"
+    printer.write_text(term_printer_script(SECRET_MASK))
+    printer.chmod(0o755)
+    long_printer = work_dir / "print-long"
+    long_printer.write_text(
+        "#!/bin/sh\n"
+        f"printf 'lng %s\\n' '{TERM_LONG_JWT}'\n"
+        f"printf 'lgr %s\\n' '{TERM_LONG_REGISTERED}'\n"
+    )
+    long_printer.chmod(0o755)
+
+    info: dict = {}
+    # Anything raised on the way out — the recorder's own last-word screen
+    # check, a strict verdict — is right to raise and wrong to let through
+    # here: it would throw away every post-condition collected above, and "the
+    # take raised" is a much worse bug report than "this row is in the buffer
+    # verbatim". Caught so both arrive.
+    exit_error: BaseException | None = None
+    try:
+        with (
+            capped_pty_reads(TERM_READ_CAP) as reads,
+            TerminalRecorder(out_dir, speech=False, strict=True) as rec,
+        ):
+            # Two of the four, before anything runs. The other two are the point
+            # of the take: TERM_SHAPE is never registered at all, and TERM_TYPED
+            # registers itself when send() is handed a Secret.
+            rec.register_secret(
+                TERM_PRINTED, TERM_ANSI, TERM_HIDE, TERM_OSC, TERM_LONG_REGISTERED
+            )
+            rec.caption("What a command prints, redacted on the way in.")
+            check_caption(b, rec.page, "What a command prints, redacted on the way in.")
+            rec.run("./print-secrets")
+            # The rendered screen, not the recorder's opinion of it. wait_for_text
+            # reads the xterm buffer, so this passing means the buffer holds the
+            # mask — and every frame is drawn from that same buffer.
+            waited = {}
+            for pattern, why in (
+                (
+                    r"^key \[redacted\]$",
+                    "the screen never showed a masked `key` row",
+                ),
+                (
+                    f"^{re.escape(TERM_HELD_LINE)}$",
+                    f"the screen never showed {TERM_HELD_LINE!r}, which the "
+                    f"program wrote with no newline before going quiet. The "
+                    f"scrubber is still holding its last characters back in case "
+                    f"they grow into a key — and every verb that syncs on the "
+                    f"screen is now waiting for text the recorder has",
+                ),
+            ):
+                began = time.monotonic()
+                try:
+                    rec.wait_for_text(pattern, timeout_s=10)
+                except RuntimeError as exc:
+                    b.fail_if(True, f"{why} — {' '.join(str(exc).split())[:200]}")
+                waited[pattern] = time.monotonic() - began
+            # Not just "it arrived": *when*. A fragment in the middle of a word
+            # is not where a credential starts, so it goes out on the first
+            # quiet poll and the screen is never behind the program. Held on
+            # the clock the token-boundary fragments get, it would arrive three
+            # seconds late — which no assertion about the final screen can see.
+            lag = waited[f"^{re.escape(TERM_HELD_LINE)}$"]
+            b.fail_if(
+                lag > TERM_HELD_MAX_WAIT_S,
+                f"{TERM_HELD_LINE!r} took {lag:.1f}s to reach the screen (bar "
+                f"{TERM_HELD_MAX_WAIT_S}s). Its last characters are a shape "
+                f"fragment in the middle of a word, where no key starts; "
+                f"holding those on the same clock as a fragment at a token "
+                f"boundary makes every finished screen lag by that clock",
+            )
+            # Release the `read` the printer is parked on, and let it exit.
+            rec.send("")
+            expect_prompt("the printer's read")
+            screen = rec._screen()
+            for what, literal in TERM_LITERALS.items():
+                if literal in (TERM_TYPED, TERM_LONG_WITNESS, TERM_LONG_REG_WITNESS):
+                    continue  # not on screen yet
+                b.fail_if(
+                    literal in screen,
+                    f"{what} is in the terminal buffer verbatim — the scrubber "
+                    f"let it through, so it is in every frame drawn from that "
+                    f"buffer and in what wait_for_text() reads",
+                )
+            b.fail_if(
+                f"{TERM_CONTROL_ROW} {TERM_CONTROL}" not in screen,
+                "the unregistered control value is not on screen intact. It is "
+                "the reference every pixel measurement here is taken against, "
+                "and a scrubber that masked everything would pass every leak "
+                "assertion in this take while recording nothing legible",
+            )
+            b.fail_if(
+                f"{TERM_REFERENCE_ROW} {SECRET_MASK}" not in screen,
+                f"the `{TERM_REFERENCE_ROW}` row does not hold {SECRET_MASK!r} — "
+                f"it is the picture every masked row is compared against, so "
+                f"without it nothing below is measured against anything",
+            )
+            printed_at = round(time.monotonic() - rec._t0, 3)
+            # Where the printer's own output ends in the read stream. The ANSI
+            # evidence below is taken over this prefix and no further: a later
+            # verb that typed the same value would put it in the stream by a path
+            # this take is not making a claim about.
+            printer_reads = len(reads.fragments)
+            rec.pause(0.8)
+            rec.shot(TERM_REDACT_SHOTS[0])
+
+            # The password path, and the one place the carry buffer is exercised
+            # by the recorder's own behaviour rather than by the read cap: the PTY
+            # echoes a typed character as it is typed, so this value arrives one
+            # character per read no matter how anything is configured.
+            rec.caption("A password typed as a Secret, echoed masked.")
+            check_caption(b, rec.page, "A password typed as a Secret, echoed masked.")
+            rec.run('read -r -p "pwd " PW')
+            rec.send(Secret(TERM_TYPED))
+            expect_prompt("send(Secret(...))")
+            b.fail_if(
+                TERM_TYPED not in rec.secrets,
+                "send(Secret(...)) typed the value without registering it, so a "
+                "caption or a narration line could still speak it",
+            )
+            b.fail_if(
+                TERM_TYPED in rec._screen(),
+                "the password the PTY echoed back is in the terminal buffer "
+                "verbatim — it arrives one character per read, which is exactly "
+                "the split a per-chunk scrub cannot see",
+            )
+            typed_at = round(time.monotonic() - rec._t0, 3)
+            rec.pause(0.8)
+            rec.shot(TERM_REDACT_SHOTS[1])
+
+            # Authored text. A command line and a typed answer are the terminal's
+            # `caption()`: the storyboard wrote them, the PTY echoes them, and the
+            # honest answer is to stop rather than to mask a command nobody could
+            # then read.
+            for verb, call in (
+                ("run", lambda: rec.run(f"echo {TERM_PRINTED}")),
+                ("send", lambda: rec.send(TERM_ANSI)),
+            ):
+                refused: Exception | None = None
+                try:
+                    call()
+                except SecretLeak as exc:
+                    refused = exc
+                b.fail_if(
+                    refused is None,
+                    f"{verb}() was handed a registered secret and typed it. It is "
+                    f"authored text echoed on screen — the same case terminal() "
+                    f"already refuses in the web recorder",
+                )
+                b.fail_if(
+                    refused is not None and str(refused).count("sk-live-") > 0,
+                    f"{verb}()'s SecretLeak quotes the secret it caught, which "
+                    f"puts the value in every log that reports the failure",
+                )
+            after = rec._screen()
+            for what, literal in TERM_LITERALS.items():
+                b.fail_if(
+                    literal in after,
+                    f"{what} reached the screen through a refused verb — the "
+                    f"guard has to run before the first keystroke, not after",
+                )
+
+            # A secret spelled out one keystroke at a time. `key()` is the one
+            # verb whose beat log entry a scrub cannot clean — the beat records
+            # the keys joined by spaces, and no literal match on the value can see
+            # `'s k - l i v e - …'` — so the only place to stop it is the call.
+            keyed: Exception | None = None
+            rec.register_secret(TERM_KEYED)
+            try:
+                rec.key(*TERM_KEYED)
+            except SecretLeak as exc:
+                keyed = exc
+            b.fail_if(
+                keyed is None,
+                "key() typed a registered secret one character at a time. Its "
+                "beat carries those characters space-separated into "
+                "timeline.json and timeline.md, which SKILL.md tells people to "
+                "commit, and nothing downstream can scrub that back out",
+            )
+            b.fail_if(
+                TERM_KEYED in rec._screen(),
+                "key() put a registered secret on screen before refusing",
+            )
+
+            grid = rec.page.evaluate(_TERM_GRID_JS)
+            if grid is None:
+                raise SmokeFailure(
+                    "terminal-redaction: the xterm.js grid could not be read, so "
+                    "no pixel assertion could be made"
+                )
+            rects: dict[str, Rect] = {}
+            for tag in [*TERM_MASKED_ROWS, TERM_CONTROL_ROW, TERM_REFERENCE_ROW]:
+                rect = term_row_rect(grid, tag)
+                if rect is not None:
+                    rects[tag] = rect
+            # Everything above is measured by pixels, so it had to happen while
+            # the rows stood still. This last case cannot: a token longer than the
+            # recorder's hold ceiling is 4 kB of base64, which wraps over fifty
+            # rows and scrolls every measured row off the screen. So it goes last,
+            # the video is graded only up to here, and it is checked on the screen
+            # text and the byte sweep instead.
+            graded_until = round(time.monotonic() - rec._t0, 3)
+            rec.run("./print-long")
+            expect_prompt("the long-token printer")
+            long_screen = rec._screen()
+            b.fail_if(
+                TERM_LONG_WITNESS in long_screen,
+                f"the first {len(TERM_LONG_WITNESS)} characters of a "
+                f"{len(TERM_LONG_JWT)}-character token are on screen. It is "
+                f"longer than the recorder's fragment ceiling, so the hold is "
+                f"clamped mid-match — and a clamp that lands inside a match "
+                f"writes the head of a credential and masks the tail",
+            )
+            b.fail_if(
+                TERM_LONG_REG_WITNESS in long_screen,
+                f"the first {len(TERM_LONG_REG_WITNESS)} characters of a "
+                f"{len(TERM_LONG_REGISTERED)}-character *registered* value are "
+                f"on screen. The ceiling that bounds a shape fragment must not "
+                f"bound this one: the registry is the guarantee, its hold is "
+                f"already bounded by the value's own length, and clamping it "
+                f"writes the whole value out seven characters at a time",
+            )
+            info = {
+                "rects": rects,
+                "printed_at": printed_at,
+                "typed_at": typed_at,
+                "graded_until": graded_until,
+                "caption_top": rec._size["height"] - 160,
+            }
+
+    except Exception as exc:  # noqa: BLE001 - reported, not swallowed
+        exit_error = exc
+    if exit_error is not None:
+        b.fail_if(
+            True,
+            f"the take did not finish cleanly: {type(exit_error).__name__}: "
+            f"{exit_error}. A SecretLeak here is the right answer to a "
+            f"registered value on the finished screen, and the leak "
+            f"assertions above say which row it was.",
+        )
+    if not info:
+        # It died before it could say where anything was on screen, so there
+        # is nothing for the pixel checks to measure. The collected
+        # post-conditions are the report.
+        return b.problems, {}
+
+    # Read after the take, so it covers every byte the PTY produced. This is
+    # the evidence for the acceptance criterion, not a diagnostic: a run where
+    # every value happened to arrive whole would grade a carry buffer that was
+    # never used.
+    info["reads"] = len(reads.fragments)
+    info["spans"] = {
+        name: fragments_spanned(reads.fragments, value.encode())
+        for name, value in (("printed", TERM_PRINTED), ("typed", TERM_TYPED))
+    }
+    printed = b"".join(reads.fragments[:printer_reads])
+    info["ansi_interleaved"] = (
+        TERM_ANSI[:TERM_ANSI_CUT].encode()
+        + b"\x1b[32m"
+        + TERM_ANSI[TERM_ANSI_CUT:].encode()
+    ) in printed
+    info["ansi_whole_in_stream"] = TERM_ANSI.encode() in printed
+    return b.problems, info
+
+
+def _term_deltas(
+    source: Path,
+    rects: dict[str, Rect],
+    tags: list[str],
+    start: float | None,
+    fps: int | None,
+    duration: float | None = None,
+) -> tuple[dict[str, list[float]], list[float], str | None]:
+    """Per-tag distance from the `ref` row, plus the control's own sharpness.
+
+    Every crop is the same size and comes out of the same frames, so the
+    comparison is between two regions of one picture — no threshold tied to
+    what CI's font rendering does to a terminal.
+    """
+    frames: dict[str, list[bytes]] = {}
+    shape: tuple[int, int] | None = None
+    for tag in [*tags, TERM_CONTROL_ROW, TERM_REFERENCE_ROW]:
+        if tag not in rects:
+            return {}, [], f"the take never found the `{tag}` row on screen"
+        got, width, height = native_frames(
+            source, rects[tag], fps, normalise=False, start=start, duration=duration
+        )
+        if not got:
+            return {}, [], f"no frames could be sampled for the `{tag}` row"
+        frames[tag] = got
+        shape = (width, height)
+    assert shape is not None
+    reference = frames[TERM_REFERENCE_ROW]
+    deltas = {
+        tag: [
+            frame_difference(a, b) for a, b in zip(frames[tag], reference, strict=False)
+        ]
+        for tag in [*tags, TERM_CONTROL_ROW]
+    }
+    control_edges = [edge_energy(f, *shape) for f in frames[TERM_CONTROL_ROW]]
+    return deltas, control_edges, None
+
+
+def _check_term_pixels(
+    source: Path,
+    label: str,
+    kind: str,
+    rects: dict[str, Rect],
+    tags: list[str],
+    start: float | None,
+    fps: int | None,
+    duration: float | None = None,
+) -> list[str]:
+    """The three-way pixel check, over one artifact.
+
+    A masked row must be the same picture as the `ref` row; the `ctl` row must
+    not be; and the `ctl` row must be sharp. The second is what says the first
+    can fail, and the third is what says neither of them is a statement about
+    a blank recording.
+    """
+    deltas, control_edges, problem = _term_deltas(
+        source, rects, tags, start, fps, duration
+    )
+    if problem is not None:
+        return [f"terminal-redaction: {label}: {problem}"]
+    failures: list[str] = []
+    sharp = min(control_edges)
+    if sharp < MIN_TERM_CONTROL_EDGE[kind]:
+        # Everything else here is "these two crops match" or "these two crops
+        # differ", and both are true of two crops of nothing at all.
+        return [
+            f"terminal-redaction: {label}: the unregistered control value "
+            f"scores {sharp:.1f} edge energy (floor "
+            f"{MIN_TERM_CONTROL_EDGE[kind]}) — there is no legible text in "
+            f"this artifact, so nothing measured in it means anything"
+        ]
+    distinct = min(deltas[TERM_CONTROL_ROW])
+    if distinct < MIN_TERM_DISTINCT_DELTA[kind]:
+        # The calibration: a 28-character key against the mask, in the same
+        # frame, is what a leak would look like. If that comparison cannot
+        # separate them, "the masked row matches the mask" is worthless.
+        return [
+            f"terminal-redaction: {label}: the control row and the reference "
+            f"row differ by only {distinct:.1f} (bar "
+            f"{MIN_TERM_DISTINCT_DELTA[kind]}) — an unmasked 28-character "
+            f"value is not distinguishable from {'[redacted]'!r} here, so "
+            f"every 'this row is masked' reading below is vacuous"
+        ]
+    for tag in tags:
+        worst = max(deltas[tag])
+        if worst > MAX_TERM_MASK_DELTA[kind]:
+            failures.append(
+                f"terminal-redaction: {label}: {TERM_MASKED_ROWS[tag]} does "
+                f"not render as the mask — the worst of {len(deltas[tag])} "
+                f"frames differs from the `ref` row by {worst:.1f} (bar "
+                f"{MAX_TERM_MASK_DELTA[kind]}), where the unmasked control "
+                f"differs by {distinct:.1f}. Something other than "
+                f"'[redacted]' is on screen at that row"
+            )
+    if not failures:
+        print(
+            f"smoke: terminal-redaction {label}: {len(tags)} rows render as "
+            f"the mask (worst "
+            f"{max(max(deltas[t]) for t in tags):.1f}), the unmasked control "
+            f"differs by {distinct:.1f} and scores {sharp:.1f} sharp"
+        )
+    return failures
+
+
+def check_terminal_redaction(out_dir: Path, info: dict, started_at: float) -> list[str]:
+    """Issue #5's acceptance criterion, one path at a time."""
+    from demo_recording import SECRET_MASK, media_duration
+
+    failures: list[str] = []
+    rects: dict[str, Rect] = info["rects"]
+    mp4 = out_dir / "demo.mp4"
+
+    # -- the split really happened -------------------------------------------
+    #
+    # Asserted before anything else, because every other assertion in this
+    # function is satisfied by a take where each value arrived in one read —
+    # and that take grades a scrubber with no carry buffer as a pass.
+    for name, spans in sorted(info["spans"].items()):
+        if spans < 2:
+            failures.append(
+                f"terminal-redaction: the {name} value was reassembled from "
+                f"{spans} os.read() fragment(s) out of {info['reads']}. This "
+                f"take exists to prove a secret split across read boundaries "
+                f"is caught; with the value arriving whole, a per-chunk "
+                f"scrub() passes and the carry buffer is untested"
+            )
+    if not info["ansi_interleaved"]:
+        failures.append(
+            "terminal-redaction: the raw PTY stream never carried the ANSI "
+            "case (value, colour escape, rest of value), so nothing here "
+            "tested matching across an escape sequence"
+        )
+    if info["ansi_whole_in_stream"]:
+        failures.append(
+            "terminal-redaction: the ANSI value appears whole in the raw "
+            "stream, which means the escape was not inside it — a literal "
+            "substring match would have found it and the case is not the one "
+            "it claims to be"
+        )
+    if not failures:
+        print(
+            f"smoke: terminal-redaction the printed key arrived in "
+            f"{info['spans']['printed']} os.read() fragments and the typed "
+            f"one in {info['spans']['typed']}, across {info['reads']} reads; "
+            f"the ANSI key was cut by a colour escape"
+        )
+
+    # -- every row is where the take said it was -----------------------------
+    wanted = [*TERM_MASKED_ROWS, TERM_CONTROL_ROW, TERM_REFERENCE_ROW]
+    missing = [tag for tag in wanted if tag not in rects]
+    if missing:
+        failures.append(
+            f"terminal-redaction: the rows {missing!r} were never found on "
+            f"screen, so their pixels were not graded at all"
+        )
+    # The recorder burns its caption bar across the bottom of the frame. A row
+    # that drifted into it would be measured against a crop of white caption
+    # text, which reads as a leak or hides one depending on which row moved.
+    for tag, rect in sorted(rects.items()):
+        if rect[1] + rect[3] > info["caption_top"]:
+            failures.append(
+                f"terminal-redaction: the `{tag}` row sits at y={rect[1]}, "
+                f"inside the caption band (from y={info['caption_top']}) — "
+                f"the crop is measuring burned-in caption text"
+            )
+
+    # -- artifacts -----------------------------------------------------------
+    if not mp4.is_file():
+        failures.append(f"terminal-redaction: {mp4} was never written")
+    elif mp4.stat().st_mtime < started_at - 1:
+        failures.append(f"terminal-redaction: {mp4} is stale — it predates this run")
+    elif mp4.stat().st_size < MIN_MP4_BYTES:
+        failures.append(f"terminal-redaction: {mp4} is only {mp4.stat().st_size} bytes")
+    else:
+        seconds = media_duration(mp4)
+        low, high = TERM_REDACT_DURATION_S
+        if not low <= seconds <= high:
+            failures.append(
+                f"terminal-redaction: demo.mp4 is {seconds:.1f}s, expected "
+                f"between {low:.0f}s and {high:.0f}s"
+            )
+
+    # -- leak path 1: the frames ---------------------------------------------
+    printed_rows = [t for t in TERM_MASKED_ROWS if t != "pwd"]
+    # Both windows end where the long-token row scrolls the screen. Past that
+    # the crops are over whatever slid into them, which reads as a leak or
+    # hides one depending on what it was.
+    printed_for = info["graded_until"] - info["printed_at"]
+    typed_for = info["graded_until"] - info["typed_at"]
+    if mp4.is_file() and not missing:
+        failures += _check_term_pixels(
+            mp4,
+            "demo.mp4, the rows a command printed",
+            "video",
+            rects,
+            printed_rows,
+            info["printed_at"],
+            TERM_REDACT_SAMPLE_FPS,
+            duration=printed_for,
+        )
+        failures += _check_term_pixels(
+            mp4,
+            "demo.mp4, the echoed password",
+            "video",
+            rects,
+            ["pwd"],
+            info["typed_at"],
+            TERM_REDACT_SAMPLE_FPS,
+            duration=typed_for,
+        )
+
+    # -- leak path 2: the stills ---------------------------------------------
+    for index, name in enumerate(TERM_REDACT_SHOTS):
+        png = out_dir / "images" / f"{name}.png"
+        if not png.is_file():
+            failures.append(f"terminal-redaction: still {png} was never captured")
+            continue
+        if png.stat().st_mtime < started_at - 1:
+            failures.append(f"terminal-redaction: still {png} is stale")
+            continue
+        if png.stat().st_size < MIN_PNG_BYTES:
+            failures.append(
+                f"terminal-redaction: still {png} is only {png.stat().st_size} bytes"
+            )
+            continue
+        if missing:
+            continue
+        # The password row only exists in the second still; the first was
+        # taken before send() ran.
+        tags = printed_rows if index == 0 else [*printed_rows, "pwd"]
+        failures += _check_term_pixels(
+            png, f"{name}.png", "still", rects, tags, None, None
+        )
+
+    # -- leak path 3: the beat log -------------------------------------------
+    timeline = out_dir / "timeline.json"
+    if not timeline.is_file():
+        failures.append("terminal-redaction: timeline.json was never written")
+    else:
+        beats = json.loads(timeline.read_text()).get("beats") or []
+        # A beat opens before its verb body runs, so both refusals are logged
+        # — with the command they refused as the `selector`. Asserted
+        # positively: "no beat holds the secret" is equally true of a log that
+        # dropped the beats.
+        masked = [b for b in beats if SECRET_MASK in (b.get("selector") or "")]
+        if len(masked) != 2:
+            failures.append(
+                f"terminal-redaction: {len(masked)} beats carry a scrubbed "
+                f"selector, expected 2 — the refused run() and the refused "
+                f"send() each held a registered value. Selectors logged: "
+                f"{[b.get('selector') for b in beats]!r}"
+            )
+        sent = [b for b in beats if b.get("verb") == "send"]
+        if len(sent) != 3:
+            failures.append(
+                f"terminal-redaction: {len(sent)} send beats, expected 3 "
+                f"(the bare Enter, the Secret, and the refused literal)"
+            )
+        # Exactly one of them was called with no string at all: the Secret.
+        # `Secret` is deliberately not a `str` so that `_verb_target` cannot
+        # pick it up and write the value into timeline.json, and this is the
+        # assertion that would notice it becoming one.
+        untargeted = [b for b in sent if b.get("selector") is None]
+        if len(untargeted) != 1:
+            failures.append(
+                f"terminal-redaction: {len(untargeted)} send beats logged no "
+                f"target, expected exactly 1 — send(Secret(...)). Selectors "
+                f"logged: {[b.get('selector') for b in sent]!r}"
+            )
+
+    # -- leak path 4: every byte the take wrote ------------------------------
+    swept = 0
+    for path in sorted(out_dir.rglob("*")):
+        if not path.is_file():
+            continue
+        swept += 1
+        data = path.read_bytes()
+        for what, literal in TERM_LITERALS.items():
+            if literal.encode() in data:
+                failures.append(
+                    f"terminal-redaction: {what} appears verbatim in "
+                    f"{path.relative_to(out_dir)}"
+                )
+    if not failures:
+        print(
+            f"smoke: terminal-redaction none of the {len(TERM_LITERALS)} "
+            f"values appears verbatim in any of the {swept} files the take wrote"
+        )
+    return failures
+
+
+# Two `printf`s at two absolute cursor positions. Nothing between them is a
+# substring of the value, and on screen they are one word — which is the whole
+# point: the scrubber reads the stream and the viewer reads the screen, and
+# cursor addressing is where those two stop agreeing. `\033[6;1H` then
+# `\033[6;13H`, so the second lands exactly where the first stopped.
+TERM_CURSOR_SCRIPT = (
+    "#!/bin/sh\n"
+    "printf '\\033[6;1Hcup %s' '__HEAD__'\n"
+    "printf '\\033[6;__COL__H%s\\n' '__TAIL__'\n"
+)
+
+
+def check_cursor_screen_leak(out_root: Path, work_dir: Path) -> list[str]:
+    """A value the stream cannot show is contiguous must fail the take.
+
+    Its own take because it has to *die*. The scrubber matches substrings of
+    the byte stream, and a program that positions the cursor twice puts a
+    value on screen without ever putting it in one substring — measured, and
+    documented in SKILL.md as uncovered. Uncovered has to mean *refused*: the
+    recorder reads the finished terminal buffer before it converts anything,
+    and a registered value found there kills the take the way an unverifiable
+    CSS mask does on the web side.
+
+    Without that check this take records a normal mp4, with the key legible in
+    every frame, `issues: []`, and `strict=True` satisfied — which is the
+    quietest failure in this whole harness.
+    """
+    if os.name != "posix":
+        return []
+    from demo_recording import SecretLeak, TerminalRecorder
+
+    label = "terminal-cursor-leak"
+    out_dir = fresh_take_dir(out_root, label)
+    script = work_dir / "cursor-write"
+    head, tail = TERM_CURSOR[:TERM_ANSI_CUT], TERM_CURSOR[TERM_ANSI_CUT:]
+    # The column the second write starts at: "cup " plus the head, one-based.
+    # Off by one and the two pieces overlap, the value on screen is not the
+    # registered one, and the take proves nothing while looking fine — which
+    # is what the premise assertion below is for.
+    column = len("cup ") + len(head) + 1
+    script.write_text(
+        TERM_CURSOR_SCRIPT.replace("__HEAD__", head)
+        .replace("__TAIL__", tail)
+        .replace("__COL__", str(column))
+    )
+    script.chmod(0o755)
+
+    failures: list[str] = []
+    raised: BaseException | None = None
+    screen = ""
+    try:
+        with TerminalRecorder(out_dir, speech=False) as rec:
+            rec.register_secret(TERM_CURSOR)
+            rec.run("./cursor-write")
+            rec.wait_for_prompt(timeout_s=20)
+            # Taken on purpose, and required to be gone afterwards: a still is
+            # written long before the take ends, and the web half shipped a
+            # round where a refused take left its stills on disk holding the
+            # value it had refused to write an mp4 for.
+            rec.shot("01-cursor")
+            screen = rec._screen()
+    except SecretLeak as exc:
+        raised = exc
+    except Exception as exc:  # noqa: BLE001 - any other failure is a failure
+        return [f"{label}: expected SecretLeak, got {type(exc).__name__}: {exc}"]
+
+    if raised is None:
+        failures.append(
+            f"{label}: a registered value written at two cursor positions is "
+            f"contiguous on screen and in no substring of the stream. The "
+            f"scrubber cannot see it — that is documented — so the recorder "
+            f"has to refuse the take at teardown instead. It returned "
+            f"normally, which means it wrote an mp4 with the key legible in "
+            f"every frame and reported nothing wrong."
+        )
+    else:
+        if TERM_CURSOR in str(raised):
+            failures.append(
+                f"{label}: the SecretLeak quotes the value it caught, which "
+                f"puts it in every log that reports the failure"
+            )
+        if "screen" not in str(raised):
+            failures.append(
+                f"{label}: the failure does not say the value was found on "
+                f"screen, so a reader cannot tell it from a mask that failed "
+                f"to apply: {str(raised)[:120]!r}"
+            )
+    # The premise, asserted rather than assumed. If the two halves ever ended
+    # up adjacent in the byte stream the scrubber would have masked them, the
+    # screen would be clean, nothing would raise — and the failure above would
+    # be reported against a take that never contained a leak to catch.
+    if TERM_CURSOR not in screen:
+        failures.append(
+            f"{label}: the value never reached the terminal screen, so this "
+            f"take exercised nothing. It is supposed to be written in two "
+            f"pieces at two cursor positions and land contiguously; check "
+            f"TERM_CURSOR_SCRIPT against the terminal's width and the row it "
+            f"writes to."
+        )
+    for name, path in (
+        ("demo.mp4", out_dir / "demo.mp4"),
+        ("timeline.json", out_dir / "timeline.json"),
+        ("the still", out_dir / "images" / "01-cursor.png"),
+    ):
+        if path.exists():
+            failures.append(
+                f"{label}: {name} survived a take that could not vouch for "
+                f"what was on screen. SKILL.md says a SecretLeak keeps "
+                f"nothing."
+            )
+    leftovers = (
+        sorted(q.name for q in (out_dir / ".video").glob("*"))
+        if (out_dir / ".video").is_dir()
+        else []
+    )
+    if leftovers:
+        failures.append(
+            f"{label}: raw capture left behind in .video/: {leftovers!r} — it "
+            f"holds the frames the mp4 was refused for"
+        )
+    if not failures:
+        print(
+            "smoke: terminal-redaction a value the stream never carried whole "
+            "is caught on the finished screen and fails the take"
+        )
+    return failures
+
+
+def run_terminal_redaction(out_root: Path) -> list[str]:
+    if os.name != "posix":
+        return []
+    out_dir = fresh_take_dir(out_root, "terminal-redaction")
+    started = time.time()
+    # The shell starts in the process cwd, so the printer lives in a directory
+    # of its own that the recorder never writes to: `./print-secrets` stays
+    # short enough to type on camera, and the file holding the literals stays
+    # out of the byte sweep, which grades what the recorder wrote.
+    work_dir = Path(tempfile.mkdtemp(prefix="demo-video-smoke-printer-"))
+    previous = Path.cwd()
+    os.chdir(work_dir)
+    try:
+        problems, info = record_terminal_redaction(out_dir, work_dir)
+        problems += check_cursor_screen_leak(out_root, work_dir)
+    except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+        return [
+            f"terminal-redaction: TerminalRecorder raised {type(exc).__name__}: {exc}"
+        ]
+    finally:
+        os.chdir(previous)
+        shutil.rmtree(work_dir, ignore_errors=True)
+    if not info:
+        return problems
+    return problems + check_terminal_redaction(out_dir, info, started)
+
+
 def run_terminal(out_root: Path) -> list[str]:
     if os.name != "posix":
         print(
@@ -5201,7 +6316,7 @@ def main() -> int:
     parser.add_argument(
         "--redaction-only",
         action="store_true",
-        help="record only the redaction take (issue #4)",
+        help="record only the redaction takes (issues #4 and #5)",
     )
     parser.add_argument(
         "--segments-only",
@@ -5281,6 +6396,10 @@ def main() -> int:
             failures += run_terminal_problems(out_root)
             failures += run_terminal_race(out_root)
             failures += run_strict_terminal(out_root)
+        # Both flags reach it: it is a terminal take and a redaction take, and
+        # whichever half somebody is changing is the half they will run.
+        if only in (None, "--terminal-only", "--redaction-only"):
+            failures += run_terminal_redaction(out_root)
         if only in (None, "--determinism-only"):
             failures += run_determinism(out_root)
     except SmokeFailure as exc:


### PR DESCRIPTION
Fixes #5.

`TerminalRecorder` pipes real shell output through a PTY into an in-browser
xterm. Anything the command prints was captured verbatim — a key echoed by a
tool, a token in a config dump, a credential in an error message. The web half
(#4) has no reach here: there is no DOM to blur.

## The "one scrub() call" assumption was wrong, and this is why

`os.read(self._fd, 65536)` returns arbitrary PTY fragments, so a secret split
across two reads is a substring of neither.

`_StreamRedactor` sits in `_pump` after the UTF-8 decoder. Per fragment it
strips SGR into a copy with an offset map, finds registered secrets and shape
matches in that copy, computes a **cut point** — the shortest suffix that could
still complete a match — masks everything before it, and carries the rest.

The cut is deliberately **not** `max(len) - 1`. A fixed window leaves a finished
screen permanently short of what the program wrote, and `wait_for_prompt` /
`wait_for_text` read that screen. It is the longest suffix that is a proper
prefix of a registered secret, or matches a shape's tail, or sits inside a match
touching the end — capped at 4096.

## Proved deliberately, not hoped for

`capped_pty_reads()` swaps the `os` module **in `demo_recording.terminal` only**
for one whose `read()` returns <= 7 bytes and keeps every fragment. The take
then asserts from those fragments that the printed key was reassembled from >= 2
— measured **5**, and the `send(Secret(...))` echo **28**. Removing the cap
makes the key arrive in **1** read on this box and that assertion fires, which
is why it exists.

## Escape interleaving: a fixed list, and the list is the reach

Matching runs against a copy with the *inert* sequences removed and matches
mapped back to raw offsets, with the escapes inside a masked run re-emitted
after the mask so colour survives. The list: SGR, mode set/reset (`\x1b[?25l`,
what every spinner emits mid-line), erase-to-EOL, BEL-terminated OSC, charset
and keypad selection. Rows `ans`, `hid` and `osc` grade three of them on the
pixels.

**It is a list, not the predicate "does not move the cursor"**, and the
difference is a leak. Measured: a CSI with an intermediate byte (`\x1b[1 q`), a
DCS string, and an ESC-aborted OSC all render the value as one word on screen
while the scrubber writes it in the clear. A *registered* value split that way
still dies at the final screen check; a shape-only token goes into the frames.
Filed as #71 and corrected in SKILL.md and the module comment.

Cursor movement is the other half and is genuinely uncovered: masking across a
jump would corrupt the redraw. **The value comes out readable, not scrambled**
— which is why the final screen check exists.

## The final screen check runs on every exit path

`_verify_redaction_final()` reads the finished terminal buffer — visible screen
*and* scrollback — and raises `SecretLeak`: no mp4, no timeline, no stills.
Three things about *when* it runs, each of which was wrong at some point in
this PR:

| | why |
|---|---|
| after the narration tail | the tail pumps a child that is still writing, so verifying first vouched for frames that are not the frames recorded |
| after `_stop()` | the scrubber withholds a trailing fragment and flushes there, so verifying first read a screen the recording does not end on |
| on **every** way out of the `with` | gated on `exc_type is None`, a wait_for_text() timeout or a Ctrl-C skipped it and kept the stills — and a terminal still is the raw screen |

Over a storyboard that already raised, the leak is printed and the original
exception propagates: a timeout replaced by a leak report costs the author the
message that says what to fix, and the artifacts are gone either way.

`terminal-cursor-leak` is three takes — `clean`, `crash`, `tail` — one per row
of that table.

## Verification

Every assertion was fault-injected and seen to fail, and the pixel assertions
grade the **rendered frames** (mp4 and PNG crops against a `[redacted]`
reference measured in the same frame), not a Python string.

Round one, 9 injections: releasing shape fragments on the first idle poll
(rows differ from the mask by 43-46); inert escapes narrowed to SGR; the
screen check stubbed out; no token-boundary rule; the fragment ceiling applied
to a registered value; the span pull-back removed; the registered-value hold
removed; AKIA and JWT shapes removed; the `key()` guard removed.

Round two, 5 more: the screen check gated back to the clean path (`crash`
keeps a 129 kB still with the key on it); the check moved back before the tail
and flush (`tail` writes an 82 kB mp4 and reports nothing wrong);
`_ANCHORED_HOLD_S` at 5.0 s (the `slw` row comes out masked and the take says
the documented limit moved); at 1.0 s (`pau` and `anc` render at 41-45 against
the mask); and the token-boundary rule removed again against the re-based lag
measurement (3.0 s against a 1.5 s bar, healthy 0.2 s).

Two assertions that **could not fail** were found and fixed rather than
trusted: `_ANCHORED_HOLD_S` was graded from one side only, so it could be set
to anything above ~0.45 s; and the held-fragment lag was timed from before the
printer ran, so it measured the script's runtime rather than the release.

## What it does not cover

Half a secret still renders if a program is killed mid-print. A registered
secret's prefix at a quiet stream is held with no timeout, so a program
printing exactly the first characters of one and waiting will appear to stall
— the recorder says so on stderr after two seconds. Only four shapes, one
spelling of each. Shape fragments are held for three seconds and no longer,
which the `slw` row now grades as a limit. Nothing sanitizes the child's
environment or its log files. And no assertion reads text back out of a frame
— the pixels prove "this row is the mask", not which mask.

Filed and not fixed here: #54, #55, #66 (line-erase and alt-screen
over-masking), #67 (teardown masking and the withholding warning are
ungraded), #71 (inert-escape under-masking), #72 (`_MAX_HOLD` releases the
head of an anchored fragment that never completes a match), #73
(`_term_deltas` compares with `zip(strict=False)`).
