### PR TITLE
The transition in and the transition out

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -318,7 +318,7 @@ recorded a console error, an uncaught exception, or a non-zero exit — see
 | `move_to` / `click` / `click_fast` / `scroll_to` | Visible cursor motion; `click_fast` for elements that re-render continuously |
 | `type_into(selector, text)` | Click a field and type visibly, key by key — form demos (checkout, login, search) |
 | `wait_for(selector)` | Wait for something the app does on its own |
-| `spotlight(selector)` | Ring + enlarge the element the caption discusses; `spotlight()` clears |
+| `spotlight(selector)` | Ring + enlarge the element the caption discusses; `spotlight()` clears. It eases in *and out* over 250 ms, and the verb waits out its own exit, so the element is back exactly as it was found before the next beat starts (~250 ms per clear on an ordinary take, ~0 under `deterministic=True`, which flattens the transition) |
 | `terminal(cmd)` / `terminal_output(text)` / `terminal_close()` | A *decorative* on-screen terminal card for off-browser actions **inside a web demo** — a prop, not a real shell. To record an actual CLI/TUI use `TerminalRecorder` (below). |
 | `redact(*selectors)` | Blur these elements for the whole take — frames and stills. **Plain CSS selectors only.** Call it **before** the first `goto()`. See **Redacting secrets**. |
 | `register_secret(*values)` | Register literal text that must never be captioned, spoken, or logged. A caption containing it raises `SecretLeak`. **Refuses values under 8 characters** — see **Redacting secrets**. |
@@ -1256,6 +1256,34 @@ with TerminalRecorder(Path(__file__).parent) as rec:
 | `wait_for_text(pattern, timeout_s=60)` | **The universal sync.** Wait until the rendered screen (visible text + scrollback, ANSI-stripped) matches `pattern`; `^`/`$` anchor to screen lines. |
 | `rec.page` | The live Playwright page (escape hatch). `rec._write(str)` sends raw bytes to the PTY. |
 
+### Opening a terminal segment on a title card
+
+**Pass `interlude=` to the constructor — do not make `interlude()` the
+storyboard's first statement.**
+
+```python
+with TerminalRecorder(
+    out_dir, segment="part2",
+    interlude="…the same thing, on the command line.",
+    interlude_hold=2.8,          # optional; the default
+) as rec:
+    rec.caption("Same filter, one command.")
+    rec.run("orders --city Berlin")
+```
+
+The recorder starts capturing when it creates the page, which is before any
+storyboard statement can paint anything — so a card raised by the first verb
+arrives ~290 ms late and the segment opens on an empty terminal with a lone
+prompt. `interlude=` raises the card from a context init script instead,
+before the page has painted at all, and the PTY, the terminal's own setup and
+the shell's first prompt all happen behind it. The recorder also **takes it
+down** when `interlude_hold` is up, so there is no `interlude("")` to forget.
+
+It records an ordinary `interlude` beat, so `timeline.json` reads the same
+either way. `Recorder` (web) has no such argument and does not need one: its
+page is blank until `goto()`, so there is no "before" to flash — and a card
+painted before that first `goto()` would be destroyed by it.
+
 ### Driving the four patterns
 
 - **Non-interactive CLI:** `run(cmd)` → `wait_for_prompt()`.
@@ -1309,7 +1337,9 @@ with TerminalRecorder(Path(__file__).parent) as rec:
    `Recorder(out_dir, segment="part1")`, poll between segments until the
    work is done, open the next segment with `rec.interlude("…a few minutes
    later…")` on `about:blank` before navigating, and `stitch()` into
-   demo.mp4. `stitch()` also merges the segments' beat logs into one
+   demo.mp4. A **terminal** segment takes its opening card as
+   `TerminalRecorder(interlude="…")` instead — see **Opening a terminal
+   segment on a title card**. `stitch()` also merges the segments' beat logs into one
    `timeline.json` / `timeline.md`, so a segmented demo commits the same two
    files as any other — you do not have to do anything for that.
 2. **Write `record.py`** in the demo folder as a short storyboard. Capture

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -67,19 +67,28 @@ window.__demoCaption = (text) => {
 
 # Interlude: a full-screen title card for jumps over real-world time the
 # recording skips (minutes of background work between two segments).
+#
+# The card's styling is a module constant because a *second* thing builds this
+# same element: a segment that opens on a card raises it from an init script,
+# before the recorder's own setup and before the page has painted at all
+# (issue #110, and see terminal.py's `_OPENING_CARD_JS`). Both have to produce
+# an element `__demoInterlude` will then recognise and fade out, which means
+# one id and one stylesheet, in one place.
+INTERLUDE_ID = "__demo_interlude"
+INTERLUDE_CSS = (
+    "position: fixed; inset: 0; display: flex; align-items: center;"
+    " justify-content: center; background: #1c1a17; color: #f7f4ee;"
+    " font: 500 30px/1.5 system-ui, sans-serif; text-align: center;"
+    " padding: 0 12%; z-index: 2147483647; opacity: 0;"
+    " transition: opacity .45s ease; pointer-events: none;"
+)
 _INTERLUDE_JS = """
 window.__demoInterlude = (text) => {
-  let el = document.getElementById('__demo_interlude');
+  let el = document.getElementById('__ID__');
   if (!el) {
     el = document.createElement('div');
-    el.id = '__demo_interlude';
-    el.style.cssText = `
-      position: fixed; inset: 0; display: flex; align-items: center;
-      justify-content: center; background: #1c1a17; color: #f7f4ee;
-      font: 500 30px/1.5 system-ui, sans-serif; text-align: center;
-      padding: 0 12%; z-index: 2147483647; opacity: 0;
-      transition: opacity .45s ease; pointer-events: none;
-    `;
+    el.id = '__ID__';
+    el.style.cssText = '__CSS__';
     document.body.appendChild(el);
   }
   el.textContent = text;
@@ -1898,7 +1907,10 @@ class _DemoBase:
                 _CAPTION_JS.replace("__CAPFONT__", str(self._caption_font_px))
                 .replace("__CAPBOTTOM__", str(self._caption_bottom_px))
             )
-            self._context.add_init_script(_INTERLUDE_JS)
+            self._context.add_init_script(
+                _INTERLUDE_JS.replace("__ID__", INTERLUDE_ID)
+                .replace("__CSS__", INTERLUDE_CSS)
+            )
             self._context.add_init_script(_BRIDGE_JS)
             # Medium-specific init scripts (cursor, spotlight, ...).
             self._init_context(self._context)

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import codecs
 import fcntl
+import json
 import os
 import pty
 import re
@@ -35,7 +36,16 @@ from collections import deque
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
-from .core import SECRET_MASK, Secret, SecretLeak, _beat_verb, _DemoBase, _env
+from .core import (
+    INTERLUDE_CSS,
+    INTERLUDE_ID,
+    SECRET_MASK,
+    Secret,
+    SecretLeak,
+    _beat_verb,
+    _DemoBase,
+    _env,
+)
 
 _ASSETS = Path(__file__).parent.parent / "assets" / "xterm"
 
@@ -123,6 +133,69 @@ window.__demoTermInit = (opts) => {
 # Soft, low-saturation pastel gradient behind the window — present enough to
 # frame the terminal, calm enough not to pull focus.
 _TERM_BG = "linear-gradient(135deg, #f6d5f0 0%, #d7e3fb 52%, #cdeede 100%)"
+
+# -- opening on a card (issue #110) ------------------------------------------
+#
+# A terminal segment that opens with `interlude()` shows a flash of bare
+# terminal first, and the gap is structural rather than a pacing mistake:
+# `__enter__` starts Chromium's screencast when it creates the page, and a
+# storyboard cannot paint anything before its own first statement. Measured on
+# the reference demo: the segment's first frame at 37.76 s, the card at
+# 38.05 s, and an empty window with a lone prompt in between. The web recorder
+# does not show it only because it has nothing on screen until `goto()` — there
+# is no "before" to flash.
+#
+# So the card stops being something a storyboard has to remember to do first
+# and becomes a property of the recorder: `TerminalRecorder(interlude="…")`
+# paints it from an **init script**, which runs before the page's own scripts
+# on every document including Chromium's initial one. That is earlier than any
+# Python statement can reach — earlier than `pty.openpty()`, earlier than
+# xterm.js is injected — so the card is up in the recording's first frame and
+# the whole of the recorder's own setup happens behind it.
+#
+# It is also the answer to the *other* end of the same seam. #91 was this card
+# left up for the rest of a take, because a storyboard remembered
+# `interlude(text)` and not `interlude("")`. A card the recorder raises is a
+# card the recorder clears — see `_open_on_card`.
+#
+# It builds the element rather than calling `__demoInterlude`, and the whole
+# difference is one line: the card is appended **already opaque**.
+# `__demoInterlude` creates it at `opacity: 0` and raises it, which is a 450 ms
+# fade — and a card that fades in over the recorder's setup is showing exactly
+# what it exists to cover. An element whose computed opacity has been 1 since
+# it entered the tree has no transition to run, so that is structural here
+# rather than a flag somebody could turn off. Everything else about it — the
+# id, the styling — is core's, so `interlude("")` finds this element and fades
+# it out like any other.
+#
+# (What the suite can say about that last point is limited, and tests/README.md
+# says where: on this box the fade-in variant is invisible in the recording
+# too, because injecting xterm.js takes longer than 450 ms and Chromium's
+# screencast has emitted nothing by then. Being opaque by construction is what
+# keeps that from being the thing holding the fix up.)
+_OPENING_CARD_JS = """
+(() => {
+  const build = () => {
+    // `document.body` is null on Chromium's initial empty document, where init
+    // scripts first run — the same guard the background paint above needs, and
+    // for the same reason (issue #25).
+    if (!document.body || document.getElementById('__ID__')) return;
+    const el = document.createElement('div');
+    el.id = '__ID__';
+    el.style.cssText = '__CSS__';
+    el.style.opacity = '1';
+    el.textContent = __TEXT__;
+    document.body.appendChild(el);
+  };
+  if (document.body) build();
+  else addEventListener('DOMContentLoaded', build);
+})();
+"""
+
+# How long the opening card is held before it fades, when nothing says
+# otherwise. The same default `interlude()` uses, because it is the same card
+# doing the same job.
+OPENING_CARD_HOLD_S = 2.8
 
 # Named keys -> the bytes a terminal program expects. Ctrl-<letter> is
 # handled generically (C-a..C-z -> 0x01..0x1a).
@@ -613,6 +686,12 @@ class TerminalRecorder(_DemoBase):
     Geometry: the recording size (viewport) drives the xterm.js grid via the
     fit addon; the resulting cols/rows are pushed to the PTY winsize so TUIs
     render correctly. `font_size` tunes how much fits on screen.
+
+    `interlude="…"` opens the segment on a full-screen title card, raised
+    before capture starts and cleared by the recorder when `interlude_hold`
+    seconds are up. Use it instead of an `interlude()` as the storyboard's
+    first statement: the storyboard's first statement is already ~290 ms too
+    late, and the viewer sees an empty terminal before the card (issue #110).
     """
 
     def __init__(
@@ -635,6 +714,8 @@ class TerminalRecorder(_DemoBase):
         locale: str | None = None,
         evidence: bool | None = None,
         type_delay_ms: int = 45,
+        interlude: str | None = None,
+        interlude_hold: float = OPENING_CARD_HOLD_S,
     ) -> None:
         # A branded, distinctive default prompt so wait_for_prompt's marker
         # is unlikely to collide with command output.
@@ -681,6 +762,10 @@ class TerminalRecorder(_DemoBase):
         # token one character at a time goes idle between every character.
         self._last_data_at = time.monotonic()
         self._withheld_warned = False
+        # The card this segment opens on, if it opens on one. See
+        # _OPENING_CARD_JS.
+        self._opening = interlude
+        self._opening_hold = interlude_hold
 
     # -- setup / teardown ---------------------------------------------------
 
@@ -701,6 +786,19 @@ class TerminalRecorder(_DemoBase):
             " if (document.body) b(); else addEventListener('DOMContentLoaded', b); })();"
             .replace("__BG__", _TERM_BG)
         )
