### PR TITLE
Retire the secret fixture, and the prose the deletions left in tests/ (#145, #156)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Config is .gitleaks.toml at the repo root: the default ruleset plus two
-      # narrow allowlist entries (vendored xterm.js, and the fixture's fake
-      # API key).
+      # Config is .gitleaks.toml at the repo root: the default ruleset plus one
+      # narrow path allowlist for vendored xterm.js.
+      #
+      # This job stays after #138, deliberately. #138 removed demo-video's
+      # ability to hide a secret *in a recording*; this scan is about a real
+      # credential reaching *the repository*, which is a different thing and
+      # costs ten seconds. The fixture's fake keys are gone, so the regex
+      # allowlist that existed for them is gone too — see .gitleaks.toml.
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,6 +1,6 @@
 # gitleaks configuration.
 #
-# The default ruleset, plus one narrowly-scoped allowlist. Nothing else is
+# The default ruleset, plus one narrowly-scoped path allowlist. Nothing else is
 # relaxed: if a scan trips on something new, fix the leak, do not widen this.
 
 [extend]
@@ -8,148 +8,41 @@ useDefault = true
 
 [allowlist]
 description = """
-Two narrow exemptions.
+One exemption, and it is not about secrets.
 
-paths: skills/demo-video/helpers/assets/ holds vendored xterm.js. A full-history
-scan reports two generic-api-key hits in it — both false positives in minified
+skills/demo-video/helpers/assets/ holds vendored xterm.js. A full-history scan
+reports two generic-api-key hits in it — both false positives in minified
 third-party code that this repo does not author and will not edit. PR-event
 scans only see the diff, so the job is green today and would go red the first
 time anyone adds a schedule or workflow_dispatch trigger. ruff.toml excludes the
 same directory for the same reason.
 
-regexes: three deliberately fake API keys the redaction test (issue #4) needs to
-look for. Two are rendered by the fixture behind ?secret=1
-(tests/fixture/index.html) — #api-key, which redaction hides, and
-#api-key-control, identical in shape and never redacted, so the smoke test has a
-sharp-text reference measured off the same frame. The third is typed by
-tests/smoke into #token as a Secret(...), so that the two ways of registering a
-secret can be proved apart. Note this entry is belt-and-braces, not
-load-bearing: the default ruleset does not flag that literal with or without
-this config — every one is spelled as a short all-caps tag followed by nothing
-but zeroes, precisely so no scanner and no human mistakes any of them for a
-credential. They are kept so that a future gitleaks release which does start
-flagging them cannot turn the job red for strings that were never secrets. The
-pattern is anchored to that fixed, closed word list and a run of literal zeroes.
-It masks nothing else.
+## The regex allowlist that used to be here, and why it is gone
 
-(The tags are four letters apart from `BIG` and `BGC`, which are three. An
-earlier version of this note said "four-letter word" as though it were a rule;
-it is not one, and the word list is what does the narrowing.)
+This file carried a second exemption: a closed word list of about thirty
+deliberately fake API keys — `sk-live-FAKE0000…`, `sk-live-CTRL0000…` — rendered
+by tests/fixture/index.html so the redaction tests had something secret-shaped
+to hide, and something secret-shaped to leave sharp as a reference.
 
-The words, and what each fixture element they belong to is for:
+demo-video no longer masks anything (#138). The fixture views that rendered
+those values are gone, the assertions that swept for them are gone, and the
+values themselves are gone: `grep -c 'sk-live-' tests/fixture/index.html` is 0.
+The one evidence-panel element that survives carries `zz-` shaped attribute
+values, which match no rule in the default set and need no exemption.
 
-  FAKE  #api-key           rendered by the app, hidden with redact()
-  CTRL  #api-key-control   never redacted — the sharp reference
-  TYPE  #token             typed as Secret(...), which registers and masks it
-  BIG   #hero-key          the same, at hero font size
-  BGC   #hero-key-control  its control
-  TEXT  #alt-key           registered through a `text=` selector
-  XPTH  #xp-key            registered through an `xpath=` selector
-  SHDW  #sd-key            inside an open shadow root
-  SHTY  #sd-token          typed into the field inside that root
-  IFRM  #if-key            inside an iframe
-  PSEU  #a1-key            rendered by a ::after pseudo-element at 48px
-  TFRM  #a2-key            a descendant scaled 4x by transform
-  ZOOM  #a3-key            a descendant at zoom: 4
-  SVGT  #a4-key            SVG <text> scaled by its viewBox
-  DEEP  #a5-key            two open shadow roots below the redacted wrapper
-  CLSD  #sd-closed-key     inside a *closed* one, which nothing can mask —
-                           the take that is told to redact it must fail
-  STMP  terminal_close()   a stamp holding a secret, which must be refused,
-                           and a shot() name that must be scrubbed
-  TKCT  #token-control     a field's control — same chrome, never redacted
-  SDCT  #sd-token-control  the same, inside the shadow root
-  LATE  a caption          set before the value in it was registered
+Note the entry was documented as belt-and-braces rather than load-bearing even
+while the fixture did render those values — the default ruleset flagged none of
+them, every one being a short all-caps tag followed by nothing but zeroes. It
+was kept against a future gitleaks release that might start flagging them. With
+no such string left in the tree, there is nothing for that to protect.
 
-...and the ?evidence=1 panel (issue #9), whose shapes leak into a *text* dump
-of the page rather than into a picture of it:
+## Why the job itself stays
 
-  WSPC  #ev-ws-key         indented on its own line in hand-written markup
-  BLED  #ev-bleed-key      in a card whose label also renders outside it
-  CHLD  #ev-child-key      split into text nodes that are ordinary on their own
-  LBLD  #ev-label-src      an accessible name sourced from outside the subtree
-  SLOT  #ev-slot-light     light DOM slotted into a redacted shadow host
-  VALU  #ev-value-key      an input value that lives on the property
-  TICK  #ev-tick-key       rewritten every 5 ms with a value nothing has seen
-  ATTR  #ev-spot-attrs     a data-* attribute the page never renders
-  JSON  #ev-spot-attrs     the same, inside a JSON blob in another attribute
-
-...and two that never render at all — they exist only inside tests/smoke, one
-per assertion about how the writer handles a value it was told about:
-
-  STAL  a planted file      a previous take's evidence, which a re-record into
-                            the same folder has to delete
-  CUTT  a padded list item  positioned so the markup cap cuts through it, which
-                            is the only place "mask, then cap" is observable.
-                            It is the one with more than sixteen zeroes — that
-                            length is what makes the straddle arithmetic land,
-                            hence the wider run below
-
-...and four more from the second review round, each a channel the recorder was
-comparing a registered value against a *transformation* of:
-
-  HATT  #ev-attr-card      mirrored into title/data-value/aria-label and an
-                           input value on siblings nothing redacts
-  VEIL  #ev-veil-card      mirrored into elements CSS hides four different ways
-                           (**not** the terminal family's HIDE below — the two
-                           were the same tag for one rebase, and `sk-live-HIDE`
-                           with eight zeroes is a *prefix* of the terminal
-                           one's sixteen, so each take's byte sweep could have
-                           matched the other's literal)
-  AMPS  #ev-spot-amp       contains an `&`, which outerHTML writes `&amp;`
-
-The wrap shape in `terminal-wrap/` is `zz-wrap-` + zeroes and gets **no**
-allowlist entry, for the same reason the terminal family below gets none: it
-matches no rule in the default set, and it cannot be `sk-live-` shaped because
-the stream scrubber's shape net would mask it before it ever reached the screen
-— which is the whole thing that take is trying to put there.
-
-`AMPS` is the one entry that is not "tag then zeroes": it is
-`sk-live-AMPS0000&sig=0000000000`, and the `&sig=` in the middle is the entire
-point of the shape. It is listed as its own alternative rather than by
-loosening the pattern, so the closed word list still does the narrowing.
-
-The word list is what keeps this narrow, not the run length: every literal is a
-short all-caps tag from that list followed by zeroes, and lengthening the run
-admits no string the word list did not already admit.
-
-The terminal half of redaction (issue #5) adds a family of its own, and they
-are not all `sk-live-` shaped because the shapes themselves are what is being
-tested. **No allowlist entry was added for any of them, and none is needed** —
-the `regexes` list below covers the web literals only. They are described here
-because this file's comments are the audit trail for every fake credential in
-the repo, and a value nobody wrote down is a value the next person has to
-re-derive:
-
-  PTYK  sk-live-…   registered, printed by a command under a PTY
-  ANSI  sk-live-…   the same, printed with a colour escape inside it
-  HIDE  sk-live-…   the same, cut by a cursor-hide escape
-  OSCT  sk-live-…   the same, cut by a window-title escape
-  PAUS  sk-live-…   the same shape, paused mid-value inside the hold window
-  SHAP  ghp_…       registered by nobody — the shape net is all that hides it
-  STRM  ghp_…       the same, written one character at a time
-  ANCH  ghp_…       the same, paused after its first character
-  SLOW  ghp_…       the same, paused *past* the hold window — the one value in
-                    the take that is supposed to render in the clear, because
-                    it grades a documented limit
-  CURS  sk-live-…   written at two cursor positions, which must kill the take
-  KEYD  sk-live-…   spelled out through key(), which must be refused
-  AKIA…             an AWS-shaped id nobody registered
-  eyJ….eyJ….        a JWT-shaped token nobody registered
-  SEND  pw-live-…   sent as Secret(...); deliberately matches no shape, so
-                    that what masks it can only be the registration
-  TCTL  zz-live-…   never registered and matching no shape, on purpose: it is
-                    the legible reference every masked row is measured against
-
-Same convention as above — a four-letter word and a run of zeroes — and the
-same reasoning: the default ruleset flags none of them. The GitHub rule wants
-exactly 36 characters after `ghp_` and these have 24; the AWS rule wants
-exactly 16 after `AKIA` and this has 24; the JWT rule wants 17 or more in each
-of the first two segments and needs the second to begin `ey`, and this one has
-neither. Verified by running gitleaks over the whole tree, not assumed.
+The scan guards against a real credential being committed to this repository by
+accident. That is unrelated to what #138 removed, which was demo-video's ability
+to hide a secret *in a recording*. Conflating the two would be exactly the
+confusion the boundary section in skills/demo-video/SKILL.md exists to prevent:
+the recorder does not defend against a secret reaching the screen, and this job
+never had anything to do with the screen.
 """
 paths = ['''^skills/demo-video/helpers/assets/''']
-regexes = [
-  '''sk-live-(FAKE|CTRL|TYPE|BIG|BGC|SHDW|SHTY|IFRM|PSEU|TFRM|ZOOM|SVGT|DEEP|CLSD|STMP|LATE|TKCT|SDCT|WSPC|BLED|CHLD|LBLD|SLOT|VALU|TICK|ATTR|JSON|STAL|CUTT|HATT|VEIL)0{4,24}''',
-  '''sk-live-AMPS0000&sig=0000000000''',
-]

--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -40,17 +40,12 @@ and a real terminal session (voice on):
 - **`evidence/beat-NN.json`** — what was on screen at every beat, in text:
   the page's ARIA tree (or the terminal's rendered screen), the spotlight
   target's markup, capped and explicitly truncated. An agent reviewing the
