### PR TITLE
Measure the picture, not only the storyboard (#97)

### DIFF
--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -51,6 +51,14 @@ and a real terminal session (voice on):
   direction, HTML entities and JSON escaping — a stated list, not an open
   promise. It is **not committed**; `SKILL.md` explains every one of those
   decisions and where they stop.
+- **A statement about the frames, not only the storyboard** — `content` in
+  `timeline.json`, plus a line on stderr, saying whether the recording shows
+  anything at all: how much picture there is where the app sits, and the
+  longest stretch in which nothing there changed. Every other artifact here
+  describes what the storyboard *did*, and all of them can be exactly right
+  over a recording that is blank or covered — a title card over a terminal
+  once cost this project 24.3 s of a 60.2 s demo with every beat, exit code
+  and evidence file reporting success. It warns; it never fails a take.
 - **A recording that reproduces, when you ask for it** — the browser's
   timezone and locale are always pinned, and `Recorder(deterministic=True)`
   additionally freezes the page's clock and flattens animations, so the same

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -812,6 +812,12 @@ working one.
   caption bar sits, and there is no room to shrink the exclusion. On a terminal
   demo that is the last few rows *before the screen starts scrolling*. Once it
   scrolls, every new line moves the whole picture and the blind window closes.
+- **A caption long enough to wrap reaches back into the measured region.** The
+  bar grows upward, so a two- or three-line caption crosses the exclusion and a
+  caption change then does count as the picture changing. Measured at 266 pixels
+  per wrap. The effect is to make a held stretch read *shorter* than it is, and
+  it cannot touch an occluded take at all, because a card covers the caption
+  too. Keep captions to one line if you want `static_for` to mean what it says.
 - **A run of held frames is measured per segment.** Two parts of a stitched
   demo that each hold still for 8s across the cut are reported as 8s, not 16s.
 

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -721,6 +721,62 @@ key is fine, renaming one is not:
   across a merged demo. `segment` and `segment_index` (its position within its
   own segment) survive the merge untouched — use that pair, not `index`, to
   name a beat in anything that has to line up across a re-stitch.
+- `content` is the only key here that describes the **frames** rather than the
+  storyboard. See the next section.
+
+### `content` — did the recording show anything?
+
+Every other field above is a statement about what the storyboard *did*, and all
+of them can be exactly right while the recording shows nothing: a title card
+left up, a modal that never closed, an app that stopped painting. That happened
+here, on this skill's own reference demo — a card covered the terminal for 24.3s
+of a 60.2s take, and the beat table, the exit codes, the evidence files and the
+stills all read like a healthy demo.
+
+So the recorder also measures the picture, over the region the app occupies in
+the encoded frame, and writes down what it found:
+
+```json
+"content": { "measured": true, "note": null,
+             "rect": [74, 110, 1132, 432], "sample_fps": 2, "frames": 47,
+             "score": 14.1, "floor": 1.5,
+             "static_for": 5.0, "static_from": 13.5, "static_limit": 12.0,
+             "warnings": [] }
+```
+
+- `score` is the median luma standard deviation over `rect`. Under `floor` the
+  frames are featureless — a page that never painted, a take recorded black.
+- `static_for` is the longest stretch, in seconds, where **nothing inside
+  `rect` changed**, and `static_from` is when it started. Reported always; a
+  stretch at or over `static_limit` also produces a warning.
+- `warnings` is empty on a healthy take, and each entry is one sentence saying
+  what to go and look at. They are also printed on stderr as the take ends, so
+  an author who never opens this file is still told.
+- `measured` is `false`, with `note` saying why, when the check could not run.
+  `content` itself is `null` only when the take encoded no mp4.
+
+**It warns; it never fails a take.** A demo that legitimately holds one frame
+through a long narrated beat is ordinary, and refusing a take on a heuristic is
+worse than the heuristic missing one. Treat a warning as "watch the video at
+this timestamp before believing the beats", not as a verdict.
+
+**It does not judge whether the demo shows the _right_ thing** — only whether
+it captured anything at all. `rect` deliberately excludes the recorder's own
+window chrome and its caption bar: a whole-frame score is dominated by them, to
+the point where a recording with the app painted flat scores *higher* than a
+working one.
+
+On a stitched demo each part measures its own `.seg.mp4` — two segments can be
+two media with two geometries — so the envelope's `content` is the worst of the
+parts on each arm with `rect: null`, every warning tagged with the segment it
+came from, and each part's own report under `segments`.
+
+You can re-run it on a demo you already have, without re-recording:
+
+```python
+from demo_recording import content_report
+print(content_report("demos/2026-07-26-x/demo.mp4", (74, 110, 1132, 432)))
+```
 
 A merged timeline says so, and says what it was built from:
 
@@ -729,9 +785,11 @@ A merged timeline says so, and says what it was built from:
   "recorder": "Recorder",
   "segments": [
     { "segment": "part1", "media": "part1.seg.mp4", "duration": 6.6,
-      "offset": 0.0, "beats": 6, "recorder": "Recorder", "determinism": {…} },
+      "offset": 0.0, "beats": 6, "recorder": "Recorder",
+      "determinism": {…}, "content": {…} },
     { "segment": "part2", "media": "part2.seg.mp4", "duration": 8.6,
-      "offset": 6.6, "beats": 9, "recorder": "Recorder", "determinism": {…} }
+      "offset": 6.6, "beats": 9, "recorder": "Recorder",
+      "determinism": {…}, "content": {…} }
   ] }
 ```
 
@@ -1560,6 +1618,11 @@ invisible to it.
   frame is captured the moment it paints, and a published video leaks forever.
   Decide what must not appear *before* the first `goto()` — see **Redacting
   secrets**, and read what it does not cover.
+- **Reading the beat table as proof the demo showed something.** It is proof
+  the storyboard *ran*. A card left up, a modal that never closed or an app
+  that stopped painting produces a complete, correct, entirely successful
+  timeline over a recording nobody can watch. Check `content` in the same file
+  — that is the field that describes the frames.
 - **Embedding video in markdown.** Repo-relative mp4s don't play inline in
   rendered markdown, and `demo.mp4` isn't committed anyway — open the guide
   with a still and point at the re-record command instead. GitHub plays only

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -739,8 +739,8 @@ the encoded frame, and writes down what it found:
 ```json
 "content": { "measured": true, "note": null,
              "rect": [74, 110, 1132, 432], "sample_fps": 2, "frames": 47,
-             "score": 14.1, "floor": 1.5,
-             "static_for": 5.0, "static_from": 13.5, "static_limit": 12.0,
+             "score": 14.1, "floor": 1.0,
+             "static_for": 5.0, "static_from": 13.5, "static_limit": 15.0,
              "warnings": [] }
 ```
 
@@ -765,6 +765,20 @@ it captured anything at all. `rect` deliberately excludes the recorder's own
 window chrome and its caption bar: a whole-frame score is dominated by them, to
 the point where a recording with the app painted flat scores *higher* than a
 working one.
+
+**Two limits worth knowing before you rely on it:**
+
+- **The bottom fifth of the app is not measured** — that is where the caption
+  bar is burned in, and there is no room to shrink the exclusion. On a terminal
+  demo that is the last few rows *before the screen starts scrolling*: output
+  landing there does not count as the picture changing, so a stretch that is
+  visibly printing can read as held. Once the screen scrolls, every new line
+  moves the whole picture and the blind window closes.
+- **A run of held frames is measured per segment.** Two parts of a stitched
+  demo that each hold still for 8s across the cut are reported as 8s, not 16s.
+
+Neither can produce a false *success*: both make the check quieter than the
+truth, never louder.
 
 On a stitched demo each part measures its own `.seg.mp4` — two segments can be
 two media with two geometries — so the envelope's `content` is the worst of the

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -801,7 +801,17 @@ window chrome and its caption bar: a whole-frame score is dominated by them, to
 the point where a recording with the app painted flat scores *higher* than a
 working one.
 
-**Three limits worth knowing before you rely on it:**
+**Five limits worth knowing before you rely on it:**
+
+- **A held stretch containing only narration is never reported.** This is the
+  verb correlation doing its job, and it is also the one blind spot that can
+  hide a real fault: a demo that raises an interlude card and then only
+  captions, holds and takes stills behind it is silent, however long the card
+  stays up. Measured: a card over 31.5s of a 34s take, no warning. There is no
+  third answer available from the frames — with the caption band excluded, an
+  honest tour of a still screen and a card left up are byte-identical. If your
+  storyboard raises a card, take it down explicitly; do not rely on this check
+  to notice.
 
 - **A caption change is invisible to the held-picture arm, by design.** The
   caption bar is the recorder's own drawing and it renders over an interlude
@@ -815,17 +825,29 @@ working one.
 - **A caption long enough to wrap reaches back into the measured region.** The
   bar grows upward, so a two- or three-line caption crosses the exclusion and a
   caption change then does count as the picture changing. Measured at 266 pixels
-  per wrap. The effect is to make a held stretch read *shorter* than it is, and
-  it cannot touch an occluded take at all, because a card covers the caption
-  too. Keep captions to one line if you want `static_for` to mean what it says.
+  per wrap. The effect is to make a held stretch read *shorter* than it is. It
+  cannot touch a take occluded by the recorder's **own** interlude card, which
+  is opaque and paints above the caption — but an app-level overlay or modal is
+  app DOM, the caption paints *over* it, so a wrapping caption can split a real
+  occlusion into stretches that each sit under the limit. Measured: 25s becomes
+  11s + 8s + 6s, and goes silent. Keep captions to one line if you want
+  `static_for` to mean what it says.
 - **A run of held frames is measured per segment.** Two parts of a stitched
   demo that each hold still for 8s across the cut are reported as 8s, not 16s.
 
-None of the three can produce a false *success*: each makes the check quieter
-than the truth, never louder.
+Three of the five can hide a real occlusion — the first, the fourth and the
+fifth. A card behind narration only, a wrapping caption splitting an app-level
+overlay into short stretches, and a hold that straddles a segment cut each
+produce a clean report on a take that shows nothing.
 
-Neither can produce a false *success*: both make the check quieter than the
-truth, never louder.
+The second and third cannot: excluding the caption bar, and not measuring the
+bottom fifth, both mean *less* of the picture counts as moving, so a stretch
+grows rather than shrinks. They push toward reporting a hold that is not there,
+not toward missing one.
+
+**A silent content report is not a guarantee that the demo shows your app.** It
+rules out the two loud failures — a recording that never rises above blank, and
+a screen that never moved while a verb was acting on it — and nothing more.
 
 On a stitched demo each part measures its own `.seg.mp4` — two segments can be
 two media with two geometries — so the envelope's `content` is the worst of the

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -740,25 +740,60 @@ the encoded frame, and writes down what it found:
 "content": { "measured": true, "note": null,
              "rect": [74, 110, 1132, 432], "sample_fps": 2, "frames": 47,
              "score": 14.1, "floor": 1.0,
-             "static_for": 5.0, "static_from": 13.5, "static_limit": 15.0,
+             "static_for": 21.5, "static_from": 3.5, "static_limit": 15.0,
+             "static_beats": [{ "index": 6, "verb": "caption", "acting": false },
+                              { "index": 7, "verb": "hold", "acting": false }],
              "warnings": [] }
 ```
 
 - `score` is the median luma standard deviation over `rect`. Under `floor` the
   frames are featureless — a page that never painted, a take recorded black.
 - `static_for` is the longest stretch, in seconds, where **nothing inside
-  `rect` changed**, and `static_from` is when it started. Reported always; a
-  stretch at or over `static_limit` also produces a warning.
+  `rect` changed**, and `static_from` is when it started. Both are reported
+  always, whatever they are.
+- `static_beats` is what the storyboard was doing during that stretch, and it
+  is what decides whether the stretch is worth a warning. See below.
 - `warnings` is empty on a healthy take, and each entry is one sentence saying
   what to go and look at. They are also printed on stderr as the take ends, so
   an author who never opens this file is still told.
 - `measured` is `false`, with `note` saying why, when the check could not run.
   `content` itself is `null` only when the take encoded no mp4.
 
-**It warns; it never fails a take.** A demo that legitimately holds one frame
-through a long narrated beat is ordinary, and refusing a take on a heuristic is
-worse than the heuristic missing one. Treat a warning as "watch the video at
-this timestamp before believing the beats", not as a verdict.
+### A long held stretch is not a problem, and this is the part to understand
+
+The example above holds one picture for **21.5s** — well past `static_limit` —
+and produces no warning at all. That is correct, and it is not a special case:
+
+> `static_for` on its own cannot tell a healthy demo from a broken one.
+
+Measured on real takes: a demo touring a rendered screen with three captions
+holds the measured region for **20–22s**. The title card that covered this
+skill's own reference demo held it for **23s**. There is no threshold between
+those two numbers, because the region measured excludes the recorder's caption
+bar — and swapping captions over a still screen is exactly what this guide tells
+you to do during a wait.
+
+So the warning needs a second condition: **did a verb that acts on the app run
+inside the stretch?**
+
+| beats inside the held stretch | verdict |
+|---|---|
+| `caption`, `interlude`, `bridge`, `hold`, `pause`, `shot`, `wait_for*` | narrated hold — silent |
+| `run`, `send`, `key`, `click`, `type_into`, `goto`, `scroll_to`, `spotlight`, `move_to`, `redact` | worth looking at — warns |
+
+A `run()` that printed nothing visible, a `click()` that moved nothing: those
+are the shapes worth a human's two minutes. A caption change over a screen
+nobody touched is not.
+
+**What the warning does and does not claim.** It states what was measured — the
+stretch, the acting beats inside it, and the region — and then says plainly that
+an overlay left up, an app that stopped painting, and a demo that legitimately
+holds still through those verbs all look identical from here. It does **not**
+name a cause. It cannot know one, and an artifact that confidently attributes
+something to the wrong place is the failure this whole field exists to remove.
+
+**It warns; it never fails a take.** Treat a warning as "watch the video at this
+timestamp before believing the beats", not as a verdict.
 
 **It does not judge whether the demo shows the _right_ thing** — only whether
 it captured anything at all. `rect` deliberately excludes the recorder's own
@@ -766,16 +801,22 @@ window chrome and its caption bar: a whole-frame score is dominated by them, to
 the point where a recording with the app painted flat scores *higher* than a
 working one.
 
-**Two limits worth knowing before you rely on it:**
+**Three limits worth knowing before you rely on it:**
 
-- **The bottom fifth of the app is not measured** — that is where the caption
-  bar is burned in, and there is no room to shrink the exclusion. On a terminal
-  demo that is the last few rows *before the screen starts scrolling*: output
-  landing there does not count as the picture changing, so a stretch that is
-  visibly printing can read as held. Once the screen scrolls, every new line
-  moves the whole picture and the blind window closes.
+- **A caption change is invisible to the held-picture arm, by design.** The
+  caption bar is the recorder's own drawing and it renders over an interlude
+  card as readily as over the app, so counting it would defeat the detector on
+  the exact occlusion it exists for. The verb correlation above is what makes
+  that survivable.
+- **The bottom fifth of the app is not measured at all** — that is where the
+  caption bar sits, and there is no room to shrink the exclusion. On a terminal
+  demo that is the last few rows *before the screen starts scrolling*. Once it
+  scrolls, every new line moves the whole picture and the blind window closes.
 - **A run of held frames is measured per segment.** Two parts of a stitched
   demo that each hold still for 8s across the cut are reported as 8s, not 16s.
+
+None of the three can produce a false *success*: each makes the check quieter
+than the truth, never louder.
 
 Neither can produce a false *success*: both make the check quieter than the
 truth, never louder.
@@ -785,11 +826,18 @@ two media with two geometries — so the envelope's `content` is the worst of th
 parts on each arm with `rect: null`, every warning tagged with the segment it
 came from, and each part's own report under `segments`.
 
-You can re-run it on a demo you already have, without re-recording:
+You can re-run it on a demo you already have, without re-recording. Pass the
+beat log too — without it the held-picture arm still measures and reports, but
+never warns, because there is nothing to correlate the stretch against:
 
 ```python
+import json
+from pathlib import Path
 from demo_recording import content_report
-print(content_report("demos/2026-07-26-x/demo.mp4", (74, 110, 1132, 432)))
+
+d = Path("demos/2026-07-26-x")
+doc = json.loads((d / "timeline.json").read_text())
+print(content_report(d / "demo.mp4", tuple(doc["content"]["rect"]), doc["beats"]))
 ```
 
 A merged timeline says so, and says what it was built from:
@@ -1637,6 +1685,10 @@ invisible to it.
   that stopped painting produces a complete, correct, entirely successful
   timeline over a recording nobody can watch. Check `content` in the same file
   — that is the field that describes the frames.
+- **Reading `content.static_for` as a score.** It is not one. A healthy demo
+  that narrates a rendered screen holds it for 20s or more, which is what a
+  covering card also measures. Read `warnings`; the number alone means nothing
+  without the beats beside it.
 - **Embedding video in markdown.** Repo-relative mp4s don't play inline in
   rendered markdown, and `demo.mp4` isn't committed anyway — open the guide
   with a still and point at the re-record command instead. GitHub plays only

