### PR TITLE
Say what demo-video records, and what it does not defend against (#141)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -5,6 +5,34 @@ description: Use when a web app, CLI, or TUI needs a screen-recorded demo video 
 
 # demo-video — self-explanatory recorded demos of a web app or terminal program
 
+## What this records, and what it does not defend against
+
+**demo-video records fixtures and example data.** Read this before pointing it
+at anything.
+
+- The tool has **no masking, no scrubbing and no redaction**. It does not hide
+  anything that reaches the screen, and it does not try to.
+- A value written into a storyboard, a caption or a timeline is an **example**.
+  A string that would be a credential in production is not one in a fixture,
+  and nothing needs to hide it.
+- **If a real credential can appear in the app you are recording, do not record
+  it.** That is the whole of the guidance. There is no setting, no verb and no
+  flag that makes it safe.
+- The corollary, stated plainly because it is a design decision and not an
+  omission: **a demo that needs a real secret to be meaningful is a demo that
+  cannot be made.** That is a constraint on what gets demoed. It is not a gap
+  waiting to be filled, and a future version will not fill it.
+
+This is a scope limit, not a security property. Nothing here is a control, so
+nothing here can be relied on as one — which is exactly why the machinery that
+used to look like one was removed rather than improved. A masking system that
+works almost always is worse than none, because it is what persuades somebody
+it is safe to point the recorder at production. The absence is the stronger
+guarantee ([#138](https://github.com/rogvid/skills/issues/138)).
+
+Recording in CI is the ordinary case and is secret-free by construction: the
+workflow refuses to record against a public host at all.
+
 ## Overview
 
 A demo is a short mp4 that explains itself to someone with zero context —
@@ -185,8 +213,6 @@ exception, or a non-zero exit. Both are
 | `wait_for(selector)` | Wait for something the app does on its own |
 | `spotlight(selector)` | Ring + enlarge the element the caption discusses; `spotlight()` clears. It eases in *and out* over 250 ms, and the verb waits out its own exit, so the element is back exactly as it was found before the next beat starts (~250 ms per clear on an ordinary take, ~0 under `deterministic=True`, which flattens the transition) |
 | `terminal(cmd)` / `terminal_output(text)` / `terminal_close()` | A *decorative* on-screen terminal card for off-browser actions **inside a web demo** — a prop, not a real shell. To record an actual CLI/TUI use `TerminalRecorder` (below). |
-| `redact(*selectors)` | Blur these elements for the whole take — frames and stills. **Plain CSS selectors only.** Call it **before** the first `goto()`. **Read [reference/secrets.md](reference/secrets.md) before using this** — including what it does not cover. |
-| `register_secret(*values)` | Register literal text that must never be captioned, spoken, or logged. A caption containing it raises `SecretLeak`. **Refuses values under 8 characters** — see [reference/secrets.md](reference/secrets.md). |
 | `interlude(text, style=…)` | Bridge a jump. `style="card"` (default) is a full-screen title card, for real time-skips; `style="light"` is a centered label over a soft scrim with the scene still visible, for short transitions. `""` fades it out. |
 | `stitch(out_dir, [segments])` | Lossless concat of segment recordings into demo.mp4, **and** merge their beat logs into one `timeline.json` / `timeline.md` beside it. `keep_parts=True` leaves each `.seg.mp4` and its `.seg.timeline.*` on disk for a re-stitch |
 | `rec.page` | The live Playwright page — the escape hatch for anything the verbs don't cover (iframes, keyboard shortcuts, drag) |


### PR DESCRIPTION
Slice 1 of #138. Prose only, and it ships before any deletion — if the code
goes before the sentence, the absence reads as an oversight and the next
person helpfully reinvents it, which is how 8,189 lines of masking got here.

## What it says

A section above the Overview, so a reader meets it before the API:

- no masking, no scrubbing, no redaction, and no attempt at any;
- a value in a fixture is an **example**, not a credential;
- if a real credential can appear in the app, **do not record it**;
- a demo that needs a real secret to be meaningful is a demo that cannot be
  made — stated as a design decision, because the failure mode this exists to
  prevent is somebody reading the absence as an unfinished feature.

The `redact()` and `register_secret()` verb-table rows go here rather than
with their code: SKILL.md must not describe a protection it is in the middle
of removing.

## Acceptance

Grepping SKILL.md for `redact`, `mask`, `scrub`, `secret` leaves two hits,
both pointers at `reference/secrets.md`, which is a deletion still pending —
allowed by #141's acceptance. Keeping them is also what keeps this commit
green: `tests/unit` asserts every `reference/` file is linked from SKILL.md.

`tests/unit` passes (51 assertions); ruff and format clean.

---

# Finding: #142–#144 cannot be separate pull requests

I attempted #142 next and got the source half done cleanly — `web.py` from
1,992 to **805 lines**, with `redact()`, the paint gate, `_REDACT_JS`,
`_CSS_ONLY_JS`, `_EVIDENCE_HARVEST_JS`, the eight masking methods and the six
`_checkpoint()` call sites gone, the `framenavigated` carve-out kept, and
`_EVIDENCE_HTML_JS` shrunk from 80 to 46 lines with its script/`srcdoc`/
attribute stripping intact. mypy and ruff green, every remaining JS blob
`node --check`ed.

**Then `tests/smoke` refused to split along the slice boundary.** #138 says
"#142 and #143 are independent of each other (different files)" — true of
`web.py` vs `terminal.py`, and not true of the suite that grades them:

| what | where it breaks |
|---|---|
| `native_frames`, `edge_energy` | #142 deletes them; `_term_deltas` (#143's terminal arm) calls both |
| `REDACT_SECRET`, `REDACT_CONTROL`, `CLOSED_SECRET` | declared in #142's constant block, consumed by #143's `check_terminal_redaction` and `check_cursor_screen_leak` |
| `run_crash_no_evidence` | a **#144** take, calls `rec.redact()` — which #142 deletes |
| `check_refused_take_marker` | asserts a take refused for a secret leak; nothing can refuse one after #142 |
| `check_secret_floor`, `check_evidence_leak_is_fatal` | #144 arms, but unreachable once #142 removes what they exercise |
| `run_evidence` (467 lines) | its `EVIDENCE_SECRETS` sweep, `EVIDENCE_KEEP` ("renders outside the mask"), the rotating-value `omitted` logic and the straddle arm are all masking; the per-beat evidence *feature* survives and needs the arm rewritten, not deleted |

Landing #142 alone leaves `tests/smoke` with undefined names. Landing it with
the terminal arms deleted leaves the terminal scrubber shipped and ungraded
for a commit.

**So the deletion is one pull request across #142/#143/#144, or the slices
need re-cutting** — plausibly: one slice for the smoke arms, then one per
source file behind it. That is a call for the maintainer, and it is why I
stopped rather than pushing an unverified ~5,000-line deletion through the
suite that is the only thing standing behind this package.

The work so far is preserved as a patch and is not in this branch:
`web.py` −1,187 and `tests/smoke` −3,546, reaching the point where
`run_evidence` needs rewriting rather than cutting.

## Also worth correcting on #142

Carve-out 4 says `CONTENT_ACTING_VERBS` containing `"redact"` "must go in the
same commit or a surviving check fails". It would not have failed.
`check_verb_classification` computes `declared - classified` — a *stale* entry
in a classification set is invisible to it, and `len(declared)` drops from 22
to 21, still over its floor of 15. The line should still go, as dead data;
the stated consequence is just not real. Checked rather than assumed, per
`wip/verified-review`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)