### PR TITLE
Record the branch's demo in CI and publish it to the pull request

### DIFF
--- a/.github/scripts/demo-comment
+++ b/.github/scripts/demo-comment
@@ -204,7 +204,16 @@ def main(argv: list[str] | None = None) -> int:
         "--demo",
         action="append",
         default=[],
-        help="a demo directory holding timeline.json",
+        help="a demo directory holding timeline.json, relative to --demo-root",
+    )
+    ap.add_argument(
+        "--demo-root",
+        default="",
+        help=(
+            "directory the --demo paths are read from. The comment still names "
+            "each demo by its --demo path, so the caller can read timelines out "
+            "of a staging area while the reader sees the repository path."
+        ),
     )
     ap.add_argument("--artifact-url")
     ap.add_argument("--artifact-bytes", type=int)
@@ -218,14 +227,16 @@ def main(argv: list[str] | None = None) -> int:
 
     demos: list[tuple[str, dict]] = []
     for raw in args.demo:
-        directory = Path(raw)
+        name = raw.rstrip("/")
+        directory = Path(args.demo_root) / name if args.demo_root else Path(name)
         timeline_path = directory / "timeline.json"
         if not timeline_path.exists():
-            # A take that refused before writing anything. Say so rather than
+            # A take that refused before writing anything, or one whose
+            # timeline was held back as not this take's. Say so rather than
             # silently dropping the demo from the comment.
             demos.append(
                 (
-                    str(directory).rstrip("/"),
+                    name,
                     {
                         "beats": [],
                         "recorder": "?",
@@ -234,18 +245,17 @@ def main(argv: list[str] | None = None) -> int:
                             "type": "NoTimeline",
                             "beat": None,
                             "verb": None,
-                            "message": "the take wrote no timeline.json",
+                            "message": (
+                                "this take published no timeline.json — it wrote none, "
+                                "or what is on disk is a previous recording's and was "
+                                "held back"
+                            ),
                         },
                     },
                 )
             )
             continue
