### PR TITLE
Extract review frames on beat boundaries instead of fps=1/3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@ __pycache__/
 # deletes them with their .seg.mp4 unless it was passed keep_parts=True.
 *.seg.timeline.json
 *.seg.timeline.md
+# Review frames pulled out of demo.mp4 for a reviewer to read, regenerated
+# wholesale by beat_frames(out_dir). SKILL.md tells *consumers* to anchor this
+# to their demo folder, because `frames` is a plausible name for a directory of
+# real source; this repo has none, so a bare pattern is safe here.
+frames/
 # Left behind only when a take crashes before the recorder cleans up.
 .video/
 .frame.png

--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -28,6 +28,12 @@ and a real terminal session (voice on):
   waits (recorded as segments, stitched losslessly).
 - **`images/*.png`** — stills captured at key moments, ready for a written
   guide.
+- **`frames/`** — one review frame per beat, plus `frames.md` embedding them
+  in order. It is what you hand the fresh-agent review: aimed at what the
+  storyboard did rather than at a stopwatch, so nothing is missed and a held
+  frame is photographed once. A stitched demo gets them too, off the merged
+  timeline. Deliberately uncaptioned, and aimed to within a beat or so rather
+  than exactly — SKILL.md says how far and why.
 - **`record.py`** — the storyboard that produced the media, and the thing
   that actually gets committed: re-runnable after the UI changes, so the
   video stays out of git history and is regenerated rather than archived.

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -39,6 +39,7 @@ Each demo gets one folder (suggested: `docs/guides/<YYYY-MM-DD>-<slug>/`):
 | `timeline.md` | The same log rendered for humans, stills embedded | yes |
 | `guide.md` | Optional written guide embedding the stills | yes |
 | `demo.mp4` | The recording (mp4 only — gifs get too big) | **no** — regenerate it, or attach it to the PR |
+| `frames/` | Review frames pulled out of `demo.mp4`, plus the sheet you hand a reviewer | **no** — a working file of a review; `beat_frames(out_dir)` regenerates it |
 
 The storyboard is the durable artifact, not the video. See **Commit the
 storyboard, not the media** in the Process section.
@@ -703,6 +704,78 @@ a resolution mismatch keeps the first part's dimensions, and one silent part
 makes concat drop every later part's narration. Recording every segment with
 the same `Recorder` settings is what keeps you clear of it.
 
