### PR TITLE
Add examples/ticket-queue, the app the demo-video loop is run against

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ or installed. (You can still pull one directly by path if you want to try it.)
 
 *Nothing in development right now.*
 
+## Examples
+
+[`examples/`](examples/) holds applications the skills are exercised against.
+They are not skills and are not installed: `examples/` contains no `SKILL.md`,
+so the installer's one-level-deep root walk never sees it.
+
+| Example | What it is |
+|---|---|
+| [`ticket-queue`](examples/ticket-queue/) | A deliberately boring support-ticket queue — a web front end and a CLI over one JSON file — recorded by the `demo-video` reference PR ([#64](https://github.com/rogvid/skills/issues/64)). |
+
 ## Issues
 
 Planned work, bugs, and design proposals live in

--- a/examples/ticket-queue/README.md
+++ b/examples/ticket-queue/README.md
@@ -1,0 +1,32 @@
+# ticket-queue — the example app the demo-video reference PR records
+
+A deliberately boring support-ticket queue: a web front end and a small CLI
+over the same `data/tickets.json`. It exists so that this repo has one real
+application to record demos of — issue
+[#64](https://github.com/rogvid/skills/issues/64).
+
+It is **not** a skill and is not installed by `npx skills add`: `examples/`
+holds no `SKILL.md`, so the CLI's one-level-deep root walk does not see it.
+
+## Running it
+
+`uv` is the only prerequisite (both executables are PEP 723 scripts; see
+`skills/script-conventions/SKILL.md`).
+
+```sh
+./serve                 # http://127.0.0.1:8901
+./tickets list
+./tickets show TQ-104
+```
+
+## What is in it
+
+| Path | What |
+|---|---|
+| `serve` | stdlib HTTP server: static `web/`, plus `GET /api/tickets` |
+| `tickets` | the CLI over the same data |
+| `web/` | one page — queue on the left, ticket detail on the right |
+| `data/tickets.json` | seven seeded tickets, `open` or `waiting` |
+
+The data is fixed and the UI computes nothing from the clock, so a recording
+of it reproduces without `deterministic=True`.

--- a/examples/ticket-queue/data/tickets.json
+++ b/examples/ticket-queue/data/tickets.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "TQ-101",
+    "title": "Invoice PDF is missing the tax line",
+    "status": "open",
+    "requester": "dana.olsen@northwind.example",
+    "opened": "2025-11-03",
+    "body": "The November invoice renders without the VAT row. Same account, October invoice was fine."
+  },
+  {
+    "id": "TQ-102",
+    "title": "Export to CSV times out on large accounts",
+    "status": "open",
+    "requester": "sam.reyes@northwind.example",
+    "opened": "2025-11-04",
+    "body": "Export of the full contact list returns a 504 after about ninety seconds."
+  },
+  {
+    "id": "TQ-103",
+    "title": "Cannot remove a seat from the team page",
+    "status": "waiting",
+    "requester": "mira.haas@northwind.example",
+    "opened": "2025-11-04",
+    "body": "The remove button is greyed out for one member. Asked the customer for a screenshot."
+  },
+  {
+    "id": "TQ-104",
+    "title": "Webhook retries stop after the first failure",
+    "status": "open",
+    "requester": "leo.fontaine@northwind.example",
+    "opened": "2025-11-05",
+    "body": "Delivery is attempted once, then the endpoint is marked dead. Expected five retries."
+  },
+  {
+    "id": "TQ-105",
+    "title": "Password reset mail lands in spam",
+    "status": "waiting",
+    "requester": "ana.petrova@northwind.example",
+    "opened": "2025-11-05",
+    "body": "Reported by three users on the same domain. Waiting on their mail administrator."
+  },
+  {
+    "id": "TQ-106",
+    "title": "Dashboard totals disagree with the report",
+    "status": "open",
+    "requester": "tom.iversen@northwind.example",
+    "opened": "2025-11-06",
+    "body": "The header total counts archived records, the report below does not."
+  },
+  {
+    "id": "TQ-107",
+    "title": "Add Norwegian to the language picker",
+    "status": "waiting",
+    "requester": "kira.lund@northwind.example",
+    "opened": "2025-11-06",
+    "body": "Feature request. Translations exist already, the option is just not listed."
+  }
+]

--- a/examples/ticket-queue/serve
+++ b/examples/ticket-queue/serve
@@ -1,0 +1,67 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Serve the ticket-queue web front end and its read-only JSON API.
+
+    ./serve [--port 8901]
+
+Stdlib only: this exists to give the example app a real HTTP origin, not to
+be a web framework.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+WEB = ROOT / "web"
+DATA = ROOT / "data" / "tickets.json"
+
+
+class Handler(SimpleHTTPRequestHandler):
+    """Static files out of web/, plus one JSON endpoint."""
+
+    def do_GET(self) -> None:  # noqa: N802  (stdlib naming)
+        if self.path.split("?")[0] == "/api/tickets":
+            body = DATA.read_bytes()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        super().do_GET()
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        """Quiet by default — a recording should not race the access log."""
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=8901)
+    args = parser.parse_args()
+
+    # Fail loudly here rather than serving a 500 from the API later.
+    json.loads(DATA.read_text())
+
+    handler = partial(Handler, directory=str(WEB))
+    server = ThreadingHTTPServer(("127.0.0.1", args.port), handler)
+    print(f"ticket-queue on http://127.0.0.1:{args.port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/ticket-queue/tickets
+++ b/examples/ticket-queue/tickets
@@ -1,0 +1,67 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Read the support queue from the command line.
+
+    ./tickets list
+    ./tickets show TQ-104
+
+Reads the same data/tickets.json the web front end serves.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DATA = Path(__file__).resolve().parent / "data" / "tickets.json"
+
+
+def load() -> list[dict]:
+    return json.loads(DATA.read_text())
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    rows = load()
+    print(f"{'ID':<8} {'STATUS':<10} TITLE")
+    for t in rows:
+        print(f"{t['id']:<8} {t['status']:<10} {t['title']}")
+    print(f"\n{len(rows)} tickets")
+    return 0
+
+
+def cmd_show(args: argparse.Namespace) -> int:
+    for t in load():
+        if t["id"].upper() == args.id.upper():
+            print(f"{t['id']}  {t['title']}")
+            print(f"status     {t['status']}")
+            print(f"requester  {t['requester']}")
+            print(f"opened     {t['opened']}")
+            print()
+            print(t["body"])
+            return 0
+    print(f"no such ticket: {args.id}", file=sys.stderr)
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="tickets", description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_list = sub.add_parser("list", help="list the queue")
+    p_list.set_defaults(func=cmd_list)
+
+    p_show = sub.add_parser("show", help="show one ticket")
+    p_show.add_argument("id")
+    p_show.set_defaults(func=cmd_show)
+
+    args = parser.parse_args()
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/ticket-queue/web/app.js
+++ b/examples/ticket-queue/web/app.js
@@ -1,0 +1,97 @@
+"use strict";
+
+let tickets = [];
+let selectedId = null;
+
+const listEl = document.getElementById("ticket-list");
+const detailEl = document.getElementById("detail");
+const liveEl = document.getElementById("live-status");
+const modalEl = document.getElementById("assign-modal");
+
+function statusPill(status) {
+  return `<span class="pill pill-${status}">${status}</span>`;
+}
+
+function renderList() {
+  listEl.innerHTML = tickets
+    .map(
+      (t) => `
+      <li>
+        <button class="ticket" type="button" data-id="${t.id}"
+                aria-current="${t.id === selectedId}">
+          <span class="ticket-id">${t.id}</span>
+          <span class="ticket-title">${t.title}</span>
+          ${statusPill(t.status)}
+        </button>
+      </li>`
+    )
+    .join("");
+}
+
+function renderDetail() {
+  const t = tickets.find((x) => x.id === selectedId);
+  if (!t) {
+    detailEl.innerHTML =
+      '<p class="detail-empty">Select a ticket to see the detail.</p>';
+    return;
+  }
+  detailEl.innerHTML = `
+    <h2>${t.title}</h2>
+    ${statusPill(t.status)}
+    <dl>
+      <dt>Ticket</dt><dd>${t.id}</dd>
+      <dt>Requester</dt>
+      <dd class="requester">
+        <span class="requester-email">${t.requester}</span>
+        <button class="copy-email" type="button"
+                title="Copy ${t.requester}">Copy</button>
+      </dd>
+      <dt>Opened</dt><dd>${t.opened}</dd>
+    </dl>
+    <p class="detail-body">${t.body}</p>
+    <details>
+      <summary>Raw payload</summary>
+      <pre>${JSON.stringify(t, null, 2)}</pre>
+    </details>
+    <div class="detail-actions">
+      <button id="open-assign" type="button">Assign…</button>
+    </div>`;
+}
+
+function render() {
+  renderList();
+  renderDetail();
+}
+
+listEl.addEventListener("click", (ev) => {
+  const button = ev.target.closest(".ticket");
+  if (!button) return;
+  selectedId = button.dataset.id;
+  render();
+});
+
+detailEl.addEventListener("click", (ev) => {
+  if (ev.target.closest(".copy-email")) {
+    liveEl.textContent = "Requester address copied.";
+    return;
+  }
+  if (ev.target.closest("#open-assign")) {
+    modalEl.hidden = false;
+  }
+});
+
+document.getElementById("assign-cancel").addEventListener("click", () => {
+  modalEl.hidden = true;
+});
+
+document.getElementById("assign-confirm").addEventListener("click", () => {
+  modalEl.hidden = true;
+  liveEl.textContent = "Ticket assigned.";
+});
+
+fetch("/api/tickets")
+  .then((r) => r.json())
+  .then((data) => {
+    tickets = data;
+    render();
+  });

--- a/examples/ticket-queue/web/index.html
+++ b/examples/ticket-queue/web/index.html
@@ -1,0 +1,47 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ticket queue</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#queue">Skip to the queue</a>
+
+    <header class="topbar">
+      <h1 id="queue-heading">Support queue</h1>
+      <p class="subtitle">Tickets waiting on the support team.</p>
+    </header>
+
+    <main class="layout">
+      <section id="queue" aria-labelledby="queue-heading">
+        <ul id="ticket-list" class="ticket-list"></ul>
+      </section>
+
+      <aside id="detail" class="detail" aria-live="polite">
+        <p class="detail-empty">Select a ticket to see the detail.</p>
+      </aside>
+    </main>
+
+    <div id="assign-modal" class="modal" hidden>
+      <div class="modal-card" role="dialog" aria-modal="true" aria-label="Assign ticket">
+        <h2>Assign ticket</h2>
+        <label for="assignee">Assign to</label>
+        <select id="assignee">
+          <option>Support rota</option>
+          <option>Billing</option>
+          <option>Platform</option>
+        </select>
+        <div class="modal-actions">
+          <button id="assign-cancel" type="button">Cancel</button>
+          <button id="assign-confirm" type="button" class="primary">Assign</button>
+        </div>
+      </div>
+    </div>
+
+    <p id="live-status" class="visually-hidden" role="status"></p>
+
+    <script src="/app.js"></script>
+  </body>
+</html>

--- a/examples/ticket-queue/web/styles.css
+++ b/examples/ticket-queue/web/styles.css
@@ -1,0 +1,269 @@
+:root {
+  --ink: #1f2430;
+  --muted: #6b7280;
+  --line: #e2e5ec;
+  --paper: #ffffff;
+  --page: #f6f7f9;
+  --accent: #eb6e14;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+}
+
+.skip-link:focus {
+  left: 8px;
+  top: 8px;
+  background: var(--paper);
+  padding: 6px 10px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.topbar {
+  padding: 20px 28px 14px;
+  border-bottom: 1px solid var(--line);
+  background: var(--paper);
+}
+
+h1 {
+  margin: 0;
+  font-size: 21px;
+  letter-spacing: -0.01em;
+}
+
+.subtitle {
+  margin: 4px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 20px;
+  padding: 20px 28px;
+  align-items: start;
+}
+
+.ticket-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.ticket {
+  width: 100%;
+  text-align: left;
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  display: grid;
+  grid-template-columns: 74px 1fr 96px;
+  gap: 12px;
+  align-items: center;
+}
+
+.ticket:hover {
+  border-color: #cdd2dc;
+}
+
+.ticket[aria-current="true"] {
+  border-color: var(--accent);
+}
+
+.ticket-id {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.ticket-title {
+  font-weight: 500;
+}
+
+.pill {
+  justify-self: end;
+  font-size: 12px;
+  padding: 2px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--page);
+  color: var(--muted);
+}
+
+.pill-open {
+  background: #eef4ff;
+  color: #2b4d8f;
+  border-color: #d4e0f7;
+}
+
+.pill-waiting {
+  background: #fdf3e6;
+  color: #8a5a12;
+  border-color: #f2e0c4;
+}
+
+.pill-escalated {
+  background: #fdecec;
+  color: #97302f;
+  border-color: #f4cfcf;
+}
+
+.detail {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 14px 16px;
+  min-height: 200px;
+}
+
+.detail-empty {
+  color: var(--muted);
+  margin: 0;
+}
+
+.detail h2 {
+  margin: 0 0 6px;
+  font-size: 16px;
+}
+
+.detail dl {
+  margin: 10px 0 0;
+  display: grid;
+  grid-template-columns: 84px 1fr;
+  gap: 4px 10px;
+  font-size: 13px;
+}
+
+.detail dt {
+  color: var(--muted);
+}
+
+.detail dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.copy-email {
+  margin-left: 6px;
+  font-size: 12px;
+  border: 1px solid var(--line);
+  background: var(--page);
+  border-radius: 5px;
+  padding: 1px 6px;
+  cursor: pointer;
+}
+
+.detail-body {
+  margin: 12px 0 0;
+  font-size: 14px;
+}
+
+details {
+  margin-top: 12px;
+  font-size: 12px;
+  color: var(--muted);
+}
+
+details pre {
+  background: var(--page);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  padding: 8px;
+  overflow-x: auto;
+}
+
+.detail-actions {
+  margin-top: 14px;
+}
+
+button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
+}
+
+.detail-actions button,
+.modal-actions button {
+  font: inherit;
+  font-size: 13px;
+  padding: 5px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  cursor: pointer;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(31, 36, 48, 0.45);
+  display: grid;
+  place-items: center;
+}
+
+.modal[hidden] {
+  display: none;
+}
+
+.modal-card {
+  background: var(--paper);
+  border-radius: 10px;
+  padding: 18px 20px;
+  width: 320px;
+  box-shadow: 0 18px 40px rgba(31, 36, 48, 0.25);
+}
+
+.modal-card h2 {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+.modal-card label {
+  display: block;
+  font-size: 13px;
+  color: var(--muted);
+  margin-bottom: 4px;
+}
+
+.modal-card select {
+  width: 100%;
+  font: inherit;
+  padding: 5px 8px;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  background: var(--paper);
+}
+
+.modal-actions {
+  margin-top: 16px;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}

--- a/ruff.toml
+++ b/ruff.toml
@@ -17,6 +17,8 @@ exclude = [
 extend-include = [
     "tests/smoke",
     "skills/*/scripts/*",  # every skill's PEP 723 executables
+    "examples/*/serve",    # the example app's PEP 723 executables
+    "examples/*/tickets",
 ]
 
 [lint]


### PR DESCRIPTION
## Why

demo-video has never been run on its own use case — there is no reference PR
anywhere showing the loop end to end ([#64](https://github.com/rogvid/skills/issues/64),
and the closing section of [#62](https://github.com/rogvid/skills/issues/62)).
Running it needs an application to record, and the repo has none:
`tests/smoke`'s fixture is a test fixture, not something a feature lands in.

This PR is step 1 of #64 — the example app at its **pre-feature** state. It is
ordinary work: no demo, no storyboard. The feature, the storyboard and the
reference review land on top of it in the next PR.

## What is here

`examples/ticket-queue/` — a support-ticket queue, deliberately boring:

- `serve` — stdlib HTTP server: static `web/`, plus `GET /api/tickets`
- `tickets` — a CLI over the same `data/tickets.json` (`list`, `show <id>`)
- `web/` — one page: queue on the left, ticket detail on the right
- seven seeded tickets, `open` or `waiting`

Both executables are PEP 723 `uv` scripts per `skills/script-conventions`, and
both actually run — `./tickets list` prints the queue, `./serve` serves the
page, and the page renders with an empty console.

## Acceptance criterion

*The repo contains one runnable application that a demo can be recorded of,
and adding it changes nothing about what `npx skills add` installs.*

Both halves checked:

- `./tickets list`, `./tickets show TQ-104` (exit 0) and `./tickets show TQ-999`
  (exit 1) behave as documented; the page loads over `./serve` and Playwright
  reports **zero console messages** on load + click.
- `examples/` holds no `SKILL.md`, so the installer's one-level-deep root walk
  does not discover it (`AGENTS.md`, "Why `wip/` stays hidden"). `skills/` is
  unchanged and non-empty.

## Fault injection

`ruff.toml` gained `examples/*/serve` and `examples/*/tickets` — extensionless
executables are invisible to ruff otherwise, so without this the new code would
have been silently unlinted while CI stayed green. That is an assertion worth
watching fail, so:

```
$ printf '\nimport os\n' >> examples/ticket-queue/serve
$ ruff check .
   |
68 |
69 | import os
   |        ^^
   |
help: Remove unused import: `os`

Found 2 errors.
```

Injection removed; `ruff check .` passes and `ruff format --check examples/`
reports `2 files already formatted` — i.e. both new executables are in scope,
not zero of them.

## Stated limits

- The app has no persistence, no auth and no write path. It is a vehicle for
  recording, and every one of those would be state a demo has to reset.
- It ships no `ensure.sh`. That is the convention for **skills**, and
  `examples/` is not one; `uv` is the only prerequisite and the README says so.
- The seed data has no `closed`/`escalated` tickets. That is deliberate — the
  next PR needs a filter value that legitimately matches nothing.