-  demo reads what the app said instead of inferring it from pixels. It is
-  plain text, which makes it the one artifact a pixel control cannot protect
-  for free — so the recorder reads what `redact()` is covering out of the page
-  and masks *that* out too, refuses to write page text it cannot vouch for,
-  and clears what a previous take left behind. "What renders in the clear"
-  means **painted**: an attribute, an input's `value`, and anything CSS hides
-  by any mechanism do not count, because a value that is only in one of those
-  was in no frame either. Matching is exact modulo whitespace in either
-  direction, HTML entities and JSON escaping — a stated list, not an open
-  promise. It is **not committed**; `SKILL.md` explains every one of those
-  decisions and where they stop.
+  demo reads what the app said instead of inferring it from pixels. The
+  serializer drops what was never **painted** — inline `<script>` text, a
+  `srcdoc` document, an attribute nothing renders, an input's `value` — because
+  a string that reached none of the frames should not have evidence as the one
+  place it exists. It clears what a previous take left behind. It is **not
+  committed**; `SKILL.md` explains those decisions and where they stop.
 - **A statement about the frames, not only the storyboard** — `content` in
   `timeline.json`, plus a line on stderr, saying whether the recording shows
   anything at all: how much picture there is where the app sits, and the
@@ -134,7 +129,6 @@ win over env vars.
 demo-video/
 ├── SKILL.md                       # the process — agents read this, in full, every time
 ├── reference/                     # the argued detail — read at the point of use
-│   ├── secrets.md                 #   redact(), register_secret(), and what they miss
 │   ├── determinism.md             #   the frozen clock, and why it is opt-in
 │   ├── timeline.md                #   the beat log, and whether the picture showed anything
 │   ├── review.md                  #   frames, per-beat evidence, acceptance criteria

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1260,10 +1260,10 @@ class _DemoBase:
             # exactly the take somebody is about to go looking at, and
             # `KeyboardInterrupt` does not derive from `Exception`.
             #