+## Review frames (`frames/`)
+
+Nobody reviewing a demo through this skill can watch a video, so every review
+is a review of frames pulled out of it. A clean exit writes them: one PNG per
+beat under `frames/`, named `beat-NN.png` for the beat's index in
+`timeline.json`, plus `frames/frames.md` — the sheet to hand a reviewer, which
+embeds them in order — and `frames/frames.json` for anything reading them by
+machine.
+
+They are aligned to **beats, not to a clock**. The old advice was
+`ffmpeg -vf fps=1/3`, which misses a short beat entirely and photographs a long
+static one twice. Each frame is taken at its beat's **midpoint** — `t_start` is
+0% into the caption bar's fade and before the verb has done anything.
+
+**How accurate that aim is, honestly.** The beat log is wall-clock; the video
+is whatever Chromium's screencast managed to record, and it drops wall time
+during idle stretches ([#18](https://github.com/rogvid/skills/issues/18)). So a
+frame cut at a beat's midpoint shows a moment slightly *ahead* of that beat in
+the demo's own story — measured at **40–120 ms** on instrumented takes, and up
+to **~600 ms** on a take that loses the browser's start-up window whole (about
+1 in 12). The practical consequence: for a beat comfortably longer than that,
+the frame is of that beat; **for a beat shorter than the drift — a bare
+`shot()`, a `wait_for()` that returned immediately — the frame can be of the
+beat after it.** `tests/smoke` measures exactly this and shows it: with the
+drift allowance removed, the frame for a 50 ms `shot()` beat that sits against
+a caption change is already showing the next beat's screen.
+
+Read the frames as *"roughly here in the demo"*, not as *"exactly this beat"*.
+When a specific short moment matters, use `shot()` — `images/*.png` are
+Playwright screenshots taken synchronously at the beat, with no video clock
+between the moment and the file. `frames/frames.md` reports the take's own
+lower bound on how much wall time the capture lost, when it lost any.
+
+**They carry no caption, and that is deliberate.** Printing the line that was
+on screen during a frame's beat under that frame is the obvious next step and
+it is not sound: the beat log and the video run on different clocks
+([#18](https://github.com/rogvid/skills/issues/18)), so the caption under a
+frame can belong to the frame next to it — and a confident wrong caption is
+worse review material than no caption at all. An earlier version tried to
+recover the mapping by finding caption transitions in the video; it mislabelled
+frames on ordinary storyboards (two captions of the same length give it no
+signal, an app that repaints under the bar gives it a stronger edge than the
+caption does, and a mid-take `goto()` destroys the bar while logging no caption
+change at all). [#60](https://github.com/rogvid/skills/issues/60) is how the
+pairing gets earned back: have the recorder render the beat index into the
+frame so extraction reads it rather than infers it.
+
+`frames.md` also carries **no verb and no selector**, for the same reason step
+6 tells you to give the reviewer nothing else: it is the document a
+context-free reviewer reads before answering what story the pictures tell.
+
+Inside a beat long enough to hide something the storyboard never scripted (3 s
+and up) the recorder also runs scene-change detection and adds
+`beat-NN-scene-1.png` for each transition it finds. Beat alignment sees what
+the storyboard wrote down; a redirect, a toast or a load finishing mid-hold is
+invisible to it.
+
+**A stitched demo gets frames; a single segment does not.** Each segment
+numbers its beats from zero and its timeline names a `.seg.mp4` that `stitch()`
+deletes, so two segments writing into one directory would collide on
+`beat-00.png` and the sheet would embed a file that is gone — a segment take
+therefore writes no frames and says why. `stitch()` writes them instead, off
+the **merged** timeline, at the first moment a whole demo exists. Nothing extra
+to run, and it is the case that needs a sheet most: a demo long enough to
+record in parts is a demo nobody wants to review by scrubbing.
+
+`frames/` is a review artifact, not documentation: **gitignore it** along with
+`demo.mp4` — it is in the file table at the top for the same reason. Nothing
+downstream reads it; `beat_frames(out_dir)` from `demo_recording` regenerates
+it from `demo.mp4` and `timeline.json` without re-recording, and clears the
+previous run's frames first.
+
 ## Failing the take on a broken app
 
 **A demo that looks perfect while the app throws `TypeError` on every render
@@ -978,26 +1051,30 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    working one, and this is the only place it shows (see **Failing the take
    on a broken app**).
 6. **Fresh-agent review (required).** You cannot watch the video, and you
-   know too much anyway — have a context-free agent watch it for you:
+   know too much anyway — have a context-free agent watch it for you. The
+   recorder has already written what they need: `frames/`, one PNG per
+   beat, and `frames/frames.md`, which embeds them in order. **Hand them
+   `frames/frames.md`.**
 
-   ```sh
-   ffmpeg -y -i demo.mp4 -vf fps=1/3 <tmpdir>/frame-%02d.png
-   ```
+   Give them the pictures and nothing else — no storyboard, no feature
+   name, no captions. `frames.md` is built that way on purpose (see
+   **Review frames** above): a `click('#refresh')` in the margin answers
+   the question you are asking before they look at anything.
 
    Dispatch a subagent told NOTHING about the feature (any context-free
-   reviewer works: a fresh session or process fed only the frames, if the
-   harness has no subagents): read the frames in
-   order; reply with (1) NARRATION — the story as understood purely from
-   the frames, (2) CONFUSIONS — anything unclear, unreadable, or
-   contradictory, (3) VERDICT — CLEAR or UNCLEAR with the reason, plus
-   whether the demo is CONVINCING: did they see evidence of the claims on
-   screen, or take the captions' word for it. If the narration misses the
-   intended story or the verdict is UNCLEAR, fix the storyboard and
-   re-record. Each round needs a NEW subagent — the previous one is no
-   longer fresh. Ship only on CLEAR with the headline claim evidenced on
-   screen. Reviewers converge in ~2 rounds; cap at 3 and surface remaining
-   findings to the user instead of looping. Findings that need a different
-   feature demoed are future demos, not blockers.
+   reviewer works: a fresh session or process fed only `frames/`, if the
+   harness has no subagents): read the frames in order; reply with
+   (1) NARRATION — the story as understood purely from the frames,
+   (2) CONFUSIONS — anything unclear, unreadable, or contradictory, and
+   (3) VERDICT — CLEAR or UNCLEAR with the reason, plus whether the demo
+   is CONVINCING: did they see evidence of the claims on screen, or take
+   the captions' word for it. If the narration misses the intended story
+   or the verdict is UNCLEAR, fix the storyboard and re-record. Each round
+   needs a NEW subagent — the previous one is no longer fresh. Ship only
+   on CLEAR with the headline claim evidenced on screen. Reviewers
+   converge in ~2 rounds; cap at 3 and surface remaining findings to the
+   user instead of looping. Findings that need a different feature demoed
+   are future demos, not blockers.
 7. **Write `guide.md`** (when a written guide is wanted): what the feature
    is, how to use it step by step — each step referencing a still —
    opening with the strongest still. Don't link `demo.mp4` from it: the
@@ -1015,7 +1092,10 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    stale by the next change to the feature and bloats history permanently,
    and anyone with the skill installed can regenerate it with
    `uv run <demo folder>/record.py`. Gitignore `demo.mp4`, `*.seg.mp4`
-   segment parts, `*.seg.timeline.*`, and `.tts/` narration caches.
+   segment parts, `*.seg.timeline.*`, `<demo folder>/frames/` (regenerated
+   from the two by `beat_frames(out_dir)` — anchor the pattern to the demo
+   folder rather than writing a bare `frames/`, which matches a directory
+   of that name anywhere in the repo), and `.tts/` narration caches.
 
    To put the demo in front of a reviewer, drag `demo.mp4` into a PR
    comment box — GitHub hosts it and renders a real player. That upload has

--- a/skills/demo-video/helpers/demo_recording/__init__.py
+++ b/skills/demo-video/helpers/demo_recording/__init__.py
@@ -8,27 +8,36 @@ Storyboards import from here:
 """
 
 from .core import (
+    FRAMES_SCHEMA,
     ISSUE_KINDS,
     MAX_ISSUES,
+    SCENE_MIN_SPAN_S,
     SECRET_MASK,
     STRICT_KINDS,
     TIMELINE_SCHEMA,
     Secret,
     SecretLeak,
     StrictTakeFailed,
+    beat_frames,
+    frames_paths,
     media_duration,
+    render_frames_md,
     render_timeline_md,
+    scene_times,
     stitch,
     timeline_paths,
     tts_clip,
+    write_beat_frames,
     write_timeline,
 )
 from .terminal import TerminalRecorder
 from .web import Recorder
 
 __all__ = [
+    "FRAMES_SCHEMA",
     "ISSUE_KINDS",
     "MAX_ISSUES",
+    "SCENE_MIN_SPAN_S",
     "SECRET_MASK",
     "STRICT_KINDS",
     "TIMELINE_SCHEMA",
@@ -37,10 +46,15 @@ __all__ = [
     "SecretLeak",
     "StrictTakeFailed",
     "TerminalRecorder",
+    "beat_frames",
+    "frames_paths",
     "media_duration",
+    "render_frames_md",
     "render_timeline_md",
+    "scene_times",
     "stitch",
     "timeline_paths",
     "tts_clip",
+    "write_beat_frames",
     "write_timeline",
 ]

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -805,6 +805,349 @@ def write_timeline(out_dir: Path | str, doc: dict) -> tuple[Path, Path]:
     return json_path, md_path
 
 
+# -- beat-aligned review frames ----------------------------------------------
+#
+# Nobody driving this skill can watch a video, so every review of a demo is a
+# review of frames pulled out of it. Sampling those uniformly in time
+# (`ffmpeg -vf fps=1/3`) misses a short beat entirely and photographs a long
+# static one twice, so the frames come off the beat log instead: one per beat,
+# at the beat's **midpoint**. `t_start` is the wrong instant to photograph —
+# for a `caption` beat it is 0% into the bar's fade-in, and for any other verb
+# it is before the verb has done anything. The midpoint is inside the beat by
+# construction, which is what `t_end` is on the record for.
+#
+# **These frames carry no caption, and that is deliberate.** The obvious next
+# step is to print each frame under the line that was on screen when its beat
+# ran, and it is not sound: the beat log and the video are on different clocks
+# (issue #18), so a frame taken at a beat's timestamp can show the neighbouring
+# line — and it would arrive labelled with the log's, which is worse than no
+# label at all. An earlier version of this file tried to recover the mapping by
+# finding caption transitions in the video. Review found it mislabelling frames
+# on ordinary storyboards, three ways that are not fixable by tuning:
+#
+#   * two captions of the same length ("Step 1 of 3." -> "Step 2 of 3.") change
+#     only glyph pixels — under 0.25 mean luma in the caption band, which is
+#     no signal at all, so whatever else repainted in the window wins;
+#   * an app that keeps repainting under the bar supplies a stronger edge than
+#     the caption does, at a time of its own choosing;
+#   * a mid-take `goto()` destroys the caption bar with the document and logs
+#     no caption change at all, so there is nothing to measure and every later
+#     frame is captioned with a line that is not on screen.
+#
+# All three are the same mistake — guessing which pixel change was the caption.
+# The sound fix is for the recorder to *state* the mapping rather than have it
+# inferred, by rendering the beat index into the frame where extraction can
+# read it back. That changes every recording's pixels, so it is its own change:
+# issue #60. Until then these frames are handed over bare, which is what the
+# uniform sampling they replace did too — they are simply aimed better.
+#
+# `frames.md` therefore prints no caption, no verb and no selector. It is the
+# sheet handed to a **context-free** reviewer who is asked what story the
+# pictures tell; a `click('#refresh')` in the margin answers the question for
+# them.
+FRAMES_DIRNAME = "frames"
+FRAMES_SCHEMA = 1
+
+# Scene-change detection, the fallback for what the storyboard did not script.
+# A beat that holds the frame for seconds can still contain a transition
+# nobody wrote down — an app finishing a load, a toast appearing, a redirect —
+# and beat alignment is blind to those by construction. Only for beats long
+# enough that one could hide in them.
+#
+# The threshold is low because ffmpeg scores a whole frame and only part of one
+# of these is the app: the recorder's own chrome is a fifth to a third of the
+# picture and never moves. Measured over the reference takes — a page's first
+# paint 0.041, a caption appearing 0.022-0.025, a table filtering to one row
+# 0.013, an idle hold 0.007 and under. Issue #57 proposes scoring the app's own
+# rect instead, which would make one threshold mean the same thing in both
+# media.
+SCENE_MIN_SPAN_S = 3.0
+SCENE_THRESHOLD = 0.02
+SCENE_MAX_EXTRA = 3
+
+# Keep the last frame inside the file: an -ss exactly at the duration decodes
+# nothing.
+_FRAME_EDGE_S = 0.05
+
+
+def frames_paths(out_dir: Path | str) -> tuple[Path, Path, Path]:
+    """(dir, json, md) for a take's beat frames."""
+    frames_dir = Path(out_dir) / FRAMES_DIRNAME
+    return frames_dir, frames_dir / "frames.json", frames_dir / "frames.md"
+
+
+def scene_times(
+    mp4: Path,
+    start: float,
+    end: float,
+    threshold: float = SCENE_THRESHOLD,
+    limit: int = SCENE_MAX_EXTRA,
+) -> list[float]:
+    """Video times between `start` and `end` where the picture changes hard.
+
+    The fallback for what the storyboard did not script. Returns at most
+    `limit` times, in order, and an empty list for a stretch of video that
+    holds still.
+    """
+    if end - start <= 0:
+        return []
+    # `metadata=print:file=-` rather than the filter's default: the default
+    # writes through ffmpeg's logger at INFO level, which `-v error` throws
+    # away — a silent way for this whole function to always return nothing.
+    proc = subprocess.run(
+        ["ffmpeg", "-v", "error", "-ss", f"{start:.3f}", "-t", f"{end - start:.3f}",
+         "-i", str(mp4),
+         "-vf", f"select='gt(scene,{threshold})',metadata=print:file=-",
+         "-an", "-f", "null", "-"],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        return []
+    times = [
+        start + float(match)
+        for match in re.findall(r"pts_time:([0-9.]+)", proc.stdout)
+    ]
+    # The first decoded frame of a seek has nothing before it to be compared
+    # with, and ffmpeg scores it 1.0. That is the seek, not a scene change.
+    return sorted(t for t in times if t > start + 0.08)[:limit]
+
+
+def _extract(mp4: Path, at: float, path: Path) -> bool:
+    """One frame of `mp4` at `at` seconds, written to `path`."""
+    proc = subprocess.run(
+        ["ffmpeg", "-y", "-v", "error", "-ss", f"{at:.3f}", "-i", str(mp4),
+         "-frames:v", "1", "-update", "1", str(path)],
+        capture_output=True,
+    )
+    return proc.returncode == 0 and path.is_file()
+
+
+def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
+    """Write one review frame per beat, and an index to read them in order.
+
+    Reads the timeline the take just wrote (or `doc`), extracts
+    `frames/beat-NN.png` at each beat's midpoint, and writes `frames/frames.md`
+    for a reviewer and `frames/frames.json` for a tool. Neither says anything
+    about what is *in* a frame — see the section header.
+
+    Returns the manifest. Safe to re-run: it is a pure function of the mp4 and
+    the timeline, so a demo whose frames were deleted can get them back without
+    re-recording, and a re-run takes the previous run's frames back off disk
+    first rather than leaving stale ones in a directory somebody is about to
+    hand to a reviewer.
+
+    **Refuses to run for a segment take, and only for that.** A single
+    segment's timeline numbers its beats from zero and describes a
+    `<segment>.seg.mp4`, so two of them would write `beat-00.png` over each
+    other and the sheet would name a file `stitch()` deletes. A *stitched*
+    demo is a different thing: `stitch()` merges the parts into one timeline
+    whose beats are renumbered and offset onto the joined video's clock, and
+    that is a whole demo — it gets frames like any other, written by `stitch()`
+    itself, and it is the case that needs a review sheet most, since a demo
+    long enough to record in parts is a demo nobody wants to scrub by hand.
+    """
+    out_dir = Path(out_dir)
+    if doc is None:
+        doc = json.loads(timeline_paths(out_dir)[0].read_text())
+    mp4 = out_dir / str(doc.get("media") or "demo.mp4")
+    frames_dir, json_path, md_path = frames_paths(out_dir)
+    beats = doc.get("beats") or []
+    manifest: dict = {
+        "schema": FRAMES_SCHEMA,
+        "generated_by": "demo-video",
+        "media": mp4.name,
+        "duration": doc.get("duration"),
+        "recorder": doc.get("recorder"),
+        "frames": [],
+        "skipped": None,
+    }
+    if doc.get("segment"):
+        manifest["skipped"] = (
+            f"{doc['segment']} is one segment of a demo, not a demo; its beats "
+            f"are numbered from zero and its media is a .seg.mp4 that stitch() "
+            f"deletes. stitch() writes the frames, off the merged timeline"
+        )
+        return manifest
+    if not beats:
+        manifest["skipped"] = "the take recorded no beats"
+        return manifest
+    if not mp4.is_file():
+        manifest["skipped"] = f"there is no {mp4.name} to extract frames from"
+        return manifest
+
+    duration = doc.get("duration")
+    if not isinstance(duration, (int, float)):
+        try:
+            duration = media_duration(mp4)
+        except (subprocess.CalledProcessError, ValueError, OSError):
+            duration = float(beats[-1].get("t_end") or 0.0)
+    last = max(0.0, float(duration) - _FRAME_EDGE_S)
+
+    planned: list[dict] = []
+    for beat in beats:
+        t_start, t_end = beat.get("t_start"), beat.get("t_end")
+        if not isinstance(t_start, (int, float)):
+            continue
+        if not isinstance(t_end, (int, float)) or t_end < t_start:
+            t_end = t_start
+        middle = min(max((float(t_start) + float(t_end)) / 2, 0.0), last)
+        index = int(beat.get("index", len(planned)))
+        planned.append({
+            "file": f"beat-{index:02d}.png",
+            "kind": "beat",
+            "beat": index,
+            "t": round(middle, 3),
+        })
+        # Only for beats long enough to hide an unscripted transition. Beat
+        # alignment sees what the storyboard wrote down; a redirect, a toast or
+        # a load finishing inside a long hold is invisible to it.
+        if float(t_end) - float(t_start) < SCENE_MIN_SPAN_S:
+            continue
+        window = (min(float(t_start), last), min(float(t_end), last))
+        for n, cut in enumerate(scene_times(mp4, *window), 1):
+            planned.append({
+                "file": f"beat-{index:02d}-scene-{n}.png",
+                "kind": "scene",
+                "beat": index,
+                "t": round(cut, 3),
+            })
+
+    # Take the previous run's sheet off disk before writing this one. A demo
+    # whose storyboard lost beats would otherwise leave frames nobody planned
+    # sitting in the directory SKILL.md tells you to hand over. Bounded to the
+    # names this function writes — never the directory.
+    frames_dir.mkdir(parents=True, exist_ok=True)
+    for stale in [*frames_dir.glob("beat-*.png"), json_path, md_path]:
+        try:
+            # missing_ok: the two manifests do not exist on a first run, and a
+            # warning about failing to delete them would be on every take.
+            stale.unlink(missing_ok=True)
+        except OSError:  # noqa: PERF203 - a leftover is worth reporting, not fatal
+            print(
+                f"demo-video: WARNING — could not remove the stale {stale.name}",
+                file=sys.stderr,
+            )
+
+    written: list[dict] = []
+    for record in planned:
+        if _extract(mp4, float(record["t"]), frames_dir / str(record["file"])):
+            written.append(record)
+        else:
+            print(
+                f"demo-video: WARNING — could not extract a frame at "
+                f"{record['t']}s for beat {record['beat']}",
+                file=sys.stderr,
+            )
+    manifest["frames"] = written
+    # How far the video is *known* to have slid under the beat log, as a floor
+    # rather than a correction. A beat that ends after the video does can only
+    # mean capture loss (issue #18); it is usually zero, and when it is not it
+    # is the one number that says how stale a frame's aim may be.
+    over = float(beats[-1].get("t_end") or 0.0) - float(duration)
+    manifest["capture_loss_at_least"] = round(max(0.0, over), 3)
+    json_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
+    md_path.write_text(render_frames_md(manifest))
+    return manifest
+
+
+def write_beat_frames(out_dir: Path | str, doc: dict, where: str) -> dict | None:
+    """`beat_frames`, without letting a review sheet cost a recording.
+
+    Everything it does is ffmpeg re-reading an mp4 that is already on disk, so
+    a failure loses the sheet and nothing else — and raising out of a take's
+    `__exit__`, or out of `stitch()` after the concat, would take the video,
+    the stills and the beat log down with it. `where` names the caller in the
+    warning, because "could not extract beat frames" during a stitch and during
+    a take are different things to go looking at.
+    """
+    try:
+        manifest = beat_frames(out_dir, doc)
+    except Exception as exc:  # noqa: BLE001 - a review sheet is not a recording
+        print(
+            f"demo-video: WARNING — {where} could not extract beat frames: "
+            f"{exc}. The video, the stills and the timeline are unaffected; "
+            f"`beat_frames(out_dir)` re-runs it.",
+            file=sys.stderr,
+        )
+        return None
+    if manifest["skipped"]:
+        # Say which, rather than announcing a directory that was never
+        # created — a segment take reaches this on every run.
+        print(
+            f"demo-video: no review frames — {manifest['skipped']}",
+            file=sys.stderr,
+        )
+        return manifest
+    print(
+        f"wrote {frames_paths(out_dir)[0]} ({len(manifest['frames'])} review frames)"
+    )
+    return manifest
+
+
+def render_frames_md(manifest: dict) -> str:
+    """The review sheet: the frames, in order, and nothing else.
+
+    Pure function of the manifest, so it can be re-rendered without the video.
+
+    **What it deliberately does not carry**: the caption each frame ran under,
+    the verb, and the selector. The first is a claim the recorder cannot check
+    (see the section header); the second and third are the storyboard, and this
+    is the document handed to a reviewer who is asked what story the pictures
+    tell on their own. `click('#refresh')` printed beside a frame answers that
+    question for them, and the `fps=1/3` handoff this replaces did not leak it.
+    """
+    frames = manifest.get("frames") or []
+    head = [f"`{manifest.get('media') or 'demo.mp4'}`"]
+    if manifest.get("duration") is not None:
+        head.append(f"{float(manifest['duration']):.1f}s")
+    head.append(f"{len(frames)} frames")
+    out = [
+        "# Review frames",
+        "",
+        " · ".join(head),
+        "",
+        "One frame per beat of the demo — per thing the storyboard did — rather "
+        "than one every N seconds, so nothing the demo does is missed and a "
+        "held frame is photographed once. Read them in order. Written by the "
+        "demo-video recorder on every clean exit; re-record rather than editing "
+        "it.",
+        "",
+        "**They are not captioned, on purpose.** The recorder knows which line "
+        "was on screen during each *beat*, but the beat log and the video run "
+        "on different clocks — see "
+        "[#18](https://github.com/rogvid/skills/issues/18) — so a caption "
+        "printed under a frame can belong to the frame next to it. A frame with "
+        "a confident wrong caption is worse than a frame with none. "
+        "[#60](https://github.com/rogvid/skills/issues/60) is how the pairing "
+        "gets earned back.",
+        "",
+    ]
+    if manifest.get("skipped"):
+        return "\n".join(out + [f"No frames were written: {manifest['skipped']}.", ""])
+    loss = manifest.get("capture_loss_at_least") or 0.0
+    if loss > 0.05:
+        out += [
+            f"This take lost at least {loss * 1000:.0f} ms of wall time to the "
+            f"capture (its last beat ends after the video does), so a frame may "
+            f"sit that much later in the demo than the beat it was aimed at.",
+            "",
+        ]
+    out += [
+        "| frame | at |",
+        "|---|---:|",
+    ]
+    for frame in frames:
+        out.append(f"| `{_md_cell(frame.get('file'))}` | {_fmt_t(frame.get('t'))} |")
+    out.append("")
+    for frame in frames:
+        name = str(frame.get("file"))
+        title = f"{name.removesuffix('.png')} — {_fmt_t(frame.get('t'))}s"
+        if frame.get("kind") == "scene":
+            title += " (an extra frame: the picture changed here)"
+        out += [f"## {title}", "", f"![{name}]({name})", ""]
+    return "\n".join(out).rstrip() + "\n"
+
+
 def _verb_target(args: tuple, kwargs: dict) -> str | None:
     """The string a verb acted on, dug out of how it happened to be called."""
     if args and isinstance(args[0], str):
@@ -1289,8 +1632,10 @@ class _DemoBase:
                 # The beat log is the durable, diffable record of the take — it
                 # outlives the mp4, which is not committed. Written after
                 # conversion so `duration` is the encoder's answer, not a guess.
-                json_path, _ = write_timeline(self.out_dir, self._timeline_doc())
+                doc = self._timeline_doc()
+                json_path, _ = write_timeline(self.out_dir, doc)
                 print(f"wrote {json_path} ({len(self._beats)} beats)")
+                self._write_beat_frames(doc)
         finally:
             # Whatever went wrong above, don't leave .video/ behind — the
             # next take into this directory would trip over it.
@@ -1605,6 +1950,16 @@ class _DemoBase:
         finally:
             record["t_end"] = round(time.monotonic() - self._t0, 3)
             self._in_beat = False
+
+    def _write_beat_frames(self, doc: dict) -> None:
+        """Extract this take's review frames (a no-op for a segment).
+
+        The frames inherit the recording's redaction rather than re-deriving
+        it: every one of them is a frame of `demo.mp4`, which is masked in the
+        page before it is ever captured. `tests/smoke` measures that on the
+        frames themselves instead of taking this paragraph's word for it.
+        """
+        write_beat_frames(self.out_dir, doc, "this take")
 
     def _media_path(self) -> Path:
         """The mp4 this take converts to on exit."""
@@ -2193,6 +2548,15 @@ def stitch(out_dir: Path, segments: list[str], keep_parts: bool = False) -> None
     merged = _merged_timeline(segments, parts, docs, durations, demo)
     json_path, _ = write_timeline(out_dir, merged)
     print(f"wrote {demo} and {json_path.name} from {len(segments)} segments")
+    # The review sheet, from the merged log rather than from any part's. A
+    # single segment's timeline cannot produce one — its beats start at zero
+    # and name a `.seg.mp4` this function is about to delete — but the merged
+    # document is a whole demo, and a demo long enough to record in parts is
+    # the one nobody wants to review by scrubbing. Written here rather than in
+    # each segment's `__exit__` for the same reason: this is the first moment
+    # a whole demo exists. Re-stitching rewrites it, clearing the last one's
+    # frames first.
+    write_beat_frames(out_dir, merged, "stitch()")
     if not keep_parts:
         # missing_ok throughout, and the media and its log in one pass: a
         # segment named twice, or a part something else already removed, must

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,8 +49,11 @@ smoke: web first caption 'A small dashboard.' logged at 3.03s, on screen at 2.95
 smoke: web closing caption 'Recorded end to end.' logged at 17.03s, on screen at 16.99s (-40 ms)
 smoke: web beat clock holds across the take (+40 ms)
 smoke: web timeline.json ok (23 beats)
+smoke: web each review frame shows its own beat's caption state (10 captioned frames from 11.2, 4 bare ones to 3.3; 9 within 0.75s of a caption change and not graded)
+smoke: web frames/ ok (23 beat frames, each byte-identical to the demo.mp4 frame it claims to be)
 smoke: web healthy app under strict=True records no problems
 smoke: redaction #api-key is blurred in every frame of demo.mp4 (worst 1.5 vs control 52.0, 3%)
+smoke: redaction #api-key is blurred in all 25 gradable review frames of 31 (worst 0.0 vs control 22.7, 0%)
 smoke: redaction still 01-key-blurred.png ok (key 1.0, token 2.9, control 39.3)
 smoke: redaction .tts/ holds 2 clips — the narrated lines, and nothing for the refused one
 smoke: redaction no artifact holds either secret verbatim
@@ -122,10 +125,8 @@ all (see Known gaps).
 
 ## What it asserts
 
-Six independent axes, because a recorder can fail on any one of them while
-looking perfect on the other five.
-Five independent axes, because a recorder can fail on any one of them while
-looking perfect on the other four.
+Eight independent axes, because a recorder can fail on any one of them while
+looking perfect on the other seven.
 
 **Artifacts** — `demo.mp4` and every still the storyboard asked for exist, were
 modified by *this* run rather than a previous one, clear a size floor
@@ -290,6 +291,117 @@ When the measurement cannot be made the run says which reason it was: a caption
 that was never drawn, a video that slid further than the search window can see,
 or a run-up that was not quiet. They look identical from inside the window, and
 only the first is the recorder losing a caption.
+
+**Review frames** — the `frames/` a reviewer is actually handed: one PNG per
+beat, and `frames.md` embedding them in order. What is graded is what the
+recorder claims, and it deliberately claims very little:
+
+- **One frame per beat, named for it.** Counted against the hand-written
+  `WEB_BEATS`/`TERMINAL_BEATS`, so a dropped frame, a doubled one or an
+  off-by-one name fails without a pixel being read. Every file on disk is named
+  by the manifest and vice versa.
+- **Each frame is the moment it says it is.** Two halves, and only together.
+  Its timestamp must be its beat's midpoint, computed *here* from
+  `timeline.json` — not imported from the recorder, because a check that
+  re-derives its expectation from the constants it is grading moves whenever
+  they do. And the PNG must be that frame: the harness **cuts the same second
+  out of `demo.mp4` again and compares the bytes**. 41 of 41 identical across
+  the two graded takes; one frame away (40 ms) is already a different file.
+
+  Exact rather than approximate, because approximate does not work here. A PNG
+  and a decoded video frame reach a luma reduction through different colour
+  conversions and sit ~1.0 mean luma apart *when they are the same frame*,
+  while two moments three seconds apart in this fixture differ by 0.87 (a
+  filtered table and a refreshed one are mostly the same white page). A
+  threshold loose enough to absorb the first cannot see the second — measured,
+  by injecting exactly that and watching it pass.
+- **The sheet leaks no storyboard.** `frames.md` goes to a *context-free*
+  reviewer who is asked what story the pictures tell. It is searched for every
+  caption in `WEB_CAPTIONS`/`TERMINAL_CAPTIONS` and every selector in the beat
+  list, and finding any of them is a failure; `frames.json` must carry no
+  `caption`, `verb` or `selector` key, because a manifest that duplicates the
+  storyboard is how it ends up back on the sheet.
+- **A re-run clears the previous run's frames**, and only those. `beat_frames()`
+  is called a second time with a planted `beat-99.png` and a planted file it did
+  not write: the first must be gone, the second must survive, and the frame list
+  must be identical. SKILL.md advertises the re-run and step 6 tells a reviewer
+  to read the whole directory, so a storyboard that lost beats between runs
+  must not leave plausible-looking frames from a demo that no longer exists.
+- **A single segment's timeline gets no frames — and only that.** Graded by
+  handing `beat_frames()` this take's own timeline with a segment name on it:
+  it must write nothing and say why. Both reasons are properties of that
+  document, not of the world around it: its beats are numbered from zero, so
+  two segments collide on `beat-00.png`, and its `media` is a `.seg.mp4` that
+  `stitch()` deletes on its way to `demo.mp4`. Neither survives the merge, so
+  the **stitched** demo gets frames like any other take — the `segments/` take
+  runs the whole of this axis, `_check_frame_captions()` included, against the
+  15-beat merged timeline `stitch()` writes.
+- **Frame N shows beat N** — issue #8's acceptance criterion, and the only
+  claim here about a frame's *content*. For every beat the hand-written
+  storyboard says had a caption bar up, the frame must show one; for every beat
+  it says had none, the frame must not. Decided by ranking rather than by a
+  threshold: each frame's caption band is reduced and measured against the
+  take's own first caption-off frame, and every captioned frame must sit
+  further from that baseline than every uncaptioned one, by at least
+  `MIN_ALIGN_BAND_DELTA`. Observed margins: web 8.1, terminal 2.3, segments
+  16.6. A recorder that stopped drawing the bar, or extraction that returned
+  one picture for every beat, collapses the two groups together and the margin
+  goes to zero — there is nothing to tune past it.
+
+  **One bit per frame, deliberately.** *Which* caption is a stronger claim and
+  this band cannot carry it: two of the fixture's own terminal captions sit 1.5
+  mean luma apart against a 1.0 floor, so a check that named them would be
+  reporting noise. That is [#60](https://github.com/rogvid/skills/issues/60).
+
+  **And a stated tolerance, which is the honest part.** The video runs ahead of
+  the beat log ([#18](https://github.com/rogvid/skills/issues/18)), so a frame
+  cut at a beat's midpoint shows a moment slightly later in the story than that
+  beat. Frames within `FRAME_CAPTION_GUARD_S` — the same `MAX_CAPTURE_LOSS_S`
+  the skew bars use, 750 ms — of a caption *change* are therefore not graded:
+  that close, the log and the video genuinely disagree about which side of the
+  change a frame is on. This is not theoretical. Set the guard to zero and the
+  suite fails on `segments/beat-13.png`, the frame for a 50 ms `shot()` beat
+  that ends 25 ms before a caption clears: the video is ~80 ms ahead, so the
+  entire beat is already past the change and the frame shows the *next* beat's
+  screen. `MIN_GRADED_CAPTION_FRAMES` and a one-of-each-class rule keep the
+  guard from turning the check off — set it to 3 s instead and the suite fails
+  with "only 0 of 23 review frames … were graded".
+
+**What is still not graded: which caption a frame shows.** The recorder makes
+no such claim, and neither does this file. An earlier round graded a caption
+printed under each frame by reading the caption bar back out of the pixels;
+that measurement worked, and the thing it was measuring did not. The recorder
+inferred which caption a frame showed by locating caption transitions in the
+video, and review found the inference mislabelling frames on ordinary
+storyboards: two captions of the same length change under 0.25 mean luma in the
+band against a 1.5 floor, an app repainting under the bar supplies a stronger
+and earlier edge than the caption does, and a mid-take `goto()` destroys the
+bar while logging no caption change to measure. The claim was withdrawn rather
+than tuned — see [#60](https://github.com/rogvid/skills/issues/60), which is
+what earning it back would take.
+
+**Scene-change detection**, the fallback for what the storyboard did not
+script, is graded directly against `demo.mp4` rather than through a take: no
+beat in either storyboard runs the 3 s the recorder needs before it reaches for
+it, and stretching one to provoke it would cost every run the seconds. It must
+see the largest change a take contains and stay quiet where nothing moves.
+
+The positive half — at least one cut somewhere in the video — is **web only**,
+and that is about the medium rather than a convenience. The biggest thing that
+happens to the web frame is the caption bar arriving, at 0.023–0.026 against
+the recorder's 0.02 threshold, while *nothing* in the terminal take reaches it:
+its largest change is two lines of shell output on a dark background at 0.011,
+against an idle 0.004. At a threshold separating those, an ordinary terminal
+repaint would be reported as a cut. Tracked in
+[#57](https://github.com/rogvid/skills/issues/57), which proposes scoring the
+app's rect instead of the whole composited frame.
+
+The quiet half runs on both, over the stretch after the **last beat's logged
+end** — where the recording holds its closing frame until it stops. Anchored
+there rather than in the middle of the take because the video only ever runs
+*ahead* of the beat log (#18), so the real end of that beat is at or before
+this; a first version picked "the middle of the longest pause beat" and a take
+that stalled 540 ms slid a caption change into it on the first run.
 
 **Problems** — what the recorder saw *behind* the pixels. This is the axis the
 other four are structurally blind to: a demo of an app throwing `TypeError` on
@@ -625,11 +737,35 @@ ordered above it in the top layer, and only the hit test at the next checkpoint
 notices. And the attack the fixture runs is the two ordinary ones, not an
 adversary.
 
+The **review frames** (`frames/`, issue #8) are a fifth artifact on disk and
+are graded on pixels like the rest. They are frames of `demo.mp4`, so they
+inherit its mask by construction — which is a reason to expect them clean, not
+a reason to skip measuring them, and this file's whole premise is that
+"inherits it by construction" is a claim rather than evidence. `#api-key` is
+scored against `#api-key-control` **in the same frame**, worst frame wins, same
+7% text bar as the video.
+
+Only frames where the *control* is legible are graded, and the count of those
+is asserted (≥ 10 of ~31). That skip is not a loophole while the control is
+what decides it: this take opens on `about:blank` for five `redact()` beats,
+raises the paint gate on purpose mid-take, and navigates once, so a handful of
+its frames legitimately show nothing at all — and a mask that blanked the whole
+recording takes the gradable count to zero and fails.
+
+And the take that *cannot* verify its mask must leave none of them behind:
+`check_unmatched_redaction` requires an empty `frames/` alongside the absent
+`demo.mp4`, the absent stills and the absent `.video/`. The frames are written
+on the way out, from the same exit path that decides whether the recording may
+be kept at all, so "it wrote no mp4" does not on its own say it wrote no frames
+of one.
+
 The two text paths are checked by searching bytes, not by asking the recorder:
 
 - every file the take wrote — `timeline.json`, `timeline.md`, the stills, the
-  mp4, the narration clips — is read and searched for both literals, with no
-  exemptions, so a leak path nobody anticipated still shows up;
+  mp4, the narration clips, `frames/` and its two manifests — is read and
+  searched for both literals, with no exemptions, so a leak path nobody
+  anticipated still shows up. It is an `rglob`, not a list, which is why the
+  review frames were covered by it the moment they existed;
 - `.tts/` must hold **exactly** the clips for the lines that were narrated —
   not merely "nothing for the refused line", which is also true of an empty
   directory. The innocent line's clip existing is what makes the refused line's
@@ -960,6 +1096,27 @@ knows is missing is worse than one that is openly absent.
   Between them a recorder that drew the wrong caption at the right moment would
   be caught, but only because two separate checks happen to overlap — no single
   assertion reads pixels back as text, and none is going to without OCR.
+- **A review frame is graded for whether a caption was on screen, not for
+  which.** `_check_frame_captions()` closes the "nothing says which beat a frame
+  shows" gap only as far as one bit goes: a captioned beat's frame must show a
+  bar and an uncaptioned one's must not. Two beats carrying *different* captions
+  are indistinguishable to it, so a stall that slid a frame from one captioned
+  beat to another captioned beat still passes. Tracked in
+  [#60](https://github.com/rogvid/skills/issues/60), which would make the
+  mapping readable off the frame instead of inferred.
+- **Frames within 750 ms of a caption change are not graded for content at
+  all**, and on these storyboards that is 8-9 of every take's frames. The
+  exclusion is real coverage lost, not a formality: it is exactly where #18's
+  drift puts a frame on the wrong side of a change, and where the harness
+  therefore cannot tell a recorder bug from the capture. `check_beat_frames()`
+  still grades those frames for placement and for byte-identity against
+  `demo.mp4`; only the pixel claim is withheld.
+- **No storyboard beat is long enough to make the recorder run scene
+  detection.** `SCENE_MIN_SPAN_S` is 3 s and the longest beat either take
+  performs is a 2 s `pause`, so the *manifest* half of that check — scene
+  frames only inside long beats — is vacuous today and says so where it is
+  written. The mechanism is graded directly instead (see **Review frames**),
+  which is what stops the vacuity from being total.
 - **The wall-clock regression cannot be fault-injected.** The recorders time
   beats with `time.monotonic()`; using `time.time()` only misreports when the
   system clock actually steps, which no assertion here can provoke. It is not
@@ -1206,13 +1363,23 @@ the crop and looking at it before it was believed.
   is a caption) so the timeline check knows to expect it. `record_segments`
   works the same way, except that its list is `SEGMENT_BEATS_FULL` and carries
   a third column, the segment the beat belongs to. Those lists are
-  deliberately hand-maintained; see **Timeline** above for why. Adding a beat
+  deliberately hand-maintained; see **Timeline** above for why — and
+  `WEB_BEATS` is also what the **Review frames** axis counts frames against and
+  searches `frames.md` for, so a stale entry there fails twice. Adding a beat
   lengthens the take; keep it inside the duration window, or widen the window
   deliberately. **Every interaction gets a `b.expect(...)` naming what it
   should have changed** — a beat with no post-condition is a beat that passes
   when the verb is a no-op. Anything that leaves the page still for more than a
   second also wants a look at `TICKER_JS`: idle is what makes the screencast
   lose time, and adding idle is how the timing bar was made flaky once already.
+- **A new caption, interlude or selector** — it goes in the hand-written lists
+  (`WEB_CAPTIONS`, `SEGMENT_INTERLUDES`, the beat list), and the **Review
+  frames** axis then requires `frames.md` *not* to contain it. That is the
+  intended direction: the sheet a context-free reviewer reads must not name the
+  thing they are being asked to discover. A caption also moves the boundaries
+  `_check_frame_captions()` guards, so adding one near the end of a storyboard
+  can push frames out of the graded set — watch the "not graded" count in the
+  pass line, and `MIN_GRADED_CAPTION_FRAMES` is the floor, not a dial.
 - **Anything in the page that must keep moving** — a second ticker, an
   animation a take is *about* — has to carry `data-demo-video-animate`, or the
   recorder's determinism rule lands it on its final frame the moment it

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,7 +53,7 @@ smoke: web each review frame shows its own beat's caption state (10 captioned fr
 smoke: web frames/ ok (23 beat frames, each byte-identical to the demo.mp4 frame it claims to be)
 smoke: web healthy app under strict=True records no problems
 smoke: redaction #api-key is blurred in every frame of demo.mp4 (worst 1.5 vs control 52.0, 3%)
-smoke: redaction #api-key is blurred in all 25 gradable review frames of 31 (worst 0.0 vs control 22.7, 0%)
+smoke: redaction all 9 masked elements are blurred in the review frames (18 gradable of 31; worst #a4-card 0.2 vs control 21.8 in beat-23.png, 1%, bar 7%)
 smoke: redaction still 01-key-blurred.png ok (key 1.0, token 2.9, control 39.3)
 smoke: redaction .tts/ holds 2 clips — the narrated lines, and nothing for the refused one
 smoke: redaction no artifact holds either secret verbatim
@@ -305,8 +305,9 @@ recorder claims, and it deliberately claims very little:
   `timeline.json` — not imported from the recorder, because a check that
   re-derives its expectation from the constants it is grading moves whenever
   they do. And the PNG must be that frame: the harness **cuts the same second
-  out of `demo.mp4` again and compares the bytes**. 41 of 41 identical across
-  the two graded takes; one frame away (40 ms) is already a different file.
+  out of `demo.mp4` again and compares the bytes**. 56 of 56 identical across
+  the three graded takes — 23 web, 18 terminal, and 15 off the stitched
+  `segments/` demo; one frame away (40 ms) is already a different file.
 
   Exact rather than approximate, because approximate does not work here. A PNG
   and a decoded video frame reach a luma reduction through different colour
@@ -741,23 +742,41 @@ The **review frames** (`frames/`, issue #8) are a fifth artifact on disk and
 are graded on pixels like the rest. They are frames of `demo.mp4`, so they
 inherit its mask by construction — which is a reason to expect them clean, not
 a reason to skip measuring them, and this file's whole premise is that
-"inherits it by construction" is a claim rather than evidence. `#api-key` is
-scored against `#api-key-control` **in the same frame**, worst frame wins, same
-7% text bar as the video.
+"inherits it by construction" is a claim rather than evidence. **Every element
+the video is graded over** is scored in the frames too, each against its own
+control **in the same frame**, worst frame wins by *ratio*, same 7% text bar as
+the video — and `#if-key` carries the video's window with it, since it holds
+its secret only until the take navigates and an emptied iframe is not a masked
+one.
+
+For one round this graded `#api-key` alone, which was the wrong single element
+to pick: `#api-key` is clean in every run, and `#if-key` is the one measured
+leaking into `demo.mp4` intermittently ([#68](https://github.com/rogvid/skills/issues/68)).
+The frames are the artifact a reviewer is *handed*, so the element most likely
+to leak was the one they were least protected from.
 
 Only frames where the *control* is legible are graded, and the count of those
-is asserted (≥ 10 of ~31). That skip is not a loophole while the control is
-what decides it: this take opens on `about:blank` for five `redact()` beats,
-raises the paint gate on purpose mid-take, and navigates once, so a handful of
-its frames legitimately show nothing at all — and a mask that blanked the whole
-recording takes the gradable count to zero and fails.
+is asserted (≥ 10 of ~31, per element). That skip is not a loophole while the
+control is what decides it: this take opens on `about:blank` for five
+`redact()` beats, raises the paint gate on purpose mid-take, and navigates
+once, so a handful of its frames legitimately show nothing at all — and a mask
+that blanked the whole recording takes the gradable count to zero and fails.
 
 And the take that *cannot* verify its mask must leave none of them behind:
 `check_unmatched_redaction` requires an empty `frames/` alongside the absent
-`demo.mp4`, the absent stills and the absent `.video/`. The frames are written
-on the way out, from the same exit path that decides whether the recording may
-be kept at all, so "it wrote no mp4" does not on its own say it wrote no frames
-of one.
+stills and the absent `.video/`.
+
+That assertion needs a **planted `demo.mp4`** to mean anything, and for one
+round it did not have one. `beat_frames()` returns "there is no demo.mp4 to
+extract frames from" *before* it creates `frames/`, and a refused take never
+converts its webm — so "no review frames survived" was true whatever the exit
+path did, and the `if clean:` guard that is supposed to keep frames off a
+refused take could be deleted without a single assertion moving. It now writes
+a real two-second mp4 into the directory first, which makes that guard the only
+thing standing between the refusal and a `frames/` directory. The mp4 check
+changes with it, from "the file does not exist" to "the file is still the one
+we planted" — the same claim, since conversion writes over it, and equally
+sharp.
 
 The two text paths are checked by searching bytes, not by asking the recorder:
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -535,6 +535,104 @@ ALIGN_ARRIVAL_FRACTION = 0.25
 # the same numbers) as MIN_CAPTION_BAND_DIFF above.
 MIN_ALIGN_BAND_DELTA = {"web": 6.0, "terminal": 1.0, "segments": 6.0}
 
+# -- review frames (frames/, issue #8) ---------------------------------------
+#
+# The recorder extracts one frame per beat and writes `frames/frames.md` for a
+# reviewer to read in order. It makes **no claim about what is in a frame** —
+# no caption, no verb, no selector — and the two things worth grading follow
+# from that:
+#
+#   * each frame really is the moment it says it is, which is checked by
+#     finding it again in demo.mp4 rather than by believing the manifest;
+#   * the sheet really is story-free, which is checked by searching it for
+#     every caption and selector the storyboard used.
+#
+# An earlier round of this file graded a caption printed under each frame, by
+# reading the caption bar back out of the pixels. That check worked; what it
+# was checking did not — the recorder inferred which caption a frame showed by
+# looking for caption transitions in the video, and review found the inference
+# mislabelling frames on ordinary storyboards (same-length captions give it no
+# signal, a repainting app gives it a stronger edge than the caption does, and
+# a mid-take `goto()` gives it nothing to measure at all). The claim was
+# withdrawn rather than tuned; see the recorder's own section header and
+# issue #60.
+
+# Nothing here: a review frame is graded against the video by **re-extracting**
+# it, byte for byte, rather than by any measure of similarity. Both sides are
+# the same ffmpeg decoding the same mp4 at the same second, so the healthy
+# answer is an identical file — 41 of 41 across the two graded takes — and one
+# frame away (40 ms) is already a different one. A luma comparison could not do
+# that: a PNG and a decoded frame reach the reduction through different colour
+# conversions and sit ~1.0 mean luma apart even when they are the same frame,
+# which is *more* than two moments three seconds apart in this fixture differ
+# by (0.87 across the refresh). The threshold that would have to absorb the
+# first cannot see the second.
+
+# How far a frame's timestamp may sit from its beat's midpoint, computed here
+# from timeline.json rather than imported from the recorder. Deliberately not
+# the recorder's own constants: a check that re-derives the expectation from
+# the numbers it is grading moves whenever they do, which is exactly how a
+# constant stops being graded at all.
+MAX_FRAME_PLACEMENT_S = 0.02
+
+# -- does frame N show beat N? (issue #8's acceptance criterion) --------------
+#
+# "N beats produce N frames" is nearly vacuous, and the two checks above are
+# about placement rather than content: they prove a frame was cut at the second
+# the manifest names, not that anything of that beat is in it. What is graded
+# here is the one thing about a frame's *content* the harness knows
+# independently — whether a caption bar was on screen — against the
+# **hand-written** storyboard rather than against the log, via
+# `_expected_context()`.
+#
+# It is one bit per frame, deliberately. Which caption is a stronger claim and
+# the band cannot carry it: two of this fixture's own captions sit 1.5 mean
+# luma apart in the terminal take against the 1.0 floor below, so a check that
+# named them would be reporting noise. See issue #60, and the recorder's own
+# section header for why the *recorder* claims nothing at all here.
+#
+# The bar is relative and computed per take: every frame whose beat carries a
+# caption must sit further from the take's own caption-off baseline than every
+# frame whose beat carries none. No absolute threshold to argue about — a take
+# that stopped drawing captions collapses the two groups together and the
+# margin goes to zero. MIN_ALIGN_BAND_DELTA is reused as the floor on that
+# margin because it is the same measurement on the same band: how far the
+# caption bar moves the caption band of this recorder. Observed margins, one
+# run: web 8.06, terminal 2.25, segments 16.62.
+#
+# FRAME_CAPTION_GUARD_S is the honest part. The video slides under the beat log
+# (issue #18) and a frame cut at a beat's midpoint therefore shows a moment up
+# to that far *ahead* of the beat in story time — measured at 40-120 ms in
+# these ticker-protected takes, but a take that loses the recorder's own
+# ~0.7 s setup window loses it uniformly, which is what MAX_CAPTURE_LOSS_S
+# already tolerates elsewhere in this file. So a frame is graded for the
+# caption it shows only when its timestamp is at least that far from a caption
+# *change*; nearer than that, the beat log and the video genuinely disagree
+# about which side of the change the frame is on, and this harness is not the
+# place to pretend otherwise. Same number, same reason, one definition.
+#
+# Concretely, on the storyboards here that skips every `shot` beat that sits
+# against a caption change — and those frames really do show the next beat's
+# screen: `01-part1` is captured while "One demo, in two parts." is up, and the
+# frame extracted at that beat's midpoint has already lost the caption, because
+# the beat is 50 ms long and the video is 80 ms ahead of it. That is #18, it is
+# not fixed here, and the guard is why no assertion in this file quietly
+# depends on it being fixed.
+FRAME_CAPTION_GUARD_S = MAX_CAPTURE_LOSS_S
+
+# ...and the guard must not be allowed to swallow the check. A regression that
+# moved every frame onto a caption boundary would otherwise grade nothing and
+# report a pass. Both classes have to survive it, and enough of them to mean
+# something: observed 14 (10/4), 9 (7/2) and 7 (2/5) across the three takes.
+MIN_GRADED_CAPTION_FRAMES = 5
+
+# Scene-change detection, graded directly rather than through a take: no beat
+# in either storyboard is long enough (SCENE_MIN_SPAN_S) for the recorder to
+# run it on its own, and lengthening one to provoke it would cost every take
+# the seconds. How far past the last beat the "nothing is happening now" window
+# starts.
+SCENE_WINDOW_PAD_S = 0.1
+
 # Written into each take directory so a later run can tell "a directory this
 # harness owns and may delete" from "somebody's source tree".
 MARKER_NAME = ".demo-video-smoke"
@@ -869,6 +967,13 @@ MIN_CONTROL_EDGE = {"still": 8.0, "video": 6.0}
 #          still catches the failure that matters for a field — not being
 #          masked at all, which reads as ~100%.
 MAX_REDACTED_EDGE_RATIO = {"text": 0.07, "field": 0.25}
+
+# How many of the redaction take's review frames have to show a legible
+# control before "the key is blurred in all of them" means anything. The take
+# opens on about:blank, raises the paint gate on purpose, and navigates once,
+# so a handful of its ~31 frames legitimately show nothing; a mask that blanked
+# the recording would show nothing in every one of them.
+MIN_GRADED_REVIEW_FRAMES = 10
 
 # Frames per second sampled from the redaction take's mp4. Every sampled frame
 # is scored and the *worst* one is graded, because one frame showing the key is
@@ -3508,6 +3613,499 @@ def check_timeline(
     return failures
 
 
+def _same_frame(mp4: Path, at: float, png: Path) -> bool:
+    """Is `png` the frame of `mp4` at `at` seconds?
+
+    Answered by cutting that frame again, with the same ffmpeg the recorder
+    used, and comparing the bytes. Exact rather than approximate, which matters
+    both ways: it resolves a single frame (40 ms), and it needs no threshold to
+    argue about. What it does *not* grade is whether `at` is the right second —
+    that is the midpoint check above, and the two are only worth anything
+    together.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        reference = Path(tmp) / "reference.png"
+        proc = subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-v",
+                "error",
+                "-ss",
+                f"{at:.3f}",
+                "-i",
+                str(mp4),
+                "-frames:v",
+                "1",
+                "-update",
+                "1",
+                str(reference),
+            ],
+            capture_output=True,
+        )
+        if proc.returncode != 0 or not reference.is_file():
+            return False
+        return (
+            hashlib.sha256(reference.read_bytes()).hexdigest()
+            == hashlib.sha256(png.read_bytes()).hexdigest()
+        )
+
+
+def check_beat_frames(
+    label: str,
+    out_dir: Path,
+    started_at: float,
+    expected_beats: list[tuple[str, str | None]],
+    expected_captions: list[str],
+    frame_size: tuple[int, int],
+    expected_interludes: list[str] = [],  # noqa: B006 - read-only, never mutated
+) -> list[str]:
+    """`frames/` — one frame per beat, at the beat's midpoint, showing it.
+
+    Four claims, and the last one is the acceptance criterion of issue #8:
+
+      * **one frame per beat**, named for the beat, counted against the
+        hand-written beat list rather than against the recorder's own idea of
+        how many beats there were;
+      * **each frame is the moment it says it is** — its timestamp is the
+        beat's midpoint computed here from `timeline.json`, and the PNG is
+        byte-identical to that second cut out of `demo.mp4` again. Only
+        together: the first without the second passes a manifest that says the
+        right time over the wrong picture, and the second without the first
+        passes a frame faithfully cut from the wrong second;
+      * **the sheet leaks no storyboard.** `frames.md` goes to a context-free
+        reviewer who is asked what story the pictures tell. A caption, a verb
+        or a selector printed beside a frame answers that for them, and the
+        `fps=1/3` handoff this replaces did not leak any of it;
+      * **frame N shows beat N** — `_check_frame_captions()`. The two above are
+        both about *placement*; a frame cut at exactly the right second of a
+        video that slid under the beat log is a picture of the wrong beat, and
+        neither of them can see it. This one looks at the pixels, against the
+        hand-written storyboard, and says so.
+    """
+    from demo_recording import FRAMES_SCHEMA
+
+    failures: list[str] = []
+    frames_dir = out_dir / "frames"
+    json_path, md_path = frames_dir / "frames.json", frames_dir / "frames.md"
+    if not json_path.is_file():
+        return [f"{label}: {json_path} was never written"]
+    if json_path.stat().st_mtime < started_at - 1:
+        return [f"{label}: {json_path} is stale — it predates this run"]
+    try:
+        manifest = json.loads(json_path.read_text())
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return [f"{label}: {json_path} is not valid JSON: {exc}"]
+    if manifest.get("schema") != FRAMES_SCHEMA:
+        failures.append(
+            f"{label}: frames.json says schema {manifest.get('schema')!r}, but "
+            f"the recorder package exports FRAMES_SCHEMA {FRAMES_SCHEMA!r}"
+        )
+    if manifest.get("skipped"):
+        return failures + [
+            f"{label}: the recorder wrote no review frames — {manifest['skipped']}"
+        ]
+
+    # -- one frame per beat, named for the beat it came from -----------------
+    listed = [f for f in manifest.get("frames") or [] if f.get("kind") == "beat"]
+    wanted = [f"beat-{i:02d}.png" for i in range(len(expected_beats))]
+    named = [str(f.get("file")) for f in listed]
+    if named != wanted:
+        failures.append(
+            f"{label}: frames/ holds {named!r} for the {len(expected_beats)} "
+            f"beats the storyboard performs — first difference at index "
+            f"{_first_difference(named, wanted)}"
+        )
+    for frame in listed:
+        if frame.get("file") != f"beat-{frame.get('beat'):02d}.png":
+            failures.append(
+                f"{label}: frame {frame.get('file')!r} claims to be beat "
+                f"{frame.get('beat')!r} — the file name and the manifest "
+                f"disagree about which beat a reviewer is looking at"
+            )
+            break
+
+    on_disk = sorted(p.name for p in frames_dir.glob("*.png"))
+    claimed = sorted(str(f.get("file")) for f in manifest.get("frames") or [])
+    if on_disk != claimed:
+        failures.append(
+            f"{label}: frames.json names {claimed!r} but frames/ holds "
+            f"{on_disk!r} — a frame was written without being listed, left "
+            f"over from an earlier run, or the other way round"
+        )
+    for name in claimed:
+        png = frames_dir / name
+        if not png.is_file():
+            failures.append(f"{label}: frames.json names {name!r}, which is not there")
+        elif png.stat().st_size < MIN_PNG_BYTES:
+            failures.append(
+                f"{label}: frame {name} is only {png.stat().st_size} bytes "
+                f"(expected at least {MIN_PNG_BYTES})"
+            )
+
+    # -- each frame is the moment it says it is ------------------------------
+    doc = json.loads((out_dir / "timeline.json").read_text())
+    beats = {b.get("index"): b for b in doc.get("beats") or []}
+    mp4 = out_dir / "demo.mp4"
+    duration = float(doc.get("duration") or 0.0)
+    measured = 0
+    for frame in listed:
+        beat = beats.get(frame.get("beat"))
+        png = frames_dir / str(frame.get("file"))
+        if beat is None or not png.is_file():
+            continue
+        middle = (float(beat["t_start"]) + float(beat["t_end"])) / 2
+        at = float(frame["t"])
+        if abs(at - middle) > MAX_FRAME_PLACEMENT_S and at < duration - 0.2:
+            failures.append(
+                f"{label}: {frame.get('file')} was taken at {at:.3f}s, but beat "
+                f"{frame.get('beat')} runs {beat['t_start']}-{beat['t_end']}s "
+                f"and its midpoint is {middle:.3f}s — the frame is not the "
+                f"moment the sheet numbers it for"
+            )
+        if not mp4.is_file() or not duration:
+            continue
+        measured += 1
+        if not _same_frame(mp4, at, png):
+            failures.append(
+                f"{label}: {frame.get('file')} is not the frame of demo.mp4 at "
+                f"the {at:.3f}s it claims — cutting that second again produces "
+                f"a different picture. It is a frame of another moment, of "
+                f"another take, or left over from an earlier run."
+            )
+    if measured < len(listed):
+        failures.append(
+            f"{label}: only {measured} of {len(listed)} review frames were "
+            f"compared against demo.mp4 — the rest went ungraded, which is not "
+            f"the same as passing"
+        )
+
+    # -- the sheet carries no storyboard -------------------------------------
+    if not md_path.is_file():
+        failures.append(f"{label}: {md_path} was never written")
+    else:
+        markdown = md_path.read_text()
+        for frame in listed:
+            name = str(frame.get("file"))
+            if f"]({name})" not in markdown:
+                failures.append(f"{label}: frames.md does not embed {name!r}")
+        spoken = {*expected_captions, *expected_interludes}
+        leaked = [text for text in spoken if text and text in markdown]
+        leaked += [
+            target
+            for _, target in expected_beats
+            if target and f"`{target}`" in markdown
+        ]
+        if leaked:
+            failures.append(
+                f"{label}: frames.md hands a context-free reviewer "
+                f"{sorted(set(leaked))!r} — the sheet is supposed to be the "
+                f"pictures and nothing else, and every one of those tells the "
+                f"reviewer what to see before they look"
+            )
+    for key in ("caption", "verb", "selector"):
+        carrying = [f["file"] for f in manifest.get("frames") or [] if key in f]
+        if carrying:
+            failures.append(
+                f"{label}: frames.json carries a {key!r} for {carrying[0]} — "
+                f"the manifest is an index into timeline.json, and duplicating "
+                f"the storyboard into it is how it ends up back on the sheet"
+            )
+
+    failures += _check_frame_captions(
+        label,
+        out_dir,
+        frame_size,
+        listed,
+        beats,
+        _expected_context(expected_beats, expected_captions, expected_interludes),
+    )
+    failures += _check_stale_frames(label, out_dir, manifest)
+    failures += _check_segment_refusal(label, out_dir, doc)
+    failures += _check_scene_fallback(label, out_dir, doc)
+
+    if not failures:
+        print(
+            f"smoke: {label} frames/ ok ({len(listed)} beat frames, each "
+            f"byte-identical to the demo.mp4 frame it claims to be)"
+        )
+    return failures
+
+
+def _check_frame_captions(
+    label: str,
+    out_dir: Path,
+    frame_size: tuple[int, int],
+    listed: list[dict],
+    beats: dict[int, dict],
+    context: list[str] | None,
+) -> list[str]:
+    """Frame N shows beat N — measured on the pixels, one bit per frame.
+
+    For every beat the **hand-written** storyboard says had a caption bar on
+    screen, the frame must show one; for every beat it says had none, the frame
+    must not. Decided without a threshold, by ranking: each frame's caption band
+    is reduced and compared against the take's own first caption-off frame, and
+    every captioned frame has to sit further from that baseline than every
+    uncaptioned one, by at least `MIN_ALIGN_BAND_DELTA[label]`. A recorder that
+    stopped drawing the bar, or extraction that returned the same picture for
+    every beat, collapses the two groups into each other and the margin goes to
+    zero or negative — there is nothing to tune it past.
+
+    Frames within `FRAME_CAPTION_GUARD_S` of a caption *change* are not graded,
+    and the constant's comment says why at length: the video runs ahead of the
+    beat log by an amount this harness bounds but does not control (#18), so
+    close to a change the two disagree about which side a frame is on and
+    neither is wrong. `MIN_GRADED_CAPTION_FRAMES` and the one-of-each rule keep
+    that exclusion from turning the check off.
+
+    The expectation comes from `_expected_context()` — the storyboard lists at
+    the top of this file — and never from `timeline.json`, which is the
+    recorder's own account of the same thing and is graded against those same
+    lists in `check_timeline()`.
+    """
+    if context is None or len(context) != len(listed):
+        # The count and the caption list are graded above and in
+        # check_timeline(); saying so a third time adds nothing, and grading a
+        # misaligned pairing would report the wrong beat.
+        return []
+
+    # A change is where the expected context stops being what it was. The
+    # *times* have to come from the log — it is the only record of when a beat
+    # ran — but which beats are boundaries does not.
+    changes = [
+        float(beats[frame["beat"]]["t_start"])
+        for i, frame in enumerate(listed)
+        if frame.get("beat") in beats and context[i] != (context[i - 1] if i else "")
+    ]
+
+    band = caption_band(frame_size)
+    reference: bytes | None = None
+    graded: list[tuple[int, str, bytes]] = []
+    for i, frame in enumerate(listed):
+        png = out_dir / "frames" / str(frame.get("file"))
+        if not png.is_file():
+            continue
+        near = min((abs(float(frame["t"]) - c) for c in changes), default=math.inf)
+        if near < FRAME_CAPTION_GUARD_S:
+            continue
+        try:
+            reduced = gray_frames(png, band)
+        except RuntimeError as exc:
+            return [f"{label}: {exc}"]
+        if not reduced:
+            return [f"{label}: {png.name} decoded to no frames"]
+        graded.append((int(frame["beat"]), context[i], reduced[0]))
+        if reference is None and not context[i]:
+            reference = reduced[0]
+
+    captioned = [(b, c, g) for b, c, g in graded if c]
+    bare = [(b, c, g) for b, c, g in graded if not c]
+    if reference is None or not captioned or len(graded) < MIN_GRADED_CAPTION_FRAMES:
+        return [
+            f"{label}: only {len(graded)} of {len(listed)} review frames "
+            f"({len(captioned)} captioned, {len(bare)} not) sit more than "
+            f"{FRAME_CAPTION_GUARD_S}s clear of a caption change, so almost "
+            f"nothing about what the frames *show* was graded. Either the "
+            f"storyboard changed caption too often to grade, or every frame "
+            f"moved onto a boundary — which is the regression this floor is "
+            f"here to catch, not a reason to lower it"
+        ]
+
+    scored = [(frame_difference(reference, g), b, c) for b, c, g in graded]
+    worst_on = min(s for s in scored if s[2])
+    worst_off = max(s for s in scored if not s[2])
+    margin = worst_on[0] - worst_off[0]
+    floor = MIN_ALIGN_BAND_DELTA[label]
+    if margin < floor:
+        return [
+            f"{label}: beat-{worst_on[1]:02d}.png should show the caption "
+            f"{worst_on[2]!r} and its caption band is only {worst_on[0]:.2f} "
+            f"from the take's caption-off baseline — beat-{worst_off[1]:02d}."
+            f"png, which should show no caption at all, is {worst_off[0]:.2f} "
+            f"from it. The two are {margin:.2f} apart, under the {floor} floor: "
+            f"the frames do not show the beats they are named for, or the "
+            f"caption bar is not being drawn"
+        ]
+    print(
+        f"smoke: {label} each review frame shows its own beat's caption state "
+        f"({len(captioned)} captioned frames from {worst_on[0]:.1f}, "
+        f"{len(bare)} bare ones to {worst_off[0]:.1f}; "
+        f"{len(listed) - len(graded)} within {FRAME_CAPTION_GUARD_S}s of a "
+        f"caption change and not graded)"
+    )
+    return []
+
+
+def _check_stale_frames(label: str, out_dir: Path, manifest: dict) -> list[str]:
+    """A re-run must take the previous run's frames off disk.
+
+    SKILL.md advertises `beat_frames(out_dir)` as re-runnable, and step 6 tells
+    a reviewer to read everything in the directory. A storyboard that lost
+    beats between runs would otherwise leave frames nobody planned sitting in
+    it — numbered, plausible, and from a demo that no longer exists.
+
+    Done here rather than through a second recording: it is a pure function of
+    the mp4 and the timeline, so a second call is free.
+    """
+    from demo_recording import beat_frames
+
+    frames_dir = out_dir / "frames"
+    planted = frames_dir / "beat-99.png"
+    keep = frames_dir / "kept-by-a-human.png"
+    try:
+        planted.write_bytes(
+            (frames_dir / str(manifest["frames"][0]["file"])).read_bytes()
+        )
+        keep.write_bytes(b"not ours\n")
+        again = beat_frames(out_dir)
+    except (OSError, IndexError, KeyError) as exc:
+        return [f"{label}: could not re-run beat_frames(): {exc}"]
+    failures: list[str] = []
+    if planted.exists():
+        failures.append(
+            f"{label}: re-running beat_frames() left {planted.name} behind — a "
+            f"frame from a previous take stays in the directory step 6 hands to "
+            f"a reviewer"
+        )
+        planted.unlink()
+    if not keep.exists():
+        failures.append(
+            f"{label}: re-running beat_frames() deleted a file it did not "
+            f"write ({keep.name}) — the cleanup is supposed to be bounded to "
+            f"the frames and the two manifests"
+        )
+    else:
+        keep.unlink()
+    if [f["file"] for f in again["frames"]] != [f["file"] for f in manifest["frames"]]:
+        failures.append(
+            f"{label}: re-running beat_frames() produced a different set of "
+            f"frames from the same mp4 and timeline"
+        )
+    return failures
+
+
+def _check_segment_refusal(label: str, out_dir: Path, doc: dict) -> list[str]:
+    """A *single segment's* timeline must write no frames — and only that.
+
+    Two properties of an unmerged segment document, both of it rather than of
+    the world around it: its beats are numbered from zero, so two segments in
+    one directory overwrite each other's `beat-00.png`; and its `media` is a
+    `<segment>.seg.mp4`, which `stitch()` deletes on its way to demo.mp4, so
+    the sheet would embed frames of a file that is gone. Neither survives the
+    merge — issue #7 landed, `stitch()` renumbers the beats onto the joined
+    video's clock and names demo.mp4 — which is why the *stitched* demo gets
+    frames like any other take, graded by running this whole function against
+    the `segments/` take rather than by arguing about it here.
+
+    Graded by handing `beat_frames()` this take's own timeline with a segment
+    name on it, into a directory of its own — no recording needed, and the
+    refusal is a property of the document rather than of how it was made.
+    """
+    from demo_recording import beat_frames
+
+    segment_dir = out_dir / ".segment-refusal"
+    segment_dir.mkdir(exist_ok=True)
+    shutil.copy(out_dir / "demo.mp4", segment_dir / "part2.seg.mp4")
+    try:
+        manifest = beat_frames(
+            segment_dir, {**doc, "segment": "part2", "media": "part2.seg.mp4"}
+        )
+    except Exception as exc:  # noqa: BLE001 - refusing must not mean raising
+        shutil.rmtree(segment_dir, ignore_errors=True)
+        return [f"{label}: beat_frames() raised on a segment take: {exc}"]
+    written = sorted(p.name for p in segment_dir.glob("frames/*"))
+    shutil.rmtree(segment_dir, ignore_errors=True)
+    if manifest["frames"] or written:
+        return [
+            f"{label}: beat_frames() wrote {written!r} for a segment take. Two "
+            f"segments collide on beat-00.png, and the sheet names a "
+            f".seg.mp4 that stitch() deletes."
+        ]
+    if not manifest.get("skipped"):
+        return [
+            f"{label}: beat_frames() wrote nothing for a segment take but does "
+            f"not say why — a caller cannot tell that from a crash"
+        ]
+    return []
+
+
+def _check_scene_fallback(label: str, out_dir: Path, doc: dict) -> list[str]:
+    """The fallback for transitions the storyboard did not script.
+
+    Graded directly against demo.mp4 rather than through a take, because no
+    beat in either storyboard runs the SCENE_MIN_SPAN_S the recorder needs
+    before it reaches for it, and stretching one to provoke it would cost every
+    run the seconds. What it has to do is see the largest change a take
+    contains and stay quiet where nothing moves.
+
+    The positive half is **web only**, and that is about the medium rather than
+    a convenience: the biggest thing that happens to the web frame is the
+    caption bar arriving, at 0.023-0.026 against the recorder's 0.02 threshold,
+    while nothing in the terminal take reaches it at all — its largest change
+    is two lines of output on a dark background at 0.011 against an idle 0.004.
+    At a threshold separating those, an ordinary terminal repaint would be
+    reported as a cut. Issue #57.
+    """
+    from demo_recording import SCENE_MIN_SPAN_S, scene_times
+
+    failures: list[str] = []
+    mp4 = out_dir / "demo.mp4"
+    beats = doc.get("beats") or []
+    duration = float(doc.get("duration") or 0.0)
+    if not mp4.is_file() or not duration or not beats:
+        return failures
+
+    if label == "web":
+        cuts = scene_times(mp4, 0.0, duration, limit=99)
+        if not cuts:
+            failures.append(
+                f"{label}: scene detection finds nothing at all in "
+                f"{duration:.1f}s of demo.mp4 — the fallback for unscripted "
+                f"transitions cannot see the largest change the take contains"
+            )
+        elif not all(0.0 <= c <= duration for c in cuts):
+            failures.append(
+                f"{label}: scene detection reports cuts at {cuts} for a "
+                f"{duration:.1f}s video — the times it returns are not in the "
+                f"window it was asked about"
+            )
+
+    # The quiet half: after the last beat the recording holds one frame until
+    # it stops. Starting at the last beat's *logged* end is safe in the one
+    # direction that matters — the video only ever runs ahead of the beat log
+    # (issue #18), so the real end of that beat is at or before this — which is
+    # why the window is anchored there and not on a beat in the middle of the
+    # take, where a stall slid a caption change into it on the first run.
+    tail = float(beats[-1].get("t_end") or 0.0) + SCENE_WINDOW_PAD_S
+    if duration - tail > 0.4:
+        held = scene_times(mp4, tail, duration)
+        if held:
+            failures.append(
+                f"{label}: scene detection reports cuts at {held} between "
+                f"{tail:.2f}s and {duration:.2f}s of demo.mp4, where the take "
+                f"holds its closing frame — it would fill a reviewer's frame "
+                f"list with pictures of nothing happening"
+            )
+
+    # And a scene frame may only appear inside a beat long enough to hide one.
+    # Vacuous while no storyboard beat reaches the threshold — tests/README.md
+    # says so — and here so that a storyboard that grows one is graded.
+    spans = {b.get("index"): float(b["t_end"]) - float(b["t_start"]) for b in beats}
+    manifest = json.loads((out_dir / "frames" / "frames.json").read_text())
+    for frame in manifest.get("frames") or []:
+        if frame.get("kind") != "scene":
+            continue
+        if spans.get(frame.get("beat"), 0.0) < SCENE_MIN_SPAN_S:
+            failures.append(
+                f"{label}: {frame.get('file')} is a scene frame inside beat "
+                f"{frame.get('beat')}, which spans "
+                f"{spans.get(frame.get('beat'), 0.0):.2f}s — under the "
+                f"{SCENE_MIN_SPAN_S}s a beat needs before it is searched"
+            )
+    return failures
+
+
 def _expected_context(
     expected_beats: list[tuple[str, str | None]],
     expected_captions: list[str],
@@ -4121,6 +4719,71 @@ def check_redaction(out_dir: Path, info: dict, started_at: float) -> list[str]:
                 + ")"
             )
 
+    # -- leak path 2b: the review frames issue #8 leaves on disk -------------
+    #
+    # They are frames of demo.mp4, so they inherit its mask by construction —
+    # which is a reason to expect them clean, not a reason to skip measuring
+    # them. Graded exactly like the video is, over the same rects, because
+    # "frames of a masked video" is a claim about how the recorder extracts
+    # them, and the whole point of this file is not to take such claims on
+    # trust. The worst frame, not the median: a paused video is a screenshot,
+    # and so is a PNG.
+    review = sorted((out_dir / "frames").glob("beat-*.png"))
+    if mp4.is_file() and not review:
+        failures.append(
+            "redaction: the take wrote no review frames, so the artifact a "
+            "reviewer is handed went ungraded for the secret it may hold"
+        )
+    elif review:
+        geom, size = info["geom"], info["size"]
+        key_rect = to_video_rect(rects["#api-key"], geom, size)
+        control_rect = to_video_rect(rects["#api-key-control"], geom, size)
+        # A frame is only gradable where the *control* is legible in it. This
+        # take opens on about:blank (five `redact()` beats before the first
+        # navigation), raises the paint gate on purpose mid-take and navigates
+        # once, and in all three the page shows nothing — so the control reads
+        # zero and so would a key that was blazing. Skipping those is not a
+        # loophole as long as it is the control deciding and the count is
+        # asserted: a mask that blanked the whole recording takes the gradable
+        # count to zero.
+        graded_frames: list[tuple[str, float, float]] = []
+        blanked: list[str] = []
+        for png in review:
+            control = _edges(png, control_rect)[0]
+            if control < MIN_CONTROL_EDGE["still"]:
+                blanked.append(png.name)
+                continue
+            graded_frames.append((png.name, _edges(png, key_rect)[0], control))
+        bar = MAX_REDACTED_EDGE_RATIO["text"]
+        if len(graded_frames) < MIN_GRADED_REVIEW_FRAMES:
+            failures.append(
+                f"redaction: only {len(graded_frames)} of {len(review)} review "
+                f"frames show a legible #api-key-control (floor "
+                f"{MIN_CONTROL_EDGE['still']}, at least "
+                f"{MIN_GRADED_REVIEW_FRAMES} needed) — {blanked!r} have no "
+                f"picture in them at all, and a blank frame passes any ratio "
+                f"taken against its own control"
+            )
+        else:
+            where, worst_key, control = max(graded_frames, key=lambda row: row[1])
+            if worst_key > control * bar:
+                failures.append(
+                    f"redaction: #api-key is legible in the review frame "
+                    f"{where} — {worst_key:.1f} edge energy against "
+                    f"{control:.1f} for the unredacted control in the same "
+                    f"frame ({worst_key / control:.0%}, bar {bar:.0%}). The "
+                    f"frames handed to a reviewer are extracted from demo.mp4 "
+                    f"after the take, and are subject to the same mask as "
+                    f"everything else it wrote."
+                )
+            else:
+                print(
+                    f"smoke: redaction #api-key is blurred in all "
+                    f"{len(graded_frames)} gradable review frames of "
+                    f"{len(review)} (worst {worst_key:.1f} vs control "
+                    f"{control:.1f}, {worst_key / control:.0%})"
+                )
+
     # -- leak path 3: captions, and the beat log they land in ----------------
     timeline = out_dir / "timeline.json"
     if not timeline.is_file():
@@ -4391,6 +5054,7 @@ def run_web(out_root: Path) -> list[str]:
             size,
         )
         + check_timeline("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
+        + check_beat_frames("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
         + check_healthy("web", out_dir)
     )
 
@@ -4893,6 +5557,21 @@ def check_unmatched_redaction(out_root: Path, base_url: str) -> list[str]:
     for leftover in (".frame.png",):
         if (out_dir / leftover).is_file():
             failures.append(f"redaction-unmatched: {leftover} survived the failed take")
+    # The review frames are frames of demo.mp4, so a take that wrote no mp4 must
+    # have written none of them either. Asserted rather than reasoned about:
+    # they are extracted on the way out, from the same exit path that decides
+    # whether the recording may be kept at all.
+    review = (
+        sorted(p.name for p in (out_dir / "frames").glob("*"))
+        if (out_dir / "frames").is_dir()
+        else []
+    )
+    if review:
+        failures.append(
+            f"redaction-unmatched: the review frames {review!r} survived a take "
+            f"that could not verify its mask — every one of them is a frame of "
+            f"the recording it was refused"
+        )
     for name in (CLOSED_SECRET,):
         for path in sorted(out_dir.rglob("*")):
             if path.is_file() and name.encode() in path.read_bytes():
@@ -5360,6 +6039,15 @@ def run_segments(out_root: Path) -> list[str]:
             size,
             expected_segments=SEGMENT_BEAT_SEGMENTS,
             expected_interludes=SEGMENT_INTERLUDES,
+        )
+        + check_beat_frames(
+            "segments",
+            out_dir,
+            started,
+            SEGMENT_BEATS,
+            SEGMENT_CAPTIONS,
+            size,
+            SEGMENT_INTERLUDES,
         )
         + check_healthy("segments", out_dir)
     )
@@ -6469,6 +7157,9 @@ def run_terminal(out_root: Path) -> list[str]:
             size,
         )
         + check_timeline(
+            "terminal", out_dir, started, TERMINAL_BEATS, TERMINAL_CAPTIONS, size
+        )
+        + check_beat_frames(
             "terminal", out_dir, started, TERMINAL_BEATS, TERMINAL_CAPTIONS, size
         )
         + check_healthy("terminal", out_dir)

--- a/tests/smoke
+++ b/tests/smoke
@@ -560,7 +560,8 @@ MIN_ALIGN_BAND_DELTA = {"web": 6.0, "terminal": 1.0, "segments": 6.0}
 # Nothing here: a review frame is graded against the video by **re-extracting**
 # it, byte for byte, rather than by any measure of similarity. Both sides are
 # the same ffmpeg decoding the same mp4 at the same second, so the healthy
-# answer is an identical file — 41 of 41 across the two graded takes — and one
+# answer is an identical file — 56 of 56 across the three graded takes (23
+# web, 18 terminal, 15 off the stitched segments demo) — and one
 # frame away (40 ms) is already a different one. A luma comparison could not do
 # that: a PNG and a decoded frame reach the reduction through different colour
 # conversions and sit ~1.0 mean luma apart even when they are the same frame,
@@ -3901,15 +3902,36 @@ def _check_frame_captions(
 
     captioned = [(b, c, g) for b, c, g in graded if c]
     bare = [(b, c, g) for b, c, g in graded if not c]
-    if reference is None or not captioned or len(graded) < MIN_GRADED_CAPTION_FRAMES:
+    # Three separate ways for this check to end up grading nothing, reported
+    # separately. They overlap in practice — a guard wide enough to take the
+    # count under the floor usually empties a class too — and a single message
+    # covering all three cannot say which one fired, which makes it impossible
+    # to show the floor failing on its own.
+    coverage = (
+        f"{len(graded)} of {len(listed)} review frames ({len(captioned)} "
+        f"captioned, {len(bare)} not) sit more than {FRAME_CAPTION_GUARD_S}s "
+        f"clear of a caption change"
+    )
+    if reference is None:
         return [
-            f"{label}: only {len(graded)} of {len(listed)} review frames "
-            f"({len(captioned)} captioned, {len(bare)} not) sit more than "
-            f"{FRAME_CAPTION_GUARD_S}s clear of a caption change, so almost "
-            f"nothing about what the frames *show* was graded. Either the "
-            f"storyboard changed caption too often to grade, or every frame "
-            f"moved onto a boundary — which is the regression this floor is "
-            f"here to catch, not a reason to lower it"
+            f"{label}: {coverage}, and not one of them is a frame of an "
+            f"uncaptioned beat — so there is no caption-off baseline to "
+            f"measure the others against, and nothing about what the frames "
+            f"*show* could be graded at all"
+        ]
+    if not captioned:
+        return [
+            f"{label}: {coverage}, and not one of them is a frame of a "
+            f"captioned beat — so 'a captioned beat's frame shows a caption' "
+            f"was not tested on anything"
+        ]
+    if len(graded) < MIN_GRADED_CAPTION_FRAMES:
+        return [
+            f"{label}: {coverage}, under the {MIN_GRADED_CAPTION_FRAMES} this "
+            f"check needs to mean anything. Either the storyboard changed "
+            f"caption too often to grade, or every frame moved onto a "
+            f"boundary — which is the regression this floor is here to catch, "
+            f"not a reason to lower it"
         ]
 
     scored = [(frame_difference(reference, g), b, c) for b, c, g in graded]
@@ -4723,11 +4745,21 @@ def check_redaction(out_dir: Path, info: dict, started_at: float) -> list[str]:
     #
     # They are frames of demo.mp4, so they inherit its mask by construction —
     # which is a reason to expect them clean, not a reason to skip measuring
-    # them. Graded exactly like the video is, over the same rects, because
-    # "frames of a masked video" is a claim about how the recorder extracts
-    # them, and the whole point of this file is not to take such claims on
-    # trust. The worst frame, not the median: a paused video is a screenshot,
-    # and so is a PNG.
+    # them. Graded over **every element the video is graded over**, against the
+    # same controls at the same font sizes, because "frames of a masked video"
+    # is a claim about how the recorder extracts them and the whole point of
+    # this file is not to take such claims on trust.
+    #
+    # One element was not enough, and it is not a hypothetical: #if-key is the
+    # one measured leaking into demo.mp4 intermittently (#68), and #api-key —
+    # the only one this check used to look at — is clean in every run of it.
+    # The frames are the artifact a reviewer is *handed*, so the element most
+    # likely to leak was the element they were least protected from.
+    #
+    # The worst frame, not the median: a paused video is a screenshot, and so
+    # is a PNG. Worst by *ratio* rather than by absolute edge energy, because
+    # the bar is a ratio — the two agree on this fixture only because the
+    # controls barely move between frames.
     review = sorted((out_dir / "frames").glob("beat-*.png"))
     if mp4.is_file() and not review:
         failures.append(
@@ -4736,53 +4768,102 @@ def check_redaction(out_dir: Path, info: dict, started_at: float) -> list[str]:
         )
     elif review:
         geom, size = info["geom"], info["size"]
-        key_rect = to_video_rect(rects["#api-key"], geom, size)
-        control_rect = to_video_rect(rects["#api-key-control"], geom, size)
-        # A frame is only gradable where the *control* is legible in it. This
-        # take opens on about:blank (five `redact()` beats before the first
-        # navigation), raises the paint gate on purpose mid-take and navigates
-        # once, and in all three the page shows nothing — so the control reads
-        # zero and so would a key that was blazing. Skipping those is not a
-        # loophole as long as it is the control deciding and the count is
-        # asserted: a mask that blanked the whole recording takes the gradable
-        # count to zero.
-        graded_frames: list[tuple[str, float, float]] = []
-        blanked: list[str] = []
-        for png in review:
-            control = _edges(png, control_rect)[0]
-            if control < MIN_CONTROL_EDGE["still"]:
-                blanked.append(png.name)
-                continue
-            graded_frames.append((png.name, _edges(png, key_rect)[0], control))
-        bar = MAX_REDACTED_EDGE_RATIO["text"]
-        if len(graded_frames) < MIN_GRADED_REVIEW_FRAMES:
+        in_frame = {n: to_video_rect(rects[n], geom, size) for n in needed}
+        at: dict[str, float] = {}
+        try:
+            listing = json.loads((out_dir / "frames" / "frames.json").read_text())
+            at = {
+                str(f["file"]): float(f["t"])
+                for f in listing.get("frames") or []
+                if f.get("file") and isinstance(f.get("t"), (int, float))
+            }
+        except (OSError, ValueError, KeyError) as exc:
             failures.append(
-                f"redaction: only {len(graded_frames)} of {len(review)} review "
-                f"frames show a legible #api-key-control (floor "
-                f"{MIN_CONTROL_EDGE['still']}, at least "
-                f"{MIN_GRADED_REVIEW_FRAMES} needed) — {blanked!r} have no "
-                f"picture in them at all, and a blank frame passes any ratio "
-                f"taken against its own control"
+                f"redaction: frames.json could not be read ({exc}), so no "
+                f"review frame could be placed in time — #if-key holds its "
+                f"secret only until the take navigates, and grading it after "
+                f"that measures an emptied iframe"
             )
-        else:
-            where, worst_key, control = max(graded_frames, key=lambda row: row[1])
-            if worst_key > control * bar:
+        # Seven of the nine share #api-key-control and each reading is a
+        # process, so measure a control once per frame rather than once per
+        # element.
+        seen: dict[tuple[str, str], float] = {}
+
+        def control_edge(png: Path, control_name: str) -> float:
+            key = (png.name, control_name)
+            if key not in seen:
+                seen[key] = _edges(png, in_frame[control_name])[0]
+            return seen[key]
+
+        bar = MAX_REDACTED_EDGE_RATIO["text"]
+        worst: dict[str, tuple[str, float, float]] = {}
+        gradable = len(review)
+        for name, control_name in sorted(graded.items()):
+            # The same windows the video is graded over, applied per frame
+            # instead of per second: #if-key holds the secret only until the
+            # take navigates away, after which the iframe is empty — and an
+            # empty crop is not a masked one.
+            window = [
+                png
+                for png in review
+                if name != "#if-key"
+                or nav_at is None
+                or at.get(png.name, 0.0) <= nav_at
+            ]
+            # A frame is only gradable where the *control* is legible in it.
+            # This take opens on about:blank (five `redact()` beats before the
+            # first navigation), raises the paint gate on purpose mid-take and
+            # navigates once, and in all three the page shows nothing — so the
+            # control reads zero and so would a key that was blazing. Skipping
+            # those is not a loophole as long as it is the control deciding and
+            # the count is asserted: a mask that blanked the whole recording
+            # takes the gradable count to zero.
+            graded_frames: list[tuple[str, float, float]] = []
+            blanked: list[str] = []
+            for png in window:
+                control = control_edge(png, control_name)
+                if control < MIN_CONTROL_EDGE["still"]:
+                    blanked.append(png.name)
+                    continue
+                graded_frames.append(
+                    (png.name, _edges(png, in_frame[name])[0], control)
+                )
+            if len(graded_frames) < MIN_GRADED_REVIEW_FRAMES:
                 failures.append(
-                    f"redaction: #api-key is legible in the review frame "
-                    f"{where} — {worst_key:.1f} edge energy against "
-                    f"{control:.1f} for the unredacted control in the same "
-                    f"frame ({worst_key / control:.0%}, bar {bar:.0%}). The "
-                    f"frames handed to a reviewer are extracted from demo.mp4 "
-                    f"after the take, and are subject to the same mask as "
-                    f"everything else it wrote."
+                    f"redaction: only {len(graded_frames)} of {len(window)} "
+                    f"review frames show a legible {control_name} (floor "
+                    f"{MIN_CONTROL_EDGE['still']}, at least "
+                    f"{MIN_GRADED_REVIEW_FRAMES} needed), so {name} went "
+                    f"ungraded in the artifact a reviewer is handed — "
+                    f"{blanked!r} have no picture in them at all, and a blank "
+                    f"frame passes any ratio taken against its own control"
                 )
-            else:
-                print(
-                    f"smoke: redaction #api-key is blurred in all "
-                    f"{len(graded_frames)} gradable review frames of "
-                    f"{len(review)} (worst {worst_key:.1f} vs control "
-                    f"{control:.1f}, {worst_key / control:.0%})"
+                continue
+            gradable = min(gradable, len(graded_frames))
+            where, key_edge, control = max(
+                graded_frames, key=lambda row: row[1] / row[2]
+            )
+            worst[name] = (where, key_edge, control)
+            if key_edge > control * bar:
+                failures.append(
+                    f"redaction: {name} is legible in the review frame "
+                    f"{where} — {key_edge:.1f} edge energy against "
+                    f"{control:.1f} for {control_name}, the unredacted control "
+                    f"of the same kind and size in the same frame "
+                    f"({key_edge / control:.0%}, bar {bar:.0%}). The frames "
+                    f"handed to a reviewer are extracted from demo.mp4 after "
+                    f"the take, and are subject to the same mask as everything "
+                    f"else it wrote."
                 )
+        if worst and len(worst) == len(graded):
+            loudest = max(worst, key=lambda n: worst[n][1] / worst[n][2])
+            where, key_edge, control = worst[loudest]
+            print(
+                f"smoke: redaction all {len(worst)} masked elements are blurred "
+                f"in the review frames ({gradable} gradable of {len(review)}; "
+                f"worst {loudest} {key_edge:.1f} vs control {control:.1f} in "
+                f"{where}, {key_edge / control:.0%}, bar {bar:.0%})"
+            )
 
     # -- leak path 3: captions, and the beat log they land in ----------------
     timeline = out_dir / "timeline.json"
@@ -5499,6 +5580,43 @@ def run_determinism(out_root: Path) -> list[str]:
     return failures
 
 
+def _plant_mp4(path: Path) -> bytes:
+    """A small, real, decodable mp4 at `path`. Returns its bytes.
+
+    Exists for one assertion, and that assertion could not fail without it.
+    `beat_frames()` returns `skipped = "there is no demo.mp4 to extract frames
+    from"` **before** it creates `frames/`, so on a take that was refused —
+    which never converts its webm — "no review frames survived" was true no
+    matter what the exit path did. Removing the `if clean:` guard that is
+    supposed to keep frames off a refused take changed nothing observable:
+    there was nothing to extract from either way. Planting a real recording
+    first makes the guard the only thing standing between the refusal and a
+    `frames/` directory, which is what the check claims to be grading.
+
+    Deliberately not a stub of arbitrary bytes: `beat_frames()` writes its two
+    manifests even when every extraction fails, so a stub would prove the
+    directory appeared rather than that frames of a video were taken out of it.
+    """
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=gray:s=320x180:d=2:r=25",
+            "-pix_fmt",
+            "yuv420p",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return path.read_bytes()
+
+
 def check_unmatched_redaction(out_root: Path, base_url: str) -> list[str]:
     """A take told to hide something it cannot reach must die, not record.
 
@@ -5515,6 +5633,12 @@ def check_unmatched_redaction(out_root: Path, base_url: str) -> list[str]:
     out_dir = fresh_take_dir(out_root, "redaction-unmatched")
     failures: list[str] = []
     raised: BaseException | None = None
+    # Planted before the take, so that "it wrote no review frames" is a claim
+    # about the exit path rather than about there being nothing to extract
+    # from — see _plant_mp4(). It also turns the mp4 assertion below from "the
+    # file does not exist" into "the file is still the one we put there",
+    # which is the same claim and equally sharp: conversion writes over this.
+    planted = _plant_mp4(out_dir / "demo.mp4")
     try:
         with Recorder(out_dir, base_url=base_url, speech=False) as rec:
             rec.redact("#sd-closed-key")
@@ -5540,11 +5664,18 @@ def check_unmatched_redaction(out_root: Path, base_url: str) -> list[str]:
             "redaction can least afford."
         )
     mp4 = out_dir / "demo.mp4"
-    if mp4.is_file():
+    if not mp4.is_file():
+        failures.append(
+            f"redaction-unmatched: the planted {mp4.name} is gone. Nothing in "
+            f"the recorder removes it, and without it the review-frame "
+            f"assertion below cannot fail — say so rather than passing"
+        )
+    elif mp4.read_bytes() != planted:
         failures.append(
             f"redaction-unmatched: {mp4} was written anyway ("
-            f"{mp4.stat().st_size} bytes) — a take that could not verify its "
-            f"mask must leave no recording behind"
+            f"{mp4.stat().st_size} bytes, over a {len(planted)}-byte "
+            f"placeholder) — a take that could not verify its mask must leave "
+            f"no recording behind"
         )
     stills = sorted(p.name for p in (out_dir / "images").glob("*.png"))
     if stills:
@@ -5557,10 +5688,12 @@ def check_unmatched_redaction(out_root: Path, base_url: str) -> list[str]:
     for leftover in (".frame.png",):
         if (out_dir / leftover).is_file():
             failures.append(f"redaction-unmatched: {leftover} survived the failed take")
-    # The review frames are frames of demo.mp4, so a take that wrote no mp4 must
-    # have written none of them either. Asserted rather than reasoned about:
-    # they are extracted on the way out, from the same exit path that decides
-    # whether the recording may be kept at all.
+    # The review frames are written on the way out, by the same exit path that
+    # decides whether the recording may be kept at all — so a take that was
+    # refused must leave none. There *is* an mp4 here, planted above, precisely
+    # so this can fail: without one the recorder skips extraction for a reason
+    # that has nothing to do with the refusal, and the guard could be deleted
+    # without a single assertion moving.
     review = (
         sorted(p.name for p in (out_dir / "frames").glob("*"))
         if (out_dir / "frames").is_dir()


### PR DESCRIPTION
Refs #8 — deliberately does **not** close it; see **What is still not proved**.

Step 6 sampled review frames with `ffmpeg -vf fps=1/3` — uniform sampling in
*time*, which can miss a short beat entirely, duplicate static ones, and gives
the reviewer no way to pair a frame with intent.

Emits `frames/beat-NN.png` at each beat's midpoint, plus `frames/frames.md` as
the reviewer's sheet.

## Segmented demos now get frames — reversed from the previous round

The earlier version of this PR refused frames for anything segmented, on the
grounds that "until a merged timeline exists there is nothing honest to build a
sheet from". #7 (e0bd3ce, now on `main`) removed that premise: `stitch()` writes
a merged `timeline.json` whose beats are renumbered onto the joined video's
clock, with per-segment offsets measured by ffprobe rather than accumulated from
the storyboard.

So the refusal is narrowed to what it is actually about, and both halves of the
reason are now properties of the **unmerged** document rather than of the
absence of a merged one:

- a single segment's beats are numbered from zero, so two segments writing into
  one directory overwrite each other's `beat-00.png`;
- its `media` is a `<segment>.seg.mp4`, which `stitch()` deletes on its way to
  `demo.mp4`, so the sheet would embed a file that is gone.

Neither survives the merge. `stitch()` writes the frames itself, from the merged
document, at the first moment a whole demo exists — and that is the case that
needs a review sheet most, since a demo long enough to record in parts is a demo
nobody wants to review by scrubbing.

**Graded against the real thing, not a hypothetical.** The `segments/` take in
`tests/smoke` (two `Recorder(segment=…)` takes, stitched) now runs the *whole*
frames axis — 15 beat frames off the merged timeline, midpoint placement,
byte-identity against the stitched `demo.mp4`, the no-storyboard-on-the-sheet
search, the re-run cleanup, and the content check below. The refusal is still
graded too, by handing `beat_frames()` a timeline with a segment name on it.

## Frame N shows beat N — the assertion that was missing

"N beats produce N frames" is nearly vacuous, and the two placement checks
(midpoint, byte-identity) prove only that a frame was cut at the second the
manifest names. A frame cut at exactly the right second of a video that has slid
under the beat log is a picture of the wrong beat, and neither can see it.

`_check_frame_captions()` looks at the pixels. For every beat the **hand-written**
storyboard says had a caption bar on screen, the frame must show one; for every
beat it says had none, the frame must not. Decided by ranking, not by a
threshold: each frame's caption band is reduced and measured against the take's
own first caption-off frame, and every captioned frame must sit further from that
baseline than every uncaptioned one, by at least `MIN_ALIGN_BAND_DELTA` — the
same floor the caption-timing measurement already uses on the same band.

Observed margins: **web 8.06, terminal 2.25, segments 16.62.** A recorder that
stopped drawing the bar, or extraction that returned one picture for every beat,
collapses the two groups into each other and the margin goes to zero.

The expectation comes from `_expected_context()` — the hand-written storyboard
lists — never from `timeline.json`, which is the recorder's own account of the
same thing and is graded against those same lists elsewhere.

**One bit per frame, deliberately.** *Which* caption is a stronger claim and this
band cannot carry it: two of the fixture's own terminal captions sit 1.5 mean
luma apart against a 1.0 floor, so a check that named them would be reporting
noise. That is #60.

## How accurate the frames actually are (issue #18)

Stated in `SKILL.md`, in `tests/README.md`, and encoded in the check rather than
assumed away.

The beat log is wall-clock; the video is whatever Chromium's screencast managed
to record, and it drops wall time during idle stretches. A frame cut at a beat's
midpoint therefore shows a moment **slightly ahead of that beat in the demo's
story** — measured at **40–120 ms** on these ticker-protected takes, and up to
**~600 ms** on a take that loses the browser's start-up window whole (about 1 in
12). Consequence, stated plainly in SKILL.md: for a beat comfortably longer than
that the frame is of that beat; **for a beat shorter than the drift the frame can
be of the beat after it.**

This is not hypothetical, and this PR does not fix it. In the `segments/` take,
`shot("01-part1")` is captured while "One demo, in two parts." is on screen. That
beat is 50 ms long and ends 25 ms before the caption clears; the video is ~80 ms
ahead, so the frame extracted at its midpoint has already lost the caption. Same
for the `91-caption-on` probe shot in all three takes.

**The tolerance, and why it is that number.** Frames whose timestamp is within
`FRAME_CAPTION_GUARD_S` of a caption *change* are not graded for content. That
constant **is** `MAX_CAPTURE_LOSS_S` (750 ms) — the bound the caption-timing bars
in this file already use, for the same reason, defined once. Inside it the log
and the video genuinely disagree about which side of a change a frame is on, and
neither is wrong. That excludes 7–9 frames per take; `tests/README.md`'s Known
gaps records the lost coverage rather than glossing it.

`MIN_GRADED_CAPTION_FRAMES` (5) plus a one-of-each-class rule stop the guard from
turning the check off — a regression that moved every frame onto a boundary would
otherwise grade nothing and report a pass.

## Fault injection

Every assertion added here was broken and watched to fail. Injections landed by
exact string or exact line number, confirmed present before the run.

| injection | observed failure |
|---|---|
| `FRAME_CAPTION_GUARD_S = 0.0` — remove the drift allowance | `segments: beat-13.png should show the caption 'Recorded end to end.' and its caption band is only 0.30 from the take's caption-off baseline — beat-14.png, which should show no caption at all, is 0.28 from it. The two are 0.02 apart, under the 6.0 floor` |
| caption bar made transparent (`background: rgba(22,20,16,0)`, `color: rgba(0,0,0,0)`) while staying in the DOM at opacity 1, so `check_caption`'s DOM assertion still passes | `web: beat-08.png should show the caption 'Filter by city.' … The two are -2.39 apart, under the 6.0 floor` |
| `FRAME_CAPTION_GUARD_S = 3.0` — guard swallows the check | `web: only 0 of 23 review frames (0 captioned, 0 not) sit more than 3.0s clear of a caption change, so almost nothing about what the frames *show* was graded` |
| `stitch()` no longer calls `write_beat_frames` | `segments: …/segments/frames/frames.json was never written` |
| `beat_frames()`' segment refusal disabled (line 964, `if False:`) | `segments: beat_frames() wrote ['beat-00.png' … 'beat-14.png', 'frames.json', 'frames.md'] for a segment take` |
| the interlude line leaked onto the sheet **and nothing else** (`"line": … if verb == "interlude" else ""`) | `segments: frames.md hands a context-free reviewer ['A few minutes later.']` |
| `if clean:` removed so frames are written on every exit path (the review's own repro) | `redaction-unmatched: the review frames ['beat-00.png' … 'frames.json', 'frames.md'] survived a take that could not verify its mask` |
| conversion run on a refused take (`if webm and webm.exists():`) | `redaction-unmatched: demo.mp4 was written anyway (65981 bytes, over a 2995-byte placeholder)` |
| `FRAME_CAPTION_GUARD_S = 1.05` — the vacuity floor, **alone** | `segments: 3 of 15 review frames (1 captioned, 2 not) sit more than 1.05s clear of a caption change, under the 5 this check needs to mean anything` |

The first is the one worth reading twice: it fails on a frame that genuinely does
show the next beat's screen. The check is sharp enough to see the thing the guard
is there to tolerate, which is why the guard is a stated tolerance rather than a
hidden assumption.

The previous round's fifteen still hold: an off-by-one frame index, a frame never
written, a frame cut three seconds from where the manifest says, every frame cut
at 0.0, the midpoint collapsed to `t_start`, stale frames left by a re-run, a
re-run deleting files it did not write, the caption and the selector printed on
the sheet, scene detection made deaf and made hair-trigger, review frames
surviving a refused mask, every review frame blank, and a mask reporting success
while hiding nothing.

## Also in this change

`frames/` is gitignored and is a row in SKILL.md's file table marked **not
committed** — it is a working file of a review, regenerated from `demo.mp4` and
`timeline.json` by `beat_frames(out_dir)`. (The bare pattern is safe in *this*
repo and nowhere else; SKILL.md still tells consumers to anchor it to their demo
folder, because `frames` is a plausible name for a directory of real source.)

`frames.md` no longer prints `verb`/`selector`, and the leak search now covers
interlude lines as well as captions. A re-run clears its own frames and only
those. Byte-exact re-extraction replaced the luma match that **passed** the
wrong-moment injection: a frame cut 3 s away scored 0.87 against a bar that had
to be ≥ 1.2 to absorb the ~1.0 pedestal between a PNG and a decoded frame.

## What is still not proved

- **Which** caption a frame shows. Two beats carrying *different* captions are
  indistinguishable to this check, so a stall that slid a frame from one
  captioned beat to another captioned beat still passes. #60.
- Frames within 750 ms of a caption change get no content grade at all — 7–9 per
  take. Both are in `tests/README.md`'s Known gaps.
- #18 itself is untouched. Nothing here reduces the drift; it is bounded,
  reported, and stated.

## Second round: review fixes (commit 2)

**Blocking finding, fixed.** `check_unmatched_redaction`'s "no review frames
survived a refused take" **could not fail**. `beat_frames()` returns `skipped =
"there is no demo.mp4 to extract frames from"` *before* it creates `frames/`,
and a refused take never converts its webm — so the assertion was true whatever
the exit path did, and the `if clean:` guard could be deleted without a single
assertion moving. Measured rather than argued:

```
WITHOUT a planted demo.mp4 (the old state):
    skipped = 'there is no demo.mp4 to extract frames from'
    frames/ exists = False, holds 0 files
    -> the 'no review frames survived' assertion stays silent
WITH a planted demo.mp4 (this fix):
    skipped = None
    frames/ exists = True, holds 4 files
    -> the 'no review frames survived' assertion FIRES
```

The harness now plants a real two-second mp4 first. The mp4 assertion changes
with it — "the file does not exist" becomes "the file is still the one we
planted", the same claim since conversion writes over it — and both are
fault-injected above.

**Review frames now graded for all 9 masked elements, not 1.** They were graded
for `#api-key` only, which is clean in every run; `#if-key` — the one measured
leaking into `demo.mp4` intermittently (#68) — was the one the reviewer-facing
PNGs were not protected from. Each element is now scored against its own control
at its own font size, carrying the video's own windows (`#if-key` only until the
take navigates, since an emptied iframe is not a masked one). Worst frame by
*ratio* rather than absolute edge energy; the bar is a ratio. CI:
`all 9 masked elements are blurred in the review frames (18 gradable of 31;
worst #a4-card 0.3 vs control 22.1 in beat-21.png, 1%, bar 7%)`.

**`MIN_GRADED_CAPTION_FRAMES` now injectable in isolation.** The three vacuity
conditions were one message, so the `guard = 3.0` injection tripped all three at
once and a floor of 1 would have printed the same thing. They are now separate
self-naming messages, and a 1.05 s guard fires the floor alone with both classes
still populated.

**Stale counts corrected** — byte-identical re-extraction is 56 of 56 across
three graded takes (23 + 18 + 15), not 41 of 41 across two.

### Filed rather than fixed, from the same review

- **#74** — no per-class floor on the caption check, and the baseline frame is
  counted in the class it defines (score definitionally 0.0). The terminal take
  is at 2 bare frames, one of them the reference: one storyboard edit from the
  ranked check silently degenerating into an absolute threshold while printing a
  healthy margin. The most worthwhile of these.
- **#75** — `beat_frames()` clamps late midpoints to `duration - 0.05`, so when
  capture loss is non-zero several tail beats ship the same picture under
  distinct `beat-NN.png` names, exempt from the placement check by construction.
- **#76** — `_discard_artifacts` does not remove `frames/`, so a refused take
  leaves a previous run's frames on disk — and step 6 now says "hand them
  `frames/frames.md`".
- **#77** — `SCENE_WINDOW_PAD_S` (0.1) is narrower than `MAX_LOG_EARLY_S` (0.25),
  the positive skew the same file tolerates.
- **#78** — `REDACT_DURATION_S` and `MAX_BLANK_RUN_S` fail on a loaded box,
  reproduced here with three smoke suites running at once. They accuse the
  recorder of something specific and wrong, which is what contaminated the
  attempt to reproduce #68.

**On #68**: it is a real intermittent product leak, not a flake — the quantity
is bimodal (0.2 on every good run, 6.0 on the bad one, same control, same
frames), which is a mask genuinely absent from at least one video frame rather
than variance. The coordinator is retitling and raising it; the interaction with
this PR is why the review-frame grading was widened to `#if-key` rather than
having its comment corrected.