--- a/skills/demo-video/helpers/demo_recording/__init__.py
+++ b/skills/demo-video/helpers/demo_recording/__init__.py
@@ -8,6 +8,11 @@ Storyboards import from here:
 """
 
 from .core import (
+    CONTENT_BLANK_FLOOR,
+    CONTENT_MOVED_PIXELS,
+    CONTENT_PIXEL_DELTA,
+    CONTENT_SAMPLE_FPS,
+    CONTENT_STATIC_WARN_S,
     EVIDENCE_DIR,
     EVIDENCE_LIMITS,
     EVIDENCE_SCHEMA,
@@ -27,9 +32,13 @@ from .core import (
     SecretLeak,
     StrictTakeFailed,
     beat_frames,
+    content_rect,
+    content_report,
     evidence_name,
     frames_paths,
     media_duration,
+    merge_content,
+    print_content_summary,
     render_frames_md,
     render_timeline_md,
     scene_times,
@@ -43,6 +52,11 @@ from .terminal import TerminalRecorder
 from .web import Recorder
 
 __all__ = [
+    "CONTENT_BLANK_FLOOR",
+    "CONTENT_MOVED_PIXELS",
+    "CONTENT_PIXEL_DELTA",
+    "CONTENT_SAMPLE_FPS",
+    "CONTENT_STATIC_WARN_S",
     "EVIDENCE_DIR",
     "EVIDENCE_LIMITS",
     "EVIDENCE_SCHEMA",
@@ -64,9 +78,13 @@ __all__ = [
     "TIMELINE_SCHEMA",
     "TerminalRecorder",
     "beat_frames",
+    "content_report",
+    "content_rect",
     "evidence_name",
     "frames_paths",
     "media_duration",
+    "merge_content",
+    "print_content_summary",
     "render_frames_md",
     "render_timeline_md",
     "scene_times",

--- a/skills/demo-video/helpers/demo_recording/__init__.py
+++ b/skills/demo-video/helpers/demo_recording/__init__.py
@@ -8,8 +8,10 @@ Storyboards import from here:
 """
 
 from .core import (
+    CONTENT_ACTING_VERBS,
     CONTENT_BLANK_FLOOR,
     CONTENT_MOVED_PIXELS,
+    CONTENT_PASSIVE_VERBS,
     CONTENT_PIXEL_DELTA,
     CONTENT_SAMPLE_FPS,
     CONTENT_STATIC_WARN_S,
@@ -52,8 +54,10 @@ from .terminal import TerminalRecorder
 from .web import Recorder
 
 __all__ = [
+    "CONTENT_ACTING_VERBS",
     "CONTENT_BLANK_FLOOR",
     "CONTENT_MOVED_PIXELS",
+    "CONTENT_PASSIVE_VERBS",
     "CONTENT_PIXEL_DELTA",
     "CONTENT_SAMPLE_FPS",
     "CONTENT_STATIC_WARN_S",

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1761,23 +1761,30 @@ def _moved_pixels(a: bytes, b: bytes) -> int:
 
 
 def _beats_within(beats: list[dict], start: float, end: float) -> list[dict]:
-    """The beats whose midpoint falls inside [start, end], classified.
+    """The beats that **began** inside [start, end], classified.
 
-    Midpoint rather than overlap, because the beat log and the video run on
-    different clocks (issue #18) and a take that lost wall time to the capture
-    slides every beat by the same amount. A beat that merely *touches* the edge
-    of the stretch is exactly the one that skew moves in or out; its midpoint is
-    the same answer `beat_frames` already trusts when it aims a frame.
+    Began, not overlapped and not midpoint-inside, and the difference is the
+    whole correctness of this. A held stretch begins at the first sample after
+    something changed — and the thing that changed is very often the verb
+    immediately before it. Measured on a healthy fixture: `run("seq 1 4")`
+    spanning 2.32-2.85 s, its output landing at 2.50 s, and the stretch
+    therefore starting at 2.50 s. By midpoint (2.585 s) that `run` is "inside a
+    stretch where nothing changed" — while in fact it is the thing that *ended*
+    the previous stretch and started this one. The warning that produced was
+    exactly the false positive this correlation exists to remove.
+
+    So a beat qualifies only if it started at or after the stretch did. The
+    error this trades for is a miss: a long acting verb that begins before the
+    stretch and runs silently through it is not counted. That is the direction
+    to be wrong in — quieter than the truth, never louder — and it is also the
+    direction the beat/video clock skew (issue #18) pushes an edge case.
     """
     found = []
     for beat in beats or []:
-        t_start, t_end = beat.get("t_start"), beat.get("t_end")
+        t_start = beat.get("t_start")
         if not isinstance(t_start, (int, float)):
             continue
-        if not isinstance(t_end, (int, float)) or t_end < t_start:
-            t_end = t_start
-        middle = (float(t_start) + float(t_end)) / 2
-        if not start <= middle <= end:
+        if not start <= float(t_start) <= end:
             continue
         verb = str(beat.get("verb") or "")
         found.append(

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -28,6 +28,7 @@ import hashlib
 import json
 import os
 import re
+import statistics
 import subprocess
 import sys
 import time
@@ -556,6 +557,18 @@ def tts_clip(
 #                          (ffprobe), `offset` (where it starts in `media`),
 #                          `beats`, `recorder`, `determinism`. Absent from a
 #                          timeline a single take wrote.
+#   content       dict?  — what the *picture* turned out to be, measured off
+#                          the encoded mp4 over the region the app occupies:
+#                          `measured` (bool), `note` (why not, when it is
+#                          false), `rect`, `sample_fps`, `frames`, `score`
+#                          (median luma stddev), `floor`, `static_for` (the
+#                          longest stretch in seconds where nothing in the rect
+#                          changed), `static_from`, `static_limit`, and
+#                          `warnings` (empty on a healthy take). **Null** on a
+#                          take that encoded no mp4. This is the only field in
+#                          this document that describes the frames rather than
+#                          the storyboard — see "did the recording show
+#                          anything?" for why it had to exist.
 #   beats         list   — the beats, in the order they ran
 #   strict        bool   — whether strict mode was on for this take (on a
 #                          merged demo: only if it was on for every segment)
@@ -1443,6 +1456,394 @@ def render_frames_md(manifest: dict) -> str:
     return "\n".join(out).rstrip() + "\n"
 
 
+# -- did the recording show anything? (issue #97) ----------------------------
+#
+# Everything above this line describes what the storyboard **did**. The beat
+# log, the evidence documents, the exit codes, the stills and the captions are
+# all statements about the program and about the verbs that drove it, and every
+# one of them can be completely correct while the recording shows nothing at
+# all.
+#
+# That is not hypothetical. Take 1 of this repo's own reference demo had a
+# title card covering the terminal for 24.3 s of a 60.2 s video — 40% of the
+# recording, with the real CLI running underneath it, invisible. `timeline.json`
+# had all 17 terminal beats in order with correct exit codes; `evidence/*.json`
+# held the full command output, because the xterm.js buffer was right and
+# merely covered; the stills, the captions and the stderr summary all read like
+# a healthy take. A reviewing agent handed the criteria plus `evidence/` and
+# `timeline.md` certified the CLI criterion as demonstrated. Only `frames/`
+# disagreed — 17 consecutive identical PNGs — and only because somebody looked
+# at the pictures.
+#
+# So the recorder measures the picture too, and writes the answer where the
+# text tier is read: `content` in the timeline envelope, plus a line on stderr.
+# Two independent arms, because the failure above defeats one of them:
+#
+#   score       median luma standard deviation over the content rect. Catches
+#               a recording that never rises above blank — a black take, a page
+#               that never painted, a mask that covered everything.
+#   static_for  the longest run of consecutive sampled frames that do not
+#               change, in seconds. Catches a recording that is *covered* or
+#               frozen, which the score cannot: the #91 card is dark with a
+#               line of white text on it and scores ~12, comfortably "content".
+#
+# **Three things about the rect, and each one was a defect somewhere.**
+#
+# 1. It is the region the *app* occupies, not the frame. A fifth to a third of
+#    every frame is the recorder's own chrome — a pastel gradient at ~230 luma
+#    framing a window at ~35 — and it never changes. Scored whole-frame, a
+#    blank recording measured 61.8 against a healthy one's 60.2: the metric ran
+#    backwards, and the chrome is why (issue #17). The recorder knows its own
+#    geometry, so it hands over the rect rather than guessing at one.
+# 2. The caption band is cut off the bottom (`CONTENT_CAPTION_TRIM`). The
+#    caption bar is burned into the recording and it is the recorder's own
+#    drawing, not the app's — leaving it in lets a caption supply the contrast
+#    for a blank app on the score arm, and lets a caption *change* count as the
+#    picture changing on the static arm. Either one turns a broken take green.
+# 3. It is sampled from the encoded mp4, after compositing, which is the file a
+#    reviewer actually watches. Measuring the raw webm would grade something
+#    nobody is handed.
+#
+# **Warn, never refuse.** A demo legitimately holding one frame through a long
+# narrated beat is ordinary, and a heuristic that fails takes is worse than a
+# heuristic that misses one — the same argument that scoped the terminal
+# verifier to registered values only (issue #5). Nothing here raises, nothing
+# here deletes an artifact, and a check that cannot run says so in `content`
+# rather than being silently absent.
+#
+# **What this deliberately does not do** is judge whether the demo shows the
+# *right* thing. That is issue #12's job, and a human's. This answers exactly
+# one question: did the recording capture anything at all.
+
+# Frames sampled per second of video. Two, not one: `static_for` is quantised
+# to this step, so at 1 fps the shortest reportable run is a full second and
+# the number a reviewer reads is coarser than the thing it describes. Past ~4
+# the decode starts to cost more than the check is worth on a 60 s take.
+CONTENT_SAMPLE_FPS = 2
+
+# Every frame is reduced to this before any arithmetic — one ffmpeg pass, no
+# image library, no extra dependency. Small on purpose: it is a blur, and a
+# blur is what makes "did this change" robust against encoder noise. It is also
+# why the static arm cannot see a single character change (~0.02 mean absolute
+# luma at this size, far under CONTENT_STATIC_DIFF) and does not try to; a
+# blinking cursor is not the demo showing something.
+_CONTENT_W, _CONTENT_H = 160, 90
+
+# How much of the content rect's height is dropped off the bottom before
+# scoring. Sized for the caption bar plus its shadow at either recorder's
+# geometry — the web caption sits at bottom:44px inside an app rect that is
+# then scaled ~0.8, the terminal's at bottom:88px in an un-composited frame —
+# and the same 0.8 keep that tests/smoke has used for its own content floor
+# since #17.
+CONTENT_CAPTION_TRIM = 0.2
+
+# Median luma standard deviation under which the content rect is "blank".
+#
+# Measured over the trimmed rect, per medium, on this repo's own takes:
+#
+#              healthy                       blank
+#   web        15.5 - 17.0                   0.1 - 1.1
+#   terminal    5.1 -  7.9                   0.2 - 0.4
+#
+# One floor for both media rather than two, and it sits in the gap: ~3.4x under
+# the weakest healthy terminal take (the tighter side by far) and ~1.4x over
+# the strongest blank one. The asymmetry is deliberate — this warns rather than
+# refusing, so a missed blank take costs a warning nobody got, while a false
+# alarm on a legitimately sparse terminal demo costs the warning its credibility
+# everywhere. tests/smoke keeps its own, higher, per-medium floors as a gate;
+# this is the floor shipped to somebody else's app.
+CONTENT_BLANK_FLOOR = 1.5
+
+# When two consecutive samples count as "the same picture": fewer than
+# CONTENT_MOVED_PIXELS of the 14 400 reduced pixels moved by more than
+# CONTENT_PIXEL_DELTA luma levels.
+#
+# **A mean absolute difference does not work here, and that was measured, not
+# assumed.** libx264 re-quantises a held frame at every I-frame, and on the
+# occluded reference take that redrew the card's glyph edges hard enough to
+# move the mean by 0.43 — while the *smallest real change* in the healthy take
+# of the same storyboard moved it by 0.71. A 1.6x gap is not a threshold, it is
+# a coin toss, and setting it either way loses the detector or floods it.
+#
+# Counting pixels separates the two cleanly, because the two phenomena have
+# different shapes: re-quantisation is a fraction of a level smeared over the
+# whole rect, while a command running or a page repainting moves a *region* by
+# tens of levels. Measured over the same two takes, per consecutive pair:
+#
+#   covered (a card over the whole terminal)   0 pixels, every pair of 46
+#   healthy terminal, real changes             2, 13, 20, 27, 31, ... 1256
+#   healthy web, real changes                 10, 13, 14, 16, 17, ... 991
+#
+# So the bar sits at 4: it never fires on the covered take (which reported
+# 0.43 mean and would have defeated any mean-based bar) and it is 2.5x under
+# the smallest change either healthy take makes. The 2-pixel terminal pair is
+# the tail of a transition whose leading edge already registered 1256 pixels
+# half a second earlier — missing it costs nothing.
+CONTENT_PIXEL_DELTA = 12
+CONTENT_MOVED_PIXELS = 4
+
+# How long the content rect may hold still before it is worth saying so.
+# `static_for` is reported *always*, whatever it is; this only decides whether
+# stderr and `warnings` mention it.
+#
+# Measured, on the longest stretch a *healthy* take holds one frame — which is
+# larger than it sounds, because a demo ends on its last screen and the
+# recording runs on for a second or two after the storyboard does:
+#
+#   reference demo, web part          4.5 s
+#   reference demo, terminal part     5.0 s
+#   tests/smoke's content take        6.0 s
+#   ...the same storyboard, covered  19.5 s
+#   reference demo take 1, covered   23.0 s
+#
+# 12 s sits 2x over the worst healthy value and 1.6x under the smallest covered
+# one, and tests/smoke's content axis re-derives that band from its own two
+# takes on every run rather than trusting this comment — halve this constant
+# and every honest demo warns, double it and the take issue #97 exists for goes
+# unremarked. Both directions turn the suite red.
+CONTENT_STATIC_WARN_S = 12.0
+
+
+def content_rect(rect: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
+    """An app rect with the recorder's own caption band cut off the bottom.
+
+    Both recorders' `_content_rect` funnel through this, so "what the check
+    measures" is one definition rather than two that drift.
+    """
+    x, y, w, h = rect
+    return (
+        max(0, int(x)),
+        max(0, int(y)),
+        max(2, int(w)),
+        max(2, int(h * (1.0 - CONTENT_CAPTION_TRIM))),
+    )
+
+
+def _content_frames(
+    mp4: Path, rect: tuple[int, int, int, int], sample_fps: int
+) -> list[bytes]:
+    """`mp4`'s content rect, sampled and reduced to grayscale frames."""
+    x, y, w, h = rect
+    chain = (
+        f"fps={sample_fps},crop={w}:{h}:{x}:{y},"
+        f"scale={_CONTENT_W}:{_CONTENT_H},format=gray"
+    )
+    proc = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", str(mp4), "-vf", chain,
+         "-an", "-f", "rawvideo", "-pix_fmt", "gray", "-"],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg could not sample {mp4.name}: "
+            f"{proc.stderr.decode(errors='replace').strip()[:300]}"
+        )
+    size = _CONTENT_W * _CONTENT_H
+    raw = proc.stdout
+    return [raw[i : i + size] for i in range(0, len(raw) - size + 1, size)]
+
+
+def _luma_stddev(frame: bytes) -> float:
+    """How much picture is in one reduced frame. A flat frame scores 0."""
+    n = len(frame)
+    mean = sum(frame) / n
+    return (sum((b - mean) ** 2 for b in frame) / n) ** 0.5
+
+
+def _moved_pixels(a: bytes, b: bytes) -> int:
+    """How many reduced pixels moved by more than `CONTENT_PIXEL_DELTA`.
+
+    The question a mean cannot answer: *did part of the picture change*, as
+    opposed to *did the whole thing shift by a fraction of a level*. See the
+    constants above for the measurement that made the difference matter.
+    """
+    return sum(
+        1 for x, y in zip(a, b, strict=True) if abs(x - y) > CONTENT_PIXEL_DELTA
+    )
+
+
+def content_report(
+    mp4: Path | str,
+    rect: tuple[int, int, int, int] | None,
+    *,
+    floor: float = CONTENT_BLANK_FLOOR,
+    sample_fps: int = CONTENT_SAMPLE_FPS,
+    static_limit: float = CONTENT_STATIC_WARN_S,
+) -> dict:
+    """Does this recording show anything? See the section header.
+
+    Pure function of the mp4 and the rect, so it can be re-run on a demo
+    somebody already has — `content_report(dir / "demo.mp4", rect)` — without
+    re-recording. `rect` is the app's region in *video* pixels, already trimmed
+    by `content_rect`; pass None and the report says, in the document itself,
+    that nothing was measured and why.
+
+    Never raises. A check that costs a take the recording it is describing is
+    worse than no check.
+    """
+    mp4 = Path(mp4)
+    report: dict = {
+        "measured": False,
+        "note": None,
+        "rect": list(rect) if rect else None,
+        "sample_fps": sample_fps,
+        "frames": 0,
+        "score": None,
+        "floor": floor,
+        "static_for": None,
+        "static_from": None,
+        "static_limit": static_limit,
+        "warnings": [],
+    }
+    if rect is None:
+        report["note"] = (
+            "this recorder does not know where the app sits in the frame, so "
+            "nothing about the picture was measured — see content_report()"
+        )
+        return report
+    if not mp4.is_file():
+        report["note"] = f"there is no {mp4.name} to measure"
+        return report
+    try:
+        frames = _content_frames(mp4, rect, sample_fps)
+    except Exception as exc:  # noqa: BLE001 - a measurement is not a recording
+        report["note"] = f"{type(exc).__name__}: {exc}"
+        return report
+    if len(frames) < 2:
+        report["note"] = (
+            f"only {len(frames)} frame(s) could be sampled from {mp4.name} at "
+            f"{sample_fps} fps, which is too few to say anything"
+        )
+        report["frames"] = len(frames)
+        return report
+
+    report["measured"] = True
+    report["frames"] = len(frames)
+    # Median, not mean and not min: one blank opening frame must not condemn a
+    # take (every web take opens on a page that has not painted yet), and one
+    # good frame must not excuse a blank one.
+    score = statistics.median(_luma_stddev(f) for f in frames)
+    report["score"] = round(score, 2)
+
+    # The longest run of consecutive samples that do not change, measured in
+    # gaps rather than frames: two identical samples 0.5 s apart is 0.5 s of
+    # held picture, not 1.0 s.
+    step = 1.0 / sample_fps
+    best_gaps = best_start = run_gaps = run_start = 0
+    for i in range(1, len(frames)):
+        if _moved_pixels(frames[i - 1], frames[i]) < CONTENT_MOVED_PIXELS:
+            run_gaps += 1
+        else:
+            run_gaps, run_start = 0, i
+        if run_gaps > best_gaps:
+            best_gaps, best_start = run_gaps, run_start
+    report["static_for"] = round(best_gaps * step, 2)
+    report["static_from"] = round(best_start * step, 2)
+
+    warnings: list[str] = []
+    if score < floor:
+        warnings.append(
+            f"there is no picture where the app should be: the content rect "
+            f"scores {score:.2f} luma stddev (median of {len(frames)} sampled "
+            f"frames over {tuple(rect)}), under the {floor} blank floor. These "
+            f"frames are featureless — a page that never painted, a take "
+            f"recorded black, or a rect that is not where the app ended up."
+        )
+    if best_gaps * step >= static_limit:
+        held = best_gaps * step
+        warnings.append(
+            f"the content rect did not change for {held:.1f}s, from "
+            f"{best_start * step:.1f}s. The beats in this timeline ran during "
+            f"that stretch and nothing in the picture moved, so whatever they "
+            f"did is not visible: a title card or modal left up over the app "
+            f"(issue #91), an overlay that never faded, or an app that stopped "
+            f"painting. Watch {mp4.name} at {best_start * step:.1f}s before "
+            f"believing the beats above it."
+        )
+    report["warnings"] = warnings
+    return report
+
+
+def merge_content(records: list[dict]) -> dict:
+    """The content report for a demo stitched out of several segments.
+
+    `records` are the merged timeline's per-segment records, each with its own
+    `content` (the report that segment wrote when it encoded its `.seg.mp4`).
+    Nothing is re-measured: a stitched demo can join a web part and a terminal
+    part, and there is no single rect for the join. So the merged answer is the
+    **worst** of the parts on each arm, and every warning is kept, attributed
+    to the segment it came from.
+
+    Under-reports rather than over-reports, in two known ways, both preferred
+    to a confident guess: a held stretch spanning a cut is reported as the
+    longer of its two halves rather than their sum, and a segment that could
+    not be measured at all lowers nothing.
+    """
+    parts = [
+        (record.get("segment"), record.get("content"))
+        for record in records
+        if isinstance(record.get("content"), dict)
+    ]
+    measured = [content for _, content in parts if content.get("measured")]
+    return {
+        "measured": bool(measured),
+        "note": (
+            None
+            if measured
+            else "no segment of this demo reported a measured picture — see "
+            "each segment's own `content` under `segments`"
+        ),
+        "rect": None,  # per segment; a merged demo may mix two geometries
+        "sample_fps": _common([c.get("sample_fps") for c in measured]),
+        "frames": sum(int(c.get("frames") or 0) for c in measured),
+        "score": min(
+            (c["score"] for c in measured if c.get("score") is not None),
+            default=None,
+        ),
+        "floor": _common([c.get("floor") for c in measured]),
+        "static_for": max(
+            (c["static_for"] for c in measured if c.get("static_for") is not None),
+            default=None,
+        ),
+        # Deliberately null: the worst run belongs to one segment's own clock,
+        # and stating it against the merged video's would be a confidently
+        # wrong timestamp. The segment's own record has it.
+        "static_from": None,
+        "static_limit": _common([c.get("static_limit") for c in measured]),
+        "warnings": [
+            f"segment {name!r}: {warning}"
+            for name, content in parts
+            for warning in (content.get("warnings") or [])
+        ],
+    }
+
+
+def print_content_summary(content: dict | None, media: str) -> None:
+    """Say what the picture check found, on stderr, unasked.
+
+    The whole point of issue #97 is that nobody was going to open the video, so
+    this is printed on every take rather than only when something is wrong: a
+    reviewer who has never seen the healthy line has no baseline for the
+    unhealthy one.
+    """
+    if not isinstance(content, dict):
+        return
+    if not content.get("measured"):
+        print(
+            f"demo-video: the picture in {media} was not measured — "
+            f"{content.get('note')}",
+            file=sys.stderr,
+        )
+        return
+    for warning in content.get("warnings") or []:
+        print(f"demo-video: WARNING — {media}: {warning}", file=sys.stderr)
+    if not content.get("warnings"):
+        print(
+            f"{media} shows a picture (content {content.get('score')} over the "
+            f"app rect, longest still stretch {content.get('static_for')}s)"
+        )
+
+
 def _verb_target(args: tuple, kwargs: dict) -> str | None:
     """The string a verb acted on, dug out of how it happened to be called."""
     if args and isinstance(args[0], str):
@@ -1649,6 +2050,12 @@ class _DemoBase:
         # #20), the review frames extracted off `media`, and the last frame in
         # `failure/`. Set in `_convert`, after ffmpeg returns.
         self._converted = False
+        # What the *picture* turned out to be (issue #97). Measured off the
+        # encoded mp4 in `__exit__`, so it is null on any take that wrote none,
+        # and it is the one thing in the timeline that describes the frames
+        # rather than the storyboard. See the "did the recording show
+        # anything?" section.
+        self._content: dict | None = None
         # The medium's screen, read once on the failure path *before* the final
         # redaction check vouches for it, and turned into a file only if that
         # check passes. See the "failure artifacts" section.
@@ -1735,6 +2142,23 @@ class _DemoBase:
         """Transform the finished mp4 in place (e.g. composite it into a
         window on a background). No-op by default; the terminal recorder
         frames itself in-page, so only the web recorder overrides this."""
+
+    def _content_rect(self) -> tuple[int, int, int, int] | None:
+        """Where the app sits in the **encoded** frame, caption band trimmed.
+
+        The one thing the picture check (issue #97) cannot work out for itself,
+        and the one thing the recorder already knows exactly: it composited the
+        frame. Returning None is honest and supported — the report then says
+        nothing was measured, rather than scoring the recorder's own chrome and
+        calling a blank take healthy (issue #17).
+
+        **Must not touch the page.** It is called after the browser is gone,
+        because the mp4 it describes does not exist until then. A medium whose
+        geometry comes from a live element reads it in `_start()` and remembers
+        it — which is also the honest thing to do, since the recording was made
+        against that layout and not against whatever the last frame had.
+        """
+        return None
 
     def _checkpoint(self) -> None:
         """Re-establish and re-verify the medium's masking, cheaply.
@@ -2090,6 +2514,14 @@ class _DemoBase:
                         file=sys.stderr,
                     )
             if keep:
+                # Before the timeline, because the timeline carries the answer
+                # (issue #97). Gated on `self._converted` for the same reason
+                # `duration` is: measuring a previous run's demo.mp4 and filing
+                # the result under this take's beats is the exact class of lie
+                # this check exists to remove. On a take that crashed but is
+                # being kept, this still runs — the mp4 is that take's, however
+                # short, and a partial recording of nothing is worth saying.
+                self._measure_content()
                 # Before the timeline, because every beat in it carries an
                 # `evidence` path: a timeline pointing at files that are not
                 # there yet is the one ordering a reader can be caught by.
@@ -2178,6 +2610,10 @@ class _DemoBase:
             # recorded are the one thing nobody thinks to go looking for, so
             # they have to arrive unasked.
             self._print_issue_summary()
+            # Last, so it is the line still on screen when the take ends. A
+            # recording nobody can see is not something to bury above ffmpeg's
+            # output (issue #97).
+            print_content_summary(self._content, self._media_path().name)
         # Two failure modes that disagree about what to leave behind, and the
         # disagreement is deliberate:
         #
@@ -3363,6 +3799,29 @@ class _DemoBase:
         name = f"{self.segment}.seg.mp4" if self.segment else "demo.mp4"
         return self.out_dir / name
 
+    def _measure_content(self) -> None:
+        """Fill in `self._content` off the mp4 this take just encoded.
+
+        Guarded twice over, because a picture check must never be able to cost
+        somebody a recording: `content_report` already refuses to raise, and
+        this catches whatever a subclass's `_content_rect` might. A take whose
+        measurement fails records *that*, in the timeline, rather than quietly
+        omitting the field and reading like a take nobody thought to check.
+        """
+        if not self._converted:
+            return
+        try:
+            rect = self._content_rect()
+        except Exception as exc:  # noqa: BLE001 - see the docstring
+            self._content = content_report(self._media_path(), None)
+            self._content["note"] = (
+                f"the recorder could not work out where the app sits in the "
+                f"frame ({type(exc).__name__}: {exc}), so nothing about the "
+                f"picture was measured"
+            )
+            return
+        self._content = content_report(self._media_path(), rect)
+
     def _timeline_doc(self, failure: dict | None = None) -> dict:
         """This take's beat log as a timeline document (see TIMELINE_SCHEMA).
 
@@ -3458,6 +3917,12 @@ class _DemoBase:
                 "timezone_id": self._timezone_id,
                 "locale": self._locale,
             },
+            # The one field here that describes the *frames* rather than the
+            # storyboard (issue #97). Null on a take that encoded no mp4 —
+            # there is nothing to measure and a previous run's file is not this
+            # take's — and a dict with `measured: false` and a `note` whenever
+            # it could not be measured. Never silently absent.
+            "content": self._content,
             "beats": beats,
             "strict": self._strict,
             "issues": issues,
@@ -3940,6 +4405,11 @@ def _merged_timeline(
                 "beats": len(doc.get("beats") or []),
                 "recorder": doc.get("recorder"),
                 "determinism": doc.get("determinism"),
+                # Carried through rather than recomputed: the segment measured
+                # its own `.seg.mp4` against its own rect, and a stitched demo
+                # may join two media with two different geometries. See
+                # `merge_content`.
+                "content": doc.get("content"),
             }
         )
         offset = round(offset + duration, 3)