-            # Scrubbed at record time as well as on the way out. The message is
-            # not the recorder's: `wait_for_text()` quotes a thousand
-            # characters of terminal screen into its timeout, and that screen
-            # can hold anything the program printed.
+            # The message is not the recorder's: `wait_for_text()` quotes a
+            # thousand characters of terminal screen into its timeout, and that
+            # screen can hold anything the program printed. It is written
+            # through verbatim — this recorder scrubs nothing (#138).
             record["error"] = {
                 "type": type(raised).__name__,
                 "message": str(raised),

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -64,7 +64,9 @@ key is fine, renaming one is not:
 - `exit_code` appears on `TerminalRecorder` `run` beats — see **Failing the
   take** below.
 - `error` appears **only on a beat whose verb raised**, carrying the
-  exception's `type` and its scrubbed `message`; it is absent from every beat
+  exception's `type` and its `message` verbatim — `wait_for_text()` quotes a
+  thousand characters of terminal screen into a timeout, and nothing filters
+  that; it is absent from every beat
   that returned. `t_start` and `t_end` are stamped either way, so this is the
   only thing that tells the two apart — do not read a beat as evidence that
   something was demonstrated without checking it. The envelope gains a

--- a/tests/README.md
+++ b/tests/README.md
@@ -74,8 +74,8 @@ tests/smoke --keep                # keep the temp dir even when it passes
 **One suite at a time, per machine.** The script takes an exclusive `flock` on
 `$TMPDIR/demo-video-smoke.lock` and refuses to start while another run holds
 it. This is not tidiness: two suites share the CPU and the software encoder,
-and the bars that measure *time* — `REDACT_DURATION_S`, `MAX_BLANK_RUN_S` — go
-red on a recorder that is working perfectly. Two such false failures cost an
+and the bars that measure *time* — `MAX_BLANK_RUN_S` and the duration ranges —
+go red on a recorder that is working perfectly. Two such false failures cost an
 afternoon, and worse, they made a genuine intermittent bug undiagnosable
 because every red run had a second, more plausible explanation.
 [#78](https://github.com/rogvid/skills/issues/78) is about the bars themselves
@@ -771,7 +771,10 @@ So the assertions were **written rather than trimmed**, and there are three:
   holds trivially in an empty file. The control asserts that the fixture's own
   rendered string is in the ARIA tree, over a floor of 400 characters, before
   anything else is claimed. It is the catalogue's vacuous sweep, and it is the
-  one assertion that fires if the capture wrote nothing.
+  one assertion that fires if the capture wrote nothing. The control beat
+  measures 1,463 characters since #145 took the leak-shape panel out of that
+  view — a narrower margin than the ~2.3 kB it had, and worth knowing before
+  anything else is deleted from the fixture.
 - **the markup serializer drops what was never on screen.** Inline `<script>`
   text, a `srcdoc` document, and value-bearing attributes (`data-*`, `title`,
   `href`, …). This survives `redact()`'s deletion for a reason that has nothing
@@ -1296,23 +1299,11 @@ knows is missing is worse than one that is openly absent.
   but not recorded is unexercised, as is a `run()` whose prompt never comes
   back and therefore ends `exit_code: null`.
 - **Nothing checks what teardown flushes.** `_pump` holds back trailing bytes
-  that could still become an exit-status escape *or* the start of a secret,
-  and `_stop` writes both to the terminal on teardown — masking a dangling
-  fragment of a registered value as it goes. No assertion reads the final
-  frame, so a regression there would lose the last few bytes of a program's
-  output silently, and `_StreamRedactor._mask_dangling` is unexercised. Making
-  it fail needs a take that ends mid-secret and an assertion on the last
-  frames of the mp4, which is a race with the screencast.
-- **Every remaining line of masking, scrubbing and redaction is now shipped
-  and completely ungraded**, and that is this slice's one real cost. #150
-  deletes the arms; #142, #143 and #144 delete the code they graded. Between
-  this pull request and those three, `redact()`, `register_secret()`, the PTY
-  scrubber and the evidence masking family are all still in the package with
-  nothing watching them at all. The window is deliberate — the arms could not
-  be split along the source-file boundaries (see #150) — and it is short by
-  construction, but a regression in any of it during that window is invisible.
-  Nothing in this repository depends on those paths: `SKILL.md` already states
-  that the recorder does not defend against a secret reaching the screen.
+  that could still become an exit-status escape, and `_stop` writes them to the
+  terminal on teardown. No assertion reads the final frame, so a regression
+  there would lose the last few bytes of a program's output silently. Making it
+  fail needs an assertion on the last frames of the mp4, which is a race with
+  the screencast.
 - **The segmented take records two parts of one storyboard, not a real
   time-skip.** Nothing waits between them, both are the web recorder against
   the same fixture, and no segment is re-recorded on its own — so the flow
@@ -1391,13 +1382,13 @@ It is deterministic on purpose — no `Math.random()`, no clock on screen, no
 animations. `#refresh` cycles three hard-coded snapshots in order, so a
 recording made today is frame-for-frame the story of one made next year.
 
-Two query-string hooks exist, inert unless asked for:
+Four query-string hooks exist, inert unless asked for:
 
 | URL | Effect | For |
 |---|---|---|
 | `?console-error=1` | logs a `console.error` **and** throws an uncaught error (Playwright `pageerror`), while the page stays usable | the Problems axis |
 | `?bad-fetch=<url>` | fetches `/definitely-missing.json` (404) and `<url>` (connection refused), both during load | the Problems axis — during load so the failures land inside the recorder's `goto` beat |
-| `?secret=1` | renders `#api-key` holding `sk-live-FAKE0000000000000000` | issue #4, redacting secrets from frames and stills |
+| `?evidence=1` | renders one element carrying `data-token` and `data-cfg` attributes the page never paints, beside text it does | issue #9, the Evidence axis |
 | `?entropy=1` | renders four clock readings (`Date`, `Intl`, `new Date().constructor`, and one posted back by a `Worker`, each read once at load) and `#entropy-spinner`, a shape turning once every 1.7 s | issue #10, the determinism takes |
 
 `?entropy=1` is the one hook the fixture's own "keep it deterministic" rule is
@@ -1417,35 +1408,6 @@ controls-off assertion, which is exactly what that assertion is for.
 One hook, one take. The graded `web/` take loads none of them, so the reference
 recording stays a recording of a working app — which is also the assertion that
 the recorder does not invent problems.
-| `?console-error=1` | logs a `console.error` **and** throws an uncaught error (Playwright `pageerror`), while the page stays usable | issue #3, failing a take on console errors |
-| `?secret=1` | pins a panel of keys to redact and controls not to: body-size, hero-size, two reachable only by `text=`/`xpath=`, two fields, and an **open shadow root** holding a third key and a third field | issue #4, redacting secrets from frames and stills |
-| `?secret=closed` | the same, plus a **closed** shadow root holding a key nothing can mask | issue #4, proving an unmaskable selector fails the take |
-
-None of them is a credential. Each is spelled with a four-letter word followed
-by nothing but zeroes so both gitleaks and a human read it as scenery — the
-default ruleset does not flag them either way. `.gitleaks.toml` allowlists the
-shape anyway, and lists what each word belongs to, as insurance against a
-future release that does start flagging it.
-
-The panel is `position: fixed` rather than in the flow, which is load-bearing
-rather than cosmetic: the redaction take measures pixels inside those elements,
-so their rect has to be identical in every frame. In the flow the panel sits
-below the fold, and anything that scrolls — Playwright scrolls a field into view
-before typing into it — would move the measured region mid-take, which reads as
-a leak or hides one depending on what slid into the crop.
-
-It also has to stay clear of the bottom 160 px, where the recorder burns its
-caption bar. A measured crop that overlaps the bar is measuring sharp white
-caption text: the shadow field scored 34% of its control that way while being,
-on inspection of the extracted pixels, thoroughly blurred. The take asserts the
-clearance for every measured element, so the layout cannot drift back into it
-silently — and two other measurement artifacts found the same way are worth
-knowing about, because both looked exactly like a leak: the recorder's own
-cursor dot parked inside a field's crop by `type_into`'s click (5.0 against
-0.8), and an `<input>`'s border blurring into its own crop (2.5 against 0.8 for
-the same value as text). Every number in this section was checked by extracting
-the crop and looking at it before it was believed.
-
 ## Adding a case
 
 - **A new thing to record** — add a beat to `record_web` / `record_terminal` in
@@ -1497,26 +1459,6 @@ the crop and looking at it before it was believed.
   "the take raises" cannot be asserted about a take that has to succeed for
   everything else to be graded, so they exist, and they are kept to a few
   seconds each and graded on nothing else.
-  over another take. Takes cost ~15 s each in CI; assertions are free. The
-  redaction take is the exception that earned its own recording: it needs a
-  different page state (`?secret=1`), a different narration setting
-  (`speech=True`), and it deliberately provokes failures — a refused caption, a
-  torn-out mask — that would corrupt the expectations of the take it shared.
-- **A new thing redaction must hide** — add it to the `?secret=1` panel, add a
-  literal to the `REDACT_*` constants in `tests/smoke`, allowlist its shape in
-  `.gitleaks.toml`, and give it *both* a masked and an unmasked measurement.
-  A redaction assertion with nothing sharp to compare against is the most
-  dangerous kind of vacuous test: it passes on a black frame. Adding it to
-  `REDACT_LITERALS` carries it into the evidence sweep for free — but check
-  that a *control* of the same kind is still found in `evidence/`, or that
-  sweep is grading an empty directory.
-- **A new thing the *terminal* scrubber must hide** — add a line to
-  `term_printer_script()`, a literal to the `TERM_*` constants, a row to
-  `TERM_MASKED_ROWS`, and allowlist the shape in `.gitleaks.toml`. Keep it 28
-  characters so it lands in the same columns as the `ctl` and `ref` rows,
-  which are what it is measured against. If it is meant to be caught by shape
-  rather than registration, do not register it — that separation is the only
-  thing that says the two mechanisms work apart.
 - **A new fact evidence must record** — add a `(verb, target, present, absent)`
   row to `WEB_EVIDENCE` / `TERMINAL_EVIDENCE`. **Fill in `absent`.** A `present`
   list alone passes on a recorder that dumped the page once and copied it into
@@ -1525,21 +1467,16 @@ the crop and looking at it before it was believed.
   are facts about `fixture/index.html`, written by hand, never read back off a
   recording.
 - **A new field in an evidence document** — give it a budget in
-  `EVIDENCE_LIMITS` if it can grow, mirror that number in
-  `EVIDENCE_LIMITS_EXPECTED` in `tests/smoke`, and make sure it is built
-  *before* the masking pass in `_evidence_doc` rather than after. Anything
-  assembled after that pass is plaintext the recorder never checked, and only
-  the end-of-document guard stands between it and the file.
-- **A new way for a value to reach evidence without reaching a picture** —
-  add it to the `?evidence=1` panel, add a literal to `EVIDENCE_SECRETS`, and
-  allowlist its shape in `.gitleaks.toml`. **Then check `EVIDENCE_KEEP` still
-  holds.** Every leak fixed here has a mirror defect: the mask that reaches
-  the new shape is the same mask that can eat an unrelated paragraph, and a
-  run where all nine secrets are absent because all nine files are
-  `[redacted]` is not a pass. Write the shape in the *markup*, the way a
-  person writes HTML, rather than assigning it from JS — an unpadded text node
-  is precisely the case that does not leak, and building the fixture that way
-  is how this axis passed for a round while five shapes walked through it.
+  `EVIDENCE_LIMITS` if it can grow, and mirror that number in
+  `EVIDENCE_LIMITS_EXPECTED` in `tests/smoke`. The two are asserted equal, so a
+  cap widened on one side has to fail rather than pass by agreeing with itself.
+- **A new thing the markup serializer must drop** — say so with a *pair* of
+  assertions, never one. Every claim in this axis is that something is
+  **absent**, and absence holds trivially over an empty capture: the arm asserts
+  `EVIDENCE_RENDERED_TEXT` is present first, and anything added here needs the
+  same kind of control. Inject the element from the storyboard
+  (`EVIDENCE_SOURCE_JS` is the pattern) rather than adding it to the fixture,
+  unless a spotlight has to be able to name it.
 
 **Prove any new assertion can fail.** Break the thing it watches — stub the verb
 out in `skills/demo-video/helpers/`, or blank the fixture — run `tests/smoke`,

--- a/tests/fixture/index.html
+++ b/tests/fixture/index.html
@@ -88,40 +88,6 @@
   .pill.hold { background: rgba(180, 121, 26, 0.14); color: var(--warn); }
   #empty { padding: 26px 20px; color: var(--ink-soft); }
 
-  /* Secret panel (only with ?secret=1) -------------------------------- */
-  /* Pinned, not in the flow. The redaction test measures pixels inside the
-     two keys below, so their rect has to be the same in every frame of a
-     take: in the flow this panel sits under the table, below the fold, and
-     anything that scrolls (Playwright scrolls a field into view before
-     typing into it) would move the measured region mid-recording — which
-     reads as a leak or hides one, depending on what slid into the crop. */
-  /* Kept clear of the bottom 160px, where the recorder burns its caption bar.
-     A measured element behind that bar is measured *through* sharp white
-     caption text, which reads as an unmasked secret; the test asserts the
-     clearance too, so this cannot regress silently. */
-  #secret-panel {
-    position: fixed; top: 10px; right: 20px; width: 620px; z-index: 5;
-    padding: 12px 16px; background: var(--surface);
-    border: 1px solid var(--line); border-radius: var(--radius);
-    box-shadow: 0 8px 24px rgba(28, 26, 23, 0.10);
-  }
-  #secret-panel .label {
-    font-size: 11px; font-weight: 600; letter-spacing: 0.08em;
-    text-transform: uppercase; color: var(--ink-soft); margin-top: 8px;
-  }
-  #secret-panel .label:first-child { margin-top: 0; }
-  /* One rule for both keys: the control is only a useful reference for the
-     redacted one if they render identically. */
-  /* One rule for every body-size key: a control is only a useful reference
-     for a redacted element if the two render identically. #sd-key lives
-     inside a shadow root and #if-key inside an iframe — all measured against
-     the same control. */
-  #api-key, #api-key-control {
-    display: block; margin-top: 4px;
-    font: 15px/1.4 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-    color: var(--ink);
-  }
-
   /* Entropy panel (only with ?entropy=1) ------------------------------ */
   /* The two things a re-recording is allowed to differ by, made large and
      high-contrast on purpose: a wall clock and a running animation. With
@@ -146,85 +112,6 @@
        angle and prove nothing about animation phase. */
     clip-path: polygon(50% 0, 100% 100%, 50% 72%, 0 100%);
     animation: entropy-spin 1.7s linear infinite;
-  }
-  /* A field is not measurable against a bare <code>. Its border blurs along
-     with its contents and smears a gradient across the crop, and its box is
-     wider than its text; both push the number up for reasons that have
-     nothing to do with the secret (measured: 2.5-3.6 against 0.8 for the same
-     value as text). So each secret field gets a control field beside it —
-     same border, same width, same padding, same font — and is graded against
-     that. Side by side, because the panel has to stay clear of the caption
-     bar and a stacked row would not fit. */
-  .field-row { display: flex; gap: 10px; margin-top: 4px; }
-  /* An iframe: same-origin via srcdoc, so `frame.evaluate` reaches it while
-     `page.locator` does not descend into it. Counting matches on the page
-     alone reported zero for an element that was in fact masked, and failed
-     the take for a leak that did not exist. */
-  /* Borderless on purpose. The redaction test crops the key inside this
-     frame, and while the frame is reloading — which it does when the take
-     clicks the reload link — it is empty; a border would then be the only
-     hard edge in the crop, and a hard edge is exactly what a measurement of
-     sharpness is looking for. It read 18% of control against a 7% bar, and
-     the "leak" was a 1px line. */
-  #if-frame {
-    display: block; margin-top: 4px; width: 265px; height: 26px;
-    border: 0; background: #fff;
-  }
-  #token, #token-control {
-    width: 265px; box-sizing: border-box; padding: 5px 9px;
-    font: 15px/1.4 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-    color: var(--ink);
-    border: 1px solid var(--line); border-radius: 8px; background: #fff;
-  }
-  /* The large pair, and the reason #hero-card exists: the test redacts the
-     *wrapper*, whose own font-size is 12px, while the value inside it is
-     44px. A recorder that scales its radius from the element the selector
-     matched blurs 44px glyphs by 8px and leaves them readable. Redacting a
-     container is the natural call — SKILL.md's own example redacts a class —
-     so this is the shape that has to work, not an edge case. */
-  #hero-card { font-size: 12px; }
-
-  /* The sufficiency axis: one shape per way CSS can render text larger than
-     its font-size says. Every one of these was a live leak against a mask
-     whose radius came from getComputedStyle(el).fontSize — which is why the
-     radius now comes from rendered geometry, and why the cover is sized from
-     client rects rather than from any text metric at all.
-
-     Their own panel, on the other side of the viewport: they are deliberately
-     large, and the redaction take needs every measured element clear of the
-     caption bar along the bottom. */
-  #shape-panel {
-    position: fixed; top: 10px; left: 20px; width: 520px; z-index: 5;
-    padding: 12px 16px; background: var(--surface);
-    border: 1px solid var(--line); border-radius: var(--radius);
-    box-shadow: 0 8px 24px rgba(28, 26, 23, 0.10);
-  }
-  #shape-panel .label {
-    font-size: 11px; font-weight: 600; letter-spacing: 0.08em;
-    text-transform: uppercase; color: var(--ink-soft); margin-top: 8px;
-  }
-  #shape-panel .label:first-child { margin-top: 0; }
-  #a1-card, #a2-card, #a3-card, #a4-card, #a5-card { font-size: 12px; }
-  #a1-card .val::after {
-    content: attr(data-secret);
-    font: 48px/1.05 ui-monospace, monospace; color: var(--ink);
-  }
-  #a1-card { height: 52px; }
-  #a2-card { height: 52px; }
-  #a2-card .val {
-    display: inline-block; transform: scale(4); transform-origin: 0 0;
-    font: 12px/1.15 ui-monospace, monospace; color: var(--ink);
-  }
-  #a3-card .val {
-    zoom: 4; font: 12px/1.15 ui-monospace, monospace; color: var(--ink);
-  }
-  #a4-card svg { display: block; width: 460px; height: 52px; }
-  #a4-card text { font: 13px/1 ui-monospace, monospace; fill: var(--ink); }
-  #hero-card .caption { color: var(--ink-soft); }
-  #hero-key, #hero-key-control {
-    display: block; margin-top: 4px;
-    font: 44px/1.05 ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-    color: var(--ink); letter-spacing: -0.01em;
   }
 </style>
 </head>