+        # After the background paint and before anything else: the card is
+        # opaque and covers the whole viewport, so what is behind it only has
+        # to be the right colour for the fade *out*. Registered here rather
+        # than evaluated in `_start()` because `_start()` navigates
+        # (`goto("about:blank")`), and an init script is the only thing that
+        # survives a navigation and precedes the first paint of what follows
+        # it.
+        if self._opening is not None:
+            context.add_init_script(
+                _OPENING_CARD_JS.replace("__ID__", INTERLUDE_ID)
+                .replace("__CSS__", INTERLUDE_CSS)
+                .replace("__TEXT__", json.dumps(self._opening))
+            )
 
     def _start(self) -> None:
         master, slave = pty.openpty()
@@ -744,10 +842,38 @@ class TerminalRecorder(_DemoBase):
              "fontSize": self._font_size},
         )
         self._set_winsize(int(dims["rows"]), int(dims["cols"]))
-        # Just enough to catch the shell's first prompt — keep it short so a
-        # segment that opens with a transition doesn't dwell on a bare, empty
-        # terminal before the transition covers it.
+        # Just enough to catch the shell's first prompt. It used to be kept
+        # short so a segment opening on a transition would not dwell on a bare
+        # terminal; with `interlude=` that dwell happens behind the card, and
+        # without it there is no card for the length of this to matter to.
         self._idle(0.15)
+        if self._opening is not None:
+            self._open_on_card()
+
+    def _open_on_card(self) -> None:
+        """Hold the card the init script raised, then take it down.
+
+        Everything before this ran behind it — the PTY, the xterm.js
+        injection, the shell's first prompt — which is the point: the segment
+        opens on intent rather than on an empty window (issue #110).
+
+        Taking it down is the other half of the same seam. #91 was this card
+        left up for the rest of a take because a storyboard remembered
+        `interlude(text)` and not `interlude("")`; a card the recorder raises
+        is a card the recorder clears, and there is no ordering left for a
+        storyboard to get wrong.
+
+        It records an ordinary `interlude` beat, so a merged timeline reads the
+        same whether the card came from here or from the verb.
+        """
+        text = self._opening or ""
+        self._no_secrets(text, "TerminalRecorder(interlude=…)")
+        clip = self._prepare_line(text)
+        with self._beat("interlude", selector="card", caption=text):
+            self._start_line(clip)
+            self.pause(self._opening_hold)
+            self.page.evaluate("() => window.__demoInterlude('')")
+            self.pause(0.6)
 
     def _stop(self) -> None:
         # Whatever _take_exit_markers held back as a possible half-marker was

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -162,14 +162,74 @@ window.__demoTerminalHide = () => {
 };
 """
 
+# How long the spotlight's enter and exit take. One constant, used as the
+# element's `transition` and as the shape of the timer that backs the exit up,
+# so the two cannot drift apart.
+SPOTLIGHT_TRANSITION = "all .25s ease"
+
+# Grace on top of the element's *computed* transition time before the exit
+# gives up waiting for `transitionend` and restores the style anyway. Covers a
+# compositor that delivers the event a frame or two late; too small and the
+# last sliver of the fade is cut off, too large and a property that never
+# transitioned at all stalls the verb.
+SPOTLIGHT_EXIT_SLACK_MS = 120
+
 # Spotlight: a highlight ring + slight scale on one element, pointing the
 # viewer at the evidence a caption is talking about (reason lines, chips).
+#
+# **The exit is animated by the same transition the entrance used**, and the
+# order below is the whole of issue #111. Restoring `__spotPrev` in one
+# `setAttribute` is what guarantees the element is handed back exactly as it
+# was found — including an inline style the app itself set — but it also
+# removes `transition` in the *same frame* as it removes `transform` and
+# `outline`, so there is nothing left to animate the exit with. The spotlight
+# eased in over 250 ms and snapped out in one frame, and the asymmetry is what
+# read as broken.
+#
+# So the spotlight's own properties are reverted individually, while the
+# transition is still on the element, and the wholesale restore waits for
+# `transitionend`. Two details that are not decoration:
+#
+#   * `transitionend` does not fire when nothing actually changed, so a timer
+#     backs it up. Its length comes from the element's own *computed*
+#     transition time rather than from a constant, which is what keeps
+#     `deterministic=True` cheap: the motion rule flattens transitions to 1 ms
+#     with `!important`, so a deterministic take's exit is over in a
+#     millisecond and the fallback never runs. A hardcoded 400 ms would have
+#     charged every deterministic take — `tests/smoke` included — nearly half a
+#     second per clear for a transition that had already finished.
+#   * the ring fades by animating its *colour* to alpha 0 rather than by
+#     clearing the `outline` shorthand. `outline-style` is not an animatable
+#     property, so clearing it makes the ring vanish in one frame while the
+#     scale eases — half a snap, which is the bug wearing a smaller hat.
+#     `background` and `transform` are cleared outright, because removing an
+#     inline declaration transitions to the value underneath it and that value
+#     is the one the element is supposed to return to.
 _SPOTLIGHT_JS = """