-        demos.append(
-            (
-                str(directory).rstrip("/"),
-                json.loads(timeline_path.read_text(encoding="utf-8")),
-            )
-        )
+        demos.append((name, json.loads(timeline_path.read_text(encoding="utf-8"))))
 
     body = render(
         demos,

--- a/.github/scripts/demo-comment
+++ b/.github/scripts/demo-comment
@@ -1,0 +1,271 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Render the pull-request comment for a recorded demo.
+
+    demo-comment --demo demos/2026-07-27-empty-state \
+                 --artifact-url https://github.com/o/r/actions/runs/1/artifacts/2 \
+                 --artifact-bytes 1234567 --retention-days 30 \
+                 --run-url https://github.com/o/r/actions/runs/1 --sha abc1234 \
+                 --out body.md
+
+The comment carries two tiers, decided in issue #2:
+
+1. **The beat table, as text.** Every caption in order, read straight out of
+   `timeline.json`. It needs no hosting, never expires, needs no access to the
+   Actions tab, and renders on GitLab and Bitbucket as readily as here. A
+   reviewer who reads twenty lines knows whether they need to watch anything.
+2. **A deep link to the artifact**, so watching is one click and an unzip.
+
+Tier 1 is what survives artifact retention. Tier 2 is what a reviewer clicks
+today. Neither substitutes for the other.
+
+The body opens with an HTML marker so the workflow can find and rewrite this
+comment rather than appending a new one on every push.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+MARKER = "<!-- demo-video-ci: one comment per pull request, rewritten on every push -->"
+
+
+def _cell(text: str) -> str:
+    """Make authored caption text safe to drop into a markdown table cell."""
+    out = (text or "").replace("\\", "\\\\").replace("|", "\\|")
+    out = " ".join(out.split())  # a newline in a cell ends the row
+    return out or "&nbsp;"
+
+
+def story_beats(beats: list[dict]) -> list[tuple[float, str]]:
+    """Collapse the beat log to the lines a viewer actually reads.
+
+    A storyboard logs one beat per verb, so a six-line demo is forty beats and
+    most of them repeat the caption above them. What a reviewer wants is the
+    narration: each caption once, at the moment it went up, in order. A caption
+    that is cleared and later shown again is two entries, because that is two
+    separate moments on screen.
+    """
+    out: list[tuple[float, str]] = []
+    previous: str | None = None
+    for beat in beats:
+        caption = (beat.get("caption") or "").strip()
+        if caption and caption != previous:
+            out.append((float(beat.get("t_start") or 0.0), caption))
+        previous = caption
+    return out
+
+
+def _human_size(n: int | None) -> str:
+    if not n:
+        return "size unknown"
+    mb = n / 1_000_000
+    return f"{mb:.1f} MB" if mb >= 1 else f"{n / 1000:.0f} kB"
+
+
+def _duration(timeline: dict) -> str:
+    d = timeline.get("duration")
+    if d is None:
+        return "no video (this take encoded none)"
+    return f"{float(d):.0f}s"
+
+
+def render_demo(name: str, timeline: dict) -> str:
+    """One demo's section: the heading, the beat table, and what went wrong."""
+    beats = timeline.get("beats") or []
+    rows = story_beats(beats)
+    failure = timeline.get("failure")
+
+    lines: list[str] = []
+    status = " — **the take did not finish**" if failure else ""
+    lines.append(f"### `{name}`{status}")
+    lines.append("")
+    lines.append(
+        f"{len(rows)} beats · {_duration(timeline)} · recorded by `{timeline.get('recorder', '?')}`"
+    )
+    lines.append("")
+
+    if rows:
+        lines.append("| # | at | Caption |")
+        lines.append("|---:|---:|---|")
+        for i, (t, caption) in enumerate(rows, start=1):
+            lines.append(f"| {i} | {t:.0f}s | {_cell(caption)} |")
+    else:
+        lines.append(
+            "_No captioned beats — this storyboard narrates nothing, "
+            "which makes the recording unreviewable on its own._"
+        )
+    lines.append("")
+
+    if failure:
+        beat = failure.get("beat")
+        where = (
+            f"beat {beat} (`{failure.get('verb')}`)"
+            if beat is not None
+            else "between beats"
+        )
+        lines.append(
+            f"> **Failed at {where}:** `{failure.get('type')}` — {_cell(failure.get('message') or '')}"
+        )
+        lines.append(">")
+        lines.append(
+            "> The beats above are the ones it got through. `failure/` in the artifacts "
+            "below has the last frame, the page text and the failing beat in full."
+        )
+        lines.append("")
+
+    issues = timeline.get("issues") or []
+    count = timeline.get("issue_count", len(issues))
+    if count:
+        lines.append(
+            f"<details><summary>{count} issue(s) the recorder saw behind the pixels</summary>"
+        )
+        lines.append("")
+        for issue in issues:
+            at = f"beat {issue['beat']}" if issue.get("beat") is not None else "no beat"
+            lines.append(
+                f"- `{issue.get('kind')}` at {at}: {_cell(issue.get('message') or '')}"
+            )
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def render(
+    demos: list[tuple[str, dict]],
+    *,
+    artifact_url: str | None,
+    artifact_bytes: int | None,
+    retention_days: int,
+    evidence_retention_days: int | None,
+    failure_artifact_url: str | None,
+    run_url: str | None,
+    sha: str | None,
+) -> str:
+    failed = any(t.get("failure") for _, t in demos)
+    lines = [MARKER, ""]
+    lines.append("## Demo video" + (" — the take failed" if failed else ""))
+    lines.append("")
+    if not demos:
+        lines.append("No storyboard on this branch needed re-recording.")
+        return "\n".join(lines) + "\n"
+
+    for name, timeline in demos:
+        lines.append(render_demo(name, timeline))
+
+    if artifact_url:
+        size = _human_size(artifact_bytes)
+        lines.append(
+            f"**[⬇ Download the recording ({size})]({artifact_url})** — GitHub zips every "
+            f"artifact, so unzip it and play `demo.mp4`."
+        )
+        lines.append("")
+        lines.append(
+            f"Kept for **{retention_days} days**, then this link dies. The beat table above "
+            "and the storyboard on this branch are the durable record; re-run the workflow "
+            "to get the video back."
+        )
+    else:
+        lines.append("_No recording was uploaded._")
+    lines.append("")
+
+    if failure_artifact_url:
+        lines.append(f"Diagnostics: **[failure dump]({failure_artifact_url})**.")
+        lines.append("")
+
+    footnote = []
+    if sha:
+        footnote.append(f"Recorded from `{sha[:7]}`.")
+    if run_url:
+        footnote.append(f"[Workflow run]({run_url}).")
+    if evidence_retention_days:
+        footnote.append(
+            f"`evidence/` and `frames/` are uploaded separately and kept "
+            f"{evidence_retention_days} days, long enough to check a disputed finding."
+        )
+    footnote.append(
+        "Which acceptance criterion each beat demonstrates is not reported yet "
+        "([#12](https://github.com/rogvid/skills/issues/12))."
+    )
+    lines.append("<sub>" + " ".join(footnote) + "</sub>")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--demo",
+        action="append",
+        default=[],
+        help="a demo directory holding timeline.json",
+    )
+    ap.add_argument("--artifact-url")
+    ap.add_argument("--artifact-bytes", type=int)
+    ap.add_argument("--retention-days", type=int, required=True)
+    ap.add_argument("--evidence-retention-days", type=int)
+    ap.add_argument("--failure-artifact-url")
+    ap.add_argument("--run-url")
+    ap.add_argument("--sha")
+    ap.add_argument("--out", required=True, help="where to write the comment body")
+    args = ap.parse_args(argv)
+
+    demos: list[tuple[str, dict]] = []
+    for raw in args.demo:
+        directory = Path(raw)
+        timeline_path = directory / "timeline.json"
+        if not timeline_path.exists():
+            # A take that refused before writing anything. Say so rather than
+            # silently dropping the demo from the comment.
+            demos.append(
+                (
+                    str(directory).rstrip("/"),
+                    {
+                        "beats": [],
+                        "recorder": "?",
+                        "duration": None,
+                        "failure": {
+                            "type": "NoTimeline",
+                            "beat": None,
+                            "verb": None,
+                            "message": "the take wrote no timeline.json",
+                        },
+                    },
+                )
+            )
+            continue
+        demos.append(
+            (
+                str(directory).rstrip("/"),
+                json.loads(timeline_path.read_text(encoding="utf-8")),
+            )
+        )
+
+    body = render(
+        demos,
+        artifact_url=args.artifact_url,
+        artifact_bytes=args.artifact_bytes,
+        retention_days=args.retention_days,
+        evidence_retention_days=args.evidence_retention_days,
+        failure_artifact_url=args.failure_artifact_url,
+        run_url=args.run_url,
+        sha=args.sha,
+    )
+    Path(args.out).write_text(body, encoding="utf-8")
+    if summary := os.environ.get("GITHUB_STEP_SUMMARY"):
+        # The job summary is the second surface: it works when the token cannot
+        # write comments, which is every pull request from a fork.
+        with open(summary, "a", encoding="utf-8") as fh:
+            fh.write(body)
+    print(body)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/demo-storyboards
+++ b/.github/scripts/demo-storyboards
@@ -1,0 +1,149 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Pick the storyboards a change makes stale, so CI records those and no others.
+
+    demo-storyboards --root . --changed-file changed.txt
+
+Reads the paths a branch changed (one per line) and prints the storyboards that
+need re-recording, one path per line. With --github-output it also writes
+`storyboards` (a JSON array) and `count` for a workflow to branch on.
+
+**The rule.** A storyboard is stale when the thing it demonstrates moved. Every
+storyboard sits under a `demos/` directory, and the directory holding that
+`demos/` is the *app root* — the code the demo is about. So
+`examples/ticket-queue/demos/2026-07-26-status-filter/record.py` has the app
+root `examples/ticket-queue`, and any change under it selects that storyboard.
+
+**The limit this leaves.** A change *outside* the app root that the demo still
+depends on — a shared library, a design system, the recorder itself — selects
+nothing, and the last recording stays the current one. Pass `--all` (or the
+workflow's `storyboards:` input) when that is what happened. The gate is a cost
+control, not a correctness proof: the storyboard is the durable artifact and
+re-running it is always available.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path, PurePosixPath
+
+DEFAULT_GLOB = "**/demos/**/record.py"
+
+
+def app_root(storyboard: str) -> str:
+    """The directory whose contents this storyboard demonstrates.
+
+    The parent of the innermost `demos/` component, as a POSIX-style relative
+    path; `""` means the repository root, which is the honest answer for a
+    storyboard at `demos/x/record.py` — there is no narrower directory to
+    attribute it to.
+    """
+    parts = PurePosixPath(storyboard).parts
+    # Innermost, not outermost: a nested `demos/` narrows the blast radius,
+    # and a narrower root records fewer storyboards, never more.
+    for i in range(len(parts) - 1, -1, -1):
+        if parts[i] == "demos":
+            return "/".join(parts[:i])
+    return "/".join(parts[:-1])
+
+
+def _within(path: str, root: str) -> bool:
+    if root == "":
+        return True
+    return path == root or path.startswith(root + "/")
+
+
+def select(storyboards: list[str], changed: list[str]) -> list[str]:
+    """Storyboards whose app root contains at least one changed path."""
+    out = []
+    for sb in sorted(set(storyboards)):
+        root = app_root(sb)
+        if any(_within(c, root) for c in changed):
+            out.append(sb)
+    return out
+
+
+def strip_prefix(changed: list[str], prefix: str) -> list[str]:
+    """Re-root a repository-relative diff onto `working-directory`.
+
+    Paths outside the prefix are dropped, not kept: they name files this
+    working directory has no storyboards for. The boundary is a `/`, so
+    `examples/ticket-queue-v2/app.js` is not inside `examples/ticket-queue` —
+    an unanchored prefix test would say it was, and would record a demo of a
+    different application on every push to its neighbour.
+    """
+    if not prefix or prefix == ".":
+        return list(changed)
+    prefix = prefix.rstrip("/") + "/"
+    return [p[len(prefix) :] for p in changed if p.startswith(prefix)]
+
+
+def _read_changed(path: str | None) -> list[str]:
+    text = (
+        sys.stdin.read() if path in (None, "-") else open(path, encoding="utf-8").read()
+    )
+    return [line.strip() for line in text.splitlines() if line.strip()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--root", default=".", help="repository root to glob from")
+    ap.add_argument(
+        "--glob", default=DEFAULT_GLOB, help=f"storyboard glob (default {DEFAULT_GLOB})"
+    )
+    ap.add_argument(
+        "--changed-file", help="file of changed paths, one per line; '-' for stdin"
+    )
+    ap.add_argument(
+        "--all", action="store_true", help="select every storyboard, ignoring the diff"
+    )
+    ap.add_argument(
+        "--explicit",
+        default="",
+        help="whitespace-separated storyboard paths to use verbatim, skipping discovery",
+    )
+    ap.add_argument(
+        "--strip-prefix",
+        default="",
+        help="repository-relative path of --root; changed paths outside it are dropped",
+    )
+    ap.add_argument("--github-output", help="path to write GITHUB_OUTPUT-style keys to")
+    args = ap.parse_args(argv)
+
+    root = os.path.abspath(args.root)
+    if args.explicit.strip():
+        chosen = args.explicit.split()
+        missing = [p for p in chosen if not os.path.exists(os.path.join(root, p))]
+        if missing:
+            print(f"no such storyboard: {', '.join(missing)}", file=sys.stderr)
+            return 2
+    else:
+        found = [
+            os.path.relpath(p, root).replace(os.sep, "/")
+            for p in Path(root).glob(args.glob)
+            if p.is_file()
+        ]
+        if args.all:
+            chosen = sorted(found)
+        else:
+            changed = strip_prefix(_read_changed(args.changed_file), args.strip_prefix)
+            chosen = select(found, changed)
+
+    for path in chosen:
+        print(path)
+
+    if args.github_output:
+        with open(args.github_output, "a", encoding="utf-8") as fh:
+            fh.write(f"storyboards={json.dumps(chosen)}\n")
+            fh.write(f"count={len(chosen)}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/demo-target-guard
+++ b/.github/scripts/demo-target-guard
@@ -1,0 +1,179 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Refuse to record a demo against anything that could be production.
+
+    demo-target-guard --url "$DEMO_VIDEO_BASE_URL" --scan demos/x/record.py
+
+A take recorded in CI drives a real application, and the mp4 it produces is an
+outbound artifact: it leaves the repository boundary the moment somebody
+downloads it, and it renders whatever was on the screen. Pointed at a
+production host it is a screen recording of real customer data, published to
+everyone with repository read access, for as long as the artifact lives.
+
+So the target is classified, not trusted:
+
+| class | example | verdict |
+|---|---|---|
+| loopback | `127.0.0.1`, `localhost`, `[::1]` | always allowed |
+| private | `10.x`, `192.168.x`, `svc.internal`, a bare hostname | allowed only with `--allow-private` |
+| public | `demo.example.com`, `93.184.216.34` | **refused, with no flag that permits it** |
+
+There is deliberately no `--allow-public`. Recording against a public host is
+not a thing this workflow should make easy to configure; a team that truly
+needs it has to write their own job and own that decision explicitly.
+
+`--scan` applies the same rule to `http(s)://` literals inside a storyboard, so
+a hardcoded production URL is refused before the browser opens.
+
+**The limit.** A storyboard that *computes* its URL at run time — from an
+environment variable this guard was not given, from a config file, by string
+concatenation — is invisible to `--scan`. This is a static check on the
+configuration and the source text, not a network egress control. A runner with
+network access can still reach the internet; what the guard stops is the
+ordinary path of pointing the workflow at the wrong host.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ipaddress
+import re
+import sys
+from urllib.parse import urlsplit
+
+LOOPBACK, PRIVATE, PUBLIC, MALFORMED = "loopback", "private", "public", "malformed"
+
+# Suffixes reserved by RFC 2606/6761/8375 or conventional for internal naming.
+_PRIVATE_SUFFIXES = (
+    ".test",
+    ".invalid",
+    ".example",
+    ".local",
+    ".internal",
+    ".localdomain",
+    ".home.arpa",
+)
+
+URL_LITERAL = re.compile(r"https?://[^\s'\"`<>)\]}\\]+")
+
+
+def classify(url: str) -> tuple[str, str]:
+    """Return (class, why) for a URL string."""
+    try:
+        parts = urlsplit(url.strip())
+    except ValueError as exc:
+        return MALFORMED, f"unparseable ({exc})"
+    if parts.scheme not in ("http", "https"):
+        return MALFORMED, f"scheme {parts.scheme or '(none)'!r} is not http or https"
+    try:
+        host = parts.hostname
+    except ValueError as exc:
+        return MALFORMED, f"unparseable host ({exc})"
+    if not host:
+        return MALFORMED, "no host"
+    host = host.rstrip(".").lower()
+
+    try:
+        ip = ipaddress.ip_address(host)
+    except ValueError:
+        ip = None
+    if ip is not None:
+        if ip.is_loopback:
+            return LOOPBACK, f"loopback address {ip}"
+        if ip.is_private or ip.is_link_local or ip.is_unspecified:
+            return PRIVATE, f"private address {ip}"
+        return PUBLIC, f"publicly routable address {ip}"
+
+    if host == "localhost" or host.endswith(".localhost"):
+        return LOOPBACK, f"{host} resolves to loopback by RFC 6761"
+    if host.endswith(_PRIVATE_SUFFIXES):
+        return PRIVATE, f"{host} is under a reserved internal suffix"
+    if "." not in host:
+        # A single label cannot be reached from the public internet without a
+        # search domain; in CI it is a service name on a container network.
+        return PRIVATE, f"{host} is a single-label host name"
+    return PUBLIC, f"{host} is a public DNS name"
+
+
+def check(url: str, allow_private: bool) -> str | None:
+    """None when the URL may be recorded against, else the reason it may not."""
+    kind, why = classify(url)
+    if kind == LOOPBACK:
+        return None
+    if kind == PRIVATE and allow_private:
+        return None
+    if kind == PRIVATE:
+        return f"{url} — {why}. Pass allow-private-network-target: true if this really is a test host."
+    if kind == PUBLIC:
+        return f"{url} — {why}. Recording a demo against a public host is refused; there is no option that permits it."
+    return f"{url} — {why}."
+
+
+def scan(text: str) -> list[str]:
+    """The http(s) literals in a blob of source, in order, deduplicated."""
+    seen, out = set(), []
+    for match in URL_LITERAL.findall(text):
+        url = match.rstrip(".,;")
+        if url not in seen:
+            seen.add(url)
+            out.append(url)
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--url", action="append", default=[], help="a URL the take will be pointed at"
+    )
+    ap.add_argument(
+        "--scan",
+        action="append",
+        default=[],
+        help="a source file to scan for URL literals",
+    )
+    ap.add_argument(
+        "--allow-private", action="store_true", help="permit private/internal hosts"
+    )
+    args = ap.parse_args(argv)
+
+    problems: list[str] = []
+    checked = 0
+    for url in args.url:
+        if not url.strip():
+            continue
+        checked += 1
+        if (reason := check(url, args.allow_private)) is not None:
+            problems.append(f"target: {reason}")
+
+    for path in args.scan:
+        try:
+            text = open(path, encoding="utf-8", errors="replace").read()
+        except OSError as exc:
+            problems.append(f"scan: cannot read {path}: {exc}")
+            continue
+        for url in scan(text):
+            checked += 1
+            if (reason := check(url, args.allow_private)) is not None:
+                problems.append(f"{path}: {reason}")
+
+    if problems:
+        print(
+            "Refusing to record. A demo recorded in CI is an outbound artifact.",
+            file=sys.stderr,
+        )
+        for line in problems:
+            print(f"  - {line}", file=sys.stderr)
+        return 2
+
+    print(
+        f"target guard: {checked} URL(s) checked, all loopback"
+        + (" or private" if args.allow_private else "")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,51 @@ jobs:
           find skills -name '*.sh' -print0 |
             xargs -0 -r uv run --with shellcheck-py shellcheck --severity=style
 
+  # The demo-video workflow is the one deliverable in this repo that CI cannot
+  # exercise by running it — GitHub is the only thing that executes a workflow.
+  # actionlint is what covers the gap: it type-checks every `${{ }}` expression
+  # against the contexts actually available and runs shellcheck over each
+  # `run:` block, which is where the two classes of bug that bit this workflow
+  # during development live (a `[ -f x ] && cp` that exits under `set -e`, and
+  # a step reading an output that a skipped step never wrote).
+  workflows:
+    name: workflows (actionlint)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      # From PyPI for the same reason shellcheck is above: one command, the
+      # same binary a contributor gets locally.
+      - name: actionlint
+        run: |
+          uv run --no-project --with actionlint-py --with shellcheck-py \
+            actionlint .github/workflows/*.yml
+
+  ci-unit:
+    name: unit (demo-video CI helpers)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: tests/ci-unit
+        run: tests/ci-unit
+
+      # An assertion nobody has watched fail is a claim, not a check. This
+      # breaks each helper in a named way and requires the tests that watch it
+      # to go red; it aborts rather than passing if an injection fails to land.
+      - name: tests/ci-unit --fault-inject
+        run: tests/ci-unit --fault-inject
+
   typecheck:
     name: typecheck (mypy)
     runs-on: ubuntu-latest

--- a/.github/workflows/demo-video.yml
+++ b/.github/workflows/demo-video.yml
@@ -350,17 +350,33 @@ jobs:
           # take's name. See the freshness check in "Stage the artifacts".
           touch "$STARTED_AT"
           status=ok
-          while IFS= read -r sb; do
+          ran=0
+          # The loop reads its list on fd 3, not stdin. `uv run` inherits stdin
+          # and drains it, so with the ordinary `done < file` the *first*
+          # storyboard swallowed the rest of the list: two were selected, one
+          # was recorded, and nothing said so. The second demo's committed
+          # artifacts were then the only thing left on disk to publish.
+          while IFS= read -r sb <&3; do
             [ -n "$sb" ] || continue
+            ran=$((ran + 1))
             echo "::group::uv run $sb"
-            if ! uv run "$sb"; then
+            if ! uv run "$sb" < /dev/null; then
               echo "::error file=$sb::the take did not finish — see failure/ in the artifacts"
               status=failed
             fi
             echo "::endgroup::"
-          done < "$CHANGED.selected"
+          done 3< "$CHANGED.selected"
+
+          # A loop that silently runs fewer storyboards than were selected is
+          # exactly the bug above, and it is invisible in the artifacts: what
+          # is missing looks like what was never asked for.
+          expected=$(grep -c . "$CHANGED.selected")
+          if [ "$ran" -ne "$expected" ]; then
+            echo "::error::selected $expected storyboard(s) but ran $ran"
+            status=failed
+          fi
           echo "status=$status" >> "$GITHUB_OUTPUT"
-          echo "record status: $status"
+          echo "record status: $status ($ran of $expected storyboards run)"
 
       # `steps.record.conclusion != 'skipped'` is load-bearing, not belt and
       # braces. `images/`, `timeline.json` and `timeline.md` are *committed*
@@ -378,6 +394,7 @@ jobs:
           rm -rf "$STAGE_DEMO" "$STAGE_WORKING" "$STAGE_FAILURE"
           mkdir -p "$STAGE_DEMO" "$STAGE_WORKING" "$STAGE_FAILURE"
           stale=0
+          silent=0
           # Second line of defence, independent of the step condition above:
           # nothing older than the moment recording began may be published.
           # A take that crashed before rewriting a file leaves the committed
@@ -400,6 +417,16 @@ jobs:
             for f in demo.mp4 timeline.md timeline.json demo-video-FAILED.md; do
               copy_fresh "$dir/$f" "$STAGE_DEMO/$dir/$f"
             done
+            # `timeline.json` is the file that decides whether this demo said
+            # anything at all this run: the comment is rendered from it, and
+            # without one the demo is reported as having published nothing.
+            # Counted separately from `stale` because a held-back *still* is
+            # ordinary — a storyboard that dropped a `shot()` leaves its
+            # committed png behind — and must not turn the check red on its own.
+            if [ ! -f "$STAGE_DEMO/$dir/timeline.json" ]; then
+              echo "::error file=$dir::published no timeline.json this run wrote"
+              silent=$((silent + 1))
+            fi
             if [ -d "$dir/images" ]; then
               mkdir -p "$STAGE_DEMO/$dir/images"
               for img in "$dir"/images/*; do
@@ -421,8 +448,12 @@ jobs:
             fi
           done < "$DEMO_DIRS"
           bytes=$(find "$STAGE_DEMO" -type f -printf '%s\n' | awk '{s+=$1} END {print s+0}')
-          echo "bytes=$bytes" >> "$GITHUB_OUTPUT"
-          echo "staged $bytes bytes ($stale file(s) held back as not this take's):"
+          {
+            echo "bytes=$bytes"
+            echo "stale=$stale"
+            echo "silent=$silent"
+          } >> "$GITHUB_OUTPUT"
+          echo "staged $bytes bytes ($stale file(s) held back as not this take's, $silent demo(s) published no timeline):"
           find "$STAGE_DEMO" -type f | sed "s|$STAGE_DEMO/|  |"
 
       - name: Upload the recording
@@ -513,8 +544,17 @@ jobs:
           fi
 
       # Last, so a take that failed still publishes everything above.
+      #
+      # `silent != 0` is part of the condition because the check and the
+      # comment must never disagree. A demo that published no timeline is
+      # reported in the comment as a take that failed, and a green check beside
+      # that sentence teaches a reviewer to ignore the comment — worse than
+      # either signal alone.
       - name: Fail the check if the take failed
-        if: always() && steps.discover.outputs.count != '0' && steps.record.outputs.status != 'ok'
+        if: >-
+          always() && steps.discover.outputs.count != '0' &&
+          (steps.record.outputs.status != 'ok' || steps.stage.outputs.silent != '0')
         run: |
-          echo "::error::A take did not finish. The recording, the beat log and failure/ are attached to this run."
+          echo "::error::A take did not finish, or a selected demo published nothing this run wrote."
+          echo "::error::The recording, the beat log and failure/ are attached to this run."
           exit 1

--- a/.github/workflows/demo-video.yml
+++ b/.github/workflows/demo-video.yml
@@ -143,6 +143,7 @@ jobs:
       STAGE_WORKING: ${{ github.workspace }}/.demo-video-ci/working
       STAGE_FAILURE: ${{ github.workspace }}/.demo-video-ci/failure
       CHANGED: ${{ github.workspace }}/.demo-video-ci/changed.txt
+      STARTED_AT: ${{ github.workspace }}/.demo-video-ci/recording-started
       COMMENT_BODY: ${{ github.workspace }}/.demo-video-ci/comment.md
       APP_LOG: ${{ github.workspace }}/.demo-video-ci/app.log
 
@@ -276,8 +277,10 @@ jobs:
         id: pw
         run: |
           set -euo pipefail
+          # `playwright.__version__` does not exist — the package exposes its
+          # version only through the distribution metadata.
           v=$(uv run --no-project --with playwright python -c \
-                'import playwright; print(playwright.__version__)')
+                'from importlib.metadata import version; print(version("playwright"))')
           echo "version=$v" >> "$GITHUB_OUTPUT"
           echo "Playwright $v"
 
@@ -340,6 +343,12 @@ jobs:
           DEMO_VIDEO_SPEECH: "0"
         run: |
           set -uo pipefail
+          # Every artifact staged later must be newer than this. `images/`,
+          # `timeline.json` and `timeline.md` are *committed* files, so they
+          # are sitting in the checkout before anything records — and staging
+          # them unconditionally publishes the previous recording under this
+          # take's name. See the freshness check in "Stage the artifacts".
+          touch "$STARTED_AT"
           status=ok
           while IFS= read -r sb; do
             [ -n "$sb" ] || continue
@@ -353,25 +362,53 @@ jobs:
           echo "status=$status" >> "$GITHUB_OUTPUT"
           echo "record status: $status"
 
+      # `steps.record.conclusion != 'skipped'` is load-bearing, not belt and
+      # braces. `images/`, `timeline.json` and `timeline.md` are *committed*
+      # files: they are in the checkout before anything records. Without this
+      # condition, a job that died during setup staged the previous
+      # recording's artifacts and posted a comment with full beat tables and a
+      # duration — a confident, entirely wrong claim that a demo had been
+      # recorded. That happened on the first real run of this workflow.
       - name: Stage the artifacts
-        if: always() && steps.discover.outputs.count != '0'
+        if: always() && steps.discover.outputs.count != '0' && steps.record.conclusion != 'skipped'
         id: stage
         working-directory: ${{ inputs.working-directory }}
         run: |
           set -euo pipefail
           rm -rf "$STAGE_DEMO" "$STAGE_WORKING" "$STAGE_FAILURE"
           mkdir -p "$STAGE_DEMO" "$STAGE_WORKING" "$STAGE_FAILURE"
+          stale=0
+          # Second line of defence, independent of the step condition above:
+          # nothing older than the moment recording began may be published.
+          # A take that crashed before rewriting a file leaves the committed
+          # one in place, and it is indistinguishable by content.
+          fresh() { [ -e "$1" ] && [ "$1" -nt "$STARTED_AT" ]; }
+          copy_fresh() {
+            if fresh "$1"; then
+              cp "$1" "$2"
+            elif [ -e "$1" ]; then
+              echo "::warning file=$1::not written by this take — left out of the artifacts"
+              stale=$((stale + 1))
+            fi
+          }
           while IFS= read -r dir; do
             [ -n "$dir" ] || continue
-            # What a human watches and what stays readable after the video is
+            # What a human watches, and what stays readable after the video is
             # gone. `demo-video-FAILED.md` travels with it deliberately: it is
             # the file that says whether the mp4 beside it is this take's.
             mkdir -p "$STAGE_DEMO/$dir"
             for f in demo.mp4 timeline.md timeline.json demo-video-FAILED.md; do
-              if [ -f "$dir/$f" ]; then cp "$dir/$f" "$STAGE_DEMO/$dir/$f"; fi
+              copy_fresh "$dir/$f" "$STAGE_DEMO/$dir/$f"
             done
-            if [ -d "$dir/images" ]; then cp -r "$dir/images" "$STAGE_DEMO/$dir/images"; fi
+            if [ -d "$dir/images" ]; then
+              mkdir -p "$STAGE_DEMO/$dir/images"
+              for img in "$dir"/images/*; do
+                copy_fresh "$img" "$STAGE_DEMO/$dir/images/$(basename "$img")"
+              done
+            fi
             # Short retention: enough to check a disputed finding, not an archive.
+            # Regenerated wholesale by every take, so no committed copy exists
+            # to go stale and a directory copy is safe.
             for sub in evidence frames; do
               if [ -d "$dir/$sub" ]; then
                 mkdir -p "$STAGE_WORKING/$dir"
@@ -385,11 +422,11 @@ jobs:
           done < "$DEMO_DIRS"
           bytes=$(find "$STAGE_DEMO" -type f -printf '%s\n' | awk '{s+=$1} END {print s+0}')
           echo "bytes=$bytes" >> "$GITHUB_OUTPUT"
-          echo "staged $bytes bytes:"
+          echo "staged $bytes bytes ($stale file(s) held back as not this take's):"
           find "$STAGE_DEMO" -type f | sed "s|$STAGE_DEMO/|  |"
 
       - name: Upload the recording
-        if: always() && steps.discover.outputs.count != '0'
+        if: always() && steps.discover.outputs.count != '0' && steps.record.conclusion != 'skipped'
         id: upload-demo
         uses: actions/upload-artifact@v4
         with:
@@ -399,7 +436,7 @@ jobs:
           retention-days: ${{ inputs.demo-retention-days }}
 
       - name: Upload the working files a finding can be checked against
-        if: always() && steps.discover.outputs.count != '0'
+        if: always() && steps.discover.outputs.count != '0' && steps.record.conclusion != 'skipped'
         uses: actions/upload-artifact@v4
         with:
           name: demo-video-working-files
@@ -418,7 +455,7 @@ jobs:
           retention-days: ${{ inputs.evidence-retention-days }}
 
       - name: Render the comment
-        if: always() && steps.discover.outputs.count != '0'
+        if: always() && steps.discover.outputs.count != '0' && steps.record.conclusion != 'skipped'
         working-directory: ${{ inputs.working-directory }}
         env:
           SCRIPTS: ${{ steps.helpers.outputs.dir }}
@@ -432,11 +469,19 @@ jobs:
         run: |
           set -euo pipefail
           args=()
+          # Read the timelines out of the *staging* directory, not the working
+          # tree. Staging is where the freshness filter was applied, so the
+          # comment can only ever describe what was actually published. The
+          # working tree still holds the committed timeline.json of the
+          # previous recording, and on the recorder's refusal path (a take
+          # that cannot verify its mask writes nothing but the marker) that
+          # file is what a reader would have been shown as current.
           while IFS= read -r dir; do
             if [ -n "$dir" ]; then args+=(--demo "$dir"); fi
           done < "$DEMO_DIRS"
           if [ -n "$FAILURE_URL" ]; then args+=(--failure-artifact-url "$FAILURE_URL"); fi
           "$SCRIPTS/demo-comment" "${args[@]}" \
+            --demo-root "$STAGE_DEMO" \
             --artifact-url "$ARTIFACT_URL" \
             --artifact-bytes "${ARTIFACT_BYTES:-0}" \
             --retention-days "$RETENTION" \
@@ -447,7 +492,7 @@ jobs:
       # One comment, found by its marker and rewritten. A branch with ten
       # pushes must not bury its pull request under ten identical comments.
       - name: Post or update the pull-request comment
-        if: always() && steps.discover.outputs.count != '0' && github.event.pull_request.number
+        if: always() && steps.discover.outputs.count != '0' && steps.record.conclusion != 'skipped' && github.event.pull_request.number
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}

--- a/.github/workflows/demo-video.yml
+++ b/.github/workflows/demo-video.yml
@@ -179,6 +179,14 @@ jobs:
           chmod +x "$dir"/demo-storyboards "$dir"/demo-target-guard "$dir"/demo-comment
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
 
+      # Before discovery, not after: the helper scripts are PEP 723 executables
+      # with a `uv run --script` shebang, so `uv` has to exist before the first
+      # one is invoked. On a run with nothing to record this is the only setup
+      # paid for, and with the cache warm it is a few seconds.
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
       - name: Work out which storyboards this branch made stale
         id: discover
         working-directory: ${{ inputs.working-directory }}
@@ -258,11 +266,6 @@ jobs:
               echo "exported ${line%%=*}"
             fi
           done <<< "$EXTRA_ENV"
-
-      - uses: astral-sh/setup-uv@v6
-        if: steps.discover.outputs.count != '0'
-        with:
-          enable-cache: true
 
       # Chromium is ~170 MB and re-downloading it on every pull request is the
       # single biggest avoidable cost in this job. The key carries the resolved

--- a/.github/workflows/demo-video.yml
+++ b/.github/workflows/demo-video.yml
@@ -1,0 +1,472 @@
+name: Demo video
+
+# Record the demos a branch made stale and publish them to its pull request.
+#
+# This is a *reusable* workflow. A consuming repository calls it in a few lines:
+#
+#   jobs:
+#     demo:
+#       permissions:
+#         contents: read
+#         pull-requests: write
+#       uses: rogvid/skills/.github/workflows/demo-video.yml@main
+#       with:
+#         working-directory: examples/ticket-queue
+#         app-command: ./serve --port 8901
+#         base-url: http://127.0.0.1:8901
+#
+# and gets one comment on the pull request, rewritten on every push, carrying
+# the beat table as text and a deep link to the mp4.
+#
+# ---------------------------------------------------------------------------
+# Trigger policy: the caller decides *when*, this workflow decides *whether*.
+#
+# Recording is not a test job. It runs a browser, encodes video with a software
+# encoder, and takes minutes rather than seconds — this repository's `smoke`
+# job is already ~8 minutes. Firing it on every push to every pull request is a
+# bill nobody signed up for, so there are two gates and they are different:
+#
+#   1. The caller's `paths:` filter — the coarse one. Point it at the part of
+#      the repository that has demos. Everything else never starts a runner.
+#   2. This workflow's own discovery — the fine one. It records a storyboard
+#      only when the branch changed something under the app that storyboard
+#      demonstrates. A pull request that touches the app but no storyboard
+#      still records; a pull request that touches neither exits in seconds.
+#
+# A label was the alternative and was rejected: it needs a human action on a
+# branch that already exists, and when somebody forgets, the failure mode is
+# *no video* — precisely the thing this workflow exists to eliminate. A path
+# filter is automatic, and it matches the house rule that whether a change is
+# demoable is decided by the author before the work starts.
+#
+# Add `concurrency` with `cancel-in-progress` in the caller. Ten pushes should
+# cost one recording.
+# ---------------------------------------------------------------------------
+
+on:
+  workflow_call:
+    inputs:
+      storyboards:
+        description: >-
+          Whitespace-separated storyboard paths to record, skipping discovery.
+          Leave empty to record the storyboards this branch made stale.
+        type: string
+        default: ""
+      storyboard-glob:
+        description: Glob that finds storyboards, relative to working-directory.
+        type: string
+        default: "**/demos/**/record.py"
+      working-directory:
+        description: Directory the app and its storyboards are rooted at.
+        type: string
+        default: "."
+      app-command:
+        description: >-
+          Command that starts the application, run in the background before
+          recording. Leave empty for a storyboard that needs no server.
+        type: string
+        default: ""
+      base-url:
+        description: >-
+          Where the app is. Exported as DEMO_VIDEO_BASE_URL and checked by the
+          target guard — loopback only, unless allow-private-network-target.
+        type: string
+        default: "http://127.0.0.1:8000"
+      ready-path:
+        description: Path polled on base-url until it answers, before recording starts.
+        type: string
+        default: "/"
+      ready-timeout-seconds:
+        type: number
+        default: 60
+      allow-private-network-target:
+        description: >-
+          Permit a private or internal host (10.x, a container service name,
+          *.internal). Public hosts are refused regardless — there is no input
+          that permits one. See .github/scripts/demo-target-guard.
+        type: boolean
+        default: false
+      extra-env:
+        description: >-
+          KEY=VALUE lines exported for the app and the storyboards. Not a place
+          for secrets: everything here is visible to the storyboard, which
+          renders what it is given onto a video that leaves this repository.
+        type: string
+        default: ""
+      demo-retention-days:
+        description: How long demo.mp4 stays downloadable. Set it, do not inherit it.
+        type: number
+        default: 30
+      evidence-retention-days:
+        description: >-
+          How long evidence/ and frames/ stay downloadable. Long enough to
+          settle a disputed finding, short enough not to be an archive.
+        type: number
+        default: 3
+      runs-on:
+        type: string
+        default: ubuntu-latest
+      timeout-minutes:
+        type: number
+        default: 25
+      helper-ref:
+        description: >-
+          Ref of rogvid/skills the CI helper scripts come from. Ignored when
+          the calling repository is rogvid/skills itself, which already has
+          them in the checkout under test.
+        type: string
+        default: main
+    outputs:
+      recorded:
+        description: How many storyboards were recorded.
+        value: ${{ jobs.record.outputs.recorded }}
+      artifact-url:
+        description: Deep link to the uploaded demo artifact; empty if there was none.
+        value: ${{ jobs.record.outputs.artifact-url }}
+
+jobs:
+  record:
+    name: record the branch's demos
+    runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    permissions:
+      contents: read
+      pull-requests: write
+    outputs:
+      recorded: ${{ steps.discover.outputs.count }}
+      artifact-url: ${{ steps.upload-demo.outputs.artifact-url }}
+    env:
+      # Where staged artifacts and scratch files go. Set once so no step has to
+      # agree with another about a path by copying a literal.
+      DEMO_DIRS: ${{ github.workspace }}/.demo-video-ci/demo-dirs.txt
+      STAGE_DEMO: ${{ github.workspace }}/.demo-video-ci/demo
+      STAGE_WORKING: ${{ github.workspace }}/.demo-video-ci/working
+      STAGE_FAILURE: ${{ github.workspace }}/.demo-video-ci/failure
+      CHANGED: ${{ github.workspace }}/.demo-video-ci/changed.txt
+      COMMENT_BODY: ${{ github.workspace }}/.demo-video-ci/comment.md
+      APP_LOG: ${{ github.workspace }}/.demo-video-ci/app.log
+
+    steps:
+      # fetch-depth: 0 because discovery diffs against the base commit, and a
+      # shallow clone does not have it.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # The helper scripts live in this repository. When the caller *is* this
+      # repository the checkout above already has them, and reaching for main
+      # instead would test main's helpers against the branch's workflow.
+      - uses: actions/checkout@v4
+        if: github.repository != 'rogvid/skills'
+        with:
+          repository: rogvid/skills
+          ref: ${{ inputs.helper-ref }}
+          path: .demo-video-helpers
+          persist-credentials: false
+
+      - name: Locate the CI helper scripts
+        id: helpers
+        run: |
+          set -euo pipefail
+          mkdir -p "$(dirname "$DEMO_DIRS")"
+          if [ "$GITHUB_REPOSITORY" = "rogvid/skills" ]; then
+            dir="$GITHUB_WORKSPACE/.github/scripts"
+            echo "Using the helper scripts from the checkout under test."
+          else
+            dir="$GITHUB_WORKSPACE/.demo-video-helpers/.github/scripts"
+          fi
+          # Packaging and some checkout paths drop the executable bit.
+          chmod +x "$dir"/demo-storyboards "$dir"/demo-target-guard "$dir"/demo-comment
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      - name: Work out which storyboards this branch made stale
+        id: discover
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          SCRIPTS: ${{ steps.helpers.outputs.dir }}
+          EXPLICIT: ${{ inputs.storyboards }}
+          GLOB: ${{ inputs.storyboard-glob }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          WORKDIR: ${{ inputs.working-directory }}
+        run: |
+          set -euo pipefail
+          if [ -n "$BASE_SHA" ]; then
+            # Two dots, not three: the checkout is the pull request's merge
+            # commit, so its diff against the base is exactly the net change.
+            git diff --name-only "$BASE_SHA" HEAD > "$CHANGED"
+          elif git rev-parse --verify --quiet HEAD^ >/dev/null; then
+            git diff --name-only HEAD^ HEAD > "$CHANGED"
+          else
+            : > "$CHANGED"
+          fi
+          echo "Changed on this branch:"; sed 's/^/  /' "$CHANGED"
+
+          # Diff paths are repository-relative and the script globs from
+          # working-directory. Re-rooting them is --strip-prefix's job, not a
+          # shell `grep`'s: the prefix test has to be anchored at a path
+          # boundary or a push to `examples/ticket-queue-v2` records
+          # `examples/ticket-queue`'s demos.
+          "$SCRIPTS/demo-storyboards" \
+            --root . --glob "$GLOB" \
+            --explicit "$EXPLICIT" \
+            --changed-file "$CHANGED" \
+            --strip-prefix "$WORKDIR" \
+            --github-output "$GITHUB_OUTPUT" > "$CHANGED.selected"
+
+          # Every later step reads the demo directories from here, so it exists
+          # even when the take never runs.
+          sed 's|/[^/]*$||' "$CHANGED.selected" | sort -u > "$DEMO_DIRS"
+          echo "Recording:"; sed 's/^/  /' "$DEMO_DIRS"
+
+      - name: Nothing to record
+        if: steps.discover.outputs.count == '0'
+        run: |
+          echo "No storyboard on this branch needs re-recording." | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # ---- everything below runs only when there is something to record ----
+
+      - name: Refuse a target that could be production
+        if: steps.discover.outputs.count != '0'
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          SCRIPTS: ${{ steps.helpers.outputs.dir }}
+          BASE_URL: ${{ inputs.base-url }}
+          ALLOW_PRIVATE: ${{ inputs.allow-private-network-target }}
+          EXTRA_ENV: ${{ inputs.extra-env }}
+        run: |
+          set -euo pipefail
+          args=(--url "$BASE_URL")
+          if [ "$ALLOW_PRIVATE" = "true" ]; then args+=(--allow-private); fi
+          while IFS= read -r sb; do
+            if [ -n "$sb" ]; then args+=(--scan "$sb"); fi
+          done < "$CHANGED.selected"
+          # extra-env is where a second URL hides — a storyboard that reads
+          # its own variable would otherwise route around base-url entirely.
+          printf '%s\n' "$EXTRA_ENV" > "$CHANGED.env"
+          args+=(--scan "$CHANGED.env")
+          "$SCRIPTS/demo-target-guard" "${args[@]}"
+
+      - name: Export the caller's extra environment
+        if: steps.discover.outputs.count != '0' && inputs.extra-env != ''
+        env:
+          EXTRA_ENV: ${{ inputs.extra-env }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r line; do
+            if [ -n "$line" ]; then
+              echo "$line" >> "$GITHUB_ENV"
+              echo "exported ${line%%=*}"
+            fi
+          done <<< "$EXTRA_ENV"
+
+      - uses: astral-sh/setup-uv@v6
+        if: steps.discover.outputs.count != '0'
+        with:
+          enable-cache: true
+
+      # Chromium is ~170 MB and re-downloading it on every pull request is the
+      # single biggest avoidable cost in this job. The key carries the resolved
+      # Playwright version so a version bump gets a fresh browser rather than a
+      # stale one that will not launch.
+      - name: Resolve the Playwright version the storyboards will get
+        if: steps.discover.outputs.count != '0'
+        id: pw
+        run: |
+          set -euo pipefail
+          v=$(uv run --no-project --with playwright python -c \
+                'import playwright; print(playwright.__version__)')
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+          echo "Playwright $v"
+
+      - name: Cache the Chromium build
+        if: steps.discover.outputs.count != '0'
+        id: browser-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}-chromium
+
+      - name: Install ffmpeg and Chromium
+        if: steps.discover.outputs.count != '0'
+        run: |
+          set -euo pipefail
+          if command -v ffmpeg >/dev/null && command -v ffprobe >/dev/null; then
+            echo "ffmpeg already present: $(ffmpeg -version | head -1)"
+          else
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends ffmpeg
+          fi
+          # On a cache hit this skips the browser download; the system
+          # libraries are not cacheable and are installed either way.
+          echo "browser cache hit: ${{ steps.browser-cache.outputs.cache-hit || 'false' }}"
+          uv run --no-project --with playwright playwright install --with-deps chromium
+
+      - name: Start the application
+        if: steps.discover.outputs.count != '0' && inputs.app-command != ''
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          APP_COMMAND: ${{ inputs.app-command }}
+        run: |
+          set -euo pipefail
+          nohup bash -c "$APP_COMMAND" > "$APP_LOG" 2>&1 &
+          echo "started: $APP_COMMAND (pid $!)"
+
+      - name: Wait for the application
+        if: steps.discover.outputs.count != '0' && inputs.app-command != ''
+        env:
+          URL: ${{ inputs.base-url }}${{ inputs.ready-path }}
+          DEADLINE: ${{ inputs.ready-timeout-seconds }}
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 "$DEADLINE"); do
+            if curl -fsS -o /dev/null "$URL"; then echo "$URL is up"; exit 0; fi
+            sleep 1
+          done
+          echo "::error::$URL never answered in ${DEADLINE}s"
+          echo "--- app log ---"; cat "$APP_LOG" || true
+          exit 1
+
+      # The take is allowed to fail here. What it left behind is the point of
+      # every step after this one, so the job is failed at the very end instead.
+      - name: Record
+        if: steps.discover.outputs.count != '0'
+        id: record
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          DEMO_VIDEO_BASE_URL: ${{ inputs.base-url }}
+          DEMO_VIDEO_SPEECH: "0"
+        run: |
+          set -uo pipefail
+          status=ok
+          while IFS= read -r sb; do
+            [ -n "$sb" ] || continue
+            echo "::group::uv run $sb"
+            if ! uv run "$sb"; then
+              echo "::error file=$sb::the take did not finish — see failure/ in the artifacts"
+              status=failed
+            fi
+            echo "::endgroup::"
+          done < "$CHANGED.selected"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "record status: $status"
+
+      - name: Stage the artifacts
+        if: always() && steps.discover.outputs.count != '0'
+        id: stage
+        working-directory: ${{ inputs.working-directory }}
+        run: |
+          set -euo pipefail
+          rm -rf "$STAGE_DEMO" "$STAGE_WORKING" "$STAGE_FAILURE"
+          mkdir -p "$STAGE_DEMO" "$STAGE_WORKING" "$STAGE_FAILURE"
+          while IFS= read -r dir; do
+            [ -n "$dir" ] || continue
+            # What a human watches and what stays readable after the video is
+            # gone. `demo-video-FAILED.md` travels with it deliberately: it is
+            # the file that says whether the mp4 beside it is this take's.
+            mkdir -p "$STAGE_DEMO/$dir"
+            for f in demo.mp4 timeline.md timeline.json demo-video-FAILED.md; do
+              if [ -f "$dir/$f" ]; then cp "$dir/$f" "$STAGE_DEMO/$dir/$f"; fi
+            done
+            if [ -d "$dir/images" ]; then cp -r "$dir/images" "$STAGE_DEMO/$dir/images"; fi
+            # Short retention: enough to check a disputed finding, not an archive.
+            for sub in evidence frames; do
+              if [ -d "$dir/$sub" ]; then
+                mkdir -p "$STAGE_WORKING/$dir"
+                cp -r "$dir/$sub" "$STAGE_WORKING/$dir/$sub"
+              fi
+            done
+            if [ -d "$dir/failure" ]; then
+              mkdir -p "$STAGE_FAILURE/$dir"
+              cp -r "$dir/failure" "$STAGE_FAILURE/$dir/failure"
+            fi
+          done < "$DEMO_DIRS"
+          bytes=$(find "$STAGE_DEMO" -type f -printf '%s\n' | awk '{s+=$1} END {print s+0}')
+          echo "bytes=$bytes" >> "$GITHUB_OUTPUT"
+          echo "staged $bytes bytes:"
+          find "$STAGE_DEMO" -type f | sed "s|$STAGE_DEMO/|  |"
+
+      - name: Upload the recording
+        if: always() && steps.discover.outputs.count != '0'
+        id: upload-demo
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-video
+          path: ${{ github.workspace }}/.demo-video-ci/demo
+          if-no-files-found: warn
+          retention-days: ${{ inputs.demo-retention-days }}
+
+      - name: Upload the working files a finding can be checked against
+        if: always() && steps.discover.outputs.count != '0'
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-video-working-files
+          path: ${{ github.workspace }}/.demo-video-ci/working
+          if-no-files-found: ignore
+          retention-days: ${{ inputs.evidence-retention-days }}
+
+      - name: Upload the failure dump
+        if: always() && steps.discover.outputs.count != '0' && steps.record.outputs.status != 'ok'
+        id: upload-failure
+        uses: actions/upload-artifact@v4
+        with:
+          name: demo-video-failure
+          path: ${{ github.workspace }}/.demo-video-ci/failure
+          if-no-files-found: warn
+          retention-days: ${{ inputs.evidence-retention-days }}
+
+      - name: Render the comment
+        if: always() && steps.discover.outputs.count != '0'
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          SCRIPTS: ${{ steps.helpers.outputs.dir }}
+          ARTIFACT_URL: ${{ steps.upload-demo.outputs.artifact-url }}
+          FAILURE_URL: ${{ steps.upload-failure.outputs.artifact-url }}
+          ARTIFACT_BYTES: ${{ steps.stage.outputs.bytes }}
+          RETENTION: ${{ inputs.demo-retention-days }}
+          EVIDENCE_RETENTION: ${{ inputs.evidence-retention-days }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS= read -r dir; do
+            if [ -n "$dir" ]; then args+=(--demo "$dir"); fi
+          done < "$DEMO_DIRS"
+          if [ -n "$FAILURE_URL" ]; then args+=(--failure-artifact-url "$FAILURE_URL"); fi
+          "$SCRIPTS/demo-comment" "${args[@]}" \
+            --artifact-url "$ARTIFACT_URL" \
+            --artifact-bytes "${ARTIFACT_BYTES:-0}" \
+            --retention-days "$RETENTION" \
+            --evidence-retention-days "$EVIDENCE_RETENTION" \
+            --run-url "$RUN_URL" --sha "$HEAD_SHA" \
+            --out "$COMMENT_BODY"
+
+      # One comment, found by its marker and rewritten. A branch with ten
+      # pushes must not bury its pull request under ten identical comments.
+      - name: Post or update the pull-request comment
+        if: always() && steps.discover.outputs.count != '0' && github.event.pull_request.number
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          MARKER: "<!-- demo-video-ci:"
+        run: |
+          set -euo pipefail
+          existing=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
+            --jq "[.[] | select(.body | startswith(\"$MARKER\")) | .id] | first // empty")
+          if [ -n "$existing" ]; then
+            url=$(gh api -X PATCH "repos/$REPO/issues/comments/$existing" \
+              -F body=@"$COMMENT_BODY" --jq .html_url)
+            echo "updated comment $existing in place: $url"
+          else
+            url=$(gh api -X POST "repos/$REPO/issues/$PR/comments" \
+              -F body=@"$COMMENT_BODY" --jq .html_url)
+            echo "posted a new comment: $url"
+          fi
+
+      # Last, so a take that failed still publishes everything above.
+      - name: Fail the check if the take failed
+        if: always() && steps.discover.outputs.count != '0' && steps.record.outputs.status != 'ok'
+        run: |
+          echo "::error::A take did not finish. The recording, the beat log and failure/ are attached to this run."
+          exit 1

--- a/.github/workflows/ticket-queue-demo.yml
+++ b/.github/workflows/ticket-queue-demo.yml
@@ -1,0 +1,49 @@
+name: ticket-queue demo
+
+# The only place in this repository that records a demo on a pull request, and
+# deliberately so. Most work here is secret-handling and artifact-integrity
+# correctness, which cannot be verified by watching — a demo of it would be
+# ceremony, and ceremony is what makes people stop watching. `examples/
+# ticket-queue` is the one application in the tree with demoable features, so
+# it is the one thing this fires on.
+#
+# The `paths:` filter is the coarse gate. The reusable workflow's own discovery
+# is the fine one: on a pull request that changes only the workflow or the
+# helper scripts, no storyboard under examples/ticket-queue is stale, so the
+# job finishes in well under a minute without starting a browser.
+
+on:
+  pull_request:
+    paths:
+      - "examples/ticket-queue/**"
+      - ".github/workflows/ticket-queue-demo.yml"
+      - ".github/workflows/demo-video.yml"
+      - ".github/scripts/demo-*"
+
+permissions:
+  contents: read
+
+# Ten pushes should cost one recording.
+concurrency:
+  group: ticket-queue-demo-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  demo:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: ./.github/workflows/demo-video.yml
+    with:
+      working-directory: examples/ticket-queue
+      app-command: ./serve --port 8901
+      base-url: http://127.0.0.1:8901
+      # The storyboards read TICKET_QUEUE_URL, so it is set here rather than
+      # left to their default — and the target guard checks it like any other.
+      extra-env: TICKET_QUEUE_URL=http://127.0.0.1:8901
+      # Long enough that a demo stays watchable through a normal review cycle
+      # and a week of holiday; short enough that a year of recordings is not
+      # sitting in the account. Stated in the comment so nobody is surprised
+      # when a revisited pull request has a dead link.
+      demo-retention-days: 30
+      evidence-retention-days: 3

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,13 @@ evidence/
 failure/
 demo-video-FAILED.md
 
+# Scratch the demo-video CI workflow writes into the checkout: staged
+# artifacts, the changed-file lists, the rendered comment body, and the
+# second checkout it makes of this repository when another repo calls it.
+# All of it is per-run and none of it is history.
+.demo-video-ci/
+.demo-video-helpers/
+
 # Smoke-test recordings. tests/smoke records into a temp dir by default; this
 # covers pointing it back into the repo (tests/smoke --out-dir tests/out).
 tests/out/

--- a/README.md
+++ b/README.md
@@ -43,6 +43,33 @@ or installed. (You can still pull one directly by path if you want to try it.)
 
 *Nothing in development right now.*
 
+## Recording a demo on a pull request
+
+[`.github/workflows/demo-video.yml`](.github/workflows/demo-video.yml) is a
+reusable GitHub Actions workflow that records the demos a branch made stale and
+posts **one comment** on the pull request — rewritten on every push — carrying
+the beat table as text and a deep link to the mp4. A consuming repo calls it in
+a few lines:
+
+```yaml
+jobs:
+  demo:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: rogvid/skills/.github/workflows/demo-video.yml@main
+    with:
+      working-directory: app
+      app-command: npm run dev -- --port 3000
+      base-url: http://127.0.0.1:3000
+```
+
+It records only storyboards whose application changed, sets an explicit
+artifact retention and says it in the comment, and **refuses to record against
+a public host** — see *Recording on a pull request (CI)* in
+[`skills/demo-video/SKILL.md`](skills/demo-video/SKILL.md) for the trigger
+policy, what is published, and what the target guard does not cover.
+
 ## Examples
 
 [`examples/`](examples/) holds applications the skills are exercised against.

--- a/ruff.toml
+++ b/ruff.toml
@@ -16,6 +16,8 @@ exclude = [
 # Without these patterns the scripts that matter most would go unlinted.
 extend-include = [
     "tests/smoke",
+    "tests/ci-unit",
+    ".github/scripts/*",   # the CI workflow's PEP 723 executables
     "skills/*/scripts/*",  # every skill's PEP 723 executables
     "examples/*/serve",    # the example app's PEP 723 executables
     "examples/*/tickets",

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -1449,12 +1449,89 @@ painted before that first `goto()` would be destroyed by it.
 
    To put the demo in front of a reviewer, drag `demo.mp4` into a PR
    comment box — GitHub hosts it and renders a real player. That upload has
-   no public API, so it stays a manual step.
+   no public API, so it stays a manual step. To stop doing it by hand
+   entirely, run the recording in the pipeline instead: see **Recording on a
+   pull request (CI)** below, which publishes the video as a job artifact and
+   the beat table as text in one comment.
 
    The exception is a video that is itself permanent documentation: a
    hand-authored showcase for a stable feature, recorded once and not
    per-change. Commit that one deliberately, knowing the repo carries it
    forever.
+
+## Recording on a pull request (CI)
+
+Everything above is a storyboard being run by hand. The point of the skill is
+that a reviewer never has to do that, so the same run belongs in the pipeline:
+a reusable GitHub Actions workflow lives at
+[`.github/workflows/demo-video.yml`](https://github.com/rogvid/skills/blob/main/.github/workflows/demo-video.yml)
+in this repository. A consuming repo calls it in a few lines:
+
+```yaml
+# .github/workflows/demo.yml
+on:
+  pull_request:
+    paths: ["app/**"]          # the coarse gate — see "What gates it" below
+
+permissions:
+  contents: read
+
+concurrency:                    # ten pushes should cost one recording
+  group: demo-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  demo:
+    permissions:
+      contents: read
+      pull-requests: write      # required: the workflow writes one comment
+    uses: rogvid/skills/.github/workflows/demo-video.yml@main
+    with:
+      working-directory: app
+      app-command: npm run dev -- --port 3000
+      base-url: http://127.0.0.1:3000
+      demo-retention-days: 30
+```
+
+**What the pull request gets.** One comment, found by a hidden marker and
+**rewritten** on every push rather than appended, carrying two things:
+
+1. **The beat table as text** — every caption in order, straight out of
+   `timeline.json`. No hosting, no expiry, no Actions access needed, and it
+   renders on GitLab and Bitbucket too. This is the tier that survives the
+   artifact expiring.
+2. **A deep link to the artifact** — `…/actions/runs/<id>/artifacts/<id>`, so
+   watching is one click and an unzip.
+
+`demo.mp4`, `timeline.md`/`.json` and `images/` upload as the `demo-video`
+artifact on an explicit `retention-days`; `evidence/` and `frames/` upload
+separately on a short one (1–7 days, long enough to check a disputed finding
+and not long enough to be an archive) and are **not** linked from the comment;
+`failure/` uploads on the failure path only. A take that does not finish fails
+the check *after* publishing all of it — the crashed take is exactly the one
+somebody needs to look at.
+
+**What gates it.** Recording is not a test job: it runs a browser and a
+software encoder, and costs minutes. Two gates, doing different work:
+
+- the caller's `paths:` filter, which decides whether a runner starts at all;
+- the workflow's own discovery, which records a storyboard only when the
+  branch changed something under the app that storyboard demonstrates — the
+  directory containing its `demos/`. A branch that changed neither exits in
+  seconds. Pass `storyboards:` explicitly to override.
+
+A label was the alternative and was rejected: it needs a human action on every
+branch, and when somebody forgets, the failure mode is *no video*.
+
+**It refuses to record against production.** The mp4 is an outbound artifact —
+it leaves the repository boundary the moment anyone downloads it, showing
+whatever was on screen. So `base-url`, the caller's `extra-env`, and the
+`http(s)://` literals inside each storyboard are all classified before the
+browser opens: loopback always passes, a private or internal host needs
+`allow-private-network-target: true`, and a **public host is refused with no
+input that permits it**. That is a static check on configuration and source
+text, not an egress control: a storyboard that computes its URL at run time is
+invisible to it.
 
 ## Common mistakes
 

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -1,0 +1,618 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Unit tests for the three helper scripts the demo-video CI workflow runs.
+
+    tests/ci-unit                  # run the suite
+    tests/ci-unit --fault-inject   # prove the suite can fail
+
+The workflow itself is YAML that only GitHub can execute, so what is tested
+here is everything the workflow *delegates*: which storyboards a diff makes
+stale, whether a target may be recorded against, and what the pull-request
+comment says. Those are the three places a wrong answer would be believed.
+
+**`--fault-inject` is the part that makes the rest mean anything.** It breaks
+one specific thing in a helper, runs the suite against the broken copy, and
+requires the named tests to fail. An injection whose search string does not
+match *exactly once* aborts the run rather than reporting a pass — an
+injection that silently did nothing would otherwise "prove" a hollow assertion
+was sound. What is deliberately NOT covered is stated at the bottom of this
+file; read it before treating a green run as coverage of the workflow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from types import ModuleType
+
+SCRIPTS = Path(__file__).resolve().parents[1] / ".github" / "scripts"
+
+
+def load(name: str, directory: Path | None = None) -> ModuleType:
+    """Import an extension-less PEP 723 executable as a module."""
+    path = (directory or SCRIPTS) / name
+    spec = importlib.util.spec_from_loader(
+        name.replace("-", "_"),
+        importlib.machinery.SourceFileLoader(name.replace("-", "_"), str(path)),
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_DIR = Path(os.environ.get("CI_UNIT_SCRIPTS", SCRIPTS))
+storyboards = load("demo-storyboards", _DIR)
+guard = load("demo-target-guard", _DIR)
+comment = load("demo-comment", _DIR)
+
+
+# --------------------------------------------------------------------------
+# demo-storyboards — which storyboards a diff makes stale
+# --------------------------------------------------------------------------
+
+
+class AppRoot(unittest.TestCase):
+    def test_parent_of_the_demos_directory(self):
+        self.assertEqual(
+            storyboards.app_root("examples/ticket-queue/demos/2026-07-26-x/record.py"),
+            "examples/ticket-queue",
+        )
+
+    def test_a_storyboard_at_the_root_attributes_to_the_whole_repository(self):
+        # There is no narrower directory to blame, and saying "" (the repo
+        # root) is honest where inventing one would not be.
+        self.assertEqual(storyboards.app_root("demos/x/record.py"), "")
+
+    def test_innermost_demos_wins(self):
+        # The narrower root records fewer storyboards, never more.
+        self.assertEqual(
+            storyboards.app_root("a/demos/b/demos/c/record.py"), "a/demos/b"
+        )
+
+    def test_no_demos_component_falls_back_to_the_storyboards_own_folder(self):
+        self.assertEqual(storyboards.app_root("a/b/record.py"), "a/b")
+
+
+class Select(unittest.TestCase):
+    SB = "examples/ticket-queue/demos/2026-07-26-status-filter/record.py"
+    OTHER = "examples/other-app/demos/2026-01-01-x/record.py"
+
+    def test_a_change_to_the_storyboard_itself_selects_it(self):
+        self.assertEqual(storyboards.select([self.SB], [self.SB]), [self.SB])
+
+    def test_a_change_to_the_app_it_demonstrates_selects_it(self):
+        # The point of the rule: a demo of code that moved is stale even when
+        # nobody touched the storyboard.
+        self.assertEqual(
+            storyboards.select([self.SB], ["examples/ticket-queue/web/app.js"]),
+            [self.SB],
+        )
+
+    def test_a_change_elsewhere_selects_nothing(self):
+        self.assertEqual(
+            storyboards.select([self.SB], ["skills/demo-video/SKILL.md", "README.md"]),
+            [],
+        )
+
+    def test_a_sibling_apps_change_does_not_select_this_one(self):
+        self.assertEqual(
+            storyboards.select(
+                [self.SB, self.OTHER], ["examples/other-app/web/app.js"]
+            ),
+            [self.OTHER],
+        )
+
+    def test_an_empty_diff_selects_nothing(self):
+        self.assertEqual(storyboards.select([self.SB], []), [])
+
+    def test_a_prefix_that_is_not_a_path_boundary_does_not_match(self):
+        # "examples/ticket-queue-v2/..." must not select the ticket-queue demo.
+        self.assertEqual(
+            storyboards.select([self.SB], ["examples/ticket-queue-v2/web/app.js"]), []
+        )
+
+
+class StripPrefix(unittest.TestCase):
+    """Re-rooting a repository-relative diff onto `working-directory`."""
+
+    CHANGED = [
+        "examples/ticket-queue/web/app.js",
+        "examples/ticket-queue-v2/web/app.js",
+        "README.md",
+        "docs/examples/ticket-queue/notes.md",
+    ]
+
+    def test_only_paths_inside_the_prefix_survive_and_are_re_rooted(self):
+        self.assertEqual(
+            storyboards.strip_prefix(self.CHANGED, "examples/ticket-queue"),
+            ["web/app.js"],
+        )
+
+    def test_a_neighbour_sharing_the_prefix_as_text_is_not_inside_it(self):
+        # The bug this exists for: `grep -F examples/ticket-queue/` matches
+        # `examples/ticket-queue-v2/…` and `docs/examples/ticket-queue/…`, and
+        # every push to either would record the wrong application's demo.
+        got = storyboards.strip_prefix(self.CHANGED, "examples/ticket-queue")
+        self.assertNotIn("web/app.js", got[1:])
+        self.assertEqual(len(got), 1)
+
+    def test_no_prefix_passes_everything_through(self):
+        self.assertEqual(storyboards.strip_prefix(self.CHANGED, ""), self.CHANGED)
+        self.assertEqual(storyboards.strip_prefix(self.CHANGED, "."), self.CHANGED)
+
+    def test_a_trailing_slash_is_the_same_prefix(self):
+        self.assertEqual(
+            storyboards.strip_prefix(self.CHANGED, "examples/ticket-queue/"),
+            ["web/app.js"],
+        )
+
+    def test_a_diff_entirely_outside_the_prefix_becomes_empty(self):
+        # This is what makes the working-directory scoping a real gate: with
+        # `working-directory: examples/ticket-queue`, every storyboard's app
+        # root is "" (the directory itself), so if anything survived the strip
+        # it would select them all.
+        self.assertEqual(
+            storyboards.strip_prefix(
+                ["README.md", "skills/x/SKILL.md"], "examples/ticket-queue"
+            ),
+            [],
+        )
+
+
+# --------------------------------------------------------------------------
+# demo-target-guard — what may be recorded against
+# --------------------------------------------------------------------------
+
+
+class Classify(unittest.TestCase):
+    def test_loopback_addresses_and_names(self):
+        for url in (
+            "http://127.0.0.1:8901",
+            "http://127.5.5.5/",
+            "http://localhost:3000/x",
+            "http://[::1]:8000",
+            "https://app.localhost",
+        ):
+            with self.subTest(url=url):
+                self.assertEqual(guard.classify(url)[0], guard.LOOPBACK)
+
+    def test_private_addresses_names_and_suffixes(self):
+        for url in (
+            "http://10.0.0.4:8080",
+            "http://192.168.1.10",
+            "http://172.16.9.9",
+            "http://web:8000",  # a container service name
+            "http://queue.internal/",
+            "http://app.test",
+        ):
+            with self.subTest(url=url):
+                self.assertEqual(guard.classify(url)[0], guard.PRIVATE)
+
+    def test_public_names_and_addresses(self):
+        for url in (
+            "https://tickets.acme.com",
+            "https://staging.acme.co.uk/queue",
+            "http://93.184.216.34",
+            "https://acme.com.",  # trailing dot is still the same public name
+        ):
+            with self.subTest(url=url):
+                self.assertEqual(guard.classify(url)[0], guard.PUBLIC)
+
+    def test_a_non_http_scheme_is_malformed(self):
+        self.assertEqual(guard.classify("file:///etc/passwd")[0], guard.MALFORMED)
+        self.assertEqual(guard.classify("not a url")[0], guard.MALFORMED)
+
+
+class Check(unittest.TestCase):
+    def test_loopback_passes_without_any_opt_in(self):
+        self.assertIsNone(guard.check("http://127.0.0.1:8901", allow_private=False))
+
+    def test_private_is_refused_by_default_and_allowed_by_the_opt_in(self):
+        self.assertIsNotNone(guard.check("http://10.0.0.4", allow_private=False))
+        self.assertIsNone(guard.check("http://10.0.0.4", allow_private=True))
+
+    def test_public_is_refused_even_with_the_opt_in(self):
+        # This is the whole point of the guard: no input makes production
+        # reachable. If this test ever passes trivially, the guard is decorative.
+        reason = guard.check("https://tickets.acme.com", allow_private=True)
+        self.assertIsNotNone(reason)
+        self.assertIn("refused", reason)
+
+    def test_the_refusal_names_the_url_so_it_can_be_fixed(self):
+        reason = guard.check("https://tickets.acme.com", allow_private=False)
+        self.assertIn("tickets.acme.com", reason)
+
+
+class Scan(unittest.TestCase):
+    SOURCE = textwrap.dedent(
+        '''
+        """A storyboard."""
+        BASE = os.environ.get("URL", "http://127.0.0.1:8901")
+        FALLBACK = "https://tickets.acme.com/queue"
+        # see http://127.0.0.1:8901 again
+        '''
+    )
+
+    def test_finds_every_distinct_literal_in_order(self):
+        self.assertEqual(
+            guard.scan(self.SOURCE),
+            ["http://127.0.0.1:8901", "https://tickets.acme.com/queue"],
+        )
+
+    def test_a_public_literal_in_a_storyboard_is_refused(self):
+        refusals = [u for u in guard.scan(self.SOURCE) if guard.check(u, False)]
+        self.assertEqual(refusals, ["https://tickets.acme.com/queue"])
+
+    def test_a_trailing_quote_or_paren_is_not_part_of_the_url(self):
+        self.assertEqual(
+            guard.scan('x = ("http://127.0.0.1:80")'), ["http://127.0.0.1:80"]
+        )
+
+
+class GuardExitCode(unittest.TestCase):
+    """The workflow only sees the exit status, so assert on that."""
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(_DIR / "demo-target-guard"), *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_loopback_exits_zero(self):
+        self.assertEqual(self._run("--url", "http://127.0.0.1:8901").returncode, 0)
+
+    def test_public_exits_two_and_says_why_on_stderr(self):
+        done = self._run("--url", "https://tickets.acme.com", "--allow-private")
+        self.assertEqual(done.returncode, 2)
+        self.assertIn("tickets.acme.com", done.stderr)
+
+
+# --------------------------------------------------------------------------
+# demo-comment — what the pull request says
+# --------------------------------------------------------------------------
+
+
+def beats(*pairs: tuple[float, str]) -> list[dict]:
+    return [{"index": i, "t_start": t, "caption": c} for i, (t, c) in enumerate(pairs)]
+
+
+TIMELINE = {
+    "schema": 1,
+    "recorder": "Recorder",
+    "duration": 21.4,
+    "issue_count": 0,
+    "issues": [],
+    "beats": beats(
+        (0.4, ""),
+        (1.0, "The support queue, every ticket the team holds."),
+        (4.4, "The support queue, every ticket the team holds."),
+        (6.0, "Escalated matches nothing."),
+        (9.0, "Escalated matches nothing."),
+        (11.0, ""),
+        (12.0, "Escalated matches nothing."),
+    ),
+}
+
+
+class StoryBeats(unittest.TestCase):
+    def test_a_caption_held_across_several_verbs_is_one_row(self):
+        rows = comment.story_beats(TIMELINE["beats"])
+        self.assertEqual(
+            [c for _, c in rows][:2],
+            [
+                "The support queue, every ticket the team holds.",
+                "Escalated matches nothing.",
+            ],
+        )
+
+    def test_a_row_carries_the_moment_the_caption_went_up(self):
+        rows = comment.story_beats(TIMELINE["beats"])
+        self.assertEqual(rows[0][0], 1.0)
+        self.assertEqual(rows[1][0], 6.0)
+
+    def test_a_caption_cleared_and_shown_again_is_two_rows(self):
+        # Two separate moments on screen, so two entries. Collapsing them
+        # would misreport a demo that returns to a state.
+        rows = comment.story_beats(TIMELINE["beats"])
+        self.assertEqual(len(rows), 3)
+        self.assertEqual(rows[2], (12.0, "Escalated matches nothing."))
+
+    def test_beats_with_no_caption_produce_no_row(self):
+        self.assertEqual(comment.story_beats(beats((0.0, ""), (1.0, "  "))), [])
+
+    def test_order_is_the_order_they_appeared(self):
+        rows = comment.story_beats(beats((0.0, "a"), (1.0, "b"), (2.0, "c")))
+        self.assertEqual([c for _, c in rows], ["a", "b", "c"])
+
+
+class Cell(unittest.TestCase):
+    def test_a_pipe_in_a_caption_is_escaped_so_the_table_survives(self):
+        # A caption is author-written prose. One `|` in it silently splits the
+        # row and every later column shifts, which is a table that lies.
+        self.assertEqual(comment._cell("cat a | grep b"), "cat a \\| grep b")
+
+    def test_a_newline_is_collapsed(self):
+        self.assertEqual(comment._cell("one\ntwo"), "one two")
+
+    def test_an_empty_caption_leaves_a_visible_cell(self):
+        self.assertEqual(comment._cell(""), "&nbsp;")
+
+
+class Render(unittest.TestCase):
+    def body(self, timeline=None, **kw):
+        opts = dict(
+            artifact_url="https://github.com/o/r/actions/runs/1/artifacts/2",
+            artifact_bytes=4_200_000,
+            retention_days=30,
+            evidence_retention_days=3,
+            failure_artifact_url=None,
+            run_url="https://github.com/o/r/actions/runs/1",
+            sha="abcdef1234567890",
+        )
+        opts.update(kw)
+        return comment.render([("demos/x", timeline or TIMELINE)], **opts)
+
+    def test_the_marker_is_the_first_thing_in_the_body(self):
+        # The workflow finds the comment to rewrite with startswith(). If the
+        # marker moves, every push posts a new comment instead.
+        self.assertTrue(self.body().startswith(comment.MARKER))
+
+    def test_every_caption_reaches_the_comment(self):
+        body = self.body()
+        for _, caption in comment.story_beats(TIMELINE["beats"]):
+            self.assertIn(caption, body)
+
+    def test_the_artifact_deep_link_is_present_with_its_size(self):
+        body = self.body()
+        self.assertIn("https://github.com/o/r/actions/runs/1/artifacts/2", body)
+        self.assertIn("4.2 MB", body)
+
+    def test_the_retention_is_stated_in_the_comment(self):
+        # Issue #2: an artifact expires and a pull request revisited after that
+        # has a dead link. Nobody should be surprised by it.
+        self.assertIn("30 days", self.body())
+
+    def test_a_take_with_no_artifact_says_so_rather_than_linking_nothing(self):
+        body = self.body(artifact_url=None)
+        self.assertIn("No recording was uploaded", body)
+        self.assertNotIn("Download the recording", body)
+
+    def test_a_failed_take_is_labelled_and_names_the_failing_beat(self):
+        broken = dict(TIMELINE)
+        broken["failure"] = {
+            "type": "TimeoutError",
+            "beat": 12,
+            "verb": "wait_for",
+            "message": "waiting for .queue-empty",
+        }
+        body = self.body(broken)
+        self.assertIn("the take failed", body)
+        self.assertIn("beat 12", body)
+        self.assertIn("wait_for", body)
+        self.assertIn("waiting for .queue-empty", body)
+
+    def test_a_clean_take_is_not_labelled_as_failed(self):
+        self.assertNotIn("the take failed", self.body())
+
+    def test_issues_behind_the_pixels_are_reported(self):
+        noisy = dict(TIMELINE)
+        noisy["issue_count"] = 1
+        noisy["issues"] = [
+            {
+                "kind": "console_error",
+                "beat": 3,
+                "message": "Cannot read properties of undefined",
+            }
+        ]
+        body = self.body(noisy)
+        self.assertIn("console_error", body)
+        self.assertIn("Cannot read properties of undefined", body)
+
+    def test_a_null_duration_is_not_reported_as_a_number(self):
+        # `duration: null` means this take encoded no video. Printing "0s"
+        # would read as a successful zero-length demo.
+        no_video = dict(TIMELINE, duration=None)
+        body = self.body(no_video)
+        self.assertIn("no video", body)
+        self.assertNotIn("· 0s ·", body)
+
+    def test_a_caption_containing_a_pipe_does_not_break_the_table(self):
+        piped = dict(TIMELINE, beats=beats((1.0, "run: cat x | wc -l")))
+        rows = [ln for ln in self.body(piped).splitlines() if ln.startswith("| 1 |")]
+        self.assertEqual(len(rows), 1)
+        unescaped = re.sub(r"\\\|", "", rows[0])
+        self.assertEqual(unescaped.count("|"), 4, rows[0])  # 4 delimiters, 3 cells
+
+
+# --------------------------------------------------------------------------
+# Fault injection
+# --------------------------------------------------------------------------
+
+# (name, script, exact text to replace, replacement, tests that must then fail)
+INJECTIONS = [
+    (
+        "app_root always returns the repository root",
+        "demo-storyboards",
+        '            return "/".join(parts[:i])',
+        '            return ""',
+        ["Select.test_a_change_elsewhere_selects_nothing"],
+    ),
+    (
+        "select ignores the path boundary and matches on a bare prefix",
+        "demo-storyboards",
+        '    return path == root or path.startswith(root + "/")',
+        "    return path.startswith(root)",
+        ["Select.test_a_prefix_that_is_not_a_path_boundary_does_not_match"],
+    ),
+    (
+        "strip_prefix tests the prefix as text instead of at a path boundary",
+        "demo-storyboards",
+        "    return [p[len(prefix) :] for p in changed if p.startswith(prefix)]",
+        "    return [p.replace(prefix, '', 1) for p in changed if prefix.rstrip('/') in p]",
+        ["StripPrefix.test_a_neighbour_sharing_the_prefix_as_text_is_not_inside_it"],
+    ),
+    (
+        "the guard permits a public host",
+        "demo-target-guard",
+        '    if kind == PUBLIC:\n        return f"{url} — {why}. Recording a demo against a public host is refused; '
+        'there is no option that permits it."',
+        "    if kind == PUBLIC:\n        return None",
+        [
+            "Check.test_public_is_refused_even_with_the_opt_in",
+            "GuardExitCode.test_public_exits_two_and_says_why_on_stderr",
+        ],
+    ),
+    (
+        "the guard forgets the --allow-private opt-in and lets private through",
+        "demo-target-guard",
+        "    if kind == PRIVATE and allow_private:\n        return None",
+        "    if kind == PRIVATE:\n        return None",
+        ["Check.test_private_is_refused_by_default_and_allowed_by_the_opt_in"],
+    ),
+    (
+        "story_beats emits one row per beat instead of one per caption",
+        "demo-comment",
+        "        if caption and caption != previous:",
+        "        if caption:",
+        ["StoryBeats.test_a_caption_held_across_several_verbs_is_one_row"],
+    ),
+    (
+        "the table cell stops escaping pipes",
+        "demo-comment",
+        '    out = (text or "").replace("\\\\", "\\\\\\\\").replace("|", "\\\\|")',
+        '    out = text or ""',
+        [
+            "Cell.test_a_pipe_in_a_caption_is_escaped_so_the_table_survives",
+            "Render.test_a_caption_containing_a_pipe_does_not_break_the_table",
+        ],
+    ),
+    (
+        "the comment loses its marker, so every push posts a new comment",
+        "demo-comment",
+        '    lines = [MARKER, ""]',
+        '    lines = [""]',
+        ["Render.test_the_marker_is_the_first_thing_in_the_body"],
+    ),
+    (
+        "the comment stops stating the retention",
+        "demo-comment",
+        '            f"Kept for **{retention_days} days**, then this link dies. The beat table above "',
+        '            f"Kept for a while{retention_days!r:.0}, then this link dies. The beat table above "',
+        ["Render.test_the_retention_is_stated_in_the_comment"],
+    ),
+    (
+        "a null duration is printed as a number",
+        "demo-comment",
+        '    if d is None:\n        return "no video (this take encoded none)"',
+        '    if d is None:\n        return "0s"',
+        ["Render.test_a_null_duration_is_not_reported_as_a_number"],
+    ),
+]
+
+
+def fault_inject() -> int:
+    """Break one thing at a time and require the named tests to notice."""
+    failures = 0
+    for name, script, old, new, must_fail in INJECTIONS:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "scripts"
+            shutil.copytree(SCRIPTS, root)
+            target = root / script
+            text = target.read_text(encoding="utf-8")
+            hits = text.count(old)
+            if hits != 1:
+                print(
+                    f"ABORT: injection {name!r} matched {hits} times in {script}, "
+                    f"expected exactly 1. The injection did not land, so nothing "
+                    f"it would have proven is proven.",
+                    file=sys.stderr,
+                )
+                print(f"       looked for: {old!r}", file=sys.stderr)
+                return 3
+            target.write_text(text.replace(old, new), encoding="utf-8")
+
+            done = subprocess.run(
+                [sys.executable, str(Path(__file__).resolve()), "--_inner"],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "CI_UNIT_SCRIPTS": str(root)},
+            )
+            noticed = {t for t in must_fail if t in done.stderr}
+            missed = set(must_fail) - noticed
+            ok = done.returncode != 0 and not missed
+            print(f"{'PASS' if ok else 'FAIL'}  break: {name}")
+            print(f"      in {script}: {old.strip().splitlines()[0][:70]}…")
+            if ok:
+                first = [
+                    ln
+                    for ln in done.stderr.splitlines()
+                    if ln.startswith(("FAIL:", "ERROR:"))
+                ]
+                for line in first[:4]:
+                    print(f"      {line}")
+            else:
+                failures += 1
+                if missed:
+                    print(f"      these tests did NOT fail: {sorted(missed)}")
+                if done.returncode == 0:
+                    print("      the suite passed against broken code")
+                print(textwrap.indent(done.stderr[-1500:], "      | "))
+            print()
+    if failures:
+        print(
+            f"{failures} injection(s) went unnoticed — those assertions grade nothing."
+        )
+        return 1
+    print(f"All {len(INJECTIONS)} injections were caught.")
+    return 0
+
+
+# --------------------------------------------------------------------------
+# What this suite does NOT cover
+# --------------------------------------------------------------------------
+#
+# Stated plainly rather than implied by silence:
+#
+# - **The workflow YAML itself.** Step ordering, `if:` conditions, artifact
+#   retention actually reaching `upload-artifact`, and the find-or-create
+#   comment logic are executed only by GitHub. They are verified by running
+#   the workflow on a real pull request and looking at the result — pushing
+#   twice and confirming there is still one comment is the only honest test of
+#   "updated in place", and it is done by hand on the reference pull request.
+# - **The recorder.** `tests/smoke` owns that.
+# - **Egress.** The target guard is a static check on configuration and source
+#   text. A storyboard that computes a URL at run time is invisible to it, and
+#   nothing here stops a runner from reaching the internet.
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--fault-inject",
+        action="store_true",
+        help="break each assertion's subject and require it to fail",
+    )
+    ap.add_argument("--_inner", action="store_true", help=argparse.SUPPRESS)
+    args, rest = ap.parse_known_args()
+    if args.fault_inject:
+        return fault_inject()
+    result = unittest.main(argv=[sys.argv[0], *rest], exit=False, verbosity=2).result
+    return 0 if result.wasSuccessful() else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import os
 import re
 import shutil
@@ -438,6 +439,89 @@ class Render(unittest.TestCase):
         self.assertEqual(unescaped.count("|"), 4, rows[0])  # 4 delimiters, 3 cells
 
 
+class CommentCli(unittest.TestCase):
+    """`--demo-root`: read from the staging area, name by the repository path.
+
+    The comment must describe what was *published*, not what is lying in the
+    working tree. `images/` and both timelines are committed files, so on any
+    path where the take did not rewrite them the working tree still holds the
+    previous recording — and rendering from there produced a comment with full
+    beat tables and a duration for a take that recorded nothing at all. That
+    happened on the first real run of this workflow.
+    """
+
+    def _run(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(_DIR / "demo-comment"), *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def test_the_timeline_is_read_from_demo_root_and_named_by_demo(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "stage"
+            (root / "demos/x").mkdir(parents=True)
+            (root / "demos/x/timeline.json").write_text(json.dumps(TIMELINE))
+            out = Path(tmp) / "body.md"
+            done = self._run(
+                "--demo",
+                "demos/x",
+                "--demo-root",
+                str(root),
+                "--retention-days",
+                "30",
+                "--out",
+                str(out),
+            )
+            self.assertEqual(done.returncode, 0, done.stderr)
+            body = out.read_text()
+            self.assertIn("`demos/x`", body)
+            self.assertNotIn(str(root), body)  # no runner path leaks to the reader
+            self.assertIn("The support queue, every ticket the team holds.", body)
+
+    def test_a_demo_absent_from_the_staging_area_is_reported_as_publishing_nothing(
+        self,
+    ):
+        # The freshness filter held its timeline back, or the take wrote none.
+        # Either way the comment must not fall back to the working tree.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "stage"
+            root.mkdir()
+            out = Path(tmp) / "body.md"
+            done = self._run(
+                "--demo",
+                "demos/x",
+                "--demo-root",
+                str(root),
+                "--retention-days",
+                "30",
+                "--out",
+                str(out),
+            )
+            self.assertEqual(done.returncode, 0, done.stderr)
+            body = out.read_text()
+            self.assertIn("the take failed", body)
+            self.assertIn("published no timeline.json", body)
+
+    def test_without_demo_root_the_demo_path_is_read_directly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / "demos/x").mkdir(parents=True)
+            (Path(tmp) / "demos/x/timeline.json").write_text(json.dumps(TIMELINE))
+            out = Path(tmp) / "body.md"
+            done = self._run(
+                "--demo",
+                f"{tmp}/demos/x",
+                "--retention-days",
+                "30",
+                "--out",
+                str(out),
+            )
+            self.assertEqual(done.returncode, 0, done.stderr)
+            self.assertIn(
+                "The support queue, every ticket the team holds.", out.read_text()
+            )
+
+
 # --------------------------------------------------------------------------
 # Fault injection
 # --------------------------------------------------------------------------
@@ -513,6 +597,24 @@ INJECTIONS = [
         '            f"Kept for **{retention_days} days**, then this link dies. The beat table above "',
         '            f"Kept for a while{retention_days!r:.0}, then this link dies. The beat table above "',
         ["Render.test_the_retention_is_stated_in_the_comment"],
+    ),
+    (
+        "--demo-root is ignored, so the comment reads the working tree",
+        "demo-comment",
+        "        directory = Path(args.demo_root) / name if args.demo_root else Path(name)",
+        "        directory = Path(name)",
+        [
+            "CommentCli.test_the_timeline_is_read_from_demo_root_and_named_by_demo",
+        ],
+    ),
+    (
+        "the missing-timeline path is unreachable, so the comment crashes instead",
+        "demo-comment",
+        "        if not timeline_path.exists():",
+        "        if False:",
+        [
+            "CommentCli.test_a_demo_absent_from_the_staging_area_is_reported_as_publishing_nothing",
+        ],
     ),
     (
         "a null duration is printed as a number",


### PR DESCRIPTION
Fixes #65.

Every demo this repository has produced was recorded by hand and copied to a desktop by hand. That is why the "review the video, not the diff" loop has never actually run: there is no CI entry point, so there is no reference pull request anywhere showing it end to end. `.github/workflows/demo-video.yml` is that entry point — a `workflow_call` reusable workflow a consuming repo references in a few lines.

**This pull request is only half of the acceptance test.** Workflow YAML is executed only by GitHub, so the proof that it works is #117, stacked on top of this, where the comment actually appears and the artifact actually downloads. Running it there found four defects that no amount of local checking would have — see *What the real runs found*.

## What the pull request gets

One comment, found by a hidden marker and **rewritten** on each push rather than appended, carrying the two tiers #2 decided on:

1. **The beat table as text** — every caption in order, straight out of `timeline.json`. No hosting, no expiry, no Actions access needed, renders on GitLab and Bitbucket too. This is the tier that survives artifact expiry.
2. **A deep link to the artifact** — `…/actions/runs/<id>/artifacts/<id>`, so watching is one click and an unzip.

| what | where it goes | retention |
|---|---|---|
| `demo.mp4`, `timeline.md`, `timeline.json`, `images/` | `demo-video` artifact, linked from the comment | **30 days, explicit** |
| the beat table | inline text in the comment | forever |
| `evidence/`, `frames/` | `demo-video-working-files` artifact, **not** linked from the comment | 3 days |
| `failure/` | `demo-video-failure` artifact, failure path only | 3 days |

Retention is set rather than inherited, and stated in the comment: the default is 90 days and org policy frequently lowers it, which is how a pull request revisited later ends up with a dead link. The storyboard and the beat table are the durable record.

A take that does not finish fails the check **after** publishing all of the above. The crashed take is exactly the one somebody needs to look at.

## What gates it, and why

Recording is not a test job. It runs a browser and a software encoder; `smoke` in this repo is already ~8 minutes. Two gates, doing different work:

1. **The caller's `paths:` filter** — decides whether a runner starts at all.
2. **The workflow's own discovery** — records a storyboard only when the branch changed something under the app that storyboard demonstrates (the directory holding its `demos/`). A branch that changed neither exits in seconds. `storyboards:` overrides it.

**A label was the alternative and was rejected.** It needs a human action on a branch that already exists, and when somebody forgets, the failure mode is *no video* — precisely the thing this workflow exists to eliminate. A path filter is automatic, and it matches the house rule that demoability is decided by the author before the work starts.

Both gates were exercised for real: on *this* pull request, which changes the workflow but nothing under `examples/ticket-queue`, the job finishes in **13 seconds** without starting a browser. On #117 it records.

**The "app moved" half of the rule earned itself immediately.** #112 made the caption on an *older* storyboard untrue without touching that storyboard. Under a storyboard-only rule nobody would have re-recorded it, and the repository would hold a demo that lies, with green CI.

## It will not record production

The mp4 is an outbound artifact: it leaves the repository boundary the moment anyone downloads it, showing whatever was on screen. Pointed at production it is a screen recording of real customer data, published to everyone with repository read access.

So the target is classified, not trusted — `base-url`, the caller's `extra-env`, and every `http(s)://` literal inside each selected storyboard:

| class | verdict |
|---|---|
| loopback (`127.0.0.1`, `localhost`, `[::1]`) | always allowed |
| private (`10.x`, a container service name, `*.internal`) | needs `allow-private-network-target: true` |
| public (`tickets.acme.com`, `93.184.216.34`) | **refused, and no input permits it** |

There is deliberately no `allow-public`. A team that truly needs it writes their own job and owns that decision.

## Verification

Following `wip/verified-review/SKILL.md`. The three places a wrong answer would be *believed* were moved out of the shell into helpers that can be tested — which storyboards a diff makes stale, whether a target may be recorded against, and what the comment says.

`tests/ci-unit` is 49 assertions over those three. `tests/ci-unit --fault-inject` breaks each subject in a named way and requires the watching test to go red:

```
PASS  break: app_root always returns the repository root
PASS  break: select ignores the path boundary and matches on a bare prefix
PASS  break: strip_prefix tests the prefix as text instead of at a path boundary
PASS  break: the guard permits a public host
PASS  break: the guard forgets the --allow-private opt-in and lets private through
PASS  break: story_beats emits one row per beat instead of one per caption
PASS  break: the table cell stops escaping pipes
PASS  break: the comment loses its marker, so every push posts a new comment
PASS  break: the comment stops stating the retention
PASS  break: --demo-root is ignored, so the comment reads the working tree
PASS  break: the missing-timeline path is unreachable, so the comment crashes instead
PASS  break: a null duration is printed as a number
All 12 injections were caught.
```

Each is a real failure mode: losing the marker means every push posts a new comment; losing the pipe escape means a caption containing `|` silently shifts every later column.

**The exactly-once guard was not decoration.** It fires on both a zero-match and a many-match pattern:

```
ABORT: injection 'bogus injection that matches nothing' matched 0 times in demo-comment,
       expected exactly 1. The injection did not land, so nothing it would have proven is proven.

ABORT: injection 'bogus injection that matches many times' matched 31 times in demo-comment,
       expected exactly 1. …
```

and it caught a real one: a `ruff format` pass reflowed one injection's target line, so that injection would silently have proven nothing.

**Writing the harness found a bug before CI ever ran.** The `working-directory` prefix scoping was an unanchored shell `grep -F "examples/ticket-queue/"`, which also matches `examples/ticket-queue-v2/…` and `docs/examples/ticket-queue/…`. With `working-directory` set, every storyboard's app root is `""`, so anything surviving that filter selects them all — a push to a *neighbouring* application would have recorded this one's demos. It is now `strip_prefix`, anchored at a path boundary, with a test and an injection.

`actionlint` joins CI for the same reason: it type-checks every `${{ }}` against the contexts really available and runs shellcheck over each `run:` block.

## What the real runs found

Stated at length because it is the argument for why #117 exists, and because two of these are the exact failure class this repository blocks on.

**1. `uv` was installed after the first helper ran.** `setup-uv` was gated behind the "is there anything to record" check to keep a no-op run cheap, and the helper scripts are PEP 723 executables. First real run: `/usr/bin/env: 'uv': No such file or directory`, exit 127.

**2. A job that died in setup published the previous recording.** `playwright.__version__` does not exist — the browser-cache key read an attribute the package has never had — so that step raised and every step after it was skipped. But staging, uploading and commenting were `if: always()`, and `images/`, `timeline.json` and `timeline.md` are **committed** files sitting in the checkout. The workflow uploaded 1.16 MB of last recording's artifacts and posted [a comment](https://github.com/rogvid/skills/pull/117#issuecomment-5089648914) with two full beat tables, two durations and a download link, having recorded nothing at all. Confidently wrong, and worse than no comment: a reviewer with nothing knows they have nothing.

Three layered defences, each covering a case the others cannot:

- publication gated on `steps.record.conclusion != 'skipped'`;
- staging copies a file only when it is **newer than the moment recording began**, which covers the case the step condition cannot — the take ran and crashed before rewriting a file a committed copy stands in for;
- the comment is rendered from the **staging directory**, so it can only describe what was published. It previously read `timeline.json` from the working tree, and on the recorder's refusal path that file is the previous recording's.

**3. `uv run` drained the loop's list, so only the first storyboard ran.** `done < "$CHANGED.selected"` puts the list on the loop body's stdin. Two storyboards were selected, one was recorded, and the job went green. Reproduced against the real storyboards:

```
$ ./real-repro.sh broken
RUN 1: demos/2026-07-26-status-filter/record.py
broken: ran 1 of 2 storyboards

$ ./real-repro.sh fixed
RUN 1: demos/2026-07-26-status-filter/record.py
RUN 2: demos/2026-07-27-empty-state/record.py
fixed: ran 2 of 2 storyboards
```

The reproduction mattered: `uv run python -c pass` does **not** drain stdin, so the obvious minimal repro says the code is fine. It is Playwright's browser launch underneath that does. The list now arrives on fd 3 and each take gets `/dev/null`, and the step compares takes run against storyboards selected — running fewer than were asked for is otherwise invisible, because what is missing looks like what was never requested.

**4. The check and the comment disagreed.** On that run the freshness filter worked: it held back the un-recorded demo's five committed files and the comment reported that demo as having published no timeline. The check was still green. A green check beside "the take failed" teaches a reviewer to stop believing the comment. Staging now counts demos that published no `timeline.json`, and the gate fails on it — deliberately *not* on held-back stills, since a storyboard that drops a `shot()` leaves its committed png behind and that is ordinary.

## What is not covered

Stated rather than implied by silence:

- **The workflow YAML itself is not fault-injectable.** Step ordering, `if:` conditions, the freshness check and the find-or-create comment logic are executed only by GitHub. Nothing in `tests/ci-unit` reaches them and I am not implying otherwise. They are verified by observation on #117, where the run that produced the lying comment is the control.
- **Egress.** The target guard is a static check on configuration and source text. A storyboard that computes its URL at run time is invisible to it, and nothing stops a runner reaching the internet.
- **Fork pull requests get no comment** — a `pull_request` from a fork has a read-only token. The beat table still reaches `$GITHUB_STEP_SUMMARY`, which does work there. Filed as #118 rather than fixed here: the obvious fix is `pull_request_target`, and this workflow runs arbitrary branch code, so that is a security conversation and not a patch.
- **Cost.** The Chromium build is cached on the resolved Playwright version, so the ~170 MB download happens once per version rather than per pull request; `playwright install --with-deps`' system libraries are not cacheable and are paid every run. Observed on #117: ~2 minutes of setup, ~95 seconds of recording for two storyboards, and 13 seconds for a run with nothing to record.

## Scope note

`.github/workflows/ticket-queue-demo.yml` is the only caller in this repository and fires only on `examples/ticket-queue/**`. Most work here is secret-handling correctness, which is not demoable — a demo job on every pull request would produce ceremony.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