@@ -3957,6 +4427,7 @@ def _merged_timeline(
         "media": demo.name,
         "duration": total,
         "determinism": _merge_determinism([r["determinism"] for r in records]),
+        "content": merge_content(records),
         "segments": records,
         "beats": beats,
         "strict": strict,
@@ -4030,6 +4501,12 @@ def stitch(out_dir: Path, segments: list[str], keep_parts: bool = False) -> None
     merged = _merged_timeline(segments, parts, docs, durations, demo)
     json_path, _ = write_timeline(out_dir, merged)
     print(f"wrote {demo} and {json_path.name} from {len(segments)} segments")
+    # Again here, and that is not duplication. The segment that recorded a
+    # covered stretch said so when it was recorded, minutes and several
+    # thousand lines of output ago; `demo.mp4` is the file somebody watches and
+    # this timeline is the file somebody commits, so the verdict has to arrive
+    # with them (issue #97).
+    print_content_summary(merged.get("content"), demo.name)
     # The review sheet, from the merged log rather than from any part's. A
     # single segment's timeline cannot produce one — its beats start at zero
     # and name a `.seg.mp4` this function is about to delete — but the merged

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1531,28 +1531,44 @@ _CONTENT_W, _CONTENT_H = 160, 90
 
 # How much of the content rect's height is dropped off the bottom before
 # scoring. Sized for the caption bar plus its shadow at either recorder's
-# geometry — the web caption sits at bottom:44px inside an app rect that is
-# then scaled ~0.8, the terminal's at bottom:88px in an un-composited frame —
-# and the same 0.8 keep that tests/smoke has used for its own content floor
-# since #17.
+# geometry — the web caption's top edge sits at 84.2% of the app rect's height
+# and the terminal's at 85.7%, with a 24 px shadow above each — and it is the
+# same 0.8 keep that tests/smoke has used for its own content floor since #17.
+#
+# **The stated limit this creates**: whatever happens in the bottom fifth of
+# the app is not measured. For a terminal that is the last few rows *before the
+# screen scrolls* — after it starts scrolling every new line moves the whole
+# picture, so the blind window is bounded and transient, but inside it a demo
+# that is visibly printing reads as held. Measured on a fixture that filled 25
+# of ~32 rows: 9.5 s of "held" picture across two commands that were plainly
+# running. There is no room to shrink the trim (the caption's shadow starts at
+# ~82%), so it is documented in SKILL.md rather than tuned away.
 CONTENT_CAPTION_TRIM = 0.2
 
 # Median luma standard deviation under which the content rect is "blank".
 #
-# Measured over the trimmed rect, per medium, on this repo's own takes:
+# Measured over the trimmed rect, on every take tests/smoke records plus this
+# repo's reference demo:
 #
-#              healthy                       blank
-#   web        15.5 - 17.0                   0.1 - 1.1
-#   terminal    5.1 -  7.9                   0.2 - 0.4
+#   blank                            0.2 - 1.1   (a real recording with the app
+#                                                 rect painted flat scores 0.21)
+#   healthy, sparsest terminal       2.0         (one failing command, nothing
+#                                                 else on screen)
+#   healthy, ordinary terminal       4.6 - 14.3
+#   healthy, web                    16.0 - 36.1
 #
-# One floor for both media rather than two, and it sits in the gap: ~3.4x under
-# the weakest healthy terminal take (the tighter side by far) and ~1.4x over
-# the strongest blank one. The asymmetry is deliberate — this warns rather than
-# refusing, so a missed blank take costs a warning nobody got, while a false
-# alarm on a legitimately sparse terminal demo costs the warning its credibility
-# everywhere. tests/smoke keeps its own, higher, per-medium floors as a gate;
-# this is the floor shipped to somebody else's app.
-CONTENT_BLANK_FLOOR = 1.5
+# One floor for both media rather than two, and it sits at 1.0 — 2x under the
+# sparsest healthy take in the suite and roughly 5x over a blank one. The
+# asymmetry is deliberate and it is not a compromise: this arm has a partner.
+# A page that never painted does not change either, so the static arm below
+# catches the blank case a second time, and a floor set high enough to catch
+# every blank take on its own would warn about honest, nearly-empty terminal
+# demos — which costs the warning its credibility everywhere.
+#
+# tests/smoke keeps its own, higher, per-medium floors as a *gate*. This is the
+# floor shipped to somebody else's app, where a false alarm is the expensive
+# failure.
+CONTENT_BLANK_FLOOR = 1.0
 
 # When two consecutive samples count as "the same picture": fewer than
 # CONTENT_MOVED_PIXELS of the 14 400 reduced pixels moved by more than
@@ -1587,21 +1603,25 @@ CONTENT_MOVED_PIXELS = 4
 # stderr and `warnings` mention it.
 #
 # Measured, on the longest stretch a *healthy* take holds one frame — which is
-# larger than it sounds, because a demo ends on its last screen and the
-# recording runs on for a second or two after the storyboard does:
+# larger than it sounds, for two reasons that are easy to forget: a demo ends
+# on its last screen and the recording runs on for a second or two after the
+# storyboard does, and a caption change is invisible here on purpose (see
+# CONTENT_CAPTION_TRIM), so a stretch narrated over a still screen counts as
+# held.
 #
 #   reference demo, web part          4.5 s
 #   reference demo, terminal part     5.0 s
 #   tests/smoke's content take        6.0 s
-#   ...the same storyboard, covered  19.5 s
-#   reference demo take 1, covered   23.0 s
+#   tests/smoke's terminal take       9.5 s   <- the worst healthy value seen
+#   ...the content storyboard, covered  ~28 s
+#   reference demo take 1, covered      23 s
 #
-# 12 s sits 2x over the worst healthy value and 1.6x under the smallest covered
-# one, and tests/smoke's content axis re-derives that band from its own two
+# 15 s sits 1.6x over the worst healthy value and 1.5x under the smallest
+# covered one. tests/smoke's content axis re-derives that band from its own two
 # takes on every run rather than trusting this comment — halve this constant
 # and every honest demo warns, double it and the take issue #97 exists for goes
 # unremarked. Both directions turn the suite red.
-CONTENT_STATIC_WARN_S = 12.0
+CONTENT_STATIC_WARN_S = 15.0
 
 
 def content_rect(rect: tuple[int, int, int, int]) -> tuple[int, int, int, int]:

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1535,14 +1535,26 @@ _CONTENT_W, _CONTENT_H = 160, 90
 # and the terminal's at 85.7%, with a 24 px shadow above each — and it is the
 # same 0.8 keep that tests/smoke has used for its own content floor since #17.
 #
-# **The stated limit this creates**: whatever happens in the bottom fifth of
-# the app is not measured. For a terminal that is the last few rows *before the
-# screen scrolls* — after it starts scrolling every new line moves the whole
-# picture, so the blind window is bounded and transient, but inside it a demo
-# that is visibly printing reads as held. Measured on a fixture that filled 25
-# of ~32 rows: 9.5 s of "held" picture across two commands that were plainly
-# running. There is no room to shrink the trim (the caption's shadow starts at
-# ~82%), so it is documented in SKILL.md rather than tuned away.
+# **This is why the static arm needs the beat log, and the reasoning is worth
+# keeping.** Excluding the caption bar is not optional: the bar is the
+# recorder's own drawing, it renders *over* an interlude card as readily as
+# over the app, and leaving it in would let a caption change count as the
+# picture changing — which defeats the detector on exactly the occlusion it
+# exists for. But the exclusion has a cost, and it is not a small one: the two
+# things this skill hands an author for keeping a still screen alive — swapping
+# captions, and narration pacing — are both invisible here **by construction**.
+# A perfectly healthy demo that tours a rendered screen with three captions
+# holds the measured region still for 20-22 s, which is indistinguishable from
+# a card covering the terminal for 23 s.
+#
+# So a held stretch on its own says nothing about whether anything is wrong,
+# and `CONTENT_ACTING_VERBS` below is what turns it into a signal. Two stated
+# limits survive that, both narrower:
+#
+#   * whatever happens in the bottom fifth of the app is not measured at all;
+#     on a terminal that is the last rows before the screen starts scrolling.
+#   * a demo that genuinely holds still *through* an acting verb warns, and is
+#     right to be looked at even though nothing is broken.
 CONTENT_CAPTION_TRIM = 0.2
 
 # Median luma standard deviation under which the content rect is "blank".
@@ -1598,30 +1610,96 @@ CONTENT_BLANK_FLOOR = 1.0
 CONTENT_PIXEL_DELTA = 12
 CONTENT_MOVED_PIXELS = 4
 
-# How long the content rect may hold still before it is worth saying so.
-# `static_for` is reported *always*, whatever it is; this only decides whether
-# stderr and `warnings` mention it.
+# How long the content rect may hold still before it is worth looking at, *and*
+# an acting verb ran inside that stretch. `static_for` is reported always,
+# whatever it is; this and CONTENT_ACTING_VERBS together decide whether stderr
+# and `warnings` mention it.
 #
-# Measured, on the longest stretch a *healthy* take holds one frame — which is
-# larger than it sounds, for two reasons that are easy to forget: a demo ends
-# on its last screen and the recording runs on for a second or two after the
-# storyboard does, and a caption change is invisible here on purpose (see
-# CONTENT_CAPTION_TRIM), so a stretch narrated over a still screen counts as
-# held.
+# Measured, on the longest stretch a take holds one frame:
 #
-#   reference demo, web part          4.5 s
-#   reference demo, terminal part     5.0 s
-#   tests/smoke's content take        6.0 s
-#   tests/smoke's terminal take       9.5 s   <- the worst healthy value seen
-#   ...the content storyboard, covered  ~28 s
-#   reference demo take 1, covered      23 s
+#   reference demo, web part                       4.5 s   healthy
+#   reference demo, terminal part                  5.0 s   healthy
+#   tests/smoke's content-shown take               6.0 s   healthy
+#   tests/smoke's terminal take                   10.0 s   healthy
+#   a terminal demo touring a screen, 2 captions  16.5 s   healthy
+#   a web demo touring a screen, 3 captions       20.0 s   healthy
+#   a terminal demo touring a screen, 3 captions  22.0 s   healthy
+#   reference demo take 1, card over the terminal 23.0 s   the defect
+#   tests/smoke's content-covered take            30.5 s   the defect
 #
-# 15 s sits 1.6x over the worst healthy value and 1.5x under the smallest
-# covered one. tests/smoke's content axis re-derives that band from its own two
-# takes on every run rather than trusting this comment — halve this constant
-# and every honest demo warns, double it and the take issue #97 exists for goes
-# unremarked. Both directions turn the suite red.
+# **Read that table before touching this constant.** There is no value of it
+# that separates the last two rows from the three above them: a healthy demo
+# narrated over a rendered screen and a demo nobody can see produce the same
+# number. That is not a tuning problem, it is what excluding the caption band
+# costs (see CONTENT_CAPTION_TRIM), and it is why duration alone never warns.
+#
+# What this constant does is set how long a stretch has to be before it is worth
+# reporting at all. 15 s is comfortably over every healthy take's ordinary holds
+# and under the shortest occlusion measured.
 CONTENT_STATIC_WARN_S = 15.0
+
+# The storyboard verbs that **act on the app**. A held picture spanning one of
+# these is worth a human's attention; a held picture spanning only the others is
+# a narrated hold — which is exactly what this skill tells authors to write:
+#
+#     "during unavoidable waits, tour what's on screen or swap the caption"
+#
+# This is the whole difference between a detector and a timer. Without it the
+# static arm fires on ordinary demos on both media — measured at 16.5-22.0 s on
+# three healthy takes, against 23.0 s for the defect it exists to catch — and
+# the sentence it prints blames an occlusion that did not happen. An artifact
+# confidently attributing something to the wrong cause is the precise failure
+# issue #97 exists to remove, so the detector must not commit it.
+#
+# The split is by *what the verb does to the picture*, not by how long it takes:
+#
+#   acting    it changed the app, the page or the terminal screen, so something
+#             should have moved in the measured region and nothing did.
+#   passive   it narrated, waited, held, or photographed. A still picture is the
+#             expected outcome there, not a symptom.
+#
+# `wait_for*` are passive on purpose: a wait that returns immediately because
+# its condition already held changes nothing, and cannot be told apart here from
+# one that really waited. Guessing would put the false positive straight back.
+#
+# tests/smoke asserts this covers **every** verb the recorders define, so a verb
+# added later cannot quietly default into either bucket.
+CONTENT_ACTING_VERBS = frozenset(
+    {
+        "click",
+        "click_fast",
+        "goto",
+        "key",
+        "move_to",
+        "redact",
+        "run",
+        "scroll_to",
+        "send",
+        "spotlight",
+        "terminal",
+        "terminal_close",
+        "terminal_output",
+        "type_into",
+    }
+)
+CONTENT_PASSIVE_VERBS = frozenset(
+    {
+        "bridge",
+        "caption",
+        "hold",
+        "interlude",
+        "pause",
+        "shot",
+        "wait_for",
+        "wait_for_prompt",
+        "wait_for_text",
+    }
+)
+
+# How many of the beats a held stretch spans are named in the report. Enough to
+# see what was going on, few enough that `timeline.json` stays a file somebody
+# opens.
+CONTENT_STATIC_BEATS_MAX = 8
 
 
 def content_rect(rect: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
@@ -1682,9 +1760,40 @@ def _moved_pixels(a: bytes, b: bytes) -> int:
     )
 
 
+def _beats_within(beats: list[dict], start: float, end: float) -> list[dict]:
+    """The beats whose midpoint falls inside [start, end], classified.
+
+    Midpoint rather than overlap, because the beat log and the video run on
+    different clocks (issue #18) and a take that lost wall time to the capture
+    slides every beat by the same amount. A beat that merely *touches* the edge
+    of the stretch is exactly the one that skew moves in or out; its midpoint is
+    the same answer `beat_frames` already trusts when it aims a frame.
+    """
+    found = []
+    for beat in beats or []:
+        t_start, t_end = beat.get("t_start"), beat.get("t_end")
+        if not isinstance(t_start, (int, float)):
+            continue
+        if not isinstance(t_end, (int, float)) or t_end < t_start:
+            t_end = t_start
+        middle = (float(t_start) + float(t_end)) / 2
+        if not start <= middle <= end:
+            continue
+        verb = str(beat.get("verb") or "")
+        found.append(
+            {
+                "index": beat.get("index"),
+                "verb": verb,
+                "acting": verb in CONTENT_ACTING_VERBS,
+            }
+        )
+    return found
+
+
 def content_report(
     mp4: Path | str,
     rect: tuple[int, int, int, int] | None,
+    beats: list[dict] | None = None,
     *,
     floor: float = CONTENT_BLANK_FLOOR,
     sample_fps: int = CONTENT_SAMPLE_FPS,
@@ -1692,15 +1801,62 @@ def content_report(
 ) -> dict:
     """Does this recording show anything? See the section header.
 
-    Pure function of the mp4 and the rect, so it can be re-run on a demo
-    somebody already has — `content_report(dir / "demo.mp4", rect)` — without
-    re-recording. `rect` is the app's region in *video* pixels, already trimmed
-    by `content_rect`; pass None and the report says, in the document itself,
-    that nothing was measured and why.
+    A function of the mp4, the rect and the beat log, so it can be re-run on a
+    demo somebody already has without re-recording:
 
-    Never raises. A check that costs a take the recording it is describing is
-    worse than no check.
+        doc = json.loads((d / "timeline.json").read_text())
+        content_report(d / "demo.mp4", tuple(doc["content"]["rect"]), doc["beats"])
+
+    `rect` is the app's region in *video* pixels, already trimmed by
+    `content_rect`; pass None and the report says, in the document itself, that
+    nothing was measured and why.
+
+    **`beats` is what makes the held-picture arm a detector rather than a
+    timer**, and leaving it out is a supported, conservative choice rather than
+    an optimisation: without it `static_for` is still measured and reported, and
+    it never warns, because there is no way to tell a demo narrating over a
+    rendered screen from a demo nobody can see. See CONTENT_ACTING_VERBS.
+
+    Never raises — the whole body is guarded, not just the ffmpeg call. This
+    runs inside `__exit__` before the timeline, the evidence and the review
+    frames are written, so an exception escaping here would cost a take every
+    artifact that section promises can never be lost.
     """
+    try:
+        return _content_report(
+            mp4, rect, beats, floor=floor, sample_fps=sample_fps,
+            static_limit=static_limit,
+        )
+    except Exception as exc:  # noqa: BLE001 - see the docstring
+        return {
+            "measured": False,
+            "note": (
+                f"the picture check itself failed ({type(exc).__name__}: "
+                f"{exc}), so nothing is claimed about these frames"
+            ),
+            "rect": list(rect) if rect else None,
+            "sample_fps": sample_fps,
+            "frames": 0,
+            "score": None,
+            "floor": floor,
+            "static_for": None,
+            "static_from": None,
+            "static_beats": None,
+            "static_limit": static_limit,
+            "warnings": [],
+        }
+
+
+def _content_report(
+    mp4: Path | str,
+    rect: tuple[int, int, int, int] | None,
+    beats: list[dict] | None,
+    *,
+    floor: float,
+    sample_fps: int,
+    static_limit: float,
+) -> dict:
+    """`content_report` without the guard. Call that, not this."""
     mp4 = Path(mp4)
     report: dict = {
         "measured": False,
@@ -1712,6 +1868,10 @@ def content_report(
         "floor": floor,
         "static_for": None,
         "static_from": None,
+        # The beats the held stretch spans, and whether each acted on the app.
+        # Null when no beat log was supplied — which is *not* the same as an
+        # empty list, and the difference decides whether the arm may warn.
+        "static_beats": None,
         "static_limit": static_limit,
         "warnings": [],
     }
@@ -1757,8 +1917,19 @@ def content_report(
             run_gaps, run_start = 0, i
         if run_gaps > best_gaps:
             best_gaps, best_start = run_gaps, run_start
-    report["static_for"] = round(best_gaps * step, 2)
-    report["static_from"] = round(best_start * step, 2)
+    held = best_gaps * step
+    began, ended = best_start * step, (best_start + best_gaps) * step
+    report["static_for"] = round(held, 2)
+    report["static_from"] = round(began, 2)
+
+    # What the storyboard was doing while the picture stood still. Verb and
+    # index only — never the selector: a selector can hold a value somebody
+    # registered as a secret, and this string goes to stderr before the take's
+    # scrubbing has run. The index is enough; the beat is in the same file.
+    spanned = None if beats is None else _beats_within(beats, began, ended)
+    acting = [b for b in (spanned or []) if b["acting"]]
+    if spanned is not None:
+        report["static_beats"] = spanned[:CONTENT_STATIC_BEATS_MAX]
 
     warnings: list[str] = []
     if score < floor:
@@ -1769,16 +1940,25 @@ def content_report(
             f"frames are featureless — a page that never painted, a take "
             f"recorded black, or a rect that is not where the app ended up."
         )
-    if best_gaps * step >= static_limit:
-        held = best_gaps * step
+    # Both conditions, and the second is the one that stops this being a timer.
+    # A long held stretch on its own is *ordinary*: a demo touring a rendered
+    # screen with three captions holds it for 20-22 s, which is what the defect
+    # this exists for also measures. Only a stretch that swallowed a verb which
+    # acted on the app is worth a human's time.
+    if held >= static_limit and acting:
+        named = ", ".join(f"beat {b['index']} `{b['verb']}`" for b in acting[:4])
+        more = f" (+{len(acting) - 4} more)" if len(acting) > 4 else ""
         warnings.append(
-            f"the content rect did not change for {held:.1f}s, from "
-            f"{best_start * step:.1f}s. The beats in this timeline ran during "
-            f"that stretch and nothing in the picture moved, so whatever they "
-            f"did is not visible: a title card or modal left up over the app "
-            f"(issue #91), an overlay that never faded, or an app that stopped "
-            f"painting. Watch {mp4.name} at {best_start * step:.1f}s before "
-            f"believing the beats above it."
+            f"the content rect held one picture for {held:.1f}s "
+            f"({began:.1f}s-{ended:.1f}s) while {len(acting)} verb(s) that act "
+            f"on the app ran inside it: {named}{more}. Nothing changed in the "
+            f"measured region while they ran. **What was measured**: the app "
+            f"rect {tuple(rect)}, which excludes the recorder's own caption bar "
+            f"— so a caption change is invisible here by design and is not what "
+            f"this reports. An overlay left up, a modal that never closed and an "
+            f"app that stopped painting all look like this; so does a demo that "
+            f"genuinely holds still through these verbs. The frames cannot tell "
+            f"those apart — open {mp4.name} at {began:.1f}s and look."
         )
     report["warnings"] = warnings
     return report
@@ -1825,10 +2005,12 @@ def merge_content(records: list[dict]) -> dict:
             (c["static_for"] for c in measured if c.get("static_for") is not None),
             default=None,
         ),
-        # Deliberately null: the worst run belongs to one segment's own clock,
-        # and stating it against the merged video's would be a confidently
-        # wrong timestamp. The segment's own record has it.
+        # Both deliberately null: the worst run belongs to one segment's own
+        # clock and to that segment's own beat numbering, and restating either
+        # against the merged video would be a confidently wrong timestamp and a
+        # confidently wrong beat index. The segment's own record has both.
         "static_from": None,
+        "static_beats": None,
         "static_limit": _common([c.get("static_limit") for c in measured]),
         "warnings": [
             f"segment {name!r}: {warning}"
@@ -1857,11 +2039,26 @@ def print_content_summary(content: dict | None, media: str) -> None:
         return
     for warning in content.get("warnings") or []:
         print(f"demo-video: WARNING — {media}: {warning}", file=sys.stderr)
-    if not content.get("warnings"):
-        print(
-            f"{media} shows a picture (content {content.get('score')} over the "
-            f"app rect, longest still stretch {content.get('static_for')}s)"
-        )
+    if content.get("warnings"):
+        return
+    held = content.get("static_for")
+    limit = content.get("static_limit")
+    # A long held stretch that did *not* warn is worth one clause rather than
+    # silence: it is the ordinary shape of a narrated demo, and a reader who
+    # only ever sees the number when something is wrong will read it as wrong.
+    why = ""
+    if isinstance(held, (int, float)) and isinstance(limit, (int, float)):
+        if held >= limit:
+            why = (
+                " — over the "
+                f"{limit}s limit, but every beat inside it was narration, a "
+                "hold or a wait, which is what a still screen is supposed to "
+                "look like"
+            )
+    print(
+        f"{media} shows a picture (content {content.get('score')} over the "
+        f"app rect, longest still stretch {held}s{why})"
+    )
 
 
 def _verb_target(args: tuple, kwargs: dict) -> str | None:
@@ -3840,7 +4037,10 @@ class _DemoBase:
                 f"picture was measured"
             )
             return
-        self._content = content_report(self._media_path(), rect)
+        # The beat log goes in, and it is what makes the held-picture arm mean
+        # anything: without it a demo narrating over a rendered screen and a
+        # demo nobody can see are the same number. See CONTENT_ACTING_VERBS.
+        self._content = content_report(self._media_path(), rect, self._beats)
 
     def _timeline_doc(self, failure: dict | None = None) -> dict:
         """This take's beat log as a timeline document (see TIMELINE_SCHEMA).
@@ -3942,7 +4142,14 @@ class _DemoBase:
             # there is nothing to measure and a previous run's file is not this
             # take's — and a dict with `measured: false` and a `note` whenever
             # it could not be measured. Never silently absent.
-            "content": self._content,
+            #
+            # Scrubbed like everything else in this document. It carries no
+            # selector today and deliberately so (see `_content_report`), but
+            # this file is committed and a field that grows a quoted string
+            # later must not be the one place the mask does not reach.
+            "content": self._evidence_scrub_deep(
+                self._scrub_deep(self._content), forbidden
+            ),
             "beats": beats,
             "strict": self._strict,
             "issues": issues,

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -45,6 +45,7 @@ from .core import (
     _beat_verb,
     _DemoBase,
     _env,
+    content_rect,
 )
 
 _ASSETS = Path(__file__).parent.parent / "assets" / "xterm"
@@ -766,6 +767,9 @@ class TerminalRecorder(_DemoBase):
         # _OPENING_CARD_JS.
         self._opening = interlude
         self._opening_hold = interlude_hold
+        # Where the xterm.js screen sits in the frame, read off the live
+        # element once the terminal exists (issue #97). See `_content_rect`.
+        self._host_box: tuple[int, int, int, int] | None = None
 
     # -- setup / teardown ---------------------------------------------------
 
@@ -842,6 +846,7 @@ class TerminalRecorder(_DemoBase):
              "fontSize": self._font_size},
         )
         self._set_winsize(int(dims["rows"]), int(dims["cols"]))
+        self._read_host_box()
         # Just enough to catch the shell's first prompt. It used to be kept
         # short so a segment opening on a transition would not dwell on a bare
         # terminal; with `interlude=` that dwell happens behind the card, and
@@ -849,6 +854,51 @@ class TerminalRecorder(_DemoBase):
         self._idle(0.15)
         if self._opening is not None:
             self._open_on_card()
+
+    def _read_host_box(self) -> None:
+        """Remember where `#__term_host` is, for the picture check (issue #97).
+
+        Read here, off the live element, rather than derived from the window
+        CSS: `_TERM_HOST_JS` positions the window with fixed insets and the
+        xterm.js fit addon decides the rest, so a change to either would
+        silently move the rect a hardcoded copy claimed to describe. Read
+        **once**, at `_start()`, because nothing after this resizes it and the
+        page is gone by the time the mp4 exists.
+
+        Failure is not fatal and not silent: `content_report` says the picture
+        was not measured, which is a truthful artifact. Refusing a take because
+        a bounding box could not be read would be the check costing somebody
+        the recording it exists to describe.
+        """
+        try:
+            box = self.page.locator("#__term_host").bounding_box()
+        except Exception as exc:  # noqa: BLE001 - a measurement is not a take
+            print(
+                f"demo-video: WARNING — could not read the terminal's box "
+                f"({type(exc).__name__}: {exc}), so this take's timeline will "
+                f"say the picture was not measured.",
+                file=sys.stderr,
+            )
+            return
+        if box:
+            self._host_box = (
+                int(box["x"]), int(box["y"]),
+                int(box["width"]), int(box["height"]),
+            )
+
+    def _content_rect(self) -> tuple[int, int, int, int] | None:
+        """The xterm.js screen's region of the frame (issue #97).
+
+        A terminal take frames itself *in the page* and `_postprocess` is a
+        no-op, so page coordinates are video coordinates: the context is
+        created with `record_video_size == viewport`. Everything outside this
+        box — the pastel background, the window chrome, the title bar — is the
+        recorder's own drawing and never changes, which is precisely what a
+        whole-frame score would end up measuring (issue #17).
+        """
+        if self._host_box is None:
+            return None
+        return content_rect(self._host_box)
 
     def _open_on_card(self) -> None:
         """Hold the card the init script raised, then take it down.

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -36,6 +36,7 @@ from .core import (
     _beat_verb,
     _DemoBase,
     _env,
+    content_rect,
 )
 
 # Pastel gradient behind the window — matches the terminal recorder's
@@ -1118,6 +1119,23 @@ class Recorder(_DemoBase):
             "winx": winx, "winy": winy,
             "appx": winx + pad, "appy": winy + bar + pad,
         }
+
+    def _content_rect(self) -> tuple[int, int, int, int] | None:
+        """Where the page lands inside the composited frame (issue #97).
+
+        `_postprocess` scales the raw recording to `appw x apph` and overlays
+        it at `appx, appy` on the window-and-background still, so this is the
+        app's region of the *encoded* file — which is the only frame anybody
+        watches. Everything outside it is the recorder's own chrome, and that
+        chrome is exactly what made a whole-frame score rank a blank recording
+        above a healthy one (issue #17).
+        """
+        geom = getattr(self, "_geom", None)
+        if not geom:
+            return None
+        return content_rect(
+            (geom["appx"], geom["appy"], geom["appw"], geom["apph"])
+        )
 
     def _init_context(self, context) -> None:
         context.add_init_script(_CURSOR_JS.replace("__ACCENT__", self._accent))

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,6 +38,8 @@ tests/smoke --segments-only       # just the two-segment take and its stitch
 tests/smoke --evidence-only       # just the per-beat evidence takes
 tests/smoke --failure-only        # just the takes that do not finish
 tests/smoke --polish-only         # just the two takes that grade how it looks
+tests/smoke --content-only        # just the pair that grades whether a
+                                  #   recording shows anything (issue #97)
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -151,8 +153,8 @@ all (see Known gaps).
 
 ## What it asserts
 
-Nine independent axes, because a recorder can fail on any one of them while
-looking perfect on the other eight.
+Ten independent axes, because a recorder can fail on any one of them while
+looking perfect on the other nine.
 
 **Artifacts** — `demo.mp4` and every still the storyboard asked for exist, were
 modified by *this* run rather than a previous one, clear a size floor
@@ -1435,6 +1437,78 @@ than the fade injecting xterm.js before Chromium's screencast emits anything.
 The recorder has no fade-in path (the element is appended already opaque, so no
 transition can run), but the suite is relying on setup cost for that and would
 not notice if it changed.
+
+### Whether the recorder notices that the recording shows nothing (issue #97)
+
+Everything above is this harness measuring the picture. The recorder now
+measures it too — `content` in `timeline.json`, plus a line on stderr — because
+a user recording their own demo does not run this suite. This axis grades that
+check, and only that: the floors and rects above stay as the harness's own,
+because **a check graded by the measurement it makes is not graded**.
+
+`content-shown/` and `content-covered/` are one terminal storyboard recorded
+twice. They differ by a single line — whether `interlude("")` takes the card
+back down — and are otherwise the same three commands, the same captions, the
+same exit codes and the same `evidence/`. That pair is issue #91 reproduced:
+under the card every beat runs and none of it reaches a frame.
+
+Every assertion is a *comparison between the two takes*, because each one has a
+way to pass vacuously alone — "the covered take warns" is satisfied by a
+recorder that warns on everything, "the shown one does not" by a recorder that
+never warns, and both by a metric measuring the wrong region entirely.
+
+| | asserted on `content-shown` | asserted on `content-covered` |
+|---|---|---|
+| `content.warnings` | empty | says "did not change" |
+| stderr from the take | no warning | `WARNING`, unasked |
+| `static_for` | under `static_limit` | ≥ 75% of the take's duration |
+| the three stills, cropped to `#__term_host` | 3 distinct files | 1 file, three times |
+| the video at the first and last `run` beat | ≤ 33 dB PSNR apart | ≥ 40 dB |
+| `evidence/` | ≥ 3 distinct screens | ≥ 3 distinct screens |
+
+The last row is the control that makes the two above it mean anything: it is
+what says the three commands really printed three different things, so "the
+frames are identical" is a statement about the *recording* rather than about a
+storyboard that did nothing. It is also #97's finding stated as one line — the
+text tier says the demo worked, the pixels say nothing was shown.
+
+Stills are compared **byte for byte** and need no threshold at all: they are
+lossless PNGs of the page. The video cannot be, so it is compared with ffmpeg's
+PSNR — 46.4 dB under the card against 26.2 dB with it down, twenty decibels, a
+hundredfold in mean squared error, with both bars in the open space between.
+
+**The recorder's `static_limit` is graded as a band, from this run's own two
+takes rather than from a number in a comment**: it must sit at least 1.6x above
+the *healthy* take's longest still stretch and at most 0.7x of the covered
+take's. Halve the constant and every honest demo warns; double it and the take
+this whole issue is about goes unremarked. Both turn the suite red.
+
+**The anti-correlated metric is a standing regression test now.** The section
+at the top of this file explains why the app's rect is measured rather than the
+frame; nothing asserted it. This axis takes `content-shown/demo.mp4`, paints
+the app rect flat black with `drawbox` — keeping the recorder's chrome, which
+is the whole point — and scores the result both ways:
+
+| | healthy | app painted flat |
+|---|---|---|
+| over the content rect | 5.3 | 0.2 |
+| over the whole frame | 82.3 | **90.3** |
+
+The rect ranks the blank recording far below the healthy one; the whole frame
+ranks it **above**. Both directions are asserted, and the second is the one
+that matters: if a future change scores the frame again, or the fixture stops
+exhibiting the anti-correlation, the suite says so instead of passing on a
+number that grades chrome.
+
+Finally, `check_content_healthy()` hangs off *every* graded take — web,
+terminal and the stitched segments demo — asserting that each reports a
+measured `content` with no warnings, a score well clear of the recorder's blank
+floor, and a scored rect that lies **inside** the app rect this harness read off
+the live recorder. That last one is the assertion that catches a recorder
+grading its own window chrome, which produces a perfectly plausible `content`
+block and a number that means nothing.
+
+`tests/smoke --content-only` records just these two takes.
 
 ### Failure artifacts — what a take that did *not* finish leaves behind
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1446,11 +1446,38 @@ a user recording their own demo does not run this suite. This axis grades that
 check, and only that: the floors and rects above stay as the harness's own,
 because **a check graded by the measurement it makes is not graded**.
 
-`content-shown/` and `content-covered/` are one terminal storyboard recorded
-twice. They differ by a single line — whether `interlude("")` takes the card
-back down — and are otherwise the same five commands, the same captions, the
-same exit codes and the same `evidence/`. That pair is issue #91 reproduced:
-under the card every beat runs and none of it reaches a frame.
+Three takes. `content-shown/` and `content-covered/` are one terminal
+storyboard recorded twice, differing by a single line — whether `interlude("")`
+takes the card back down — and otherwise the same five commands, the same
+captions, the same exit codes and the same `evidence/`. That pair is issue #91
+reproduced: under the card every beat runs and none of it reaches a frame.
+
+`content-toured/` is a **different** healthy storyboard, and it exists because
+the pair above structurally cannot reach the failure that matters most here.
+The recorder's content rect excludes its own caption bar, so swapping captions
+over a still screen is invisible to the held-picture arm — and swapping captions
+over a still screen is precisely what `SKILL.md` tells authors to do during a
+wait. Measured on real takes:
+
+| take | `static_for` |
+|---|---|
+| healthy terminal, 2 touring captions | 16.5s |
+| healthy web, 3 touring captions | 20.0s |
+| healthy terminal, 3 touring captions | 21.5–22.0s |
+| **reference take 1, card over the terminal** | **23.0s** |
+
+There is no threshold between the healthy rows and the defect. The first
+version of this axis warned on duration alone and would have called all three
+healthy takes broken — in `timeline.json`, blaming "a title card or modal left
+up over the app", which never happened. It went unnoticed because
+`CONTENT_COMMANDS` was deliberately capped at three-line commands with no
+touring captions "to stay clear of" the limit: **a fixture shaped to avoid a
+failure mode cannot grade it.** That is the catalogue's *config-hidden path*.
+
+So the recorder correlates the stretch with the beat log — a held picture
+spanning only `caption`/`hold`/`shot`/`wait_for*` is a narrated hold; one
+spanning `run`/`click`/`goto`/`type_into`/… is worth a human's time — and
+`content-toured/` is asserted **silent** while holding *past* the limit.
 
 Five commands rather than three because the covered take cannot hold one frame
 for longer than it runs, and the band below needs it well clear of the
@@ -1470,7 +1497,7 @@ never warns, and both by a metric measuring the wrong region entirely.
 
 | | asserted on `content-shown` | asserted on `content-covered` |
 |---|---|---|
-| `content.warnings` | empty | says "did not change" |
+| `content.warnings` | empty | says "held one picture" |
 | stderr from the take | no warning | `WARNING`, unasked |
 | `static_for` | under `static_limit` | ≥ 75% of the take's duration |
 | the five stills, cropped to `#__term_host` | 5 distinct files | 1 file, five times |
@@ -1527,6 +1554,30 @@ that matters: if a future change scores the frame again, or the fixture stops
 exhibiting the anti-correlation, the suite says so instead of passing on a
 number that grades chrome.
 
+Three more assertions round it out.
+
+**`content-toured/` must hold past the limit and be met with silence**, and the
+first half is the premise the second needs: if the take stopped holding long
+enough it would keep passing after the thing it grades regressed, so
+`static_for >= static_limit` is asserted explicitly. The mechanism is asserted
+too, not just the symptom — `content.static_beats` must be non-empty and must
+contain no acting verb — because "no warning" alone would also pass on a
+recorder whose static arm was simply switched off.
+
+**The covered take's message must not name a cause.** It is asserted to contain
+neither "title card or modal left up" nor "is not visible", and to say which
+region was measured. A warning that blames an overlay is wrong on three of this
+suite's own healthy takes, and a confidently wrong artifact is the thing #97
+exists to remove — the detector must not become an instance of it.
+
+**Every storyboard verb must be classified.** `check_verb_classification()`
+scrapes `@_beat_verb("…")` and `self._beat("…")` out of the package source —
+scraped rather than imported, so an omission cannot hide on both sides — and
+requires each of the 22 verbs to be in exactly one of the recorder's two sets.
+An unclassified verb silently counts as passive, which would quietly switch the
+arm off for a whole class of demo. It aborts if the scrape finds fewer than 15
+verbs, so a broken regex reports itself instead of passing on an empty set.
+
 Finally, `check_content_healthy()` hangs off *every* graded take — web,
 terminal and the stitched segments demo — asserting that each reports a
 measured `content` with no warnings, a score well clear of the recorder's blank
@@ -1535,7 +1586,13 @@ the live recorder. That last one is the assertion that catches a recorder
 grading its own window chrome, which produces a perfectly plausible `content`
 block and a number that means nothing.
 
-`tests/smoke --content-only` records just these two takes.
+What it deliberately does **not** assert is that `static_for` stays under
+`static_limit`. That rule was there in the first version and it was wrong: a
+healthy demo narrating a rendered screen holds the measured region for longer
+than the limit and is supposed to. What a healthy take owes is silence, not a
+small number.
+
+`tests/smoke --content-only` records just these three takes.
 
 ### Failure artifacts — what a take that did *not* finish leaves behind
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1448,9 +1448,20 @@ because **a check graded by the measurement it makes is not graded**.
 
 `content-shown/` and `content-covered/` are one terminal storyboard recorded
 twice. They differ by a single line — whether `interlude("")` takes the card
-back down — and are otherwise the same three commands, the same captions, the
+back down — and are otherwise the same five commands, the same captions, the
 same exit codes and the same `evidence/`. That pair is issue #91 reproduced:
 under the card every beat runs and none of it reaches a frame.
+
+Five commands rather than three because the covered take cannot hold one frame
+for longer than it runs, and the band below needs it well clear of the
+recorder's limit. **Each prints at most three lines, and that is a constraint
+rather than a style**: the recorder's content rect drops the bottom fifth of
+the terminal, so output landing in the last rows of a not-yet-scrolled screen
+is outside the measured region. An earlier version of this storyboard filled 25
+of ~32 rows and pushed two commands into that band, where the *healthy* take
+reported 9.5 s of held picture while it was visibly printing. That limit is
+real and is stated in `SKILL.md`; the fixture stays clear of it so that what is
+graded here is the check rather than the limit.
 
 Every assertion is a *comparison between the two takes*, because each one has a
 way to pass vacuously alone — "the covered take warns" is satisfied by a
@@ -1462,25 +1473,41 @@ never warns, and both by a metric measuring the wrong region entirely.
 | `content.warnings` | empty | says "did not change" |
 | stderr from the take | no warning | `WARNING`, unasked |
 | `static_for` | under `static_limit` | ≥ 75% of the take's duration |
-| the three stills, cropped to `#__term_host` | 3 distinct files | 1 file, three times |
-| the video at the first and last `run` beat | ≤ 33 dB PSNR apart | ≥ 40 dB |
-| `evidence/` | ≥ 3 distinct screens | ≥ 3 distinct screens |
+| the five stills, cropped to `#__term_host` | 5 distinct files | 1 file, five times |
+| `evidence/` | ≥ 5 distinct screens | ≥ 5 distinct screens |
+
+…plus one assertion across the pair: the video at the first and last `run` beat
+must be **at least 8 dB PSNR further apart in the covered take than in the
+shown one**.
 
 The last row is the control that makes the two above it mean anything: it is
-what says the three commands really printed three different things, so "the
+what says the five commands really printed five different things, so "the
 frames are identical" is a statement about the *recording* rather than about a
 storyboard that did nothing. It is also #97's finding stated as one line — the
 text tier says the demo worked, the pixels say nothing was shown.
 
 Stills are compared **byte for byte** and need no threshold at all: they are
 lossless PNGs of the page. The video cannot be, so it is compared with ffmpeg's
-PSNR — 46.4 dB under the card against 26.2 dB with it down, twenty decibels, a
-hundredfold in mean squared error, with both bars in the open space between.
+PSNR — and that comparison is **relative between the two takes**, which was
+learned the expensive way. The first version asserted "the covered take reads
+at least 40 dB": 47.5 dB on the development machine, **39.8 dB on the CI
+runner**, where a different x264 build re-quantises a held frame slightly
+differently, and the suite went red on a recorder that was working. That is the
+catalogue's *threshold tuned to this box*, and the fix is the one this file
+already uses for the caption band — compare the takes against each other, same
+run, same encoder, no absolute number claimed:
+
+| | this box | CI runner |
+|---|---|---|
+| covered | 47.5 dB | 39.8 dB |
+| shown | 25.5 dB | 25.9 dB |
+| gap | 22.0 dB | 13.9 dB |
 
 **The recorder's `static_limit` is graded as a band, from this run's own two
 takes rather than from a number in a comment**: it must sit at least 1.6x above
 the *healthy* take's longest still stretch and at most 0.7x of the covered
-take's. Halve the constant and every honest demo warns; double it and the take
+take's — one run measured `15.0s sits in [8.8, 21.3]s (healthy 5.5s, covered
+30.5s)`. Halve the constant and every honest demo warns; double it and the take
 this whole issue is about goes unremarked. Both turn the suite red.
 
 **The anti-correlated metric is a standing regression test now.** The section
@@ -1491,7 +1518,7 @@ is the whole point — and scores the result both ways:
 
 | | healthy | app painted flat |
 |---|---|---|
-| over the content rect | 5.3 | 0.2 |
+| over the content rect | 6.6 | 0.2 |
 | over the whole frame | 82.3 | **90.3** |
 
 The rect ranks the blank recording far below the healthy one; the whole frame

--- a/tests/README.md
+++ b/tests/README.md
@@ -1559,7 +1559,12 @@ Three more assertions round it out.
 **`content-toured/` must hold past the limit and be met with silence**, and the
 first half is the premise the second needs: if the take stopped holding long
 enough it would keep passing after the thing it grades regressed, so
-`static_for >= static_limit` is asserted explicitly. The mechanism is asserted
+`static_for >= static_limit` is asserted explicitly. **That premise has already
+earned its keep**: the first version of this take used sentence-length captions,
+which wrapped to three lines on the CI runner — and a wrapping caption bar grows
+*upward*, past the bottom fifth the content rect trims off and into the measured
+region, 266 changed pixels a time. The stretch fell from 25.0s to 11.0s and the
+take stopped reaching the path it exists for. CI said so instead of passing. The mechanism is asserted
 too, not just the symptom — `content.static_beats` must be non-empty and must
 contain no acting verb — because "no warning" alone would also pass on a
 recorder whose static arm was simply switched off.

--- a/tests/smoke
+++ b/tests/smoke
@@ -196,12 +196,47 @@ CONTENT_KEEP = 0.8
 # that, and only that — the numbers above stay as this harness's own gate, on
 # purpose: a check graded by the measurement it makes is not graded.
 #
-# Two takes of one storyboard, differing in a single line — whether the opening
-# title card is taken down. That is issue #91 exactly, and recording both is
-# what stops each assertion here from being satisfiable by a take that shows
-# nothing (the covered one) or by a take that never holds still (the shown one).
+# **Three** takes, and the third is the one this axis got wrong the first time.
+#
+#   content-shown     the storyboard below, card taken down. Healthy.
+#   content-covered   the same storyboard, card left up. Issue #91 exactly.
+#   content-toured    a *different* healthy storyboard: one command, then a
+#                     rendered screen narrated with touring captions.
+#
+# The first two differ by a single line, which is what stops each assertion from
+# being satisfiable by a take that shows nothing or by one that never holds
+# still. The third exists because the first two, on their own, **structurally
+# cannot reach the failure that matters most here**.
+#
+# The recorder's content rect excludes its own caption bar, so swapping captions
+# over a still screen is invisible to the held-picture arm — and swapping
+# captions over a still screen is precisely what SKILL.md tells authors to do
+# during a wait. A healthy demo written that way holds the measured region for
+# 16.5-22.0 s, against 23.0 s for the card that covered the reference demo's
+# first take. The two are indistinguishable by duration, and the first version
+# of this axis never noticed, because `CONTENT_COMMANDS` below was deliberately
+# shaped to keep the fixture clear of long holds. A fixture that cannot reach
+# the failure path grades the constant against a sample chosen to exclude it.
+#
+# `content-toured` is that path, asserted **silent**: it must hold longer than
+# the recorder's own limit and warn about nothing, because every beat inside the
+# stretch is a caption or a hold. Remove the verb correlation from the recorder
+# and this take goes red.
 CONTENT_TAKES = ("content-shown", "content-covered")
+CONTENT_TOURED = "content-toured"
 CONTENT_CARD = "Everything after this is covered."
+
+# The touring storyboard: one command that renders something worth looking at,
+# then captions that talk about what is already on screen without touching it.
+# Long captions on purpose — the recorder holds a caption for roughly reading
+# speed, so these are what produce a stretch past CONTENT_STATIC_WARN_S with no
+# acting verb anywhere inside it.
+CONTENT_TOUR_COMMAND = ("The queue, as the command line prints it.", "seq 1 4")
+CONTENT_TOUR_CAPTIONS = (
+    "Each line above is one ticket, in the order the queue holds them.",
+    "The number on the left is the identifier the CLI and the web app share.",
+    "Nothing here is filtered yet — this is the whole queue, exactly as stored.",
+)
 
 # Five commands rather than three, and the length is load-bearing rather than
 # thorough: the covered take can hold one frame for no longer than it runs, and
@@ -219,6 +254,9 @@ CONTENT_CARD = "Everything after this is covered."
 # printing. The limit is real and is written down in SKILL.md; this keeps the
 # fixture clear of it, so what is graded here is the check rather than the
 # limit.
+#
+# Keeping this pair clear of long holds is also what made `content-toured`
+# necessary: a fixture shaped to avoid a failure mode cannot grade it.
 CONTENT_COMMANDS = (
     ("The first command.", "seq 1 3"),
     ("The second, printing something else.", "printf 'alpha\\nbravo\\n'"),
@@ -3205,6 +3243,61 @@ def record_content(out_dir: Path, cleared: bool) -> tuple[list[str], dict]:
     return b.problems, {"app": app, "size": size}
 
 
+def record_content_toured(out_dir: Path) -> tuple[list[str], dict]:
+    """A healthy demo that narrates a rendered screen without touching it.
+
+    Written the way `SKILL.md` tells storyboard authors to write one — *"during
+    unavoidable waits, tour what's on screen or swap the caption"* — and it is
+    the shape that made the first version of this check wrong. One command puts
+    something on screen; after that every beat is a caption or a hold, so the
+    measured region legitimately holds one picture for longer than the
+    recorder's own limit, with nothing occluded and nothing broken.
+
+    The recorder must say nothing about it. If it warns, its message blames an
+    overlay that never existed, in `timeline.json`, which is the failure issue
+    #97 was filed to remove.
+    """
+    from demo_recording import TerminalRecorder
+
+    b = Beats(CONTENT_TOURED)
+    caption, command = CONTENT_TOUR_COMMAND
+
+    with TerminalRecorder(
+        out_dir, speech=False, strict=True, deterministic=True
+    ) as rec:
+        start_ticker(b, rec.page)
+        rec.caption(caption)
+        rec.run(command)
+        try:
+            rec.wait_for_prompt(timeout_s=15)
+        except RuntimeError as exc:
+            b.fail_if(True, f"the shell prompt never came back — {exc}")
+        rec.shot("01-toured")
+        # Everything from here is narration over a screen nobody touches again.
+        # `hold()` after each caption so the stretch is made of holds as well as
+        # captions — both passive, and a stretch of only one verb would be a
+        # thinner claim than the mix a real storyboard produces.
+        for line in CONTENT_TOUR_CAPTIONS:
+            rec.caption(line)
+            rec.hold()
+        rec.caption("")
+
+        box = rec.page.locator("#__term_host").bounding_box()
+        if box is None:
+            raise SmokeFailure(
+                f"{CONTENT_TOURED}: #__term_host has no box — nothing rendered"
+            )
+        app: Rect = (
+            int(box["x"]),
+            int(box["y"]),
+            int(box["width"]),
+            int(box["height"]),
+        )
+        size = (rec._size["width"], rec._size["height"])
+
+    return b.problems, {"app": app, "size": size}
+
+
 class EntropyTake(NamedTuple):
     """One recording of the entropy storyboard, and what it rendered."""
 
@@ -4092,12 +4185,11 @@ def check_content_healthy(label: str, out_dir: Path, app_rect: Rect) -> list[str
             f"{label}: content.static_for is {still!r} and content.static_limit "
             f"is {limit!r}; a measured take must have both"
         )
-    elif still >= limit:
-        failures.append(
-            f"{label}: this healthy take held one frame for {still}s, at or "
-            f"over the recorder's own {limit}s limit — the storyboard idles "
-            f"longer than the limit allows, so every take of it warns"
-        )
+    # Deliberately *no* assertion that `still` stays under `limit`. It used to
+    # be here and it was wrong: a healthy demo narrating over a rendered screen
+    # holds the measured region for longer than the limit and is supposed to,
+    # which is what `content-toured` exists to prove. What a healthy take owes
+    # is silence, not a small number.
 
     if content.get("warnings"):
         failures.append(
@@ -4107,8 +4199,64 @@ def check_content_healthy(label: str, out_dir: Path, app_rect: Rect) -> list[str
     if not failures:
         print(
             f"smoke: {label} content ok (score {score}, longest still "
-            f"{still}s under {limit}s, over {len(rects)} rect(s) "
+            f"{still}s against a {limit}s limit, over {len(rects)} rect(s) "
             f"{[tuple(r) for r in rects]})"
+        )
+    return failures
+
+
+def declared_verbs() -> set[str]:
+    """Every verb name the recorders record a beat under.
+
+    Scraped from the package source rather than imported, on purpose: the point
+    is to catch a verb that exists and is in *neither* of the recorder's two
+    classification sets, and asking the recorder which verbs it has would let
+    the same omission hide on both sides.
+    """
+    found: set[str] = set()
+    for path in (HELPERS_DIR / "demo_recording").glob("*.py"):
+        source = path.read_text()
+        found |= set(re.findall(r'@_beat_verb\(\s*"([a-z_]+)"', source))
+        found |= set(re.findall(r'self\._beat\(\s*"([a-z_]+)"', source))
+    return found
+
+
+def check_verb_classification() -> list[str]:
+    """Every storyboard verb must be classified acting or passive (issue #97).
+
+    The held-picture arm only warns when an *acting* verb ran inside the
+    stretch — that is the whole difference between a detector and a timer. A
+    verb added later and left out of both sets silently becomes passive, and
+    the arm quietly stops noticing a whole class of demo. Free to check, and it
+    needs no recording.
+    """
+    from demo_recording import CONTENT_ACTING_VERBS, CONTENT_PASSIVE_VERBS
+
+    declared = declared_verbs()
+    if len(declared) < 15:
+        return [
+            f"content: only {len(declared)} storyboard verbs were found in the "
+            f"package source ({sorted(declared)}) — the scrape is broken, so "
+            f"the classification below is being checked against almost nothing"
+        ]
+    classified = CONTENT_ACTING_VERBS | CONTENT_PASSIVE_VERBS
+    failures = []
+    missing = sorted(declared - classified)
+    if missing:
+        failures.append(
+            f"content: {missing} record beats but are in neither "
+            f"CONTENT_ACTING_VERBS nor CONTENT_PASSIVE_VERBS. An unclassified "
+            f"verb counts as passive, so a held picture spanning it never "
+            f"warns — decide which it is rather than letting it default"
+        )
+    both = sorted(CONTENT_ACTING_VERBS & CONTENT_PASSIVE_VERBS)
+    if both:
+        failures.append(f"content: {both} are classified as both acting and passive")
+    if not failures:
+        print(
+            f"smoke: all {len(declared)} storyboard verbs are classified "
+            f"({len(CONTENT_ACTING_VERBS & declared)} acting, "
+            f"{len(CONTENT_PASSIVE_VERBS & declared)} passive)"
         )
     return failures
 
@@ -4252,23 +4400,40 @@ def check_content_pair(takes: dict[str, dict]) -> list[str]:
             f"card *is* taken down: {shown_c['warnings']}"
         )
     still = " ".join(str(w) for w in covered_c.get("warnings") or [])
-    if "did not change" not in still:
+    if "held one picture" not in still:
         failures.append(
             f"{CONTENT_TAKES[1]}: the recorder did not report a held picture "
             f"for a take whose title card covered every beat. This is issue "
             f"#91 reproduced, and `content.warnings` says {covered_c.get('warnings')!r}"
         )
+    # The message must describe what was measured and must not name a cause it
+    # cannot know. A warning that blames an overlay is wrong on three of this
+    # suite's own healthy takes, and a confidently wrong artifact is the thing
+    # #97 exists to remove — the detector must not become an instance of it.
+    for banned in ("title card or modal left up", "is not visible"):
+        if banned in still:
+            failures.append(
+                f"{CONTENT_TAKES[1]}: the warning asserts {banned!r}, a cause "
+                f"the frames cannot establish — a held stretch has honest "
+                f"explanations too (see {CONTENT_TOURED})"
+            )
+    if "caption bar" not in still:
+        failures.append(
+            f"{CONTENT_TAKES[1]}: the warning does not say what region was "
+            f"measured. It excludes the recorder's own caption bar, so a "
+            f"reader who does not know that cannot tell what the silence means"
+        )
 
     # 2. ...and on stderr, unasked, which is the half of the acceptance
     #    criterion no artifact can carry.
     err = covered["stderr"]
-    if "WARNING" not in err or "did not change" not in err:
+    if "WARNING" not in err or "held one picture" not in err:
         failures.append(
             f"{CONTENT_TAKES[1]}: nothing on stderr said the recording holds "
             f"still. A reviewer who does not open timeline.json gets no signal "
             f"at all. Captured stderr: {err[-400:]!r}"
         )
-    if "did not change" in shown["stderr"]:
+    if "held one picture" in shown["stderr"]:
         failures.append(
             f"{CONTENT_TAKES[0]}: stderr warned about a healthy take, so the "
             f"warning above says nothing"
@@ -4348,6 +4513,81 @@ def check_content_pair(takes: dict[str, dict]) -> list[str]:
 
     # 6. The anti-correlated metric (issue #17), as a standing regression test.
     failures += _check_scored_region(shown, shown_c)
+    return failures
+
+
+def check_content_toured(out_dir: Path, stderr: str) -> list[str]:
+    """A healthy demo that holds still past the limit must be met with silence.
+
+    The false positive this axis was blind to. `content-toured` narrates a
+    rendered screen the way SKILL.md tells authors to, so the measured region
+    holds one picture for longer than `static_limit` with nothing occluded.
+    Three assertions, and the first is the premise the other two need:
+
+    1. it really does hold past the limit — otherwise this take proves nothing
+       and would keep passing after the check regressed;
+    2. `content.warnings` is empty and nothing reached stderr;
+    3. the stretch is populated with beats and **none of them acted on the
+       app**, which is the mechanism rather than the symptom. Without it, "no
+       warning" would also pass on a recorder whose static arm was simply
+       switched off.
+    """
+    content = content_of(out_dir)
+    if content is None or not content.get("measured"):
+        return [
+            f"{CONTENT_TOURED}: no measured `content` in timeline.json "
+            f"({None if content is None else content.get('note')})"
+        ]
+    held, limit = content.get("static_for"), content.get("static_limit")
+    if not isinstance(held, (int, float)) or not isinstance(limit, (int, float)):
+        return [f"{CONTENT_TOURED}: static_for is {held!r}, limit {limit!r}"]
+
+    failures: list[str] = []
+    if held < limit:
+        failures.append(
+            f"{CONTENT_TOURED}: this take was written to hold one picture past "
+            f"the recorder's {limit}s limit and only held it for {held}s, so "
+            f"it does not reach the false-positive path at all. Lengthen the "
+            f"touring captions — as written, this take would keep passing "
+            f"after the thing it grades regressed"
+        )
+    if content.get("warnings"):
+        failures.append(
+            f"{CONTENT_TOURED}: the recorder warned about a healthy demo that "
+            f"narrates a rendered screen — nothing is occluded, the terminal is "
+            f"fully drawn, and every beat in the held stretch is a caption or a "
+            f"hold. The warning says {content['warnings']!r}"
+        )
+    if "WARNING" in stderr and "held one picture" in stderr:
+        failures.append(
+            f"{CONTENT_TOURED}: stderr carried a held-picture warning for a "
+            f"healthy take: {stderr[-400:]!r}"
+        )
+
+    spanned = content.get("static_beats")
+    if not spanned:
+        failures.append(
+            f"{CONTENT_TOURED}: content.static_beats is {spanned!r}. The take "
+            f"held a picture for {held}s and the recorder recorded no beats "
+            f"inside it, so 'no acting verb ran' is vacuous rather than true"
+        )
+    else:
+        acting = [b for b in spanned if b.get("acting")]
+        if acting:
+            failures.append(
+                f"{CONTENT_TOURED}: the held stretch is reported as spanning "
+                f"acting verbs {[b.get('verb') for b in acting]}, but this "
+                f"storyboard touches nothing after its one command — either "
+                f"the classification is wrong or the stretch is misaligned "
+                f"with the beat log"
+            )
+        elif not failures:
+            print(
+                f"smoke: {CONTENT_TOURED} held one picture for {held}s, over "
+                f"the {limit}s limit, across "
+                f"{[b.get('verb') for b in spanned]} — and the recorder said "
+                f"nothing, which is correct"
+            )
     return failures
 
 
@@ -7234,53 +7474,76 @@ def run_terminal_opening(out_root: Path) -> list[str]:
     )
 
 
-def run_content(out_root: Path) -> list[str]:
-    """One storyboard recorded twice: card taken down, and card left up.
+def _record_content_take(out_root: Path, name: str, record) -> tuple[list[str], dict]:
+    """Record one content take, capturing its stderr.
 
-    Issue #97's acceptance criterion, and the closest thing this suite has to
-    the defect that motivated it — take 1 of the reference demo, where a title
-    card covered 24.3 s of a 60.2 s recording and every artifact reported a
-    healthy take.
-
-    stderr is captured per take, not just inspected afterwards, because half
-    the criterion is that the warning arrives *unasked*: an author who never
-    opens timeline.json still has to be told. `print` writes through
-    `sys.stderr` at call time, so redirecting it here catches the recorder's
-    own output and nothing else's.
+    stderr is captured rather than merely inspected afterwards, because half
+    the acceptance criterion is that the verdict arrives *unasked*: an author
+    who never opens timeline.json still has to be told, and — for the healthy
+    takes — must not be told something untrue. `print` resolves `sys.stderr` at
+    call time, so redirecting here catches the recorder's own output and
+    nothing else's.
     """
-    takes: dict[str, dict] = {}
+    out_dir = fresh_take_dir(out_root, name)
+    captured = io.StringIO()
+    try:
+        with contextlib.redirect_stderr(captured):
+            found, info = record(out_dir)
+    except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+        sys.stderr.write(captured.getvalue())
+        return [f"{name}: TerminalRecorder raised {type(exc).__name__}: {exc}"], {}
+    # Put it back on the real stderr: a run that fails later should not also
+    # have swallowed the recorder's own account of itself.
+    sys.stderr.write(captured.getvalue())
+    if not (out_dir / "demo.mp4").is_file():
+        found = [*found, f"{name}: demo.mp4 was never written"]
+    return found, {"out_dir": out_dir, "info": info, "stderr": captured.getvalue()}
+
+
+def run_content(out_root: Path) -> list[str]:
+    """Three takes: card taken down, card left up, and a narrated hold.
+
+    The first two are issue #97's acceptance criterion — take 1 of the
+    reference demo, where a title card covered 24.3 s of a 60.2 s recording and
+    every artifact reported a healthy take.
+
+    The third is the false positive that criterion does not cover, and it is
+    the reason this phase is not just a pair. A healthy demo touring a rendered
+    screen holds the measured region for longer than the covered take does; a
+    check that warned on duration alone would call it broken, in
+    `timeline.json`, naming a cause that never happened.
+    """
     problems: list[str] = []
+    takes: dict[str, dict] = {}
     previous = Path.cwd()
     # `ls -1` is one of the beats; pin the shell's directory so the take does
     # not depend on where the suite was started.
     os.chdir(REPO_ROOT)
     try:
         for name, cleared in zip(CONTENT_TAKES, (True, False), strict=True):
-            out_dir = fresh_take_dir(out_root, name)
-            captured = io.StringIO()
-            try:
-                with contextlib.redirect_stderr(captured):
-                    found, info = record_content(out_dir, cleared=cleared)
-            except Exception as exc:  # noqa: BLE001 - a raising take is a failure
-                sys.stderr.write(captured.getvalue())
-                return [f"{name}: TerminalRecorder raised {type(exc).__name__}: {exc}"]
-            # Put it back on the real stderr: a run that fails later should not
-            # also have swallowed the recorder's own account of itself.
-            sys.stderr.write(captured.getvalue())
+            found, take = _record_content_take(
+                out_root,
+                name,
+                lambda out_dir, cleared=cleared: record_content(
+                    out_dir, cleared=cleared
+                ),
+            )
             problems += found
-            takes[name] = {
-                "out_dir": out_dir,
-                "info": info,
-                "stderr": captured.getvalue(),
-            }
+            if take:
+                takes[name] = take
+        toured_problems, toured = _record_content_take(
+            out_root, CONTENT_TOURED, record_content_toured
+        )
+        problems += toured_problems
     finally:
         os.chdir(previous)
-    for name, take in takes.items():
-        if not (take["out_dir"] / "demo.mp4").is_file():
-            problems.append(f"{name}: demo.mp4 was never written")
     if problems:
         return problems
-    return check_content_pair(takes)
+    return (
+        check_verb_classification()
+        + check_content_pair(takes)
+        + check_content_toured(toured["out_dir"], toured["stderr"])
+    )
 
 
 def run_web_problems(out_root: Path) -> list[str]:

--- a/tests/smoke
+++ b/tests/smoke
@@ -52,12 +52,23 @@ Playwright 1.49 or newer: evidence uses `locator.aria_snapshot()`, and the
    the only one whose take records with `deterministic=False`, because the
    determinism rule flattens the transition it is about.
 
+8. **Picture** — whether the *recorder* notices that a recording shows nothing.
+   Axis 2 is this harness measuring the frames; this one grades the equivalent
+   check the recorder now ships, which is what a user recording their own demo
+   actually gets. One terminal storyboard is recorded twice, differing only in
+   whether its title card is taken back down (issue #91's shape), and the two
+   takes are compared against each other — the covered one must say so in
+   `timeline.json` and on stderr, the shown one must not. The floors above are
+   deliberately not shared with it: a check graded by the measurement it makes
+   is not graded.
+
     tests/smoke                 # every take
     tests/smoke --web-only
     tests/smoke --terminal-only
     tests/smoke --determinism-only
     tests/smoke --redaction-only
     tests/smoke --polish-only
+    tests/smoke --content-only
     tests/smoke --out-dir /tmp/smoke
 
 Narration is forced off (`speech=False`) for the web and terminal takes: CI has
@@ -175,6 +186,57 @@ CONTENT_SAMPLE_FPS = 1
 # caption bar across the bottom; including it would let the caption supply the
 # contrast for an otherwise blank app.
 CONTENT_KEEP = 0.8
+
+# -- the recorder's own picture check (issue #97) -----------------------------
+#
+# Everything above measures the picture from *here*. The recorder now measures
+# it too, and writes the answer into `content` in timeline.json plus a line on
+# stderr, so that a reviewer who never opens the video is not left reading a
+# beat table that describes a recording nobody can see. What follows grades
+# that, and only that — the numbers above stay as this harness's own gate, on
+# purpose: a check graded by the measurement it makes is not graded.
+#
+# Two takes of one storyboard, differing in a single line — whether the opening
+# title card is taken down. That is issue #91 exactly, and recording both is
+# what stops each assertion here from being satisfiable by a take that shows
+# nothing (the covered one) or by a take that never holds still (the shown one).
+CONTENT_TAKES = ("content-shown", "content-covered")
+CONTENT_CARD = "Everything after this is covered."
+
+# The band `CONTENT_STATIC_WARN_S` has to sit inside, measured on this run's own
+# two takes rather than hardcoded: a healthy take of this storyboard holds its
+# longest frame for `shown.static_for`, and the covered one holds the card for
+# nearly its whole length. The recorder's constant must be comfortably above
+# the first and comfortably below the second, or it is a bar that grades
+# nothing — halve it and healthy demos warn constantly, double it and the take
+# this whole issue is about goes unremarked.
+#
+# Measured on this repo's reference demo (a 60 s two-part demo of a real app),
+# for the same reason the band is checked rather than the endpoints: healthy
+# 4.5 s (web part) and 5.0 s (terminal part), covered 23.0 s.
+CONTENT_STATIC_HEADROOM = 1.6  # x above the healthy take's longest still run
+CONTENT_STATIC_MARGIN = 0.7  # x below the covered take's still run
+
+# How far a healthy take's `score` must sit above the floor the recorder warns
+# under. Its own floor is one number for both media and deliberately low (a
+# warning shipped to somebody else's app, not a gate); this asks that the takes
+# recorded here are nowhere near it.
+CONTENT_SCORE_HEADROOM = 3.0
+
+# What fraction of the covered take must be one held frame before the assertion
+# "the card covered this take" is worth making. The card goes up a beat in and
+# fades over 0.45 s, so it is never the whole file.
+CONTENT_COVERED_FRACTION = 0.75
+
+# How far apart, in dB PSNR, two moments of one take may be before this harness
+# calls them the same picture — measured on the video rather than on the
+# lossless stills, because a codec makes byte equality impossible there.
+# Measured over the app rect, between the first and last `run` beat: 46.4 dB
+# under the card, 26.2 dB with the card down. Twenty decibels is a hundredfold
+# in mean squared error, so the two bars below sit in open space rather than
+# next to either number.
+CONTENT_HELD_PSNR_DB = 40.0
+CONTENT_MOVED_PSNR_DB = 33.0
 
 # Duration windows, in seconds. Wide on purpose: the lower bound catches a
 # take that died early, the upper one catches a hang, and everything in
@@ -3048,6 +3110,73 @@ def record_terminal_opening(out_dir: Path) -> tuple[list[str], dict]:
     return b.problems, {"corner": corner, "app": app, "size": size}
 
 
+def record_content(out_dir: Path, cleared: bool) -> tuple[list[str], dict]:
+    """One storyboard, recorded with the title card taken down — or left up.
+
+    The A/B of issue #91, and the only difference between the two takes is the
+    `interlude("")` on the line below. Everything else about them is identical,
+    which is what makes the comparison worth anything: the covered take has the
+    same beats, the same commands, the same exit codes and the same evidence as
+    the take beside it, and differs only in whether any of it reached a frame.
+
+    Terminal rather than web on purpose. That is the medium #91 happened in,
+    and it is the harder case for the picture check: an occluding card is dark,
+    carries a line of text, and scores as perfectly good *content* — only the
+    fact that nothing ever changes gives it away.
+    """
+    from demo_recording import TerminalRecorder
+
+    label = CONTENT_TAKES[0] if cleared else CONTENT_TAKES[1]
+    b = Beats(label)
+
+    def expect_prompt(rec, after: str) -> None:
+        try:
+            rec.wait_for_prompt(timeout_s=15)
+        except RuntimeError as exc:
+            b.fail_if(True, f"after {after}, the shell prompt never came back — {exc}")
+
+    with TerminalRecorder(
+        out_dir, speech=False, strict=True, deterministic=True
+    ) as rec:
+        start_ticker(b, rec.page)
+        rec.interlude(CONTENT_CARD)
+        if cleared:
+            rec.interlude("")
+
+        # Three commands whose output is different every time, each followed by
+        # a hold. Under the card every one of them runs, exits zero, lands in
+        # `evidence/` and changes nothing on screen — which is the finding.
+        for n, (caption, command) in enumerate(
+            (
+                ("The first command.", "seq 1 8"),
+                ("The second, printing something else.", "printf 'alpha\\nbravo\\n'"),
+                ("And a listing.", "ls -1"),
+            ),
+            start=1,
+        ):
+            rec.caption(caption)
+            rec.run(command)
+            expect_prompt(rec, f"run({command!r})")
+            rec.shot(f"{n:02d}-content")
+            rec.hold()
+        rec.caption("")
+
+        box = rec.page.locator("#__term_host").bounding_box()
+        if box is None:
+            raise SmokeFailure(
+                f"{label}: #__term_host has no box — the terminal never rendered"
+            )
+        app: Rect = (
+            int(box["x"]),
+            int(box["y"]),
+            int(box["width"]),
+            int(box["height"]),
+        )
+        size = (rec._size["width"], rec._size["height"])
+
+    return b.problems, {"app": app, "size": size}
+
+
 class EntropyTake(NamedTuple):
     """One recording of the entropy storyboard, and what it rendered."""
 
@@ -3822,6 +3951,577 @@ def _check_video(
         print(
             f"smoke: {label} demo.mp4 ok ({seconds:.1f}s, {size // 1024} kB, "
             f"content {score:.1f})"
+        )
+    return failures
+
+
+# -- the recorder's `content` field (issue #97) -------------------------------
+
+
+def content_of(out_dir: Path, name: str = "timeline.json") -> dict | None:
+    """The `content` report out of a take's timeline, or None if there is none."""
+    path = out_dir / name
+    if not path.is_file():
+        return None
+    try:
+        doc = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    got = doc.get("content")
+    return got if isinstance(got, dict) else None
+
+
+def content_rects(out_dir: Path) -> list[list]:
+    """Every rect this take's timeline claims to have scored.
+
+    One for a single take; one per part for a stitched demo, whose envelope
+    reports `rect: null` on purpose — two segments can be two media with two
+    geometries, and inventing a single rect for the join would be a number that
+    describes neither.
+    """
+    doc = json.loads((out_dir / "timeline.json").read_text())
+    found = []
+    for content in [doc.get("content")] + [
+        record.get("content") for record in doc.get("segments") or []
+    ]:
+        if isinstance(content, dict) and isinstance(content.get("rect"), list):
+            found.append(content["rect"])
+    return found
+
+
+def check_content_healthy(label: str, out_dir: Path, app_rect: Rect) -> list[str]:
+    """What every healthy take in this suite must say about its own picture.
+
+    Cheap enough to hang off every take that already records, and that breadth
+    is the point: the picture check has to be *wired in* on the web recorder,
+    the terminal recorder and a stitched demo, and "it works on the take
+    written to test it" is how a feature ships broken everywhere else.
+
+    `app_rect` is where this harness independently believes the app sits —
+    read off `rec._geom` or the live `#__term_host` at record time, never from
+    the recorder's report. Comparing the two is the assertion that matters: a
+    recorder scoring the whole frame, or a rect off in the chrome, produces a
+    perfectly plausible `content` block and a number that means nothing (issue
+    #17, and the anti-correlation measured in check_content_pair below).
+    """
+    failures: list[str] = []
+    content = content_of(out_dir)
+    if content is None:
+        return [
+            f"{label}: timeline.json carries no `content` — the recorder said "
+            f"nothing at all about whether the recording shows anything (#97)"
+        ]
+    if not content.get("measured"):
+        return [
+            f"{label}: the recorder did not measure this take's picture — "
+            f"{content.get('note')}"
+        ]
+
+    rects = content_rects(out_dir)
+    if not rects:
+        failures.append(
+            f"{label}: this take's timeline names no scored rect at all, so "
+            f"nothing says which part of the frame `score` describes"
+        )
+    for rect in rects:
+        if len(rect) != 4:
+            failures.append(f"{label}: a content rect is {rect!r}, not four numbers")
+            continue
+        x, y, w, h = (int(v) for v in rect)
+        ax, ay, aw, ah = app_rect
+        inside = ax <= x and ay <= y and x + w <= ax + aw and y + h <= ay + ah
+        if not inside:
+            failures.append(
+                f"{label}: the recorder scored {tuple(rect)}, which is not "
+                f"inside the app rect {app_rect} this harness measured — it is "
+                f"grading its own window chrome, which scores well on a blank "
+                f"recording (issue #17)"
+            )
+        elif w * h < 0.5 * aw * ah:
+            failures.append(
+                f"{label}: the recorder scored {tuple(rect)}, only "
+                f"{100 * w * h / (aw * ah):.0f}% of the app rect {app_rect} — "
+                f"too small a keyhole to say the recording shows anything"
+            )
+
+    score, floor = content.get("score"), content.get("floor")
+    if not isinstance(score, (int, float)) or not isinstance(floor, (int, float)):
+        failures.append(
+            f"{label}: content.score is {score!r} and content.floor is "
+            f"{floor!r}; a measured take must have both"
+        )
+    elif score < floor * CONTENT_SCORE_HEADROOM:
+        failures.append(
+            f"{label}: this take scores {score} over its content rect, under "
+            f"{CONTENT_SCORE_HEADROOM}x the recorder's {floor} blank floor — "
+            f"either the take really is nearly blank, or the floor has been "
+            f"raised until it no longer separates one from the other"
+        )
+
+    still, limit = content.get("static_for"), content.get("static_limit")
+    if not isinstance(still, (int, float)) or not isinstance(limit, (int, float)):
+        failures.append(
+            f"{label}: content.static_for is {still!r} and content.static_limit "
+            f"is {limit!r}; a measured take must have both"
+        )
+    elif still >= limit:
+        failures.append(
+            f"{label}: this healthy take held one frame for {still}s, at or "
+            f"over the recorder's own {limit}s limit — the storyboard idles "
+            f"longer than the limit allows, so every take of it warns"
+        )
+
+    if content.get("warnings"):
+        failures.append(
+            f"{label}: the recorder warned about a take this suite grades as "
+            f"healthy: {content['warnings']}"
+        )
+    if not failures:
+        print(
+            f"smoke: {label} content ok (score {score}, longest still "
+            f"{still}s under {limit}s, over {len(rects)} rect(s) "
+            f"{[tuple(r) for r in rects]})"
+        )
+    return failures
+
+
+def blanked_copy(mp4: Path, rect: Rect, out: Path) -> bool:
+    """`mp4` with `rect` painted flat black — a real recording, blank where the
+    app was.
+
+    The known-bad input the picture check has to be run against, and it has to
+    be *this* shape rather than a synthesized flat video: the whole finding
+    behind issue #17 is that the recorder's own chrome dominates a whole-frame
+    score, so the control must keep the chrome and lose only the app. A flat
+    video has no chrome and proves nothing about which region is being scored.
+    """
+    x, y, w, h = rect
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-i",
+            str(mp4),
+            "-vf",
+            f"drawbox=x={x}:y={y}:w={w}:h={h}:color=black:t=fill",
+            "-an",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-crf",
+            "23",
+            "-r",
+            "25",
+            str(out),
+        ],
+        capture_output=True,
+    )
+    return proc.returncode == 0 and out.is_file()
+
+
+def frame_at(mp4: Path, at: float, rect: Rect, out: Path) -> bytes | None:
+    """`rect` of the frame of `mp4` at `at` seconds, as PNG bytes.
+
+    Cropped, and to a rect this harness derived itself — the recorder's report
+    is not consulted. Two things outside the app rect change on every take of
+    this suite and neither is the demo: the caption bar, and TICKER_JS's 8x8
+    corner element, which exists precisely to keep the screencast painting
+    while the storyboard idles. A whole-frame comparison would find every pair
+    of frames different and quietly prove nothing.
+    """
+    x, y, w, h = rect
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-ss",
+            f"{at:.3f}",
+            "-i",
+            str(mp4),
+            "-vf",
+            f"crop={w}:{h}:{x}:{y}",
+            "-frames:v",
+            "1",
+            "-update",
+            "1",
+            str(out),
+        ],
+        capture_output=True,
+    )
+    if proc.returncode != 0 or not out.is_file():
+        return None
+    return out.read_bytes()
+
+
+def beat_midpoints(out_dir: Path, verb: str) -> list[tuple[int, float]]:
+    """(index, midpoint) for every beat with this verb, in order."""
+    doc = json.loads((out_dir / "timeline.json").read_text())
+    got: list[tuple[int, float]] = []
+    for beat in doc.get("beats") or []:
+        if beat.get("verb") != verb:
+            continue
+        start, end = beat.get("t_start"), beat.get("t_end")
+        if isinstance(start, (int, float)) and isinstance(end, (int, float)):
+            got.append((int(beat.get("index", len(got))), (start + end) / 2))
+    return got
+
+
+def screens_differ(out_dir: Path) -> tuple[int, str]:
+    """How many distinct screens this take's evidence recorded, and one of them.
+
+    Deliberately the *text* tier: `evidence/*.json` is what a reviewing agent
+    reads, and on the take issue #97 came from it was completely correct while
+    the recording showed nothing. Reading it here is how this harness knows the
+    covered take's commands really ran — independently of any pixel.
+    """
+    seen: list[str] = []
+    for path in sorted((out_dir / "evidence").glob("beat-*.json")):
+        try:
+            doc = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        text = evidence_screen_text(doc).strip()
+        if text and text not in seen:
+            seen.append(text)
+    return len(seen), (seen[-1] if seen else "")
+
+
+def check_content_pair(takes: dict[str, dict]) -> list[str]:
+    """The two content takes, against each other and against the recorder.
+
+    One storyboard, recorded twice, differing only in whether the title card is
+    taken down. Every assertion here is a *comparison*, because every one of
+    them has a way to pass vacuously on its own: "the covered take warns" is
+    satisfied by a recorder that warns on everything, "the shown take does not"
+    by a recorder that never warns, and both by a metric that is measuring the
+    wrong region entirely.
+    """
+    failures: list[str] = []
+    shown, covered = takes[CONTENT_TAKES[0]], takes[CONTENT_TAKES[1]]
+    reports = {}
+    for name, take in takes.items():
+        content = content_of(take["out_dir"])
+        if content is None or not content.get("measured"):
+            failures.append(
+                f"{name}: no measured `content` in timeline.json "
+                f"({None if content is None else content.get('note')})"
+            )
+        else:
+            reports[name] = content
+    if len(reports) != 2:
+        return failures
+    shown_c, covered_c = reports[CONTENT_TAKES[0]], reports[CONTENT_TAKES[1]]
+
+    # 1. The verdicts, opposite ways round.
+    if shown_c.get("warnings"):
+        failures.append(
+            f"{CONTENT_TAKES[0]}: the recorder warned about the take whose "
+            f"card *is* taken down: {shown_c['warnings']}"
+        )
+    still = " ".join(str(w) for w in covered_c.get("warnings") or [])
+    if "did not change" not in still:
+        failures.append(
+            f"{CONTENT_TAKES[1]}: the recorder did not report a held picture "
+            f"for a take whose title card covered every beat. This is issue "
+            f"#91 reproduced, and `content.warnings` says {covered_c.get('warnings')!r}"
+        )
+
+    # 2. ...and on stderr, unasked, which is the half of the acceptance
+    #    criterion no artifact can carry.
+    err = covered["stderr"]
+    if "WARNING" not in err or "did not change" not in err:
+        failures.append(
+            f"{CONTENT_TAKES[1]}: nothing on stderr said the recording holds "
+            f"still. A reviewer who does not open timeline.json gets no signal "
+            f"at all. Captured stderr: {err[-400:]!r}"
+        )
+    if "did not change" in shown["stderr"]:
+        failures.append(
+            f"{CONTENT_TAKES[0]}: stderr warned about a healthy take, so the "
+            f"warning above says nothing"
+        )
+
+    # 3. The covered take really is covered, for most of its length.
+    duration = json.loads((covered["out_dir"] / "timeline.json").read_text()).get(
+        "duration"
+    )
+    held = covered_c.get("static_for") or 0.0
+    if (
+        isinstance(duration, (int, float))
+        and held < duration * CONTENT_COVERED_FRACTION
+    ):
+        failures.append(
+            f"{CONTENT_TAKES[1]}: the card covered the take but the recorder "
+            f"reports only {held}s of held picture in {duration}s of video — "
+            f"under {CONTENT_COVERED_FRACTION:.0%}. The detector is finding "
+            f"changes that are not there (encoder noise, a cursor, the caption "
+            f"band leaking into the rect), so it will split a long occlusion "
+            f"into stretches too short to warn about"
+        )
+
+    # 4. The band the recorder's constant has to sit in, from this run's own
+    #    two takes rather than from a number somebody typed.
+    limit = shown_c.get("static_limit")
+    healthy = shown_c.get("static_for") or 0.0
+    if not isinstance(limit, (int, float)):
+        failures.append(f"content: content.static_limit is {limit!r}")
+    else:
+        low, high = healthy * CONTENT_STATIC_HEADROOM, held * CONTENT_STATIC_MARGIN
+        if not low <= limit <= high:
+            failures.append(
+                f"content: the recorder warns at {limit}s, outside the "
+                f"[{low:.1f}, {high:.1f}]s band this run measured — a healthy "
+                f"take of this storyboard holds {healthy}s and the covered one "
+                f"holds {held}s. Below the band every honest demo warns; above "
+                f"it, the take this check exists for does not"
+            )
+        else:
+            print(
+                f"smoke: content static limit {limit}s sits in "
+                f"[{low:.1f}, {high:.1f}]s (healthy {healthy}s, covered {held}s)"
+            )
+
+    # 5. The evidence tier agrees the covered take *ran*, and the pixels
+    #    disagree that any of it was shown. That pair is the whole finding of
+    #    #97, and it is measured here without asking the recorder anything:
+    #    ffmpeg cuts two frames from the middles of two different `run` beats
+    #    and they are byte-identical.
+    for take, name, is_covered in (
+        (covered, CONTENT_TAKES[1], True),
+        (shown, CONTENT_TAKES[0], False),
+    ):
+        failures += _check_occlusion(
+            take["out_dir"], name, keep_top(take["info"]["app"]), covered=is_covered
+        )
+
+    # 6. The anti-correlated metric (issue #17), as a standing regression test.
+    failures += _check_scored_region(shown, shown_c)
+    return failures
+
+
+def crop_png(src: Path, rect: Rect, out: Path) -> bytes | None:
+    """`rect` of a PNG, losslessly, as bytes."""
+    x, y, w, h = rect
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-i",
+            str(src),
+            "-vf",
+            f"crop={w}:{h}:{x}:{y}",
+            "-frames:v",
+            "1",
+            "-update",
+            "1",
+            str(out),
+        ],
+        capture_output=True,
+    )
+    if proc.returncode != 0 or not out.is_file():
+        return None
+    return out.read_bytes()
+
+
+def psnr_db(a: Path, b: Path) -> float | None:
+    """ffmpeg's PSNR between two images, in dB. Infinity becomes `math.inf`."""
+    done = subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "info",
+            "-i",
+            str(a),
+            "-i",
+            str(b),
+            "-lavfi",
+            "psnr",
+            "-f",
+            "null",
+            "-",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    found = re.search(r"average:([0-9.]+|inf)", done.stderr)
+    if not found:
+        return None
+    return math.inf if found.group(1) == "inf" else float(found.group(1))
+
+
+def _check_occlusion(out_dir: Path, label: str, rect: Rect, covered: bool) -> list[str]:
+    """Was the app covered for this whole take? Answered without the recorder.
+
+    Two independent readings of the same three moments, neither of which asks
+    the recorder anything, and one control that stops both from being vacuous:
+
+    * **the stills**, cropped to `rect` and compared byte for byte. Lossless
+      PNGs of the page, so this needs no threshold at all: under a card the
+      three are one file three times, and with the card down they are three
+      files.
+    * **the recording**, at the midpoints of the first and last `run` beat,
+      compared by ffmpeg's PSNR. The stills are the page and the video is what
+      a reviewer watches; a codec makes byte equality impossible there, and the
+      two takes sit 46.4 dB and 26.2 dB apart — twenty decibels, a hundredfold
+      in error — so the bars below are nowhere near either measurement.
+    * **`evidence/`**, which must hold several *different* screens either way.
+      That is the control: it is what says the three commands really printed
+      three different things, so that "the frames are identical" is a statement
+      about the recording rather than about a storyboard that did nothing.
+
+    `covered=True` is asserted for the covered take and `covered=False` for the
+    shown one. Running both is what makes each mean something: a comparison
+    that answered "identical" for every take would pass the first and fail the
+    second.
+    """
+    runs = beat_midpoints(out_dir, "run")
+    if len(runs) != 3:
+        return [f"{label}: the take recorded {len(runs)} run beats, expected 3"]
+    distinct, last = screens_differ(out_dir)
+    if distinct < 3:
+        return [
+            f"{label}: evidence/ holds {distinct} distinct screens, so the "
+            f"commands did not print three different things and comparing "
+            f"their frames proves nothing"
+        ]
+
+    failures: list[str] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        work = Path(tmp)
+        shots = sorted((out_dir / "images").glob("*-content.png"))
+        if len(shots) != 3:
+            return [f"{label}: {len(shots)} stills named *-content.png, expected 3"]
+        cropped = [crop_png(s, rect, work / f"s{n}.png") for n, s in enumerate(shots)]
+        if any(c is None for c in cropped):
+            return [f"{label}: a still could not be cropped to {rect}"]
+        unique = len({hashlib.sha256(c).hexdigest() for c in cropped})  # type: ignore[arg-type]
+        if covered and unique != 1:
+            failures.append(
+                f"{label}: the three stills show {unique} different pictures "
+                f"where the terminal is, so the card did not cover this take "
+                f"and every assertion about occlusion here measures something "
+                f"else"
+            )
+        if not covered and unique != 3:
+            failures.append(
+                f"{label}: the three stills show only {unique} distinct "
+                f"picture(s) where the terminal is, over {distinct} distinct "
+                f"evidence screens ({last.splitlines()[-1][:60]!r}) — the "
+                f"recording is not showing what the terminal did"
+            )
+
+        mp4 = out_dir / "demo.mp4"
+        first = frame_at(mp4, runs[0][1], rect, work / "a.png")
+        final = frame_at(mp4, runs[-1][1], rect, work / "b.png")
+        if first is None or final is None:
+            return failures + [
+                f"{label}: could not cut frames at the run beats' midpoints"
+            ]
+        quality = psnr_db(work / "a.png", work / "b.png")
+    if quality is None:
+        return failures + [f"{label}: ffmpeg reported no PSNR for the two frames"]
+    bar = CONTENT_HELD_PSNR_DB if covered else CONTENT_MOVED_PSNR_DB
+    if covered and quality < bar:
+        failures.append(
+            f"{label}: the video at beats {runs[0][0]} and {runs[-1][0]} "
+            f"differs by {quality:.1f} dB PSNR, under the {bar} dB bar — the "
+            f"card is not holding the picture still and `static_for` above is "
+            f"describing something this harness cannot see"
+        )
+    if not covered and quality > bar:
+        failures.append(
+            f"{label}: the video at beats {runs[0][0]} and {runs[-1][0]} is "
+            f"{quality:.1f} dB PSNR apart, over the {bar} dB bar — two beats "
+            f"of a take whose card came down look the same, so the comparison "
+            f"used for the covered take cannot distinguish them"
+        )
+    if not failures:
+        print(
+            f"smoke: {label} stills {unique}/3 distinct where the terminal is, "
+            f"video {quality:.1f} dB apart, over {distinct} evidence screens"
+        )
+    return failures
+
+
+def _check_scored_region(take: dict, content: dict) -> list[str]:
+    """Prove the rect is what makes the score mean anything (issue #17).
+
+    Blank the app out of a real recording, keeping the recorder's chrome, and
+    score it twice: over the content rect, and over the whole frame. The rect
+    must rank the blanked copy far *below* the healthy one; the whole frame
+    must fail to — that is the measured anti-correlation this check exists to
+    keep fixed, and asserting it here means a future "simplification" back to a
+    whole-frame score turns red instead of quietly scoring chrome.
+    """
+    from demo_recording import content_report
+
+    mp4 = take["out_dir"] / "demo.mp4"
+    rect = tuple(int(v) for v in content["rect"])
+    frame: Rect = (0, 0, take["info"]["size"][0], take["info"]["size"][1])
+    # Outside the take's own directory: a blanked demo.mp4 sitting beside the
+    # real one is exactly the artifact this whole issue is about somebody
+    # picking up by mistake, and a run that fails leaves the directory behind.
+    with tempfile.TemporaryDirectory() as tmp:
+        return _scored_region_failures(
+            mp4, rect, frame, Path(tmp) / "blanked.mp4", content_report
+        )
+
+
+def _scored_region_failures(
+    mp4: Path, rect: Rect, frame: Rect, blanked: Path, content_report
+) -> list[str]:
+    if not blanked_copy(mp4, rect, blanked):
+        return ["content: ffmpeg could not build the blanked control"]
+
+    healthy_rect = content_report(mp4, rect)
+    blank_rect = content_report(blanked, rect)
+    healthy_frame = content_report(mp4, frame)
+    blank_frame = content_report(blanked, frame)
+    for name, report in (
+        ("healthy/rect", healthy_rect),
+        ("blank/rect", blank_rect),
+        ("healthy/frame", healthy_frame),
+        ("blank/frame", blank_frame),
+    ):
+        if not report.get("measured"):
+            return [f"content: {name} could not be measured — {report.get('note')}"]
+
+    failures: list[str] = []
+    floor = healthy_rect["floor"]
+    if not blank_rect["score"] < floor < healthy_rect["score"]:
+        failures.append(
+            f"content: scored over the content rect, the blanked recording "
+            f"({blank_rect['score']}) and the healthy one "
+            f"({healthy_rect['score']}) do not straddle the {floor} floor — "
+            f"the score arm cannot tell a blank recording from a working one"
+        )
+    if not blank_rect["warnings"]:
+        failures.append(
+            "content: a recording with its app painted flat produced no warning at all"
+        )
+    # The point of the rect, stated as the thing that goes wrong without it.
+    if blank_frame["score"] < healthy_frame["score"]:
+        failures.append(
+            f"content: scored over the *whole frame*, the blanked recording "
+            f"({blank_frame['score']}) already ranks below the healthy one "
+            f"({healthy_frame['score']}). The anti-correlation this rect "
+            f"exists for is not present in this fixture, so passing the rect "
+            f"assertion above no longer demonstrates anything — rebuild the "
+            f"control or drop this claim (issue #17)"
+        )
+    else:
+        print(
+            f"smoke: content rect {healthy_rect['score']} vs blanked "
+            f"{blank_rect['score']} (floor {floor}); whole frame "
+            f"{healthy_frame['score']} vs blanked {blank_frame['score']} — "
+            f"the frame ranks the blank recording higher, the rect does not"
         )
     return failures
 
@@ -6292,6 +6992,9 @@ def check_take(
     supply the contrast for a blank app.
     """
     failures: list[str] = []
+    # Before the trim: the recorder does its own, and what is asserted about
+    # `content.rect` is that it lands inside the region the *app* occupies.
+    app_rect = video_rect
     video_rect = keep_top(video_rect)
     still_rect = keep_top(still_rect)
 
@@ -6389,6 +7092,12 @@ def check_take(
                     f"smoke: {label} caption is visible on screen (delta {delta:.1f})"
                 )
 
+    # What the recorder itself says about the picture (issue #97). On every
+    # graded take, not only the one written for it: the check has to be wired
+    # into the web recorder, the terminal recorder and `stitch()`, and each of
+    # those is a separate place to have forgotten it.
+    failures += check_content_healthy(label, out_dir, app_rect)
+
     return failures
 
 
@@ -6471,6 +7180,55 @@ def run_terminal_opening(out_root: Path) -> list[str]:
         + check_opening_card(out_dir, info)
         + check_healthy("terminal-opening", out_dir)
     )
+
+
+def run_content(out_root: Path) -> list[str]:
+    """One storyboard recorded twice: card taken down, and card left up.
+
+    Issue #97's acceptance criterion, and the closest thing this suite has to
+    the defect that motivated it — take 1 of the reference demo, where a title
+    card covered 24.3 s of a 60.2 s recording and every artifact reported a
+    healthy take.
+
+    stderr is captured per take, not just inspected afterwards, because half
+    the criterion is that the warning arrives *unasked*: an author who never
+    opens timeline.json still has to be told. `print` writes through
+    `sys.stderr` at call time, so redirecting it here catches the recorder's
+    own output and nothing else's.
+    """
+    takes: dict[str, dict] = {}
+    problems: list[str] = []
+    previous = Path.cwd()
+    # `ls -1` is one of the beats; pin the shell's directory so the take does
+    # not depend on where the suite was started.
+    os.chdir(REPO_ROOT)
+    try:
+        for name, cleared in zip(CONTENT_TAKES, (True, False), strict=True):
+            out_dir = fresh_take_dir(out_root, name)
+            captured = io.StringIO()
+            try:
+                with contextlib.redirect_stderr(captured):
+                    found, info = record_content(out_dir, cleared=cleared)
+            except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+                sys.stderr.write(captured.getvalue())
+                return [f"{name}: TerminalRecorder raised {type(exc).__name__}: {exc}"]
+            # Put it back on the real stderr: a run that fails later should not
+            # also have swallowed the recorder's own account of itself.
+            sys.stderr.write(captured.getvalue())
+            problems += found
+            takes[name] = {
+                "out_dir": out_dir,
+                "info": info,
+                "stderr": captured.getvalue(),
+            }
+    finally:
+        os.chdir(previous)
+    for name, take in takes.items():
+        if not (take["out_dir"] / "demo.mp4").is_file():
+            problems.append(f"{name}: demo.mp4 was never written")
+    if problems:
+        return problems
+    return check_content_pair(takes)
 
 
 def run_web_problems(out_root: Path) -> list[str]:
@@ -10483,6 +11241,12 @@ def main() -> int:
         "(issues #110 and #111)",
     )
     parser.add_argument(
+        "--content-only",
+        action="store_true",
+        help="record only the pair that grades whether the recorder notices a "
+        "recording showing nothing (issue #97)",
+    )
+    parser.add_argument(
         "--allow-concurrent",
         action="store_true",
         help="run even when another suite holds the machine lock. The timing "
@@ -10514,6 +11278,7 @@ def main() -> int:
             ("--evidence-only", args.evidence_only),
             ("--failure-only", args.failure_only),
             ("--polish-only", args.polish_only),
+            ("--content-only", args.content_only),
         )
         if on
     ]
@@ -10588,6 +11353,11 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
         failures += run_spotlight(out_root)
     if only in (None, "--terminal-only", "--polish-only"):
         failures += run_terminal_opening(out_root)
+    # Whether the recorder notices a recording that shows nothing (issue #97).
+    # Reachable from --terminal-only as well as its own flag: it is a terminal
+    # take, and the card it leaves up is the terminal recorder's card.
+    if only in (None, "--terminal-only", "--content-only"):
+        failures += run_content(out_root)
     if only in (None, "--web-only"):
         failures += run_web_problems(out_root)
         failures += run_strict_web(out_root)

--- a/tests/smoke
+++ b/tests/smoke
@@ -203,6 +203,30 @@ CONTENT_KEEP = 0.8
 CONTENT_TAKES = ("content-shown", "content-covered")
 CONTENT_CARD = "Everything after this is covered."
 
+# Five commands rather than three, and the length is load-bearing rather than
+# thorough: the covered take can hold one frame for no longer than it runs, and
+# the band below needs the covered value to sit well clear of the recorder's
+# limit. Each prints something different, so `evidence/` can say the take
+# really did five things while the frames say none of them showed.
+#
+# **Every one of them prints at most three lines, and that is a constraint, not
+# a style.** The recorder's content rect drops the bottom fifth of the terminal
+# (its caption bar is burned in there), so output landing in the last few rows
+# of a not-yet-scrolled screen is outside the measured region. An earlier
+# version of this storyboard ran `seq 1 8` and two `ls -1`s, filled 25 of ~32
+# rows, and pushed the last two commands into that band — where the *healthy*
+# take reported 9.5 s of held picture for a stretch in which it was visibly
+# printing. The limit is real and is written down in SKILL.md; this keeps the
+# fixture clear of it, so what is graded here is the check rather than the
+# limit.
+CONTENT_COMMANDS = (
+    ("The first command.", "seq 1 3"),
+    ("The second, printing something else.", "printf 'alpha\\nbravo\\n'"),
+    ("A listing, cut short.", "ls -1 | head -2"),
+    ("Two more words.", "printf 'charlie\\ndelta\\n'"),
+    ("And one that says where it is.", "basename $PWD"),
+)
+
 # The band `CONTENT_STATIC_WARN_S` has to sit inside, measured on this run's own
 # two takes rather than hardcoded: a healthy take of this storyboard holds its
 # longest frame for `shown.static_for`, and the covered one holds the card for
@@ -228,15 +252,26 @@ CONTENT_SCORE_HEADROOM = 3.0
 # fades over 0.45 s, so it is never the whole file.
 CONTENT_COVERED_FRACTION = 0.75
 
-# How far apart, in dB PSNR, two moments of one take may be before this harness
-# calls them the same picture — measured on the video rather than on the
-# lossless stills, because a codec makes byte equality impossible there.
-# Measured over the app rect, between the first and last `run` beat: 46.4 dB
-# under the card, 26.2 dB with the card down. Twenty decibels is a hundredfold
-# in mean squared error, so the two bars below sit in open space rather than
-# next to either number.
-CONTENT_HELD_PSNR_DB = 40.0
-CONTENT_MOVED_PSNR_DB = 33.0
+# How much *further apart* in dB PSNR the covered take's two sampled moments
+# must be than the shown take's. Measured on the video rather than the lossless
+# stills, because a codec makes byte equality impossible there.
+#
+# **Relative, not absolute, and that was learned the expensive way.** The first
+# version asserted "the covered take reads at least 40 dB". It measured 46.4 dB
+# on the development machine and **39.8 dB** on the CI runner — a different
+# x264 build re-quantising a held frame slightly differently — so the suite
+# went red on a recorder that was working perfectly. The catalogue entry for
+# that is "the threshold tuned to this box", and the fix is the one this file
+# already uses for the caption band: compare the two takes against each other,
+# in the same run, on the same encoder, so no absolute number is claimed.
+#
+#            this box    CI runner
+#   covered   47.5 dB     39.8 dB
+#   shown     25.5 dB     25.9 dB
+#   gap       22.0 dB     13.9 dB
+#
+# 8 dB is a sixfold difference in mean squared error and sits under both.
+CONTENT_PSNR_GAP_DB = 8.0
 
 # Duration windows, in seconds. Wide on purpose: the lower bound catches a
 # take that died early, the upper one catches a hang, and everything in
@@ -3146,14 +3181,7 @@ def record_content(out_dir: Path, cleared: bool) -> tuple[list[str], dict]:
         # Three commands whose output is different every time, each followed by
         # a hold. Under the card every one of them runs, exits zero, lands in
         # `evidence/` and changes nothing on screen — which is the finding.
-        for n, (caption, command) in enumerate(
-            (
-                ("The first command.", "seq 1 8"),
-                ("The second, printing something else.", "printf 'alpha\\nbravo\\n'"),
-                ("And a listing.", "ls -1"),
-            ),
-            start=1,
-        ):
+        for n, (caption, command) in enumerate(CONTENT_COMMANDS, start=1):
             rec.caption(caption)
             rec.run(command)
             expect_prompt(rec, f"run({command!r})")
@@ -4291,12 +4319,31 @@ def check_content_pair(takes: dict[str, dict]) -> list[str]:
     #    #97, and it is measured here without asking the recorder anything:
     #    ffmpeg cuts two frames from the middles of two different `run` beats
     #    and they are byte-identical.
+    apart: dict[str, float | None] = {}
     for take, name, is_covered in (
         (covered, CONTENT_TAKES[1], True),
         (shown, CONTENT_TAKES[0], False),
     ):
-        failures += _check_occlusion(
+        found, apart[name] = _check_occlusion(
             take["out_dir"], name, keep_top(take["info"]["app"]), covered=is_covered
+        )
+        failures += found
+    held_db, moved_db = apart[CONTENT_TAKES[1]], apart[CONTENT_TAKES[0]]
+    if held_db is None or moved_db is None:
+        failures.append("content: one of the two takes yielded no PSNR reading")
+    elif held_db - moved_db < CONTENT_PSNR_GAP_DB:
+        failures.append(
+            f"content: the covered take's two sampled moments are {held_db:.1f} "
+            f"dB PSNR apart and the shown take's {moved_db:.1f} dB — a gap of "
+            f"{held_db - moved_db:.1f} dB, under the {CONTENT_PSNR_GAP_DB} dB "
+            f"one. Whatever the absolute numbers are on this encoder, the card "
+            f"is not holding the video visibly stiller than the storyboard does"
+        )
+    else:
+        print(
+            f"smoke: content video held {held_db:.1f} dB against moved "
+            f"{moved_db:.1f} dB — {held_db - moved_db:.1f} dB apart, over the "
+            f"{CONTENT_PSNR_GAP_DB} dB gap"
         )
 
     # 6. The anti-correlated metric (issue #17), as a standing regression test.
@@ -4356,62 +4403,80 @@ def psnr_db(a: Path, b: Path) -> float | None:
     return math.inf if found.group(1) == "inf" else float(found.group(1))
 
 
-def _check_occlusion(out_dir: Path, label: str, rect: Rect, covered: bool) -> list[str]:
+def _check_occlusion(
+    out_dir: Path, label: str, rect: Rect, covered: bool
+) -> tuple[list[str], float | None]:
     """Was the app covered for this whole take? Answered without the recorder.
 
-    Two independent readings of the same three moments, neither of which asks
-    the recorder anything, and one control that stops both from being vacuous:
+    Returns (failures, the PSNR between the two sampled moments). Two
+    independent readings, neither of which asks the recorder anything, and one
+    control that stops both from being vacuous:
 
     * **the stills**, cropped to `rect` and compared byte for byte. Lossless
       PNGs of the page, so this needs no threshold at all: under a card the
-      three are one file three times, and with the card down they are three
-      files.
-    * **the recording**, at the midpoints of the first and last `run` beat,
-      compared by ffmpeg's PSNR. The stills are the page and the video is what
-      a reviewer watches; a codec makes byte equality impossible there, and the
-      two takes sit 46.4 dB and 26.2 dB apart — twenty decibels, a hundredfold
-      in error — so the bars below are nowhere near either measurement.
-    * **`evidence/`**, which must hold several *different* screens either way.
-      That is the control: it is what says the three commands really printed
-      three different things, so that "the frames are identical" is a statement
-      about the recording rather than about a storyboard that did nothing.
+      five are one file five times, and with the card down they are five files.
+      This is the assertion made *here*, per take.
+    * **the recording**, at the midpoints of the first and last `run` beat. The
+      stills are the page and the video is what a reviewer watches; a codec
+      makes byte equality impossible there, so the reading is handed back and
+      compared *against the other take's* by the caller — an absolute dB bar is
+      a bar tuned to one x264 build, which this suite found out by going red on
+      CI at 39.8 dB after measuring 47.5 dB here.
+    * **`evidence/`**, which must hold as many *different* screens as there are
+      commands, either way. That is the control: it is what says the commands
+      really printed different things, so that "the frames are identical" is a
+      statement about the recording rather than about a storyboard that did
+      nothing.
 
     `covered=True` is asserted for the covered take and `covered=False` for the
     shown one. Running both is what makes each mean something: a comparison
     that answered "identical" for every take would pass the first and fail the
     second.
     """
+    wanted = len(CONTENT_COMMANDS)
     runs = beat_midpoints(out_dir, "run")
-    if len(runs) != 3:
-        return [f"{label}: the take recorded {len(runs)} run beats, expected 3"]
+    if len(runs) != wanted:
+        return (
+            [f"{label}: the take recorded {len(runs)} run beats, expected {wanted}"],
+            None,
+        )
     distinct, last = screens_differ(out_dir)
-    if distinct < 3:
-        return [
-            f"{label}: evidence/ holds {distinct} distinct screens, so the "
-            f"commands did not print three different things and comparing "
-            f"their frames proves nothing"
-        ]
+    if distinct < wanted:
+        return (
+            [
+                f"{label}: evidence/ holds {distinct} distinct screens, so the "
+                f"{wanted} commands did not print {wanted} different things and "
+                f"comparing their frames proves nothing"
+            ],
+            None,
+        )
 
     failures: list[str] = []
     with tempfile.TemporaryDirectory() as tmp:
         work = Path(tmp)
         shots = sorted((out_dir / "images").glob("*-content.png"))
-        if len(shots) != 3:
-            return [f"{label}: {len(shots)} stills named *-content.png, expected 3"]
+        if len(shots) != wanted:
+            return (
+                [
+                    f"{label}: {len(shots)} stills named *-content.png, expected "
+                    f"{wanted}"
+                ],
+                None,
+            )
         cropped = [crop_png(s, rect, work / f"s{n}.png") for n, s in enumerate(shots)]
         if any(c is None for c in cropped):
-            return [f"{label}: a still could not be cropped to {rect}"]
+            return [f"{label}: a still could not be cropped to {rect}"], None
         unique = len({hashlib.sha256(c).hexdigest() for c in cropped})  # type: ignore[arg-type]
         if covered and unique != 1:
             failures.append(
-                f"{label}: the three stills show {unique} different pictures "
+                f"{label}: the {wanted} stills show {unique} different pictures "
                 f"where the terminal is, so the card did not cover this take "
                 f"and every assertion about occlusion here measures something "
                 f"else"
             )
-        if not covered and unique != 3:
+        if not covered and unique != wanted:
             failures.append(
-                f"{label}: the three stills show only {unique} distinct "
+                f"{label}: the {wanted} stills show only {unique} distinct "
                 f"picture(s) where the terminal is, over {distinct} distinct "
                 f"evidence screens ({last.splitlines()[-1][:60]!r}) — the "
                 f"recording is not showing what the terminal did"
@@ -4421,33 +4486,20 @@ def _check_occlusion(out_dir: Path, label: str, rect: Rect, covered: bool) -> li
         first = frame_at(mp4, runs[0][1], rect, work / "a.png")
         final = frame_at(mp4, runs[-1][1], rect, work / "b.png")
         if first is None or final is None:
-            return failures + [
-                f"{label}: could not cut frames at the run beats' midpoints"
-            ]
+            return (
+                failures
+                + [f"{label}: could not cut frames at the run beats' midpoints"],
+                None,
+            )
         quality = psnr_db(work / "a.png", work / "b.png")
     if quality is None:
-        return failures + [f"{label}: ffmpeg reported no PSNR for the two frames"]
-    bar = CONTENT_HELD_PSNR_DB if covered else CONTENT_MOVED_PSNR_DB
-    if covered and quality < bar:
-        failures.append(
-            f"{label}: the video at beats {runs[0][0]} and {runs[-1][0]} "
-            f"differs by {quality:.1f} dB PSNR, under the {bar} dB bar — the "
-            f"card is not holding the picture still and `static_for` above is "
-            f"describing something this harness cannot see"
-        )
-    if not covered and quality > bar:
-        failures.append(
-            f"{label}: the video at beats {runs[0][0]} and {runs[-1][0]} is "
-            f"{quality:.1f} dB PSNR apart, over the {bar} dB bar — two beats "
-            f"of a take whose card came down look the same, so the comparison "
-            f"used for the covered take cannot distinguish them"
-        )
+        failures.append(f"{label}: ffmpeg reported no PSNR for the two frames")
     if not failures:
         print(
-            f"smoke: {label} stills {unique}/3 distinct where the terminal is, "
-            f"video {quality:.1f} dB apart, over {distinct} evidence screens"
+            f"smoke: {label} stills {unique}/{wanted} distinct where the terminal "
+            f"is, video {quality:.1f} dB apart, over {distinct} evidence screens"
         )
-    return failures
+    return failures, quality
 
 
 def _check_scored_region(take: dict, content: dict) -> list[str]:

--- a/tests/smoke
+++ b/tests/smoke
@@ -228,15 +228,32 @@ CONTENT_CARD = "Everything after this is covered."
 
 # The touring storyboard: one command that renders something worth looking at,
 # then captions that talk about what is already on screen without touching it.
-# Long captions on purpose — the recorder holds a caption for roughly reading
-# speed, so these are what produce a stretch past CONTENT_STATIC_WARN_S with no
-# acting verb anywhere inside it.
-CONTENT_TOUR_COMMAND = ("The queue, as the command line prints it.", "seq 1 4")
+#
+# **Every caption is short enough that it cannot wrap, and the hold is explicit
+# rather than left to reading speed.** Both were learned from CI. The first
+# version used sentence-length captions and the recorder'"'"'s automatic hold; on the
+# runner two of them wrapped to three lines, and a caption bar that wraps grows
+# *upward* — past the 20% the content rect trims off the bottom and into the
+# measured region. Each wrap then registered as 266 changed pixels, chopping the
+# take'"'"'s held stretch from 25.0s to 11.0s and taking it below the limit it exists
+# to sit above. The premise assertion in check_content_toured() caught it, which
+# is the whole reason that assertion is there.
+#
+# The underlying behaviour is a real (and safe) property of the check, recorded
+# in SKILL.md: a wrapping caption makes a held stretch look *shorter* than it is,
+# never longer, and it cannot reach an occluded take at all because a card
+# covers the caption too.
+CONTENT_TOUR_COMMAND = ("Four tickets, oldest first.", "seq 1 4")
 CONTENT_TOUR_CAPTIONS = (
-    "Each line above is one ticket, in the order the queue holds them.",
-    "The number on the left is the identifier the CLI and the web app share.",
-    "Nothing here is filtered yet — this is the whole queue, exactly as stored.",
+    "Each line is one ticket.",
+    "The left column is the id.",
+    "Nothing is filtered here.",
 )
+
+# How long each touring caption stays up. Explicit because the automatic hold is
+# derived from word count, and captions short enough not to wrap are short
+# enough to be held for under two seconds — which would not reach the limit.
+CONTENT_TOUR_HOLD_S = 6.0
 
 # Five commands rather than three, and the length is load-bearing rather than
 # thorough: the covered take can hold one frame for no longer than it runs, and
@@ -3279,7 +3296,7 @@ def record_content_toured(out_dir: Path) -> tuple[list[str], dict]:
         # thinner claim than the mix a real storyboard produces.
         for line in CONTENT_TOUR_CAPTIONS:
             rec.caption(line)
-            rec.hold()
+            rec.hold(CONTENT_TOUR_HOLD_S)
         rec.caption("")
 
         box = rec.page.locator("#__term_host").bounding_box()


### PR DESCRIPTION
Fixes #97.

## Round 2: the held-picture arm was a timer, not a detector

Review found it firing on ordinary healthy demos on both media, with a message
that named a cause which had not happened. Both are fixed; the detail is in
[the round-2 comment](#issuecomment). Short version:

| take | `static_for` |
|---|---|
| healthy terminal, 2 touring captions | 16.5s |
| healthy web, 3 touring captions | 20.0s |
| healthy terminal, 3 touring captions | 21.5–22.0s |
| **reference take 1, card over the terminal** | **23.0s** |

No threshold separates those. The stretch is now correlated with the beat log:
a held picture spanning only `caption`/`hold`/`shot`/`wait_for*` is a narrated
hold and is silent; one spanning `run`/`click`/`goto`/… warns. The message
states what was measured and no longer asserts a cause.

## What this does

The recorder measures the encoded mp4 over the region the app occupies, and
writes the answer where the text tier is read: `content` in the `timeline.json`
envelope, plus a line on stderr as the take ends. It warns; it never refuses.

```json
"content": { "measured": true, "note": null,
             "rect": [74, 110, 1132, 432], "sample_fps": 2, "frames": 47,
             "score": 14.1, "floor": 1.0,
             "static_for": 5.0, "static_from": 13.5, "static_limit": 15.0,
             "warnings": [] }
```

Two arms, because the defect this came from defeats one of them:

* **`score`** — median luma standard deviation over the rect. Catches a
  recording that never rises above blank.
* **`static_for`** — the longest stretch where nothing inside the rect changed.
  Catches a recording that is *covered*, which the score cannot: the #91 card
  is dark with a line of white text on it and scores 12.4, comfortably
  "content".

`stitch()` carries each part's report into `segments` and reports the worst of
them on the envelope, with every warning tagged by segment. `content_report()`
is exported so a demo somebody already has can be re-checked without
re-recording.

## Acceptance: the reference demo's take 1 would have been caught

The broken take is not committed, so it was reconstructed — `record.py` from
`examples/ticket-queue/demos/2026-07-26-status-filter/` with the single line
`rec.interlude("")` removed, which is exactly what #91 was. Recorded against
the real app on this branch:

```
demo-video: WARNING — part2.seg.mp4: the content rect did not change for 23.0s,
from 0.0s. The beats in this timeline ran during that stretch and nothing in
the picture moved, so whatever they did is not visible: a title card or modal
left up over the app (issue #91), an overlay that never faded, or an app that
stopped painting. Watch part2.seg.mp4 at 0.0s before believing the beats above
it.
demo-video: WARNING — demo.mp4: segment 'part2': the content rect did not
change for 23.0s, from 0.0s. …
```

…and in the committed `timeline.json`:

```json
"content": { "measured": true, "score": 12.39, "floor": 1.0,
             "static_for": 23.0, "static_limit": 15.0,
             "warnings": ["segment 'part2': the content rect did not change for 23.0s…"] }
```

The same storyboard **with** the line restored, on the same branch, says
nothing:

```
part1.seg.mp4 shows a picture (content 15.29 over the app rect, longest still stretch 4.5s)
part2.seg.mp4 shows a picture (content 14.26 over the app rect, longest still stretch 5.0s)
demo.mp4 shows a picture (content 14.26 over the app rect, longest still stretch 5.0s)
```

Nobody opened the video for either verdict.

## Two measurements that decided the design

**The rect, not the frame.** `content-shown/demo.mp4` with the app rect painted
flat black by `drawbox` — a real recording, chrome intact, blank where the app
was:

| | healthy | app painted flat |
|---|---|---|
| over the content rect | 6.58 | **0.21** |
| over the whole frame | 82.25 | **90.33** |

The whole frame ranks the blank recording *higher*, which is #17's finding
reproduced on this fixture. Both rows are now asserted in `tests/smoke`, the
second included: if a future change scores the frame again, or the fixture
stops exhibiting the anti-correlation, the suite says so instead of passing on
a number that grades chrome.

**Counting pixels, not averaging them.** The first implementation used mean
absolute luma difference between consecutive samples, and it could not work.
libx264 re-quantises a held frame at every I-frame, which redrew the occluding
card's glyph edges hard enough to move the mean by **0.43** — while the
smallest *real* change in the healthy take of the same storyboard moved it by
**0.71**. A 1.6x gap is a coin toss. Counting reduced pixels that moved by more
than 12 luma levels separates the two phenomena by their shape instead:

| | moved pixels, per consecutive pair |
|---|---|
| covered (card over the whole terminal) | 0, on every one of 46 pairs |
| healthy terminal, real changes | 2, 13, 20, 27, 31, … 1256 |
| healthy web, real changes | 10, 13, 14, 16, 17, … 991 |

The bar sits at 4. With the mean-based bar the covered take reported 12.5s of
held picture instead of 23.0s; with this one it reports the whole segment.

## Tests

A tenth axis in `tests/smoke` (`--content-only`): **one storyboard recorded
twice**, differing only in whether `interlude("")` takes the card back down.
Same three commands, same captions, same exit codes, same `evidence/`.

| | `content-shown` | `content-covered` |
|---|---|---|
| `content.warnings` | empty | says "did not change" |
| stderr from the take (captured) | no warning | `WARNING`, unasked |
| `static_for` | under `static_limit` | ≥ 75% of the take's duration |
| five stills cropped to `#__term_host` | 5 distinct files | 1 file, five times |
| `evidence/` | ≥ 5 distinct screens | ≥ 5 distinct screens |

…plus one assertion across the pair: the video at the first and last `run` beat
must be **at least 8 dB PSNR further apart in the covered take than in the
shown one**.

Every row is a comparison, because each has a way to pass vacuously alone. The
last row is the control that makes the two above it mean anything — it is what
says the five commands really printed five different things, so "the frames
are identical" is a statement about the *recording*. It is also #97's finding
in one line: the text tier says the demo worked, the pixels say nothing was
shown.

**The primary assertions share no helper with the check.** The stills are
compared byte for byte (lossless PNGs, no threshold at all); the video is
compared with ffmpeg's PSNR; the rect the harness crops to is its own reading of
the live `#__term_host`, never the recorder's report.

One assertion does use the production scorer, and it is worth naming rather than
glossing: `_check_scored_region` imports `content_report` to grade the #17
anti-correlation. That is deliberate — the claim being made is *about* that
function's behaviour on a known-bad input — but it means that one row is not
independent of the code it grades, and an earlier version of this section
claimed otherwise.

`check_content_healthy()` also hangs off *every* graded take — web, terminal and
the stitched segments demo — because the check has to be wired into three
places and "it works on the take written to test it" is how a feature ships
broken everywhere else.

**`CONTENT_STATIC_WARN_S` is graded as a band, not trusted as a constant.** It
must sit at least 1.6x above the healthy take's longest still stretch and at
most 0.7x of the covered take's, both derived from that run's own recordings:

```
smoke: content static limit 15.0s sits in [8.8, 21.3]s (healthy 5.5s, covered 30.5s)
```

## A bar that was tuned to this box, and how CI said so

Worth recording, because it is a catalogue entry caught in the act. The first
version of the video comparison asserted an **absolute** bar: "the covered
take's two sampled moments read at least 40 dB PSNR". It measured 47.5 dB here
and CI went red at **39.8 dB** — a different x264 build re-quantising a held
frame slightly differently — on a recorder that was working perfectly.

It is now relative between the two takes, in the same run on the same encoder,
which is the pattern this suite already uses for the caption band:

| | this box | CI runner |
|---|---|---|
| covered | 47.5 dB | 39.8 dB |
| shown | 25.5 dB | 25.9 dB |
| gap | 22.0 dB | 13.9 dB |

The same run also showed the `terminal` take holding one frame for **10.0 s**
on CI against 9.5 s here, which is why `CONTENT_STATIC_WARN_S` is 15 s rather
than 12: at 12 the graded terminal take had 1.26x of headroom, and a bar with
that much margin against an unrelated storyboard's idle is a flaky red waiting
to happen.

## A limit found while building the fixture

Lengthening the content storyboard from three commands to five made the
**healthy** take report 9.5 s of held picture while it was visibly printing.
The cause is real and is now documented in `SKILL.md`: the content rect drops
the bottom fifth of the app (the caption bar is burned in there), so on a
terminal that is the last few rows *before the screen starts scrolling*. Once
it scrolls, every new line moves the whole picture and the window closes.
There is no room to shrink the trim — the caption's shadow starts at ~82% of
the app rect — so it is a stated limit, and the fixture's commands are capped
at three lines each to stay clear of it.

## Fault injection

Eleven injections, each a single exact string with the harness aborting unless
it matched exactly once, each run against the suite, each restored afterwards.
**All eleven were caught.** Full transcript:

```
--- break: any pixel difference counts as a change (a mean-style bar)
    in core.py: CONTENT_PIXEL_DELTA = 12
    exit 1, 4 failure(s)
    - content-covered: the recorder did not report a held picture for a take whose title card covered every beat. This is issue #91 reproduced, and `content.warnings` says []
    - content-covered: nothing on stderr said the recording holds still. …
    - content-covered: the card covered the take but the recorder reports only 9.0s of held picture in 31.32s of video — under 75%. …
    - content: the recorder warns at 15.0s, outside the [5.6, 6.3]s band this run measured — a healthy take of this storyboard holds 3.5s and the covered one holds 9.0s. …
    PASS

--- break: nothing short of a whole repaint counts as a change
    in core.py: CONTENT_PIXEL_DELTA = 12
    exit 1, 3 failure(s)
    - content-shown: the recorder warned about the take whose card *is* taken down: ['the content rect did not change for 31.5s, from 0.0s. …']
    - content-shown: stderr warned about a healthy take, so the warning above says nothing
    - content: the recorder warns at 15.0s, outside the [50.4, 21.7]s band this run measured — a healthy take of this storyboard holds 31.5s and the covered one holds 31.0s. …
    PASS

--- break: the still-picture limit is doubled
    in core.py: CONTENT_STATIC_WARN_S = 15.0
    exit 1, 1 failure(s)
    - content: the recorder warns at 30.0s, outside the [8.8, 21.3]s band this run measured — a healthy take of this storyboard holds 5.5s and the covered one holds 30.5s. Below the band every honest demo warns; above it, the take this check exists for does not
    PASS

--- break: the still-picture limit is halved
    in core.py: CONTENT_STATIC_WARN_S = 15.0
    exit 1, 1 failure(s)
    - content: the recorder warns at 7.5s, outside the [8.8, 21.7]s band this run measured — a healthy take of this storyboard holds 5.5s and the covered one holds 31.0s. …
    PASS

--- break: the blank floor drops to zero, so nothing is ever blank
    in core.py: CONTENT_BLANK_FLOOR = 1.0
    exit 1, 1 failure(s)
    - content: scored over the content rect, the blanked recording (0.21) and the healthy one (6.64) do not straddle the 0.0 floor — the score arm cannot tell a blank recording from a working one
    PASS

--- break: the verdict never reaches stderr
    in core.py: if not isinstance(content, dict):
    exit 1, 1 failure(s)
    - content-covered: nothing on stderr said the recording holds still. A reviewer who does not open timeline.json gets no signal at all. …
    PASS

--- break: the timeline stops carrying the picture at all
    in core.py: "content": self._content,
    exit 1, 2 failure(s)
    - content-shown: no measured `content` in timeline.json (None)
    - content-covered: no measured `content` in timeline.json (None)
    PASS

--- break: the terminal recorder cannot say where the terminal is
    in terminal.py: if self._host_box is None:
    exit 1, 2 failure(s)
    - content-shown: no measured `content` in timeline.json (this recorder does not know where the app sits in the frame, so nothing about the picture was measured — see content_report())
    - content-covered: no measured `content` in timeline.json (…)
    PASS

--- break: the web recorder scores the whole frame, chrome included
    in web.py: return content_rect(
    exit 1, 1 failure(s)
    - web: the recorder scored (0, 0, 1280, 576), which is not inside the app rect (128, 90, 1024, 576) this harness measured — it is grading its own window chrome, which scores well on a blank recording (issue #17)
    PASS

--- break: the covered take is not actually covered (the fixture's own control)
    in smoke: rec.interlude(CONTENT_CARD)
    exit 1, 6 failure(s)
    - content-covered: the recorder did not report a held picture for a take whose title card covered every beat. …
    - content-covered: nothing on stderr said the recording holds still. …
    - content-covered: the card covered the take but the recorder reports only 5.5s of held picture in 32.16s of video — under 75%. …
    - content: the recorder warns at 15.0s, outside the [8.8, 3.8]s band this run measured — a healthy take of this storyboard holds 5.5s and the covered one holds 5.5s. …
    - content-covered: the 5 stills show 5 different pictures where the terminal is, so the card did not cover this take and every assertion about occlusion here measures something else
    - content: the covered take's two sampled moments are 25.4 dB PSNR apart and the shown take's 25.5 dB — a gap of -0.1 dB, under the 8.0 dB one. Whatever the absolute numbers are on this encoder, the card is not holding the video visibly stiller than the storyboard does
    PASS

--- break: stitch() drops the segments' picture reports
    in core.py: "content": merge_content(records),
    exit 1, 1 failure(s)
    - segments: timeline.json carries no `content` — the recorder said nothing at all about whether the recording shows anything (#97)
    PASS

All injections caught.
```

The last one is a break in the **fixture**, not the product: it makes the
covered take clear its card, so the take stops being covered. It is the control
that stops every assertion above it from being satisfiable by a harness that
answers "identical" regardless — and note that it is the only injection all six
covered-side assertions fire on at once.

Three injections initially reported FAIL because my *expected* substring was
wrong, not because the assertion missed. Each is shown above re-run with the
corrected expectation and the suite's real message.

## Stated limits

Non-blocking, recorded here rather than as a round of review:

* **The bottom fifth of the app is not measured** — that is where the caption
  bar is burned in, and there is no room to shrink the exclusion (the caption's
  shadow starts at ~82% of the app rect). On a terminal that is the last few
  rows before the screen starts scrolling; measured at 9.5 s of "held" picture
  on a fixture that was visibly printing. Stated in `SKILL.md`.
* **A held stretch spanning a segment boundary is under-reported.** Each part
  measures its own `.seg.mp4`; two segments that each hold still for 8s across
  a cut are reported as 8s, not 16s. Under-reporting is the direction to prefer
  over a confident guess, and each part's own number is in `segments`.
* **The static arm cannot see a single character changing** (~0.02 mean luma at
  the 160x90 reduction, far under the bar) and does not try to. A blinking
  cursor is not the demo showing something.
* **A demo that legitimately holds one frame for more than 15s will warn.** It
  is a warning, and the sentence it prints is true; the limit is graded as a
  band rather than tuned to make that never happen.
* **The blank floor is one number for both media, and it is deliberately low
  (1.0).** The suite keeps its own higher per-medium floors as a gate. The
  shipped floor goes to somebody else's app, where a false alarm costs the
  warning its credibility everywhere — and the score arm has a partner: a page
  that never painted does not change either, so the static arm catches the
  blank case a second time.
* **The reference demo's committed `timeline.json` files predate this field.**
  They carry no `content`; the next re-record adds it. Re-recording them here
  would churn the stills for no verification gain.

## Not demoable

This change's acceptance criterion is verified by reading stderr and a JSON
field, not by watching — per `CLAUDE.md`'s test, a video of it would be
ceremony. **No demo video is expected.** The `ticket-queue demo` job does not
fire on this branch either: its `paths:` filter is
`examples/ticket-queue/**`, `.github/workflows/{ticket-queue-demo,demo-video}.yml`
and `.github/scripts/demo-*`, and this diff touches none of them.

## Verification run

* `tests/smoke` (full suite, every take): **PASSED**
* `tests/smoke --content-only`: **PASSED**
* 11 fault injections: **all caught**
* `ruff check`, `ruff format --check`, `mypy skills/demo-video/helpers/`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