@@ -290,17 +177,13 @@
  *   ?console-error=1  page logs a console error and throws on load (issue #3)
  *   ?bad-fetch=<url>  page fetches a missing path and <url>, both on load,
  *                     so the failures land during the recorder's goto (#3)
- *   ?secret=1         renders #api-key holding an obviously-fake secret (issue #4)
  *   ?entropy=1        renders four clock readings (Date, Intl, the Date
  *                     constructor, and one posted back by a Worker) and a
  *                     spinning shape — what determinism pins down (issue #10)
- *   ?evidence=1       renders the shapes that leak into a *text* dump of the
- *                     page but not into a picture of it: whitespace-padded
- *                     markup, an accessible name sourced from outside the
- *                     subtree, slotted light DOM, a property-only input
- *                     value, a value rewritten every 5 ms, a value split
- *                     across elements, and value-bearing attributes nothing
- *                     renders (issue #9)
+ *   ?evidence=1       renders one element carrying value-bearing attributes
+ *                     the page never paints, beside text it does — what a
+ *                     *text* account of a page can hold that a picture of it
+ *                     cannot (issue #9)
  */
 
 // Three fixed snapshots. #refresh cycles through them in order, so a
@@ -402,224 +285,6 @@ render();
 
 var params = new URLSearchParams(window.location.search);
 
-if (params.has("secret")) {
-  var panel = document.createElement("div");
-  panel.id = "secret-panel";
-  var label = document.createElement("div");
-  label.className = "label";
-  label.textContent = "Integration key";
-  var code = document.createElement("code");
-  code.id = "api-key";
-  // NOT a credential. A fixture literal, spelled FAKE and all zeroes on
-  // purpose so both gitleaks and a human read it as scenery. Used by the
-  // redaction work (issue #4) to prove a secret never reaches a frame.
-  code.textContent = "sk-live-FAKE0000000000000000";
-  panel.appendChild(label);
-  panel.appendChild(code);
-  // The control. Same font, same size, same length, same shape — and
-  // deliberately NOT registered for redaction, so the smoke test has a
-  // sharp-text reference measured off the very same frame as the blurred
-  // one. That is what makes the blur assertion self-calibrating (no absolute
-  // sharpness threshold tied to CI font rendering) and what stops a recorder
-  // that blurs the entire page from passing: the control must stay sharp.
-  var controlLabel = document.createElement("div");
-  controlLabel.className = "label";
-  controlLabel.textContent = "Control key (never redacted)";
-  var control = document.createElement("code");
-  control.id = "api-key-control";
-  control.textContent = "sk-live-CTRL0000000000000000";
-  panel.appendChild(controlLabel);
-  panel.appendChild(control);
-  // An empty field for a secret the demo *types* rather than one the app
-  // renders — the type_into(selector, Secret(...)) half of issue #4.
-  var tokenLabel = document.createElement("div");
-  tokenLabel.className = "label";
-  tokenLabel.textContent = "Paste a token / control";
-  var tokenRow = document.createElement("div");
-  tokenRow.className = "field-row";
-  var token = document.createElement("input");
-  token.id = "token";
-  token.type = "text";
-  token.autocomplete = "off";
-  token.placeholder = "sk-live-…";
-  // The control field: identical chrome, never redacted. The test types into
-  // it too, rather than pre-filling it, so the encoder sees both fields
-  // change at the same moment — a freshly re-coded region carries ringing a
-  // static one does not, which on its own measured 2.5 against 0.8.
-  var tokenControl = document.createElement("input");
-  tokenControl.id = "token-control";
-  tokenControl.type = "text";
-  tokenControl.autocomplete = "off";
-  tokenControl.placeholder = "sk-live-…";
-  tokenRow.appendChild(token);
-  tokenRow.appendChild(tokenControl);
-  // A second pair at hero size. A blur radius calibrated for 15px text leaves
-  // this readable, so the recorder scales its radius and the test measures
-  // both sizes (issue #4 review).
-  var heroCard = document.createElement("div");
-  heroCard.id = "hero-card";
-  var heroLabel = document.createElement("div");
-  heroLabel.className = "label";
-  heroLabel.textContent = "Hero key (wrapper is redacted, not the value)";
-  var hero = document.createElement("code");
-  hero.id = "hero-key";
-  hero.textContent = "sk-live-BIG000000000";
-  var heroControlLabel = document.createElement("div");
-  heroControlLabel.className = "label";
-  heroControlLabel.textContent = "Hero control (never redacted)";
-  var heroControl = document.createElement("code");
-  heroControl.id = "hero-key-control";
-  heroControl.textContent = "sk-live-BGC000000000";
-  heroCard.appendChild(heroLabel);
-  heroCard.appendChild(hero);
-  panel.appendChild(heroCard);
-  panel.appendChild(heroControlLabel);
-  panel.appendChild(heroControl);
-  // An iframe holding a key, reached by a plain CSS selector. srcdoc keeps
-  // it same-origin and dependency-free; the point is the frame boundary,
-  // which page.locator() does not cross even when frame.evaluate() does.
-  var ifLabel = document.createElement("div");
-  ifLabel.className = "label";
-  ifLabel.textContent = "Key inside an iframe";
-  var iframe = document.createElement("iframe");
-  iframe.id = "if-frame";
-  iframe.setAttribute(
-    "srcdoc",
-    '<body style="margin:0;padding:3px 8px;font:15px/1.4 ui-monospace,monospace">' +
-    '<code id="if-key">sk-live-IFRM00000000</code></body>'
-  );
-  panel.appendChild(ifLabel);
-  panel.appendChild(iframe);
-
-  panel.appendChild(tokenLabel);
-  panel.appendChild(tokenRow);
-
-  // -- the sufficiency shapes ----------------------------------------------
-  //
-  // Each is a wrapper with a small font-size, holding a value rendered much
-  // larger by a different mechanism, and each is redacted *by the wrapper* —
-  // which is how a storyboard names a card. A mask that asks the wrapper how
-  // big its text is gets 12px for all five.
-  var shapePanel = document.createElement("div");
-  shapePanel.id = "shape-panel";
-  var shapes = [
-    ["a1", "Pseudo-element (::after, 48px)", function (card, val) {
-      // The value is not in the DOM as text at all: it is generated content.
-      val.setAttribute("data-secret", "sk-live-PSEU0000");
-    }],
-    ["a2", "Descendant transform: scale(4)", function (card, val) {
-      val.textContent = "sk-live-TFRM0000";
-    }],
-    ["a3", "Descendant zoom: 4", function (card, val) {
-      val.textContent = "sk-live-ZOOM0000";
-    }],
-    ["a4", "SVG text scaled by viewBox", function (card, val) {
-      val.innerHTML =
-        '<svg viewBox="0 0 115 15" preserveAspectRatio="xMinYMin meet">' +
-        '<text x="0" y="12">sk-live-SVGT0000</text></svg>';
-    }],
-    ["a5", "Value two shadow roots below the wrapper", function (card, val) {
-      // A host inside the redacted wrapper, whose own shadow root holds
-      // another host, whose shadow root holds the value: the ordinary
-      // composition of "redact a card" and "the value is in a child
-      // component". One level of shadow recursion misses it.
-      var outer = val.attachShadow({ mode: "open" });
-      var inner = document.createElement("div");
-      outer.appendChild(inner);
-      var deep = inner.attachShadow({ mode: "open" });
-      deep.innerHTML =
-        '<code style="font:44px/1.1 ui-monospace,monospace;color:#1c1a17">' +
-        'sk-live-DEEP0000</code>';
-    }],
-  ];
-  shapes.forEach(function (shape) {
-    var id = shape[0], label = shape[1], fill = shape[2];
-    var head = document.createElement("div");
-    head.className = "label";
-    head.textContent = label;
-    var card = document.createElement("div");
-    card.id = id + "-card";
-    var val = document.createElement(id === "a5" ? "div" : "span");
-    val.className = "val";
-    val.id = id + "-key";
-    card.appendChild(val);
-    fill(card, val);
-    shapePanel.appendChild(head);
-    shapePanel.appendChild(card);
-  });
-  document.body.appendChild(shapePanel);
-
-  // A link that navigates the page without the recorder's goto(). Every
-  // navigation raises the first-paint gate, and for a while only goto()
-  // lowered it — so a link click, go_back(), a form submit or location.href
-  // left the rest of the take a blank white window that still reported
-  // success.
-  var again = document.createElement("a");
-  again.id = "reload-link";
-  again.href = window.location.search || "?secret=1";
-  again.textContent = "Reload this view";
-  again.style.cssText =
-    "display:inline-block;margin-top:8px;font-size:12px;color:#1f6feb";
-  panel.appendChild(again);
-
-  // -- shadow DOM ----------------------------------------------------------
-  //
-  // A web component, the way Lit / Stencil / LWC / Shoelace / Ionic build one:
-  // an *open* shadow root holding a key and a field. Playwright's engine sees
-  // straight through the boundary (`page.locator('#sd-key').count()` is 1) and
-  // `document.querySelectorAll('#sd-key').length` is 0, so a mask built on
-  // querySelectorAll silently covers nothing while click() and type_into()
-  // work perfectly — a live credential typed into a clear field on camera.
-  // Styles do not cross the boundary either: a document-level rule computes
-  // to `none` on these elements, only an inline style or a stylesheet placed
-  // *inside* the root reaches them.
-  var host = document.createElement("div");
-  host.id = "sd-host";
-  panel.appendChild(host);
-  var root = host.attachShadow({ mode: "open" });
-  root.innerHTML =
-    '<style>' +
-    '  .label { font-size: 11px; font-weight: 600; letter-spacing: .08em;' +
-    '    text-transform: uppercase; color: #6b6558; margin-top: 8px; }' +
-    '  code, input { display: block; margin-top: 4px;' +
-    '    font: 15px/1.4 ui-monospace, "SF Mono", Menlo, Consolas, monospace;' +
-    '    color: #1c1a17; }' +
-    '  input { width: 265px; box-sizing: border-box; padding: 5px 9px;' +
-    '    border: 1px solid #e2ddd3; border-radius: 8px; background: #fff; }' +
-    '  .row { display: flex; gap: 10px; margin-top: 4px; }' +
-    '  .row input { margin-top: 0; }' +
-    '</style>' +
-    '<div class="label">Shadow key</div>' +
-    '<code id="sd-key">sk-live-SHDW00000000</code>' +
-    '<div class="label">Shadow token / control</div>' +
-    '<div class="row">' +
-    '  <input id="sd-token" type="text" autocomplete="off" placeholder="sk-live-…">' +
-    '  <input id="sd-token-control" type="text" autocomplete="off"' +
-    '    placeholder="sk-live-…">' +
-    '</div>';
-
-  // A *closed* root, which nothing can reach: not document.querySelector, not
-  // Playwright's engine, not an injected stylesheet. There is no way to mask
-  // what is in here, so the only honest behaviour is for a take that was told
-  // to redact it to fail loudly instead of recording a clean-looking leak.
-  // Only reached when explicitly asked for, so the normal redaction take does
-  // not have to fail.
-  if (params.get("secret") === "closed") {
-    var closedHost = document.createElement("div");
-    closedHost.id = "sd-closed-host";
-    panel.appendChild(closedHost);
-    var closed = closedHost.attachShadow({ mode: "closed" });
-    closed.innerHTML =
-      '<div style="font-size:11px;font-weight:600;letter-spacing:.08em;' +
-      'text-transform:uppercase;color:#6b6558;margin-top:8px">Closed key</div>' +
-      '<code id="sd-closed-key" style="display:block;margin-top:4px;' +
-      'font:15px/1.4 ui-monospace,monospace;color:#1c1a17">' +
-      'sk-live-CLSD00000000</code>';
-  }
-
-  document.body.appendChild(panel);
-}
-
 if (params.has("bad-fetch")) {
   // Deliberate network breakage for the failed-request detection work
   // (issue #3). Two shapes: a response the server answers with 404, and a
@@ -701,192 +366,34 @@ if (params.has("entropy")) {
   document.querySelector(".page").prepend(entropy);
 }
 
-if (params.has("gate-attack")) {
-  // Two ways an ordinary page defeats a first-paint gate built out of
-  // `html{visibility:hidden}`, both of them things real apps do by accident:
-  //
-  //   1. a descendant declaring `visibility: visible` — Tailwind's `visible`
-  //      utility, a `.modal` rule, an animation end-state — which wins over
-  //      an inherited `hidden` on the root;
-  //   2. a script that removes unknown <style> elements from <head>, or
-  //      re-renders the head wholesale.
-  //
-  // Both run for the first two seconds of the page's life, which is exactly
-  // the window the gate exists to cover.
-  var unhide = document.createElement("style");
-  unhide.textContent =
-    "#secret-panel, #secret-panel * { visibility: visible !important; }";
-  document.head.appendChild(unhide);
-  var attack = setInterval(function () {
-    var gate = document.getElementById("__demo_redact_gate");
-    if (gate) gate.remove();
-    document.querySelectorAll("style").forEach(function (node) {
-      if (node !== unhide && node.textContent.indexOf("visibility") !== -1) {
-        node.remove();
-      }
-    });
-  }, 16);
-  setTimeout(function () { clearInterval(attack); }, 2000);
-}
-
 if (params.has("evidence")) {
-  // Per-beat evidence (issue #9) is a *text* dump of the page, so it leaks in
-  // shapes that no pixel assertion has ever had to care about. Each element
-  // here is one of those shapes, and every one of them reached an evidence
-  // file readable before it existed.
+  // Per-beat evidence (issue #9) is a *text* account of the page, so it can
+  // carry strings that were never on anybody's screen. This view renders one
+  // element of that shape: visible text, plus two attributes holding values
+  // the page never paints — one plain, one a JSON blob, because those reach
+  // the serializer through the same getAttribute() path but read differently
+  // to a human.
   //
-  // Its own hook rather than rows in `?secret=1`, because that panel's exact
-  // rect is what the redaction take measures sharpness over: adding to it
-  // moves the crops and silently regrades the pixel assertions.
+  // The panel used to hold thirty more elements. They were the leak shapes the
+  // masking assertions swept for, and they went with the mask (#142, #144):
+  // 30 of the 31 ids here had no reader left in tests/smoke. What remains is
+  // what `run_evidence` names — this element's markup, and the text it
+  // renders, which is the control proving the absence assertions are not
+  // holding trivially over an empty capture.
   //
-  // The keys are written into the *markup* below rather than assigned from JS
-  // on purpose. `el.textContent = "…"` produces one unpadded text node, which
-  // is precisely the case that does *not* leak — the fixture was passing by
-  // accident until this panel was written the way a human writes HTML.
+  // The values are `zz-` shaped rather than credential-shaped. The assertions
+  // grade the attribute *names*, so the shape is free, and a value that looked
+  // like a key would only earn back a .gitleaks.toml allowlist entry.
   var ev = document.createElement("div");
   ev.id = "ev-panel";
   ev.style.cssText =
     "position:fixed;top:8px;left:8px;width:520px;z-index:5;background:#fff;" +
     "border:1px solid #d8d2c6;border-radius:8px;padding:8px 10px;" +
     "font:12px/1.5 ui-monospace,monospace;color:#1c1a17;";
-  ev.innerHTML = [
-    // L1 — a value on its own line, indented, the way hand-written HTML puts
-    // it. textContent comes back "\n      sk-live-WSPC…\n    " while the ARIA
-    // tree says "sk-live-WSPC…", and a plain str.replace between the two
-    // finds nothing at all.
-    '<div id="ev-ws-card"><span class="lbl">Whitespace key</span>',
-    '  <code id="ev-ws-key">',
-    '    sk-live-WSPC00000000',
-    '  </code>',
-    '</div>',
-    // The mirror defect: a redacted card whose *label* is an ordinary word
-    // that also renders, unredacted, elsewhere on the page. Harvesting every
-    // node of the card registers "Revenue" as a mask unless the harvest knows
-    // what else the page renders.
-    '<div id="ev-bleed-card"><span class="lbl">Revenue</span>',
-    '  <code id="ev-bleed-key">sk-live-BLED00000000</code>',
-    '</div>',
-    // "live" is in here on purpose too: the split key below breaks into the
-    // text nodes "sk-", "live" and "-CHLD…", and a harvest that masked every
-    // one of them would rewrite every other key on the page.
-    '<p id="ev-bleed-outside">Revenue for the quarter was steady, and the ',
-    'feed is live.</p>',
-    // ...and the same defect one level meaner: a key whose own characters are
-    // split into text nodes that are each ordinary strings on their own.
-    '<div id="ev-child-card"><span class="lbl">Split key</span>',
-    '  <code id="ev-child-key">sk-<i>live</i>-CHLD00000000</code>',
-    '</div>',
-    // L2 — the accessible name comes from an element *outside* the redacted
-    // subtree, so no walk of that subtree can find it.
-    // display:none on purpose: aria-labelledby names a hidden element just as
-    // happily as a visible one, so this value is on nobody's screen and in
-    // nobody's frame — and it is still the redacted card's accessible name.
-    '<span id="ev-label-src" style="display:none">sk-live-LBLD00000000</span>',
-    // role= is load-bearing: a plain <div> has no role, so an ARIA snapshot
-    // shows no accessible name for it and the shape would prove nothing. With
-    // a role, the hidden element's text *is* this card's name in the tree.
-    '<div id="ev-labelled-card" role="group" aria-labelledby="ev-label-src">',
-    '  <span class="lbl">Labelled elsewhere</span></div>',
-    // L4 — light DOM slotted into a redacted element that lives *inside* a
-    // shadow root. The redacted element is #ev-slot-inner below, whose own
-    // textContent is empty: the value is a light child of the host, painted
-    // through the <slot>. It is inside the redaction in the flattened tree and
-    // outside it in the DOM, and only one of those is what renders.
-    '<div id="ev-slot-card"><span id="ev-slot-light">',
-    'sk-live-SLOT00000000</span></div>',
-    // An input value that lives on the *property*. Set from JS below, with no
-    // `value` attribute at all, so reading attributes finds nothing.
-    '<div id="ev-value-card"><span class="lbl">Field</span>',
-    '  <input id="ev-value-key" readonly></div>',
-    // L3 — rewritten every 5 ms with a value nothing has seen before, which
-    // is what a countdown, a ticker or a rotating token does.
-    '<div id="ev-tick-card"><span class="lbl">Rotating</span>',
-    '  <code id="ev-tick-key">sk-live-TICK00000000</code></div>',
-    // L5/L6 live in a spotlight target that is deliberately NOT redacted.
-    // Their values are registered as secrets instead, which is the other half
-    // of the contract: register_secret() has to reach markup too.
-    '<div id="ev-spot-split">a token: harbor<b>zenith</b>7725 </div>',
-    '<div id="ev-spot-attrs" data-token="sk-live-ATTR00000000"',
-    '  data-cfg=\'{"key":"sk-live-JSON00000000"}\'>nothing rendered here</div>',
-    // B1a — the value is inside a redacted card AND mirrored into attributes
-    // on siblings that are *not* redacted. The harvest reads those attributes
-    // when deciding what "renders in the clear", so every one of them was
-    // enough to exempt the key from masking everywhere: in all six evidence
-    // files, and — because the storyboard captions it — in timeline.json and
-    // timeline.md as well.
-    //
-    // A copy-to-clipboard button carrying the key it copies is ordinary UI,
-    // which is what makes this the shape a real app hits first. `srcdoc`,
-    // `alt`, `placeholder` and `content` reach the harvest through the
-    // identical getAttribute() path and need no separate element here; the
-    // input below is the one channel that does, because its value lives on the
-    // property and no attribute holds it.
-    '<div id="ev-attr-card"><span class="lbl">Copyable key</span>',
-    '  <code id="ev-attr-key">sk-live-HATT00000000</code>',
-    '</div>',
-    '<button id="ev-attr-title" title="sk-live-HATT00000000">Copy</button>',
-    '<button id="ev-attr-data" data-value="sk-live-HATT00000000">Copy</button>',
-    '<button id="ev-attr-label" aria-label="sk-live-HATT00000000">Copy</button>',
-    '<input id="ev-attr-input" readonly>',
-    // B1b — the same trick with CSS instead of attributes. Every one of these
-    // is reported visible by `checkVisibility()` called with no arguments,
-    // which models `display` and `content-visibility` and nothing else. Only
-    // the `display:none` case above was ever excluded, and that is the one
-    // shape this fixture happened to use.
-    '<div id="ev-veil-card"><span class="lbl">Mirrored key</span>',
-    '  <code id="ev-veil-key">sk-live-VEIL00000000</code>',
-    '</div>',
-    // A screen-reader-only clip: 1x1 with the content clipped away. In the
-    // accessibility tree, on nobody\'s screen.
-    '<span id="ev-veil-sr" style="position:absolute;width:1px;height:1px;',
-    'overflow:hidden;clip-path:inset(50%);white-space:nowrap">',
-    'sk-live-VEIL00000000</span>',
-    '<span id="ev-veil-opacity" style="opacity:0">sk-live-VEIL00000000</span>',
-    '<span id="ev-veil-vis" style="visibility:hidden">sk-live-VEIL00000000</span>',
-    '<span id="ev-veil-off" style="position:absolute;left:-9999px">',
-    'sk-live-VEIL00000000</span>',
-    // B3 — a registered secret containing an ampersand, which `outerHTML`
-    // writes as `&amp;`. The mask searches for the raw literal and misses; the
-    // withhold fallback strips tags but not entities and misses; the
-    // end-of-document backstop is a raw substring test and misses. The file
-    // came out with `aria` saying `token=[redacted]` and `html` carrying the
-    // value in full, two lines apart. `&` in a credential is ordinary — a
-    // presigned URL, a SAS token.
-    '<div id="ev-spot-amp">token=sk-live-AMPS0000&amp;sig=0000000000</div>'
-  ].join("\n");
+  ev.innerHTML =
+    '<div id="ev-spot-attrs" data-token="zz-attr-00000000"\n' +
+    '  data-cfg=\'{"key":"zz-json-00000000"}\'>nothing rendered here</div>';
   document.body.appendChild(ev);
-
-  // The slot host: a shadow root whose <slot> renders the light child above,
-  // wrapped in the element the take actually redacts.
-  var slotHost = document.getElementById("ev-slot-card");
-  var slotRoot = slotHost.attachShadow({ mode: "open" });
-  slotRoot.innerHTML =
-    '<span class="lbl">Slotted</span> ' +
-    '<span id="ev-slot-inner"><slot></slot></span>';
-
-  // Property, not attribute: `getAttribute("value")` returns null for this.
-  document.getElementById("ev-value-key").value = "sk-live-VALU00000000";
-
-  // ...and the same, on an input that is *outside* every redacted card. The
-  // harvest used to read `node.value` when deciding what renders in the clear,
-  // so this one field exempted the key in #ev-attr-card from masking. An
-  // input's value is not painted in the general case at all — a password field
-  // renders dots — and this is the only channel in that family that no
-  // attribute carries.
-  document.getElementById("ev-attr-input").value = "sk-live-HATT00000000";
-
-  // A fresh value every 5 ms. Deliberately faster than the ~15 ms a capture
-  // spends reading the page (harvest, ARIA snapshot, harvest): at 25 ms the
-  // three round trips often fit between two ticks, and the recorder's refusal
-  // to straddle a repaint went untested about half the time.
-  var tick = 0;
-  setInterval(function () {
-    var el = document.getElementById("ev-tick-key");
-    if (el) {
-      tick += 1;
-      el.textContent = "sk-live-TICK" + String(tick).padStart(8, "0");
-    }
-  }, 5);
 }
 
 if (params.has("console-error")) {

--- a/tests/smoke
+++ b/tests/smoke
@@ -7,8 +7,7 @@
 
 Serves `tests/fixture/` with a throwaway `python3 -m http.server`, records a
 short web demo against it with `Recorder`, records a short terminal demo with
-`TerminalRecorder`, records a third take against a page that renders a secret,
-and grades each take on separate axes:
+`TerminalRecorder`, and grades each take on separate axes:
 
 1. **Artifacts** — demo.mp4 and every still exist, were written by *this* run,
    are not trivially small, and are not repeats of each other.
@@ -32,15 +31,11 @@ and grades each take on separate axes:
    storyboard is recorded three times against a page that renders four clocks
    and an animation; the two takes with `deterministic=True` must match byte
    for byte, and the one recorded with the recorder's *defaults* must not.
-5. **Redaction** — a registered secret reaches no frame, still, caption or TTS
-   cache entry. Graded on pixel sharpness against an unredacted control key in
-   the same frame, and on a byte search of everything the take wrote. The
-   terminal half (issue #5) grades the PTY scrubber the same way, against a
-   value split across `os.read()` boundaries on purpose.
 6. **Evidence** — every beat left a text account of what was on screen, capped
    and explicitly truncated, from which a reader can state what the frame
-   showed without decoding one. Its own leak path, because it is the only
-   artifact here that is *plain text* and `redact()` only covers pixels.
+   showed without decoding one. Graded on its own because it is the only
+   artifact here that is *plain text*: a picture can only hold what was
+   painted, and this can hold more than that.
 
 Playwright 1.49 or newer: evidence uses `locator.aria_snapshot()`, and the
 `page.accessibility` API that predates it has since been removed.
@@ -428,7 +423,7 @@ SERVER_START_TIMEOUT_S = 15.0
 #
 # The graded takes stay recordings of a working app on purpose. They are the
 # reference demo a reader watches, and the fixture hooks belong in takes of
-# their own — the pattern the sibling PRs use for `?secret=1`.
+# their own — the pattern `?evidence=1` and `?entropy=1` follow.
 MISSING_PATH = "/definitely-missing.json"
 
 
@@ -464,25 +459,6 @@ BETWEEN_BEATS_JS = "() => console.error('__M__')".replace("__M__", BETWEEN_BEATS
 # rather than 1 because it proves the *status* was read rather than "something
 # went wrong" inferred from any other signal.
 TERMINAL_FAILING_COMMAND = "(exit 3)"
-
-# ...and the same, printed on a line long enough to **wrap**. `__termText()`
-# emits one xterm.js buffer row per line joined with newlines and never consults
-# `isWrapped`, so a credential that crosses the last column arrives split:
-# `"…sk-live-WRAP0000\n000000000000 wrapped-marker…"` — fully legible, and
-# recovered by anyone who pipes the file through `tr -d '\n'`. The mask missed
-# it, and so did the end-of-document backstop, which is the failure a backstop
-# exists to not have.
-#
-# The take before this one could never provoke it: `echo printed-below` plus a
-# 20-character secret is ~60 columns against a ~120-column terminal. A real
-# `env`, `aws configure get` or `curl -v` wraps every time. So this one is
-# padded to the measured width of the terminal, deliberately, and the padding
-# is computed at record time from `term.cols` rather than guessed.
-TERMINAL_WRAP_MARKER = "wrapped-marker"
-# How many characters of the secret land on the first row. Any value strictly
-# between 1 and len(secret) exercises the split; 8 keeps both halves long enough
-# to be obviously a fragment of one string in the failure message.
-TERMINAL_WRAP_HEAD = 8
 
 # The regression from the first round of review: two run()s with no wait
 # between them. The shell buffers the second command and runs it after the
@@ -1233,19 +1209,22 @@ TERMINAL_EVIDENCE = [
 # nothing else — no video, no stills. It carries three things the graded takes
 # structurally cannot:
 #
-#   1. **The leak shapes.** Every element in that panel reached an evidence
-#      file readable during review, and none of them is visible to any pixel
-#      assertion ever written here: a value is not less legible in JSON for
-#      having been covered on screen. They are graded by a byte sweep, the same
-#      way redaction is, with unredacted controls proving the sweep is not
-#      looking at an empty file.
+#   1. **What a text account can hold that a picture cannot.** The fixture
+#      renders one element whose attributes carry strings it never paints, and
+#      the storyboard injects two more shapes of the same kind (inline script
+#      text, a `srcdoc` document). None of them is visible to any pixel
+#      assertion ever written here — an attribute is in no frame either way —
+#      so the serializer that drops them needs a check of its own.
 #   2. **The size cap.** Truncation cannot be provoked on the fixture as it
-#      stands — its whole ARIA tree is 2.3 kB against a 12 kB cap — and
+#      stands — its whole ARIA tree is ~1.5 kB against a 12 kB cap — and
 #      slackening the cap to meet the fixture would be grading the wrong
 #      number. So the take bloats the page on purpose.
 #   3. **The segment naming.** It records with `segment=`, which no other take
 #      here does, so `evidence/<segment>.seg.beat-NN.json` is exercised rather
 #      than merely designed (issue #22).
+#
+# The segment is still called "shapes" after the leak shapes it was written
+# for (#138). The name is load-bearing only as a path component.
 EVIDENCE_SEGMENT = "shapes"
 # What the evidence take grades, after #150 removed everything about masking.
 #
@@ -1258,9 +1237,12 @@ EVIDENCE_SEGMENT = "shapes"
 EVIDENCE_RENDERED_TEXT = "nothing rendered here"
 # The same string, asserted in the *markup* of the element that renders it.
 EVIDENCE_ATTR_RENDERED = "nothing rendered here"
-# An ARIA tree under this is not a page. The fixture's evidence view is several
-# thousand characters; this is a floor on "something was captured", not a bar
-# on the fixture's size.
+# An ARIA tree under this is not a page. The fixture's evidence view measures
+# 1,463 characters on the control beat; this is a floor on "something was
+# captured", not a bar on the fixture's size. The margin narrowed when #145
+# took the leak-shape panel out of that view (it was ~2.3 kB), which is worth
+# knowing before anything else is deleted from the fixture — but 400 is still
+# well clear of what a *blank* capture produces, which is what it grades.
 EVIDENCE_MIN_ARIA_CHARS = 400
 # The element whose attributes carry strings it never renders.
 EVIDENCE_ATTR_TARGET = "#ev-spot-attrs"
@@ -1306,60 +1288,6 @@ EVIDENCE_BLOAT_JS = """(n) => {
   }
   document.body.appendChild(box);
 }""".replace("__ID__", EVIDENCE_BLOAT_ID)
-
-
-# The recorder's narration defaults, written out by hand so this file computes
-# the cache path the way core.py does rather than by asking core.py. If either
-# default changes, the "the innocent line really was cached" assertion below
-# fails — which is the point: that assertion is what makes the absence of the
-# leaking line's entry mean something.
-TTS_VOICE_ID = "EXAVITQu4vr4xnSDxMaL"
-TTS_MODEL_ID = "eleven_multilingual_v2"
-
-# Sharpness, as mean absolute difference between neighbouring pixels of a
-# crop. Text has hard glyph edges and scores tens; a gaussian blur is exactly
-# the operation that removes them.
-#
-# **The crop is normalised to a fixed text height first**, and that is the
-# whole reason this number means "legible" rather than "small". Sharpness is
-# scale-dependent: the bigger the text, the fewer edges per pixel, so a sharp
-# 44 px key scores *lower* than a sharp 15 px one. Measured on this fixture
-# with a constant 8 px blur and only the font size varied:
-#
-#   font    control   blurred   ratio    legible to a human?
-#   15px      37.7      1.0      2.7%    no
-#   40px      16.4      1.6     10.0%    borderline
-#   52px      12.3      1.6     13.4%    YES
-#   68px       9.4      1.7     17.7%    YES
-#
-# The denominator collapses while the numerator stays flat, so a raw ratio
-# passes text anyone can read. Scaling every crop to the same text height
-# before measuring removes that: a blur that is proportional to the text
-# survives the rescale as a blur, and a constant 8 px blur on 44 px text
-# rescales into a ~3 px blur on 15 px text, which is legible and scores like
-# it. The measurement then tracks legibility instead of geometry.
-#
-# Both bars are needed and neither alone is enough:
-#
-#   * MIN_CONTROL_EDGE — the unredacted control key must be legibly sharp in
-#     the same frame. Without it, a black video, a blank page, or a mask that
-#     blurred everything all pass the ratio trivially.
-#   * MAX_REDACTED_EDGE_RATIO — the redacted key, as a fraction of that
-#     control, both normalised. Self-calibrating: a fraction of a reference
-#     measured off the same frame needs no absolute threshold tied to CI font
-#     rendering.
-#
-# Calibration numbers live in tests/README.md, measured across both font sizes
-# and against the injected faults.
-NORMALISED_TEXT_H = 22
-MIN_CONTROL_EDGE = {"still": 8.0, "video": 6.0}
-
-# How many of the redaction take's review frames have to show a legible
-# control before "the key is blurred in all of them" means anything. The take
-# opens on about:blank, raises the paint gate on purpose, and navigates once,
-# so a handful of its ~31 frames legitimately show nothing; a mask that blanked
-# the recording would show nothing in every one of them.
-MIN_GRADED_REVIEW_FRAMES = 10
 
 
 class _StoryboardFailed(RuntimeError):
@@ -2806,36 +2734,6 @@ def record_entropy(out_dir: Path, base_url: str, deterministic: bool) -> Entropy
             max(2, int(box["height"] * scale_y)),
         )
     return EntropyTake(b.problems, out_dir, clock, still_rect, video_rect, spin_rect)
-
-
-# -- redaction take ----------------------------------------------------------
-
-# The tightest box around an element's rendered text, in page coordinates.
-# The element's own box is mostly empty background (these are display:block),
-# and empty background has no edges either way — measuring it would dilute the
-# sharp control and the blurred key by the same large factor and cost the
-# measurement most of its margin. Falls back to the element box for an <input>,
-# whose value is not in a text node a Range can select.
-_TEXT_RECT_JS = """(el) => {
-  if (!el) return null;
-  const range = document.createRange();
-  range.selectNodeContents(el);
-  let box = range.getBoundingClientRect();
-  if (box && box.width >= 4 && box.height >= 4)
-    return [box.x, box.y, box.width, box.height];
-  // An <input>: its value is not in a text node a Range can select, so fall
-  // back to the element box minus its border and padding. The border is a
-  // hard edge that survives being blurred with the text behind it, and
-  // including it measures the chrome instead of the secret.
-  const cs = getComputedStyle(el);
-  const inset = (a, b) => parseFloat(cs[a] || 0) + parseFloat(cs[b] || 0) + 1;
-  box = el.getBoundingClientRect();
-  const l = inset('borderLeftWidth', 'paddingLeft');
-  const t = inset('borderTopWidth', 'paddingTop');
-  const r = inset('borderRightWidth', 'paddingRight');
-  const b = inset('borderBottomWidth', 'paddingBottom');
-  return [box.x + l, box.y + t, box.width - l - r, box.height - t - b];
-}"""
 
 
 # -- assertions --------------------------------------------------------------

--- a/tests/unit
+++ b/tests/unit
@@ -11,11 +11,11 @@
 
 **`dependencies = []` is the point of this file, not an accident.** Everything
 tested here — the coverage report, the timeline's two renderings, the content
-and opening measurements, the merge a stitch performs, the two secret types —
-is a function of documents and values. None of it drives a browser. Until
-issue #139 it was nonetheless unreachable without one, because `core` imported
-Playwright at module scope and `__init__` imported both recorders eagerly, so
-the recorder's only check was `tests/smoke`: 12,369 lines, Chromium and ffmpeg
+and opening measurements, the merge a stitch performs — is a function of
+documents and values. None of it drives a browser. Until issue #139 it was
+nonetheless unreachable without one, because `core` imported Playwright at
+module scope and `__init__` imported both recorders eagerly, so the recorder's
+only check was `tests/smoke`: 12,369 lines at the time, Chromium and ffmpeg
 required, ten minutes, one suite at a time behind an exclusive `flock`.
 
 That cost is what issue #136 measures, and it is why the fault-injection rule
@@ -654,6 +654,71 @@ class SkillDocs(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# tests/smoke carries nothing it does not read (issue #156)
+# --------------------------------------------------------------------------
+#
+# When #138 deleted the masking surface it left seven constants and a block of
+# JavaScript behind in `tests/smoke` — `MIN_CONTROL_EDGE`, `NORMALISED_TEXT_H`,
+# `MIN_GRADED_REVIEW_FRAMES`, `TERMINAL_WRAP_MARKER`, `TERMINAL_WRAP_HEAD`,
+# `TTS_VOICE_ID`, `TTS_MODEL_ID`, `_TEXT_RECT_JS` — each with the prose that
+# justified it, and each describing machinery that no longer exists. Nothing
+# noticed for three merged pull requests: a constant nobody reads breaks
+# nothing.
+#
+# It is worth an assertion rather than a habit because the residue is the thing
+# a reader trusts most: `MIN_CONTROL_EDGE`'s comment stated a bar the suite was
+# no longer applying, in a file whose whole job is to state what is graded.
+#
+# The limit of the check, stated because it is the kind that quietly narrows: a
+# name referenced *only* from inside a string — a `getattr`, a config key — reads
+# as dead here. There are none today. If one appears, the fix is to read it in
+# code or to say in a comment why it cannot be.
+
+SMOKE = Path(os.environ.get("UNIT_SMOKE", REPO / "tests" / "smoke"))
+
+# Below this, `tests/smoke` was not parsed — an empty or truncated file makes
+# "nothing is unread" hold trivially, the catalogue's vacuous sweep. It is 271
+# today; this is a floor on "a suite was read", not a bar on its size.
+SMOKE_DEFINITION_FLOOR = 200
+
+
+class SmokeResidue(unittest.TestCase):
+    def test_no_module_level_definition_in_tests_smoke_goes_unread(self):
+        import ast
+        from collections import Counter
+
+        tree = ast.parse(SMOKE.read_text(encoding="utf-8"))
+        defined: dict[str, int] = {}
+        for node in tree.body:
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        defined[target.id] = node.lineno
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                defined[node.target.id] = node.lineno
+            elif isinstance(
+                node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+            ):
+                defined[node.name] = node.lineno
+
+        # The haystack, before anything is claimed about it.
+        self.assertGreaterEqual(len(defined), SMOKE_DEFINITION_FLOOR)
+
+        read = Counter(
+            n.id
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+        )
+        dead = sorted((line, name) for name, line in defined.items() if not read[name])
+        self.assertEqual(
+            dead,
+            [],
+            f"{len(dead)} definition(s) in {SMOKE.name} that nothing reads: "
+            + ", ".join(f"{name} (line {line})" for line, name in dead),
+        )
+
+
+# --------------------------------------------------------------------------
 # Fault injection
 # --------------------------------------------------------------------------
 
@@ -820,6 +885,17 @@ INJECTIONS = [
         "| reference/narration.md | When",
         ["SkillDocs.test_every_reference_file_is_linked_from_skill_md"],
     ),
+    (
+        "a deletion leaves a constant in tests/smoke that nothing reads",
+        "tests/smoke",
+        # Modelled on what #138 actually left behind: a name defined beside a
+        # live one, with prose that reads as though it still grades something.
+        'TERMINAL_FAILING_COMMAND = "(exit 3)"',
+        'TERMINAL_FAILING_COMMAND = "(exit 3)"\n'
+        "# How sharp the control key has to be for the ratio to mean anything.\n"
+        "MIN_CONTROL_EDGE = 8.0",
+        ["SmokeResidue.test_no_module_level_definition_in_tests_smoke_goes_unread"],
+    ),
 ]
 
 
@@ -830,15 +906,20 @@ def fault_inject() -> int:
         with tempfile.TemporaryDirectory() as tmp:
             # The whole skill, not just the package: two injections break
             # SKILL.md, and the documentation assertions are as much a check
-            # as the behavioural ones.
+            # as the behavioural ones. `tests/smoke` is copied alongside it
+            # because one assertion reads that file rather than the package —
+            # residue in the *harness* is the defect it grades.
             skill = Path(tmp) / "demo-video"
             shutil.copytree(REPO / "skills" / "demo-video", skill)
             root = skill / "helpers"
-            target = (
-                skill / module
-                if module.endswith(".md")
-                else root / "demo_recording" / module
-            )
+            smoke = Path(tmp) / "smoke"
+            shutil.copy(REPO / "tests" / "smoke", smoke)
+            if module == "tests/smoke":
+                target = smoke
+            elif module.endswith(".md"):
+                target = skill / module
+            else:
+                target = root / "demo_recording" / module
             text = target.read_text(encoding="utf-8")
             hits = text.count(old)
             if hits != 1:
@@ -860,6 +941,7 @@ def fault_inject() -> int:
                     **os.environ,
                     "UNIT_HELPERS": str(root),
                     "UNIT_SKILL_DIR": str(skill),
+                    "UNIT_SMOKE": str(smoke),
                 },
             )
             noticed = {t for t in must_fail if t in done.stderr}
@@ -898,10 +980,10 @@ def fault_inject() -> int:
 # Stated plainly rather than implied by silence:
 #
 # - **Anything that drives a browser or a PTY.** `_DemoBase`, `Recorder` and
-#   `TerminalRecorder` — every storyboard verb, the redaction masking and its
-#   verification, per-beat evidence harvesting, the failure dump, narration
-#   pacing and the ffmpeg composite — are `tests/smoke`'s, and this suite does
-#   not reduce what smoke has to run. It runs the half that never needed one.
+#   `TerminalRecorder` — every storyboard verb, per-beat evidence capture, the
+#   failure dump, narration pacing and the ffmpeg composite — are
+#   `tests/smoke`'s, and this suite does not reduce what smoke has to run. It
+#   runs the half that never needed one.
 # - **Anything measured off real frames.** `content_report`'s ffmpeg sampling,
 #   `opening_gap`, `_luma_stddev` and `_moved_pixels` need a video to be true
 #   about. What is graded here is the logic *around* them: the warning


### PR DESCRIPTION
Two slices in one pull request, because they edit the same regions of
`tests/README.md` and splitting them would touch the fixture tables twice.

## Acceptance

**#145** — `tests/smoke` passes with the fixture's secret panel gone, no
surviving arm requests `?secret=`, and the gitleaks decision is recorded with
its reason.

**#156** — `tests/smoke`'s docstring lists only axes that have a take, no symbol
in it is defined and never read, and `tests/README.md` states no capability the
package does not have and no instruction naming a symbol that is gone.

Both met. Details below, including the two places the issues were wrong.

## #145 — the fixture, the allowlist, and the job

`tests/fixture/index.html`: **904 → 411 lines.** The `?secret=1` and
`?secret=closed` views are gone, and so is `?gate-attack`, which existed only to
attack the first-paint gate #142 deleted. Neither had a caller — `?secret=` was
requested by no arm, `gate-attack` by nothing at all.

**The `?evidence=1` panel shrank too, which #145 did not anticipate.** It also
held `sk-live-*` values — 11 of the surviving allowlist tags — so the issue's
"with the fixture panel gone there is nothing to allow" would not have held.
Checking that turned up the reason it can hold anyway: **30 of the panel's 31
element ids had no reader left in `tests/smoke`.** Only `#ev-spot-attrs` is
used, and its assertion grades the attribute *names* (`data-token`, `data-cfg`)
rather than their values, so the shape is free. The panel is now that one
element with `zz-` shaped attributes.

`grep -c 'sk-live-' tests/fixture/index.html` is **0**, and `.gitleaks.toml`
goes **155 → 48 lines** — the whole `regexes` list, not just the `?secret=1`
half. The `paths` entry stays; it is about vendored xterm.js and never was about
secrets.

### The gitleaks job stays

#138 removed demo-video's ability to hide a secret *in a recording*. This scan
is about a real credential reaching *the repository* — a different thing, ten
seconds, and conflating the two would be exactly what the boundary section in
`SKILL.md` exists to prevent. The reason is written into the workflow and
`.gitleaks.toml` rather than left to be re-derived.

**Verified, not assumed** — which is what the old config claimed for itself.
gitleaks 8.21.2 under the new config:

```
$ gitleaks detect --source . --config .gitleaks.toml --no-git
INF scan completed in 1.17s
INF no leaks found

$ gitleaks detect --source . --config .gitleaks.toml --log-opts="--all"
INF 44 commits scanned.
INF no leaks found
```

The history scan matters: it covers the commits where the fixture still rendered
those values, with no regex allowlist standing between them and the ruleset.

## #156 — residue

**The docstring named an axis that has no take.** `tests/smoke` listed
**5. Redaction** — "a registered secret reaches no frame, still, caption or TTS
cache entry" — numbered `5.` beside Determinism's `5.`. `grep '^def run_'`
returns 22 takes and none of them is it. It also explained the *evidence* axis
by reference to `redact()`.

**Seven constants were defined and never read**, each carrying the prose that
justified it: `MIN_CONTROL_EDGE`, `NORMALISED_TEXT_H`, `MIN_GRADED_REVIEW_FRAMES`,
`TERMINAL_WRAP_MARKER`, `TERMINAL_WRAP_HEAD`, `TTS_VOICE_ID`, `TTS_MODEL_ID`,
plus the `_TEXT_RECT_JS` blob and a `-- redaction take --` banner over nothing.
The last three are past what #156 filed; the scan below found them.

`TTS_VOICE_ID` / `TTS_MODEL_ID` are worth naming separately: they are #157's
hole made concrete. They existed to compute a cache path by hand so the "the
innocent line really was cached" assertion meant something — and narration only
ever ran because `.tts/` was a leak path. Their arithmetic is now only in git
history, noted on #157.

**`tests/README.md` made two claims a reader would act on.** Its Known gaps said
"`redact()`, `register_secret()`, the PTY scrubber and the evidence masking
family are all still in the package" — false since #144. Its contributor
instructions said to "add a literal to the `REDACT_*` constants in
`tests/smoke`", which do not exist. Historical narration about what was removed
and why is kept; it is accurate.

**Four sites outside `tests/`, which #155 did not reach:**

| where | said |
|---|---|
| `core.py` | the beat's error message is "Scrubbed at record time as well as on the way out" — it is `str(raised)`, verbatim |
| `reference/timeline.md` | documented `error.message` as scrubbed, which is an artifact claim |
| `README.md` | the recorder reads "what `redact()` is covering" out of the page |
| `README.md` | listed `secrets.md` in a tree of `reference/`, deleted by #142 |

## The check that would have caught this

`tests/unit` gains `SmokeResidue`: an AST scan for module-level definitions in
`tests/smoke` that nothing loads. **271 definitions today, 0 unread.**

Fault-injected rather than asserted. The harness now copies `tests/smoke`
alongside the skill so a `tests/smoke` target can be broken. The injection adds
a constant beside a live one, with prose that reads as though it still grades
something — modelled on what #138 actually left:

```
PASS  break: a deletion leaves a constant in tests/smoke that nothing reads
      in tests/smoke: TERMINAL_FAILING_COMMAND = "(exit 3)"…
      FAIL: test_no_module_level_definition_in_tests_smoke_goes_unread

AssertionError: Lists differ: [(463, 'MIN_CONTROL_EDGE')] != []
```

**21 of 21 injections caught.**

The vacuity floor was broken separately, because a scan over an unparsed file
reports "nothing dead" trivially — the catalogue's vacuous sweep:

```
$ UNIT_SMOKE=/tmp/tiny.py tests/unit SmokeResidue
AssertionError: 1 not greater than or equal to 200
```

## Stated limits

- **The residue scan reads code, not strings.** A name referenced only from
  inside a string — a `getattr`, a config key — would read as dead. There are
  none today; if one appears the fix is to read it in code or say in a comment
  why it cannot be.
- **The evidence take's margin narrowed.** Its control beat asserts ≥400
  characters of page text and now measures **1,463**, down from ~2.3 kB before
  the panel shrank. Still well clear of what a blank capture produces, which is
  what the floor grades — but the next person deleting from that fixture should
  know, so the number is recorded at the constant and in `tests/README.md`.
- **`tests/README.md` still contradicts itself in places** unrelated to masking
  (a duplicated `?console-error=1` row was removed here as collateral). That is
  #47 and is not addressed.
- **The `EVIDENCE_SEGMENT = "shapes"` name** still refers to the leak shapes it
  was written for. Renaming it would move every `evidence/shapes.seg.*` path; it
  is load-bearing only as a path component, and that is now said in a comment.

## Verification

- full `tests/smoke`: **PASSED**, 94 reported checks
- assertion sites unchanged against baseline — 11 `b.expect`, 288
  `failures.append`, 11 `smoke:` reports, in both trees
- `tests/unit`: 47 tests, `--fault-inject`: 21/21
- `ruff==0.14.2` check + format, `mypy==1.18.2`: clean
- `gitleaks 8.21.2`: clean, working tree and history

Fixes #145
Fixes #156