-window.__demoSpotlight = (el) => {
-  window.__demoSpotlightClear();
+window.__demoSpotlightMs = (el) => {
+  // What the browser says this element's transition costs, not what this file
+  // asked for. The determinism rule overrides it with `!important`.
+  let cs;
+  try { cs = getComputedStyle(el); } catch (e) { return 0; }
+  const worst = (value) => (value || '').split(',').reduce((max, part) => {
+    const text = part.trim();
+    const n = parseFloat(text);
+    if (!isFinite(n)) return max;
+    return Math.max(max, /ms$/.test(text) ? n : n * 1000);
+  }, 0);
+  return worst(cs.transitionDuration) + worst(cs.transitionDelay);
+};
+window.__demoSpotlight = async (el) => {
+  // Awaited: a second spotlight on the *same* element would otherwise read
+  // `__spotPrev` off a style attribute the pending exit has not finished
+  // reverting, and then the exit's restore would wipe the new highlight.
+  await window.__demoSpotlightClear();
   window.__spotEl = el;
-  window.__spotPrev = el.getAttribute('style') || '';
-  el.style.transition = 'all .25s ease';
+  // `getAttribute`, not `getAttribute(...) || ''` — an element that had no
+  // style attribute at all must get none back, or "returned exactly as found"
+  // is one `style=""` short of true.
+  window.__spotPrev = el.getAttribute('style');
+  el.style.transition = '__TRANSITION__';
   el.style.outline = '3px solid rgba(__ACCENT__,.85)';
   el.style.outlineOffset = '3px';
   el.style.borderRadius = '6px';
@@ -177,10 +237,36 @@ window.__demoSpotlight = (el) => {
   el.style.transform = 'scale(1.02)';
 };
 window.__demoSpotlightClear = () => {
-  if (window.__spotEl) {
-    window.__spotEl.setAttribute('style', window.__spotPrev);
-    window.__spotEl = null;
-  }
+  const el = window.__spotEl;
+  if (!el) return Promise.resolve(false);
+  const prev = window.__spotPrev;
+  window.__spotEl = null;
+  window.__spotPrev = null;
+  el.style.outlineColor = 'rgba(__ACCENT__,0)';
+  el.style.background = '';
+  el.style.transform = '';
+  const restore = () => {
+    if (prev === null || prev === undefined) el.removeAttribute('style');
+    else el.setAttribute('style', prev);
+  };
+  const ms = window.__demoSpotlightMs(el);
+  if (!(ms > 0)) { restore(); return Promise.resolve(true); }
+  return new Promise((resolve) => {
+    let done = false;
+    // Hoisted, so `finish` can unsubscribe it.
+    function onEnd(event) { if (event.target === el) finish(); }
+    const finish = () => {
+      if (done) return;
+      done = true;
+      el.removeEventListener('transitionend', onEnd);
+      restore();
+      resolve(true);
+    };
+    // This element's own transition only. A descendant's bubbles up here too,
+    // and one that finishes early would restore the style mid-fade.
+    el.addEventListener('transitionend', onEnd);
+    setTimeout(finish, ms + __SLACK_MS__);
+  });
 };
 """
 
@@ -1039,7 +1125,11 @@ class Recorder(_DemoBase):
             _TERMINAL_JS.replace("__TERM_TITLE__", self._terminal_title)
             .replace("__TERM_PROMPT__", self._terminal_prompt)
         )
-        context.add_init_script(_SPOTLIGHT_JS.replace("__ACCENT__", self._accent))
+        context.add_init_script(
+            _SPOTLIGHT_JS.replace("__ACCENT__", self._accent)
+            .replace("__TRANSITION__", SPOTLIGHT_TRANSITION)
+            .replace("__SLACK_MS__", str(SPOTLIGHT_EXIT_SLACK_MS))
+        )
 
     def _start(self) -> None:
         # Any navigation raises the paint gate, and only a checkpoint lowers
@@ -1706,8 +1796,33 @@ class Recorder(_DemoBase):
     @_beat_verb("spotlight")
     def spotlight(self, selector: str | None = None) -> None:
         """Highlight one element while the caption talks about it;
-        spotlight() with no argument clears it."""
+        spotlight() with no argument clears it.
+
+        **The verb waits out the exit transition.** Clearing a spotlight now
+        animates (issue #111), and a verb that returned mid-fade would hand the
+        next beat a half-restored element: this beat's evidence records the
+        spotlight target's `outerHTML` *including its style attribute*, and
+        `redact()`'s observer re-asserts the mask off the same attribute. Both
+        would then read a value that depends on when the compositor happened to
+        fire, which is not a thing a storyboard can be written against. So when
+        this returns, the previous element's inline style is byte-identical to
+        what the spotlight found.
+
+        What it costs is bounded and self-calibrating rather than a flat
+        charge: the wait is the element's *computed* transition time, so a
+        clear takes ~250 ms longer than it used to on an ordinary take and ~1 ms
+        longer under `deterministic=True`, where the motion rule flattens
+        transitions. Measured end to end, including the verb's own `pause(0.3)`:
+        0.55 s against 0.31 s before, and 0.33 s deterministic. A storyboard
+        that moves a highlight from one element to the next pays it once — the
+        old element's exit runs, then the new one's entrance — and what it buys
+        is that the two are never on screen half-lit at the same time.
+        """
         self._checkpoint()
+        # `evaluate` resolves the promise the clear returns, so this line does
+        # not come back until the exit transition has run to its end and the
+        # style attribute has been put back. That is the whole of the paragraph
+        # above, and it is one word: `evaluate`.
         self.page.evaluate("() => window.__demoSpotlightClear()")
         if selector:
             self.page.locator(selector).first.evaluate(

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,6 +37,7 @@ tests/smoke --redaction-only      # just the secret-redaction takes
 tests/smoke --segments-only       # just the two-segment take and its stitch
 tests/smoke --evidence-only       # just the per-beat evidence takes
 tests/smoke --failure-only        # just the takes that do not finish
+tests/smoke --polish-only         # just the two takes that grade how it looks
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -1346,6 +1347,94 @@ two, and reverting the elasticity puts that string back in the log.
 
 `tests/smoke --evidence-only` records just the evidence take and the refusal
 take, which is what makes an injection loop over this axis affordable.
+
+### How the recording looks — the spotlight's exit, and the card a terminal segment opens on
+
+Two takes, and the only two in this file that grade defects **a human found by
+watching**. Everything else here grades something a viewer cannot see; these
+grade the picture, from the viewer's side, out of nothing but pixels.
+
+`spotlight/` records with the recorder's **default**, `deterministic=False`,
+which no other take does. That is not a preference: the determinism rule
+flattens every CSS transition to 1 ms with `!important`, so under it the
+spotlight's enter and its exit both snap, both are correct, and an assertion
+about easing cannot fail for the reason it claims. Injecting `deterministic=True`
+into the take is one of the arms below, and it fires the control.
+
+**A transition is measured as the states it passes through.** Around each
+spotlight beat, every frame of the element's crop is scored by how far it is
+from the settled frame at the end of the window, as a fraction of how far the
+frame at the start of it is; a frame between 12% and 88% is one the transition
+was part way through. A snap produces none — not "few": there is no
+intermediate state for a frame to be in. The first version of this counted
+frames that *changed*, which is not the same claim and is not safe: a hard cut
+in H.264 rings for a frame or two afterwards, so a snap also produces three
+consecutive frames that differ from each other, and the bar had to sit
+uncomfortably close to them.
+
+|  | enter | exit |
+|---|---|---|
+| eased, four takes | 3-4 | 3-4 |
+| the pre-#111 clear, injected | 3-4 | **0** |
+| recorded with `deterministic=True` | **0** | **0** |
+
+The **enter is a control, not the thing under test**: it eased before the change
+and eases after it, so it reads 3-4 in every arm where the recorder is
+non-deterministic. A run where the exit is the only empty one is a reading about
+the exit; a run where both are empty is a reading about the take's settings, and
+says so in its own message.
+
+Two things pixels cannot say are asserted in the storyboard instead. The
+element's inline `style` must be **identical before and after** — attribute
+present or absent, and its value — which is #111's other half and is invisible
+in every frame. And `spotlight()`'s clear must **take at least 0.45 s**, which
+pins the decision that the verb waits out its own exit. That second one exists
+because injecting a clear that resolves early *passed* a version of this take
+that only compared the style: the verb ends in a 300 ms pause, so a style read
+after it is 300 ms too late to see a restore that was still pending. A lower
+bound on a wait is also the one timing bar contention cannot turn red.
+
+`terminal-opening/` records a segment opened with
+`TerminalRecorder(interlude=…)` and reads **one corner of the frame**, outside
+the terminal window, at 20 fps for the whole take:
+
+| | mean luma |
+|---|---|
+| the card (`#1c1a17`, full bleed) | 26 |
+| bare terminal (the recorder's pastel gradient) | 226 |
+
+Neither number is a threshold anybody tuned — they are two constants in the
+recorder's own styling, an order of magnitude apart, and the corner is read off
+the live `#__term_win` box rather than hardcoded. Three statements, each broken
+by a different mistake: the recording's **first** frame is card; the card
+covers at least the first second (it is held 2.5); and the corner **does** end
+up bare, which is the control — without it, the first two are equally true of a
+recorder that painted a black rectangle and stopped, and that is exactly
+[#91](https://github.com/rogvid/skills/issues/91).
+
+Nine injections, each one exact string in one file, with a driver that refuses
+to run unless the pattern matched exactly once:
+
+| injected | what fires |
+|---|---|
+| the pre-#111 clear (restore the whole style attribute in one assignment) | exit passes through 0 intermediate frames |
+| the individual reverts kept, but the attribute restored in the same frame | exit passes through 0 |
+| record the take with `deterministic=True` | the enter control reads 0, and says which of the two causes it is |
+| the enter's `transform` removed | "the highlight never went on, so the exit measurement is about nothing" |
+| the clear leaves `style=""` on an element that had no attribute | the before/after style comparison |
+| the clear's promise resolves before the transition ends | the 0.45 s bar |
+| the card raised 400 ms into the document instead of at document start | first frame is bare, and the prefix is 0.00 s |
+| the card built at `opacity: 0` like `interlude()` builds it | the same two, plus the content floor |
+| the card never cleared | "the corner never reaches 150 mean luma — the card is never taken down" |
+
+**What this does not catch**, and is a stated limit rather than an oversight: a
+card that *fades in* over 450 ms rather than being painted opaque is invisible
+here. Measured — a faded-in card and a painted one produce byte-identical
+corner readings for the first 14 frames, because the recorder spends longer
+than the fade injecting xterm.js before Chromium's screencast emits anything.
+The recorder has no fade-in path (the element is appended already opaque, so no
+transition can run), but the suite is relying on setup cost for that and would
+not notice if it changed.
 
 ### Failure artifacts — what a take that did *not* finish leaves behind
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -45,11 +45,19 @@ and grades each take on separate axes:
 Playwright 1.49 or newer: evidence uses `locator.aria_snapshot()`, and the
 `page.accessibility` API that predates it has since been removed.
 
+7. **Polish** — how the recording *looks*: the spotlight leaves an element the
+   way it arrived, and a terminal segment opens on its title card rather than
+   on a bare prompt. The only axis here graded on defects a human found by
+   watching rather than a test found by measuring (issues #110 and #111), and
+   the only one whose take records with `deterministic=False`, because the
+   determinism rule flattens the transition it is about.
+
     tests/smoke                 # every take
     tests/smoke --web-only
     tests/smoke --terminal-only
     tests/smoke --determinism-only
     tests/smoke --redaction-only
+    tests/smoke --polish-only
     tests/smoke --out-dir /tmp/smoke
 
 Narration is forced off (`speech=False`) for the web and terminal takes: CI has
@@ -121,7 +129,18 @@ MIN_PNG_BYTES = 5_000
 # therefore checked separately via getComputedStyle rather than by pixels.
 # "segments" is the web recorder against the same fixture, composited the same
 # way, so it takes the web numbers here and in the two dicts below.
-MIN_CONTENT_STDDEV = {"web": 6.0, "terminal": 2.0, "segments": 6.0}
+MIN_CONTENT_STDDEV = {
+    "web": 6.0,
+    "terminal": 2.0,
+    "segments": 6.0,
+    # The two takes that grade how a recording *looks* (issues #110/#111) are
+    # the same two media against the same fixture, so they take the same
+    # numbers. They are here only as a floor under the frame-shape assertions
+    # that follow: neither of those can tell a black take from a working one,
+    # because "nothing changed" is what a black take also reports.
+    "spotlight": 6.0,
+    "terminal-opening": 2.0,
+}
 
 # Pixel proof that the caption bar reached the screen, as the mean absolute
 # luma change in the caption band between two stills taken back to back — one
@@ -805,6 +824,163 @@ MAX_MERGE_OFFSET_ERROR_S = 0.1
 # by the boundary, and neither is satisfied by a constant shift of any
 # segment's beats — which is what this bar, at any width, cannot say.
 MAX_CROSS_SEGMENT_DRIFT_S = MAX_CAPTURE_LOSS_S
+
+# -- how the recording looks (issues #110 and #111) ---------------------------
+#
+# Two defects a human found by watching the reference demo, which is a first
+# for this project: everything else in this file grades something a viewer
+# cannot see. Both are therefore graded on *frames*, from the viewer's side —
+# what the picture does — and not on any property the recorder could report
+# about itself.
+#
+# ## The spotlight's exit (issue #111)
+#
+# `spotlight()` eased in over 250 ms and snapped out in one frame, because the
+# clear restored the element's whole `style` attribute in one assignment and
+# that removed `transition` in the same frame as `transform`. The asymmetry is
+# what read as wrong.
+#
+# **A transition is measured as the states it passes through**, which is the
+# one thing a snap cannot fake. Around each spotlight beat, every frame is
+# scored by how far it is from the *settled* frame at the end of the window, as
+# a fraction of how far the frame at the start of the window is. A transition
+# that eases spends several frames part of the way; one that snaps is either
+# fully one state or fully the other and spends none.
+#
+# It is deliberately not a count of frames that "changed", which was the first
+# version of this and is not the same claim. A hard cut in H.264 rings for a
+# frame or two afterwards, so a snap also produces two or three consecutive
+# frames that differ from each other — while producing no frame that is
+# *partly* one state and partly the other. Measured on this fixture, intermediate
+# frames per window (see the fault injections in tests/README.md):
+#
+#                                       enter   exit
+#   eased (this recorder), 4 takes       3-4     3-4
+#   the pre-#111 clear, injected         3-4      0
+#   recorded with deterministic=True       0      0
+#
+# The enter is the control and is deliberately *not* the thing under test: it
+# eased before this change and eases after it, so it reads 4 either way. A run
+# where the exit is the only empty one is a reading about the exit; a run where
+# both are empty is a reading about the measurement, and says so in its own
+# message.
+#
+# **This take records with `deterministic=False`, and it has to.** The
+# determinism rule flattens every transition to 1 ms with `!important`, so
+# under it both directions snap and both are correct — an assertion in a
+# deterministic take cannot fail for this reason and would be grading nothing.
+# It is the one take in this file that needs the recorder's default.
+SPOTLIGHT_TARGET = "#kpi-rev"
+
+# Grown around the element before the rect is mapped into the video, in page
+# pixels: the ring sits 3 px outside it at a 3 px offset and the scale pushes
+# another ~1%, so a crop of the element's own box would miss most of what the
+# spotlight actually changes.
+SPOTLIGHT_PAD_PX = 14
+
+# What counts as "part of the way", as a fraction of the window's total change.
+# Both ends are generous: a frame within 12% of either settled state is called
+# settled, so encoder ringing after a hard cut — measured at 7% — cannot be
+# read as an eased frame, and neither can the last frame of a real transition.
+SPOTLIGHT_MID_BAND = (0.12, 0.88)
+
+# How many intermediate frames a transition must pass through. A 250 ms ease at
+# 25 fps puts 3-4 frames inside the band; a snap puts none there, because there
+# is no intermediate state for a frame to be in. The bar is between them and
+# the broken reading is a hard zero rather than a small number.
+MIN_SPOTLIGHT_MID_FRAMES = 2
+
+# How much the window's two ends must differ before anything is concluded from
+# the frames between them. The spotlight moves this crop by ~21 mean luma; a
+# window whose ends agree is one where the highlight never went on or never
+# came off, and every "intermediate" fraction computed against it is noise
+# divided by noise.
+SPOTLIGHT_MIN_TOTAL = 5.0
+
+# The window each spotlight beat is measured over, as (before, after) its
+# `t_start`. Wide on both sides on purpose. Before: the screencast can lose
+# wall time, so a beat's frames can sit slightly *earlier* in the video than
+# the log says (issue #18, measured at ~0.1 s with the ticker running). After:
+# a clear that has nothing to animate falls through to its timeout instead of
+# `transitionend`, and lands ~370 ms late — which is a broken take, and the
+# window has to be wide enough to catch it rather than miss it and report the
+# right answer for the wrong reason.
+SPOTLIGHT_WINDOW_S = (0.5, 1.0)
+
+# The storyboard's own pacing. Long enough that the two spotlight windows above
+# cannot overlap, and that each has quiet either side of it.
+SPOTLIGHT_HOLD_S = 1.5
+SPOTLIGHT_DURATION_S = (5.0, 30.0)
+
+# **The clearing verb waits out its own exit transition**, and this is where
+# that decision is pinned. Not a restatement of the frame assertions above: a
+# recorder that animates the exit but returns from `spotlight()` in the middle
+# of it satisfies every one of them — measured, by injecting exactly that, and
+# it passed a version of this take that only compared the element's inline
+# style before and after. It passed because the verb ends in a 300 ms pause, so
+# a style read *after* the verb is 300 ms too late to see a restore that was
+# still pending when it returned.
+#
+#   the verb waits          0.55 s   (250 ms transition + the verb's 300 ms)
+#   the verb returns early  0.31 s   (the 300 ms pause and nothing else)
+#
+# A lower bound on a wait is the one kind of timing bar a loaded machine cannot
+# turn red: contention only ever makes this larger. It is *also* below what a
+# deterministic take would read (0.33 s), which is deliberate — the enter
+# control above fires on that too, and two assertions naming the same cause
+# from different sides is how a determinism flip stays impossible to miss.
+MIN_SPOTLIGHT_CLEAR_S = 0.45
+
+# ## The card a terminal segment opens on (issue #110)
+#
+# `TerminalRecorder.__enter__` starts capturing before a storyboard can paint
+# anything, so a segment whose first statement was `interlude()` opened on
+# ~290 ms of empty terminal — measured on the reference demo, part2 starting at
+# 37.76 s and the card painting at 38.05 s. `TerminalRecorder(interlude="…")`
+# raises the card from an init script instead, before the page has a frame.
+#
+# Graded on frames, because the acceptance criterion is about frames: *no
+# bare-terminal frames before the card*. A timestamp comparison is a proxy for
+# that and would still pass on a card that was painted on time and drawn
+# transparent.
+#
+# The discriminator is one corner of the frame, outside the terminal window:
+#
+#   the card         a full-bleed #1c1a17 rectangle          luma ~26
+#   bare terminal    the recorder's pastel gradient          luma ~225
+#
+# An order of magnitude apart, and neither number is a threshold anybody tuned
+# — they are two constants in the recorder's own styling. The corner is read
+# off the live `#__term_win` box rather than hardcoded, so a change to the
+# window chrome carries it.
+OPENING_CARD = "…and the same thing, on the command line."
+
+# Held long enough that the dark prefix below has 2.5x of margin over its bar,
+# and short enough that this take stays a few seconds.
+OPENING_HOLD_S = 2.5
+
+# 20 fps is plenty for a card that is up for seconds, and keeps the sweep to a
+# few hundred frames.
+OPENING_SAMPLE_FPS = 20
+
+# What counts as the card, and what counts as the gradient behind it. The gap
+# between them is deliberately enormous and deliberately empty: a frame that
+# lands between the two is the card mid-fade, and the assertions below refuse
+# to call that either one.
+OPENING_CARD_MAX_LUMA = 60.0
+OPENING_BARE_MIN_LUMA = 150.0
+
+# How much of the video must be card before anything else. The card is held for
+# OPENING_HOLD_S, so a healthy take reads ~2.5 s here; the bar is at 1.0 s,
+# which leaves room for a screencast that stalls (issue #18) without leaving
+# room for a card that arrives after the terminal does.
+MIN_OPENING_CARD_S = 1.0
+
+# Frames the corner sweep must produce before anything is concluded from it. A
+# sweep of three frames would satisfy every assertion below by accident.
+MIN_OPENING_FRAMES = 40
+
+OPENING_DURATION_S = (5.0, 30.0)
 
 # -- per-beat evidence (issue #9) ---------------------------------------------
 #
@@ -2707,6 +2883,169 @@ def record_segments(
         rec.caption("")
 
     return b.problems, video_rect, still_rect, size
+
+
+def record_spotlight(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
+    """A spotlight put up and taken down again, with quiet either side.
+
+    Recorded with the recorder's **default** (`deterministic=False`), which no
+    other take in this file does on purpose. The determinism rule flattens
+    every CSS transition to 1 ms, so under it the spotlight's enter and its
+    exit both snap — correctly and consistently — and an assertion about
+    easing has nothing to say. Issue #111 is only visible in a take that
+    records real motion.
+    """
+    from demo_recording import Recorder
+
+    b = Beats("spotlight")
+
+    with Recorder(
+        out_dir, base_url=base_url, speech=False, strict=True, deterministic=False
+    ) as rec:
+        rec.goto("/")
+        rec.wait_for(SPOTLIGHT_TARGET)
+        # The ticker, but not start_ticker(): that helper also asserts the
+        # determinism CSS is in force, and this take deliberately records
+        # without it. What the ticker is for here is only that the screencast
+        # keeps emitting frames through the quiet stretches, so the windows
+        # below sit where the beat log says they do.
+        rec.page.evaluate(TICKER_JS)
+        b.fail_if(
+            not rec.page.evaluate("() => !!document.getElementById('__smoke_ticker')"),
+            "the compositor ticker did not attach — the windows this take "
+            "measures its two transitions in are not trustworthy",
+        )
+        # Nothing else may move in the element's rect, or a frame that differs
+        # from the one before it stops meaning "the spotlight is moving".
+        rec.pause(SPOTLIGHT_HOLD_S)
+
+        style_before = rec.page.locator(SPOTLIGHT_TARGET).first.evaluate(
+            "el => [el.hasAttribute('style'), el.getAttribute('style')]"
+        )
+        rec.spotlight(SPOTLIGHT_TARGET)
+        lit = rec.page.locator(SPOTLIGHT_TARGET).first.evaluate(
+            "el => getComputedStyle(el).transform"
+        )
+        # Cheap, and it separates "the exit did not animate" from "the
+        # spotlight never went on in the first place", which look identical in
+        # a frame sweep that finds nothing.
+        b.fail_if(
+            lit in ("none", "", None),
+            f"spotlight({SPOTLIGHT_TARGET!r}) left the element's computed "
+            f"transform at {lit!r} — the highlight never went on, so the exit "
+            f"measurement below is about nothing",
+        )
+        rec.pause(SPOTLIGHT_HOLD_S)
+
+        clearing = time.monotonic()
+        rec.spotlight()
+        cleared_in = time.monotonic() - clearing
+        # #111's second half, and the one no pixel can see: the element is
+        # handed back exactly as it was found, byte for byte, including having
+        # no style attribute at all when it started with none.
+        style_after = rec.page.locator(SPOTLIGHT_TARGET).first.evaluate(
+            "el => [el.hasAttribute('style'), el.getAttribute('style')]"
+        )
+        b.fail_if(
+            style_after != style_before,
+            f"after spotlight() cleared, {SPOTLIGHT_TARGET}'s inline style is "
+            f"(has_attr, value) {style_after!r}, but it was {style_before!r} "
+            f"before the spotlight — the element was not returned as it was "
+            f"found. If only the flag differs, the clear is leaving an empty "
+            f"style attribute behind; if the value differs too, it is leaving "
+            f"the spotlight's own properties on the element.",
+        )
+        # ...and the decision that goes with it: the verb waits. See
+        # MIN_SPOTLIGHT_CLEAR_S for why the assertion above cannot say this.
+        b.fail_if(
+            cleared_in < MIN_SPOTLIGHT_CLEAR_S,
+            f"spotlight() cleared and returned in {cleared_in:.2f}s, under the "
+            f"{MIN_SPOTLIGHT_CLEAR_S}s bar — it did not wait out its own exit "
+            f"transition, so the next beat starts mid-fade and this beat's "
+            f"evidence records a style attribute that depends on when the "
+            f"compositor happened to fire. (A take that recorded with "
+            f"deterministic=True reads about this too; the enter control in "
+            f"check_spotlight_transitions says which of the two it is.)",
+        )
+        rec.pause(SPOTLIGHT_HOLD_S)
+
+        box = rec.page.locator(SPOTLIGHT_TARGET).first.bounding_box()
+        if box is None:
+            raise SmokeFailure(
+                f"{SPOTLIGHT_TARGET} has no box — tests/fixture/index.html "
+                f"changed and this take is aimed at nothing"
+            )
+        pad = SPOTLIGHT_PAD_PX
+        page_rect: Rect = (
+            int(box["x"]) - pad,
+            int(box["y"]) - pad,
+            int(box["width"]) + 2 * pad,
+            int(box["height"]) + 2 * pad,
+        )
+        geom = dict(rec._geom)
+        size = (rec._size["width"], rec._size["height"])
+
+    return b.problems, {
+        "rect": to_video_rect(page_rect, geom, size),
+        "app": (geom["appx"], geom["appy"], geom["appw"], geom["apph"]),
+        "size": size,
+    }
+
+
+def record_terminal_opening(out_dir: Path) -> tuple[list[str], dict]:
+    """A terminal segment opened with `TerminalRecorder(interlude=…)`.
+
+    Deliberately the shape issue #110 measured on the reference demo: a
+    terminal segment whose first thing on screen is a title card. The
+    storyboard says nothing about the card — that is the whole point of the
+    constructor argument — so everything the assertions read comes from the
+    recorder's own behaviour.
+    """
+    from demo_recording import TerminalRecorder
+
+    b = Beats("terminal-opening")
+
+    with TerminalRecorder(
+        out_dir,
+        speech=False,
+        strict=True,
+        deterministic=True,
+        interlude=OPENING_CARD,
+        interlude_hold=OPENING_HOLD_S,
+    ) as rec:
+        start_ticker(b, rec.page)
+        rec.caption("The card came up before the terminal did.")
+        rec.run("echo opened on a card")
+        try:
+            rec.wait_for_prompt(timeout_s=15)
+        except RuntimeError as exc:
+            b.fail_if(True, f"the shell prompt never came back — {exc}")
+        rec.pause(0.6)
+        rec.caption("")
+
+        win = rec.page.locator("#__term_win").bounding_box()
+        host = rec.page.locator("#__term_host").bounding_box()
+        if win is None or host is None:
+            raise SmokeFailure(
+                "#__term_win/#__term_host has no box — the terminal window "
+                "never rendered, so there is no margin to read the card out of"
+            )
+        app: Rect = (
+            int(host["x"]),
+            int(host["y"]),
+            int(host["width"]),
+            int(host["height"]),
+        )
+        size = (rec._size["width"], rec._size["height"])
+
+    # The strip of background to the right of the terminal window. Outside the
+    # window on purpose — inside it the card and the terminal are both dark and
+    # the two are told apart by their text, which is not a robust thing to
+    # measure. Also the opposite corner from TICKER_JS's 8x8 element, so the
+    # ticker cannot contribute a single level to this.
+    right = int(win["x"] + win["width"])
+    corner: Rect = (right + 8, 0, max(8, size[0] - right - 16), 50)
+    return b.problems, {"corner": corner, "app": app, "size": size}
 
 
 class EntropyTake(NamedTuple):
@@ -4797,6 +5136,241 @@ def check_healthy(label: str, out_dir: Path) -> list[str]:
     return failures
 
 
+def video_fps(mp4: Path) -> float:
+    """The recording's own frame rate, from the container.
+
+    Read rather than assumed, and the frames below are decoded at the source's
+    rate rather than through an `fps=` filter. A resample onto a grid that does
+    not share the video's phase duplicates frames, and a duplicated frame is
+    indistinguishable from a frame in which nothing moved — which is exactly
+    the thing being measured. Sampling this measurement's own artefact was
+    worth two readings of the same healthy take that differed by half.
+    """
+    out = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=r_frame_rate",
+            "-of",
+            "csv=p=0",
+            str(mp4),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+    num, _, den = out.partition("/")
+    rate = float(num) / float(den or 1)
+    if not 1.0 <= rate <= 240.0:
+        raise SmokeFailure(f"{mp4} reports an implausible frame rate {out!r}")
+    return rate
+
+
+def _transition_shape(frames: list[bytes], fps: float, t_start: float) -> dict:
+    """How far through a transition each frame of one spotlight window is.
+
+    Nothing here is imported from the recorder. It is a picture, two settled
+    states either side of it, and the question of whether anything was ever
+    part way between them.
+    """
+    before, after = SPOTLIGHT_WINDOW_S
+    lo = max(0, int((t_start - before) * fps))
+    hi = min(len(frames), int((t_start + after) * fps) + 1)
+    window = frames[lo:hi]
+    if len(window) < 2:
+        return {"frames": len(window), "total": 0.0, "mid": []}
+    settled = window[-1]
+    total = frame_difference(window[0], settled)
+    low, high = SPOTLIGHT_MID_BAND
+    mid = []
+    if total > 0:
+        for frame in window:
+            share = frame_difference(frame, settled) / total
+            if low < share < high:
+                mid.append(round(share, 3))
+    return {"frames": len(window), "total": total, "mid": mid}
+
+
+def check_spotlight_transitions(out_dir: Path, info: dict) -> list[str]:
+    """The spotlight leaves the way it arrived (issue #111).
+
+    Both spotlight beats are measured the same way, and the enter is the
+    control: it eased before this change and eases after it, so a reading where
+    only the exit passes through nothing is a reading about the exit.
+    """
+    failures: list[str] = []
+    mp4 = out_dir / "demo.mp4"
+    doc = json.loads((out_dir / "timeline.json").read_text())
+    beats = [b for b in doc.get("beats", []) if b.get("verb") == "spotlight"]
+    if len(beats) != 2:
+        return [
+            f"spotlight: the take logged {len(beats)} spotlight beat(s), "
+            f"expected 2 (one to put the highlight up, one to take it down) — "
+            f"there is nothing to measure"
+        ]
+    enter, clear = beats
+    if enter.get("selector") != SPOTLIGHT_TARGET or clear.get("selector") is not None:
+        failures.append(
+            f"spotlight: the two spotlight beats target "
+            f"{enter.get('selector')!r} and {clear.get('selector')!r}, expected "
+            f"{SPOTLIGHT_TARGET!r} and None — they are not the enter and the "
+            f"exit, so the reading below is mislabelled"
+        )
+    fps = video_fps(mp4)
+    # One decode of the whole recording, sliced by frame index afterwards. Two
+    # seeks into the same file would each carry their own rounding, and the two
+    # windows would then be measured on grids that do not agree.
+    frames = gray_frames(mp4, rect=info["rect"])
+    readings: dict[str, dict] = {}
+    for name, beat in (("enter", enter), ("exit", clear)):
+        t_start = beat.get("t_start")
+        if not isinstance(t_start, (int, float)):
+            failures.append(
+                f"spotlight: the {name} beat has t_start {t_start!r}, so its "
+                f"window cannot be placed in the video"
+            )
+            continue
+        readings[name] = _transition_shape(frames, fps, float(t_start))
+    span = sum(SPOTLIGHT_WINDOW_S)
+    for name, shape in readings.items():
+        # Two ways the reading below can be about nothing, each with its own
+        # message: too few frames in the window, or two ends that agree.
+        want = int(span * fps * 0.6)
+        if shape["frames"] < want:
+            failures.append(
+                f"spotlight: the {name} window holds {shape['frames']} of the "
+                f"video's {len(frames)} frames, expected at least {want} at "
+                f"{fps:.0f} fps — the recording is short of the window, so what "
+                f"is measured in it is not the transition"
+            )
+        if shape["total"] < SPOTLIGHT_MIN_TOTAL:
+            failures.append(
+                f"spotlight: the {name} window's two ends differ by only "
+                f"{shape['total']:.2f} mean luma over {info['rect']}, under the "
+                f"{SPOTLIGHT_MIN_TOTAL} floor — the highlight did not go on or "
+                f"did not come off in this window at all, and every fraction "
+                f"computed against it is noise over noise"
+            )
+    if "enter" in readings and len(readings["enter"]["mid"]) < MIN_SPOTLIGHT_MID_FRAMES:
+        failures.append(
+            f"spotlight: the *enter* transition passed through "
+            f"{len(readings['enter']['mid'])} intermediate frame(s) "
+            f"{readings['enter']['mid']}, under the "
+            f"{MIN_SPOTLIGHT_MID_FRAMES} bar. This is the control, not the "
+            f"thing under test: either the spotlight is not being drawn, or "
+            f"this take lost its `deterministic=False` and the motion rule "
+            f"flattened the transition to 1 ms. Until it passes, the exit "
+            f"reading below proves nothing."
+        )
+    if "exit" in readings:
+        mid = readings["exit"]["mid"]
+        if len(mid) < MIN_SPOTLIGHT_MID_FRAMES:
+            failures.append(
+                f"spotlight: clearing the spotlight passed through {len(mid)} "
+                f"intermediate frame(s) {mid}, under the "
+                f"{MIN_SPOTLIGHT_MID_FRAMES} bar, while the enter passed "
+                f"through {len(readings.get('enter', {}).get('mid', []))}. The "
+                f"highlight snaps out instead of easing out (issue #111) — the "
+                f"clear is removing `transition` in the same frame as the "
+                f"properties it is meant to animate, so the element is either "
+                f"fully highlighted or fully normal and never in between."
+            )
+    if not failures:
+        print(
+            f"smoke: spotlight eases both ways (enter "
+            f"{len(readings['enter']['mid'])} intermediate frames, exit "
+            f"{len(readings['exit']['mid'])})"
+        )
+    return failures
+
+
+def check_opening_card(out_dir: Path, info: dict) -> list[str]:
+    """A terminal segment opens on its card, not on a bare terminal (#110).
+
+    Three statements about one sweep of one corner of the frame, and each is
+    broken by a different mistake:
+
+      * the *first* frame is the card — a card raised at the storyboard's first
+        statement, or faded in rather than painted, fails here;
+      * every frame up to the first bare-terminal one is card, and there is at
+        least MIN_OPENING_CARD_S of them — a card that arrives after the
+        terminal does fails here;
+      * the corner does end up bare — a card that is never taken down (#91's
+        half of this seam) fails here, and without it the first two are equally
+        true of a recorder that painted a black rectangle and stopped.
+    """
+    failures: list[str] = []
+    mp4 = out_dir / "demo.mp4"
+    corner = info["corner"]
+    frames = gray_frames(mp4, rect=corner, sample_fps=OPENING_SAMPLE_FPS)
+    luma = [sum(f) / len(f) for f in frames]
+    if len(luma) < MIN_OPENING_FRAMES:
+        return [
+            f"terminal-opening: the corner sweep decoded {len(luma)} frames at "
+            f"{OPENING_SAMPLE_FPS} fps over {corner}, under the "
+            f"{MIN_OPENING_FRAMES} floor — every statement below would be "
+            f"satisfied by a video too short to hold the card at all"
+        ]
+
+    def kind(value: float) -> str:
+        if value <= OPENING_CARD_MAX_LUMA:
+            return "card"
+        if value >= OPENING_BARE_MIN_LUMA:
+            return "bare"
+        return "between"
+
+    if kind(luma[0]) != "card":
+        failures.append(
+            f"terminal-opening: the recording's first frame reads "
+            f"{luma[0]:.1f} mean luma in the corner at {corner}, which is "
+            f"{kind(luma[0])!r} and not the card (card <= "
+            f"{OPENING_CARD_MAX_LUMA}, bare terminal >= "
+            f"{OPENING_BARE_MIN_LUMA}). The segment opens on the terminal and "
+            f"the card arrives afterwards — issue #110."
+        )
+    # The prefix ends at the first frame that is not card — including a frame
+    # that is neither, which is the card mid-fade and is not "before the card"
+    # by any reading.
+    prefix = 0
+    while prefix < len(luma) and kind(luma[prefix]) == "card":
+        prefix += 1
+    prefix_s = prefix / OPENING_SAMPLE_FPS
+    if prefix_s < MIN_OPENING_CARD_S:
+        failures.append(
+            f"terminal-opening: the card covers only the first {prefix_s:.2f}s "
+            f"of the recording ({prefix} frames at {OPENING_SAMPLE_FPS} fps), "
+            f"under the {MIN_OPENING_CARD_S}s bar for a card held "
+            f"{OPENING_HOLD_S}s. Frame {prefix} reads {luma[min(prefix, len(luma) - 1)]:.1f} "
+            f"— the viewer sees the terminal before the card that is supposed "
+            f"to be covering it."
+        )
+    bare = [i for i, value in enumerate(luma) if kind(value) == "bare"]
+    if not bare:
+        failures.append(
+            f"terminal-opening: the corner never reaches "
+            f"{OPENING_BARE_MIN_LUMA} mean luma in "
+            f"{len(luma) / OPENING_SAMPLE_FPS:.1f}s — the card the recorder "
+            f"raised is never taken down (issue #91), and the whole take is "
+            f"behind it. Corner range {min(luma):.1f}..{max(luma):.1f}."
+        )
+    elif kind(luma[-1]) != "bare":
+        failures.append(
+            f"terminal-opening: the recording's last frame reads {luma[-1]:.1f} "
+            f"in the corner ({kind(luma[-1])!r}) — the card came back, or never "
+            f"finished fading"
+        )
+    if not failures:
+        print(
+            f"smoke: terminal-opening card covers the first {prefix_s:.2f}s "
+            f"(corner {luma[0]:.0f} -> {luma[-1]:.0f}), then clears"
+        )
+    return failures
+
+
 # Longest stretch of blank frames a redacted take may record, in seconds.
 # The first-paint gate legitimately blanks the window while the mask is
 # resolved and verified — measured at 0.30-0.55 s per navigation — so this is
@@ -5855,6 +6429,47 @@ def run_web(out_root: Path) -> list[str]:
         + check_beat_frames("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
         + check_evidence("web", out_dir, WEB_EVIDENCE, WEB_EVIDENCE_SCOPE)
         + check_healthy("web", out_dir)
+    )
+
+
+def run_spotlight(out_root: Path) -> list[str]:
+    """The spotlight's enter and exit, in a take that records real motion."""
+    out_dir = fresh_take_dir(out_root, "spotlight")
+    with fixture_server() as base_url:
+        try:
+            problems, info = record_spotlight(out_dir, base_url)
+        except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+            return [f"spotlight: Recorder raised {type(exc).__name__}: {exc}"]
+    mp4 = out_dir / "demo.mp4"
+    if not mp4.is_file():
+        return problems + [f"spotlight: {mp4} was never written"]
+    return (
+        problems
+        + _check_video("spotlight", mp4, SPOTLIGHT_DURATION_S, keep_top(info["app"]))
+        + check_spotlight_transitions(out_dir, info)
+        + check_healthy("spotlight", out_dir)
+    )
+
+
+def run_terminal_opening(out_root: Path) -> list[str]:
+    """A terminal segment that opens on a card rather than on a bare prompt."""
+    out_dir = fresh_take_dir(out_root, "terminal-opening")
+    try:
+        problems, info = record_terminal_opening(out_dir)
+    except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+        return [
+            f"terminal-opening: TerminalRecorder raised {type(exc).__name__}: {exc}"
+        ]
+    mp4 = out_dir / "demo.mp4"
+    if not mp4.is_file():
+        return problems + [f"terminal-opening: {mp4} was never written"]
+    return (
+        problems
+        + _check_video(
+            "terminal-opening", mp4, OPENING_DURATION_S, keep_top(info["app"])
+        )
+        + check_opening_card(out_dir, info)
+        + check_healthy("terminal-opening", out_dir)
     )
 
 
@@ -9862,6 +10477,12 @@ def main() -> int:
         help="record only the takes that do not finish (issues #11/#20/#24/#46)",
     )
     parser.add_argument(
+        "--polish-only",
+        action="store_true",
+        help="record only the two takes that grade how a recording looks "
+        "(issues #110 and #111)",
+    )
+    parser.add_argument(
         "--allow-concurrent",
         action="store_true",
         help="run even when another suite holds the machine lock. The timing "
@@ -9892,6 +10513,7 @@ def main() -> int:
             ("--segments-only", args.segments_only),
             ("--evidence-only", args.evidence_only),
             ("--failure-only", args.failure_only),
+            ("--polish-only", args.polish_only),
         )
         if on
     ]
@@ -9959,6 +10581,13 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
     # After the graded takes, never instead of them: these five record
     # nothing worth looking at, and if a recorder is broken the messages
     # above are the ones that say how.
+    # How the recording *looks* (issues #110/#111). Reachable from the medium
+    # flags as well as from --polish-only, because whoever is changing the
+    # spotlight is running --web-only.
+    if only in (None, "--web-only", "--polish-only"):
+        failures += run_spotlight(out_root)
+    if only in (None, "--terminal-only", "--polish-only"):
+        failures += run_terminal_opening(out_root)
     if only in (None, "--web-only"):
         failures += run_web_problems(out_root)
         failures += run_strict_web(out_root)


### PR DESCRIPTION
Two defects a human found by watching the reference demo — the first in this
project caught by the video review step rather than by a test. Both are
demoable by this repo's own rule, so **this PR has a demo and the video is what
should be reviewed**; the numbers below are here so the reviewer can check the
video against them, not instead of it.

## #111 — the spotlight eased in and snapped out

`__demoSpotlightClear` restored the element's whole `style` attribute in one
assignment. That is correct and worth keeping — it is what guarantees the
element is handed back exactly as it was found, including an inline style the
app itself set — but it removed `transition` in the *same frame* as it removed
`transform` and `outline`, so there was nothing left to animate the exit with.

The spotlight's own properties are now reverted individually while the
transition is still on the element, and the wholesale restore waits for
`transitionend`. Three things about that:

- **The ring fades by animating its colour to alpha 0**, not by clearing the
  `outline` shorthand. `outline-style` is not animatable, so clearing it makes
  the ring vanish in one frame while the scale eases — half a snap.
  `background` and `transform` *are* cleared outright, because removing an
  inline declaration transitions to the value underneath it, which is the value
  the element is supposed to return to.
- **The `transitionend` fallback timer is sized from the element's own
  computed transition time**, not from a constant. `deterministic=True`
  flattens transitions to 1 ms with `!important`, so under determinism the
  exit is over in a millisecond and the timer never runs. A hardcoded 400 ms
  would have charged every deterministic take — `tests/smoke` included —
  nearly half a second per clear for a transition that had already finished.
- **An element that had no `style` attribute gets none back.** `__spotPrev`
  was `getAttribute('style') || ''`, so a clear left `style=""` behind. That is
  invisible in every frame and is exactly what the acceptance criterion's
  "byte-identical" asks about.

### The decision the issue asked for: the verb waits

`spotlight()` blocks until the exit transition has finished and the style
attribute is back. Two reasons and one measurement:

- **Two consumers read that attribute.** This beat's evidence records the
  spotlight target's `outerHTML` *including* `style`, and `redact()`'s
  MutationObserver re-asserts the mask off the same attribute. A verb that
  returns mid-fade makes both of them read a value that depends on when the
  compositor happened to fire. A storyboard cannot be written against that,
  and an artifact that varies run to run is the kind this repo refuses.
- **Overlapping buys nothing here.** The clear runs *before* the new entrance,
  so "overlap" would mean two elements half-lit at once, which is worse to
  watch, not better.

What it costs, measured end to end including the verb's existing `pause(0.3)`:

| | before | after |
|---|---|---|
| `deterministic=False` | 0.31 s | **0.55 s** |
| `deterministic=True` | 0.31 s | 0.33 s |

## #110 — a terminal segment opening on ~290 ms of bare terminal

`TerminalRecorder(interlude="…")`, painted before capture starts, rather than
suppressing frames or leaving it to the storyboard.

I went with the constructor argument over "hold the first frame until the first
beat" for the reason the issue gives — it makes *a segment opens on a card* a
property of the recorder rather than something every storyboard must remember —
plus one the issue implies: the recorder that raises the card is then the one
that can clear it, which closes #91's end of the same seam. There is no
ordering left for a storyboard to get wrong.

Mechanism: a **context init script**, which runs before the page's own scripts
on every document including Chromium's initial one. That is earlier than any
Python statement can reach — earlier than `pty.openpty()`, earlier than
xterm.js is injected — and it survives `_start()`'s own `goto("about:blank")`,
which an `evaluate()` would not. The card is appended **already opaque**;
`__demoInterlude` creates it at `opacity: 0` and raises it, which is a 450 ms
fade, and a card that fades in over the recorder's setup is showing exactly
what it exists to cover.

`interlude()` is unchanged, #91's clearing behaviour is unchanged, and the
opening card records an ordinary `interlude` beat so `timeline.json` reads the
same whichever raised it. `Recorder` (web) deliberately does **not** get the
argument — see stated limits.

## How it is graded

Two takes in `tests/smoke`, reachable as `--polish-only` and from the medium
flags. Both grade pixels, from the viewer's side, importing nothing from the
recorder.

`spotlight/` records with `deterministic=False` — the only take in the file
that does, and it has to: the determinism rule flattens the transition the
assertion is about, so under it both directions snap, both are correct, and the
assertion could not fail for the reason it claims.

**A transition is measured as the states it passes through.** Every frame of
the element's crop is scored by how far it is from the settled frame at the end
of its window, as a fraction of how far the frame at the start is; a frame
between 12% and 88% is one the transition was part way through. A snap produces
**none** — not "few", because there is no intermediate state to be in.

| intermediate frames | enter | exit |
|---|---|---|
| eased, four takes | 3-4 | 3-4 |
| the pre-#111 clear, injected | 3-4 | **0** |
| recorded with `deterministic=True` | **0** | **0** |

The first version of this counted frames that *changed*, which is not the same
claim: a hard cut in H.264 rings for a frame or two afterwards, so a snap also
produces three consecutive frames that differ from each other and the bar had
to sit uncomfortably close to them. It was also unstable — an `fps=` filter
whose grid did not share the video's phase duplicates frames, and a duplicated
frame is indistinguishable from one in which nothing moved. Two readings of the
same healthy take differed by half before the sweep switched to native rate.

`terminal-opening/` reads one corner of the frame, outside the terminal window,
at 20 fps for the whole take. The card is `#1c1a17` full-bleed (26 mean luma);
bare terminal is the recorder's pastel gradient (226). Neither is a threshold
anybody tuned — they are two constants in the recorder's own styling, an order
of magnitude apart, and the corner is read off the live `#__term_win` box.
Three statements: the **first** frame is card; the card covers at least the
first second (it is held 2.5); and the corner **does** end up bare, which is
the control — without it the first two are equally true of a recorder that
painted a black rectangle and stopped, which is #91.

## Fault injection

Nine, each one exact string in one file, through a driver that refuses to run
unless the pattern matched **exactly once** and prints the diff before running.

| injected | fails with |
|---|---|
| the pre-#111 clear restored back | `clearing the spotlight passed through 0 intermediate frame(s) [], under the 2 bar, while the enter passed through 4` |
| individual reverts kept, attribute restored in the same frame | `…passed through 0 intermediate frame(s) [], …while the enter passed through 3` |
| record the take with `deterministic=True` | `the *enter* transition passed through 0 intermediate frame(s) … either the spotlight is not being drawn, or this take lost its deterministic=False` |
| the enter's `transform` removed | `spotlight('#kpi-rev') left the element's computed transform at 'none' — the highlight never went on, so the exit measurement below is about nothing` |
| the clear leaves `style=""` | `#kpi-rev's inline style is (has_attr, value) [True, ''], but it was [False, None] before the spotlight` |
| the clear's promise resolves early | `spotlight() cleared and returned in 0.32s, under the 0.45s bar — it did not wait out its own exit transition` |
| the card raised 400 ms into the document | `the recording's first frame reads 226.5 mean luma … which is 'bare' and not the card` + `the card covers only the first 0.00s` |
| the card built at `opacity: 0` | the same two, plus the content floor |
| the card never cleared | `the corner never reaches 150.0 mean luma in 12.8s — the card the recorder raised is never taken down (issue #91). Corner range 25.8..27.0` |

**One of these found a real hole in my own work.** The clear-resolves-early
injection *passed* a version of this take whose only non-pixel assertion
compared the element's inline style before and after. It passed because the
verb ends in a 300 ms pause, so a style read after the verb is 300 ms too late
to see a restore that was still pending when it returned — and the frames are
identical either way, because the transition does animate.
`MIN_SPOTLIGHT_CLEAR_S` is the assertion that exists because of it, and a lower
bound on a wait is also the one kind of timing bar contention cannot turn red.

Full `tests/smoke` green locally (all phases, including the segments take that
uses `interlude()` and the redaction take whose observer assertion is about
`spotlight()`'s style rewrite). Recorded on an idle 16-core box with the suite
lock held; `--polish-only` run four times for stability before the bars were
set.

## Stated limits

- **A card that *fades in* over 450 ms is not caught.** Measured: a faded-in
  card and a painted one produce byte-identical corner readings for the first
  14 frames, because the recorder spends longer than the fade injecting
  xterm.js before Chromium's screencast emits anything. The recorder has no
  fade-in path — the element is appended already opaque, so no transition can
  run — but the suite is relying on setup cost for that and would not notice if
  it changed. `tests/README.md` says so.
- **`Recorder` (web) gets no `interlude=`.** It does not have the defect: its
  page is blank until `goto()`, so there is no "before" to flash — and a card
  painted before that first `goto()` would be destroyed by it, so the mechanism
  would have to be a different one solving a problem that does not exist.
- **`spotlight()` is 0.24 s slower per clear** on a non-deterministic take.
  Deliberate, argued above, and ~0 under `deterministic=True`.
- **The exit's easing is not asserted to be the *same* easing as the
  entrance**, only that both pass through intermediate states over comparable
  windows. Both read the one `SPOTLIGHT_TRANSITION` constant, so they cannot
  differ without somebody editing the constant, but no assertion says so.

Fixes #110
Fixes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)
