### PR TITLE
Grade the speech path: cache key, pacing, and whether the mix carries audio (#157)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/__init__.py
+++ b/skills/demo-video/helpers/demo_recording/__init__.py
@@ -65,6 +65,7 @@ from .frames import (
     scene_times,
     write_beat_frames,
 )
+from .narration import tts_clip
 from .stitching import stitch
 from .timeline import (
     EVIDENCE_DIR,
@@ -83,16 +84,17 @@ from .timeline import (
 )
 
 if TYPE_CHECKING:  # the real classes, for type checkers and editors only
-    from .core import tts_clip
     from .terminal import TerminalRecorder
     from .web import Recorder
 
-# Everything that cannot be reached without Playwright. `tts_clip` is here for
-# the same reason the recorders are: it lives in `core`, which imports it.
+# Everything that cannot be reached without Playwright — which is now only the
+# two recorders. `tts_clip` used to be here too, for the same reason: it lived
+# in `core`, which imports Playwright at module scope. It does not need one
+# (a cache key is a function of three strings), so #157 moved it to
+# `narration` and it is imported eagerly above like everything else.
 _LAZY = {
     "Recorder": ".web",
     "TerminalRecorder": ".terminal",
-    "tts_clip": ".core",
 }
 
 

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -24,15 +24,12 @@ from __future__ import annotations
 
 import datetime as _dt
 import functools
-import hashlib
 import json
 import os
 import re
 import subprocess
 import sys
 import time
-import urllib.error
-import urllib.request
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
@@ -56,6 +53,7 @@ from .failure import (
     FAILURE_SCHEMA,
 )
 from .frames import _FRAME_EDGE_S, _extract, write_beat_frames
+from .narration import tts_clip
 from .timeline import (
     ATTRIBUTION_SLACK_S,
     EVIDENCE_DIR,
@@ -409,54 +407,6 @@ def _env_flag(name: str) -> bool | None:
     if value is None:
         return None
     return value.lower() in ("1", "true", "yes", "on")
-
-
-def tts_clip(
-    text: str,
-    cache_dir: Path,
-    voice_id: str,
-    model_id: str,
-    api_key: str,
-) -> Path:
-    """Synthesize one narration line with ElevenLabs, cached by content.
-
-    The cache key includes voice and model, so switching either re-generates.
-    Cached clips make retakes free — the API is only hit for new lines.
-    """
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    key = hashlib.sha256(f"{voice_id}|{model_id}|{text}".encode()).hexdigest()[:20]
-    clip = cache_dir / f"{key}.mp3"
-    if clip.exists():
-        return clip
-    req = urllib.request.Request(
-        f"https://api.elevenlabs.io/v1/text-to-speech/{voice_id}"
-        "?output_format=mp3_44100_128",
-        data=json.dumps({"text": text, "model_id": model_id}).encode(),
-        headers={"xi-api-key": api_key, "Content-Type": "application/json"},
-    )
-    # Free-tier keys get 429 "system_busy" under load, and any network can
-    # blip mid-recording — retry with backoff rather than losing a take.
-    for attempt in range(5):
-        try:
-            with urllib.request.urlopen(req, timeout=60) as resp:
-                partial = clip.with_suffix(".part")
-                partial.write_bytes(resp.read())
-                partial.rename(clip)  # atomic: no truncated clip is cached
-            return clip
-        except urllib.error.HTTPError as e:
-            detail = e.read().decode()[:300]
-            if e.code in (429, 500, 502, 503) and attempt < 4:
-                time.sleep(2 ** (attempt + 1))
-                continue
-            raise RuntimeError(
-                f"ElevenLabs TTS failed ({e.code}): {detail}"
-            ) from e
-        except (urllib.error.URLError, TimeoutError) as e:
-            if attempt < 4:
-                time.sleep(2 ** (attempt + 1))
-                continue
-            raise RuntimeError(f"ElevenLabs TTS failed: {e}") from e
-    raise AssertionError("unreachable")
 
 
 def _verb_target(args: tuple, kwargs: dict) -> str | None:

--- a/skills/demo-video/helpers/demo_recording/narration.py
+++ b/skills/demo-video/helpers/demo_recording/narration.py
@@ -1,0 +1,114 @@
+"""Synthesizing a narration line, and caching it by content.
+
+This is the whole of the recorder's speech path that does not need a browser:
+given a line of text and a voice, produce an mp3 and remember it. What a
+`_DemoBase` does with the clip — waiting one line out before starting the next,
+mixing it onto the video at the offset the line appeared — stays in `core`,
+because it needs the recorder's clock and its idle loop.
+
+It lives here rather than in `core` for the reason the recorders are lazy
+(#139): `core` imports Playwright at module scope, and none of this does. A
+cache key is a function of three strings; it should not cost a browser to check
+that it is the right one.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# How long to wait between retries, and how many. Free-tier keys get 429
+# "system_busy" under load, and any network can blip mid-recording — losing a
+# take to either is worse than the delay.
+TTS_ATTEMPTS = 5
+TTS_RETRY_CODES = (429, 500, 502, 503)
+# Characters of the sha256 kept. 20 hex characters is 80 bits: the cache is
+# per-take and holds tens of lines, so this is collision-free by an enormous
+# margin and short enough to read in a directory listing.
+TTS_KEY_CHARS = 20
+
+# What separates the three fields before hashing.
+#
+# **It must be a character that cannot occur in a voice or model id**, and that
+# is the entire reason the concatenation is unambiguous. Voice and model ids
+# are alphanumeric (`EXAVITQu4vr4xnSDxMaL`, `eleven_multilingual_v2`), so any
+# non-alphanumeric character does. The *text* may contain it freely: it is the
+# last field, so nothing follows it that a stray separator could be mistaken
+# for.
+#
+# A separator an id could hold would make two different takes hash the same
+# string, and the symptom would be a take replaying another voice's audio with
+# correct timing — the failure this whole module is graded on.
+TTS_KEY_SEP = "|"
+
+# Where a cache miss goes. A module constant rather than a literal buried in
+# `tts_clip` so a caller that must not reach the real service can say so.
+#
+# `tests/smoke`'s narration take points this at a closed local port before it
+# records. Every line it narrates is a cache hit, so nothing should be
+# requested at all — and pinning the endpoint is what turns "should" into
+# "cannot": a key the recorder computes differently from the harness fails in
+# milliseconds against a dead socket, instead of putting a fabricated
+# credential on the wire to a third party to find out.
+TTS_API_BASE = "https://api.elevenlabs.io/v1/text-to-speech"
+
+
+def _tts_key(text: str, voice_id: str, model_id: str) -> str:
+    """The cache filename stem for one line, in one voice, from one model.
+
+    **All three inputs are in the key, and that is the contract.** Switching
+    voice or model has to re-generate rather than replay the old audio — a
+    cache that keyed on text alone would hand a take recorded in one voice the
+    clips of another, and nothing downstream would notice: the mp4 would come
+    out with a full, correctly-timed audio track in the wrong voice.
+    """
+    joined = TTS_KEY_SEP.join((voice_id, model_id, text))
+    return hashlib.sha256(joined.encode()).hexdigest()[:TTS_KEY_CHARS]
+
+
+def tts_clip(
+    text: str,
+    cache_dir: Path,
+    voice_id: str,
+    model_id: str,
+    api_key: str,
+) -> Path:
+    """Synthesize one narration line with ElevenLabs, cached by content.
+
+    Cached clips make retakes free — the API is only hit for new lines, and
+    `api_key` is not read at all on a hit. That is what lets `tests/smoke`
+    grade the pacing and the audio mix without a key or a network: seed the
+    cache with clips of known duration and every line is a hit.
+    """
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    clip = cache_dir / f"{_tts_key(text, voice_id, model_id)}.mp3"
+    if clip.exists():
+        return clip
+    req = urllib.request.Request(
+        f"{TTS_API_BASE}/{voice_id}?output_format=mp3_44100_128",
+        data=json.dumps({"text": text, "model_id": model_id}).encode(),
+        headers={"xi-api-key": api_key, "Content-Type": "application/json"},
+    )
+    for attempt in range(TTS_ATTEMPTS):
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                partial = clip.with_suffix(".part")
+                partial.write_bytes(resp.read())
+                partial.rename(clip)  # atomic: no truncated clip is cached
+            return clip
+        except urllib.error.HTTPError as e:
+            detail = e.read().decode()[:300]
+            if e.code in TTS_RETRY_CODES and attempt < TTS_ATTEMPTS - 1:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            raise RuntimeError(f"ElevenLabs TTS failed ({e.code}): {detail}") from e
+        except (urllib.error.URLError, TimeoutError) as e:
+            if attempt < TTS_ATTEMPTS - 1:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            raise RuntimeError(f"ElevenLabs TTS failed: {e}") from e
+    raise AssertionError("unreachable")

--- a/tests/README.md
+++ b/tests/README.md
@@ -209,20 +209,37 @@ terminal *take* additionally skips itself with a message if `os.name` is not
 
 The runner deletes every `DEMO_VIDEO_*` variable plus `ELEVENLABS_API_KEY` from
 its own environment before recording, so a sourced project `.env` cannot change
-what the test measures. Every take then forces narration off (`speech=False`).
+what the test measures. Every take then forces narration off (`speech=False`) —
+except one.
 
-**Nothing here exercises the speech path any more, and that is a gap this file
-states rather than leaves to be discovered.** One take used to record with
-`speech=True` against a stubbed synthesizer, because the `.tts/` cache was a
-leak path it had to prove clean and with narration off it does not exist. That
-take went with the masking ([#138](https://github.com/rogvid/skills/issues/138)),
-and the synthesizer, the cache key, the pacing and the ffmpeg audio mix went
-ungraded with it. See "Known gaps".
+**The narration take records with `speech=True`, from a seeded cache**
+([#157](https://github.com/rogvid/skills/issues/157)). The speech path had been
+graded only by accident: the redaction axis swept every file a take wrote for a
+registered value, `.tts/` was one of those files, so some take had to really
+synthesize speech for that sweep to mean anything. #150 deleted the sweep and
+with it the only reason anything ran the synthesizer, the pacing or the mix.
+
+What makes it affordable to grade on purpose: `tts_clip` returns a cached clip
+*before* it reads `api_key`, and the recorder only requires the env var to be
+non-empty. So a take whose every line is already in `.tts/` runs the entire real
+path with no key, no network, and none of the non-determinism a remote service
+brings. The clips are tones of a known length rather than speech, which is what
+makes the pacing bar exact — a real clip's duration is whatever ElevenLabs
+decided, and a bar you cannot predict is one you end up widening until it
+passes.
+
+The cache is seeded by a key this file computes **by hand**, not by calling
+`_tts_key`. A harness that seeded itself through the function under test would
+agree with that function's bugs by construction, and a key that dropped the
+voice would still find every clip. Here a divergence is a cache *miss*, and a
+miss fails the take.
+
+Still ungraded: the HTTP call itself and its retry ladder. See "Known gaps".
 
 ## What it asserts
 
-Ten independent axes, because a recorder can fail on any one of them while
-looking perfect on the other nine.
+Eleven independent axes, because a recorder can fail on any one of them while
+looking perfect on the other ten.
 
 **Artifacts** — `demo.mp4` and every still the storyboard asked for exist, were
 modified by *this* run rather than a previous one, clear a size floor
@@ -803,6 +820,55 @@ been watched to fail:
 | `srcdoc` leaves the stripped-attribute list | beat 6's `html` carries a srcdoc document, and the attribute |
 | the page ARIA snapshot returns `""` | beat 2's tree is 0 characters, under the 400 this grades |
 
+**Narration** — the take really spoke, waited for itself, and the audio landed
+where the line did. Recorded from a seeded cache, as described above.
+
+Four things, and the third is the one the axis exists for:
+
+- **nothing was synthesized.** `.tts/` holds exactly the files seeded before the
+  take and no more. A new file means the recorder computed a different key than
+  this harness did — the two are written independently on purpose — and went
+  looking for it.
+- **a beat cannot start while the previous line is still speaking.** The first
+  line's clip (1.6 s) outlasts its beat's hold (0.5 s), so the *next* beat's
+  `t_start` must be at least 1.6 s after the line began. `_finish_line` idles
+  between beats, so this gap is the only place the wait is observable.
+  **With a control**: the second line's clip is 0.3 s and finishes inside its
+  hold, so nothing is added — a recorder that idled a fixed amount after every
+  line passes the first bar and fails this one.
+- **the mix carries audio where a line is, and silence where none is.** Mean
+  volume over a 0.4 s window, measured with `volumedetect`. Inside the first
+  line it must clear −60 dBFS; over the window *before* it, it must stay under
+  −80. **Neither bar means anything alone.** A silent track passes every other
+  assertion in this suite — it is present, `aac`, stereo, 44.1 kHz, and exactly
+  as long as the video — and that is precisely the failure that leaves every
+  artifact looking healthy. A track of noise, or a mix that laid one clip across
+  the whole timeline, clears the loud bar everywhere and fails the quiet one.
+  Measured on the seeded tones: **−25 dBFS inside a line against −91 before
+  one**, so both bars sit a long way from either number.
+- **the stream is shaped the way `stitch()` needs.** `aac`, 2 channels,
+  44100 Hz. `_convert` pins these with `aformat` rather than letting `amix`
+  decide, because mono TTS clips otherwise yield a mono track that `-c copy`
+  cannot concatenate with the stereo silence of a segment that narrated nothing.
+
+**All four were fault-injected**, none of them having been watched to fail
+before:
+
+| break | what fired |
+|---|---|
+| `_finish_line` stops idling out the remaining clip | *the beat after a 1.6s line started 0.56s after it began — the recorder cut its own narration off* |
+| `_convert` takes the `anullsrc` branch with lines present | *the window inside the first line measures −91.0 dBFS, under the −60.0 this grades* |
+| `adelay` is pinned to 0 instead of the line's offset | *the window **before** the first line measures −19.4 dBFS — audio is playing where no line was spoken* |
+| the `aformat` filter is dropped from the graph | *audio channels is 1, expected 2 — stitch() cannot join streams that disagree* |
+| `_tts_key` hashes different text than the harness seeds | the take raises: `ElevenLabs TTS failed: Connection refused` |
+
+The last one is why `TTS_API_BASE` exists as a module constant. Before it, that
+break put `NARRATION_KEY` on the wire to `api.elevenlabs.io` and read a 401
+back — an outbound request carrying a fabricated credential to a third party, on
+a path somebody breaking things deliberately is *expected* to take. The take now
+pins the endpoint to a closed local port for its duration, so a miss cannot
+leave the machine.
+
 ### How the recording looks — the spotlight's exit, and the card a terminal segment opens on
 
 Two takes, and the only two in this file that grade defects **a human found by
@@ -1203,6 +1269,23 @@ Three things about how these are built are worth knowing before trusting them:
 
 Things a pass does **not** prove. They are listed because an assertion nobody
 knows is missing is worse than one that is openly absent.
+
+- **Nothing calls the ElevenLabs API.** The narration take grades everything a
+  cache hit reaches — the key, the pacing, the mix — and by construction never
+  takes the miss path, which is the point. So `tts_clip`'s request, its 429/5xx
+  retry ladder with backoff, the `.part`-then-rename that keeps a truncated
+  download out of the cache, and every error message it raises are unexercised.
+  A regression there costs a take at record time with a legible exception, which
+  is the mildest failure in this file — but it is a gap, and closing it needs a
+  local HTTP stub rather than a real key. `TTS_API_BASE` is the seam that would
+  take one.
+
+- **The no-lines audio branch is ungraded.** `_convert` gives a speech-enabled
+  segment that narrated nothing a track of `anullsrc` silence, so `stitch()`'s
+  `-c copy` concat sees uniform streams. Every take here either narrates or
+  disables speech, so that branch runs nowhere. Ironically it is exactly what
+  the mix injection above *produces*, which is how we know the silence is well
+  formed — but nothing asserts it is what a line-less segment gets.
 
 - **A conversion failure writes no `failure/` dump**, only the marker, the
   timeline with `duration: null` and the stderr line. The dump is built from

--- a/tests/smoke
+++ b/tests/smoke
@@ -65,12 +65,16 @@ Playwright 1.49 or newer: evidence uses `locator.aria_snapshot()`, and the
     tests/smoke --content-only
     tests/smoke --out-dir /tmp/smoke
 
-Narration is forced off (`speech=False`) throughout: CI has no
-ELEVENLABS_API_KEY and no assertion here depends on audio. The one take that
-exercised the speech path did so because the `.tts/` cache was a leak path it
-had to prove clean, and it went with the masking (#150) — so the synthesizer,
-the pacing and the audio mix are now **ungraded**, which is stated here rather
-than left to be discovered. See "Known gaps".
+Narration is forced off (`speech=False`) in every take but one: CI has no
+ELEVENLABS_API_KEY and nothing else here depends on audio.
+
+The exception is the narration take (#157), which records with `speech=True`
+against a **seeded cache**. `tts_clip` returns a cached clip before it reads
+`api_key`, so a take whose every line is already in `.tts/` runs the real path
+— pacing, the line log, the ffmpeg mix — with no key and no network. The
+endpoint is pinned at a closed local port for the length of that take, so a
+miss cannot reach the real service either. What stays ungraded is the HTTP
+call and its retry ladder; see "Known gaps".
 
 Unix only, because the terminal takes drive a PTY. The *package* no longer
 requires one — `demo_recording/__init__.py` resolves both recorders lazily
@@ -1202,6 +1206,88 @@ TERMINAL_EVIDENCE = [
         [],
     ),
 ]
+
+# -- the narration take (issue #157) ------------------------------------------
+#
+# The speech path used to be graded by accident. The redaction axis swept every
+# file a take wrote for a registered value, `.tts/` was one of those files, and
+# so some take had to really synthesize speech for the sweep to mean anything.
+# #150 deleted the sweep, and with it the only reason any take ran the
+# synthesizer, the pacing or the audio mix at all.
+#
+# **The trick that makes this affordable: a seeded cache.** `tts_clip` returns a
+# cached clip before it reads `api_key`, and the recorder only requires the env
+# var to be non-empty. So a take whose every line is already in `.tts/` runs the
+# entire real path — pacing, `_lines`, `media_duration`, the ffmpeg mix — with
+# no key, no network, and no non-determinism from a remote service. What stays
+# ungraded is the HTTP call and its retry ladder, which is stated in
+# tests/README.md rather than implied.
+#
+# The clips are tones of a known duration rather than speech, which is what
+# makes the pacing assertion exact: a real clip's length is whatever ElevenLabs
+# decided, and a bar you cannot predict is a bar you end up widening until it
+# passes.
+NARRATION_KEY = "not-a-real-key-and-must-never-be-used"
+# The recorder's narration defaults, written out by hand so this file computes
+# the cache path the way core.py does rather than by asking core.py.
+#
+# **Hand-written on purpose**, and this is the catalogue's "check that shares
+# the bug's blind spot" avoided deliberately: a harness that seeded its cache by
+# calling `_tts_key` would agree with that function's bugs by construction, and
+# a key that dropped the voice would still find every clip. Here, a key the
+# recorder computes differently from this file is a cache *miss*, the miss goes
+# to the network with a fake key, and the take fails loudly.
+#
+# If either default changes this file has to change with it, which is the cost
+# of that property and is meant to be paid.
+NARRATION_VOICE_ID = "EXAVITQu4vr4xnSDxMaL"
+NARRATION_MODEL_ID = "eleven_multilingual_v2"
+NARRATION_KEY_CHARS = 20
+
+# (line, clip seconds). The first is deliberately *long* against its beat's
+# hold, so the recorder has to wait it out and the wait is visible in the beat
+# log. The second is deliberately short, and is the control: if the pacing
+# assertion fired on any narrated line rather than on the one whose clip
+# outlasts its hold, a recorder that simply idled after every line would pass.
+NARRATION_LONG_LINE = "This line runs longer than the beat that carries it."
+NARRATION_LONG_S = 1.6
+NARRATION_SHORT_LINE = "This one is over quickly."
+NARRATION_SHORT_S = 0.3
+# The hold each of the two lines is given. The long clip outlasts its hold by
+# 1.1s; the short one finishes with 0.5s to spare.
+NARRATION_HOLD_S = 0.5
+NARRATION_LINES = (
+    (NARRATION_LONG_LINE, NARRATION_LONG_S),
+    (NARRATION_SHORT_LINE, NARRATION_SHORT_S),
+)
+
+# Mean volume, in dBFS, measured over a 0.4s window of the finished mp4.
+#
+# Both bars are needed and neither alone means anything:
+#
+#   * NARRATION_LOUD_DBFS — a window inside a spoken line has to carry audio.
+#     Without it, `anullsrc` silence passes every other assertion here: the
+#     stream is present, stereo, 44.1 kHz and exactly as long as the video.
+#     Silence is *the* failure this take exists to catch, because it is the one
+#     that leaves every artifact looking right.
+#   * NARRATION_QUIET_DBFS — a window before the first line has to be silent.
+#     Without it, a mix that laid one clip across the whole track, or a track of
+#     noise, passes the loud bar everywhere.
+#
+# Measured on the tone clips this take seeds: -25 dB inside a line against
+# -91 dB before one, so the bars sit either side of a 66 dB gap and are nowhere
+# near either measurement.
+NARRATION_LOUD_DBFS = -60.0
+NARRATION_QUIET_DBFS = -80.0
+NARRATION_WINDOW_S = 0.4
+# What `stitch()`'s lossless concat requires of every segment's audio, and the
+# reason `_convert` pins the format rather than letting amix decide: mono TTS
+# clips would otherwise yield a mono track that `-c copy` cannot join with the
+# stereo silence of a segment that narrated nothing.
+NARRATION_CODEC = "aac"
+NARRATION_CHANNELS = 2
+NARRATION_SAMPLE_RATE = 44100
+
 
 # -- the evidence take (issue #9) ---------------------------------------------
 #
@@ -7418,6 +7504,289 @@ def run_evidence(out_root: Path) -> list[str]:
     return failures
 
 
+def seed_tts_cache(out_dir: Path) -> dict[str, Path]:
+    """Put a clip of known duration where the recorder will look for one.
+
+    The key is computed here rather than imported — see `NARRATION_VOICE_ID`
+    for why that separation is the point and not an oversight.
+    """
+    tts = out_dir / ".tts"
+    tts.mkdir(parents=True, exist_ok=True)
+    seeded: dict[str, Path] = {}
+    for text, seconds in NARRATION_LINES:
+        joined = f"{NARRATION_VOICE_ID}|{NARRATION_MODEL_ID}|{text}"
+        key = hashlib.sha256(joined.encode()).hexdigest()[:NARRATION_KEY_CHARS]
+        clip = tts / f"{key}.mp3"
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                f"sine=frequency=440:duration={seconds}",
+                "-b:a",
+                "128k",
+                str(clip),
+            ],
+            check=True,
+        )
+        seeded[text] = clip
+    return seeded
+
+
+def mean_dbfs(mp4: Path, start: float, seconds: float) -> float | None:
+    """Mean volume of one window of the mp4's audio, in dBFS.
+
+    `None` when ffmpeg reported no measurement at all, which is a different
+    failure from a quiet window and is reported as one.
+    """
+    done = subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "info",
+            "-ss",
+            f"{start}",
+            "-t",
+            f"{seconds}",
+            "-i",
+            str(mp4),
+            "-af",
+            "volumedetect",
+            "-f",
+            "null",
+            "-",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    match = re.search(r"mean_volume:\s*(-?\d+(?:\.\d+)?) dB", done.stderr)
+    return float(match.group(1)) if match else None
+
+
+def record_narration(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
+    """A take that really narrates, from a cache seeded before it starts."""
+    from demo_recording import Recorder, narration
+
+    b = Beats("narration")
+    seeded = seed_tts_cache(out_dir)
+    before = sorted(p.name for p in (out_dir / ".tts").iterdir())
+
+    # Point a cache miss at a closed local port. Every line here is seeded, so
+    # nothing should be requested — this is what makes that "cannot" rather
+    # than "should": when a break makes the recorder compute a different key
+    # than `seed_tts_cache` did, the miss dies against a dead socket in
+    # milliseconds. Before this, that break put NARRATION_KEY on the wire to
+    # api.elevenlabs.io and read the 401 back, which is a network dependency
+    # and a fabricated credential sent to a third party, on a path a test is
+    # *expected* to take while someone is breaking things deliberately.
+    real_base = narration.TTS_API_BASE
+    narration.TTS_API_BASE = f"http://127.0.0.1:{free_port()}/v1/text-to-speech"
+
+    # The recorder reads this at construction and refuses `speech=True`
+    # without it. It is never sent anywhere: every line is a cache hit, and
+    # `tts_clip` returns before it builds a request.
+    os.environ["ELEVENLABS_API_KEY"] = NARRATION_KEY
+    try:
+        with Recorder(out_dir, base_url=base_url, speech=True, strict=True) as rec:
+            b.expect("constructing with speech=True", rec._speech, True)
+            rec.goto("/")
+            rec.wait_for("#kpi-rev")
+            rec.interlude(NARRATION_LONG_LINE, hold=NARRATION_HOLD_S)
+            rec.caption(NARRATION_SHORT_LINE)
+            rec.pause(NARRATION_HOLD_S)
+            rec.caption("")
+            rec.pause(0.4)
+            lines = list(rec._lines)
+    finally:
+        os.environ.pop("ELEVENLABS_API_KEY", None)
+        narration.TTS_API_BASE = real_base
+
+    after = sorted(p.name for p in (out_dir / ".tts").iterdir())
+    b.fail_if(
+        after != before,
+        f"the take wrote to .tts/: {sorted(set(after) - set(before))}. Every "
+        f"line was seeded, so a new file means the recorder computed a "
+        f"different key than this file did and went to the network for it",
+    )
+    b.expect("recording two narrated lines", len(lines), len(NARRATION_LINES))
+    return b.problems, {"lines": lines, "seeded": seeded}
+
+
+def check_narration_pacing(out_dir: Path) -> list[str]:
+    """A beat cannot start while the previous line is still being spoken."""
+    label = "narration"
+    failures: list[str] = []
+    doc = json.loads((out_dir / "timeline.json").read_text())
+    beats = doc.get("beats", [])
+
+    def after(verb: str, caption: str) -> tuple[dict, dict] | None:
+        for i, beat in enumerate(beats[:-1]):
+            if beat.get("verb") == verb and beat.get("caption") == caption:
+                return beat, beats[i + 1]
+        return None
+
+    long_pair = after("interlude", NARRATION_LONG_LINE)
+    short_pair = after("caption", NARRATION_SHORT_LINE)
+    if long_pair is None or short_pair is None:
+        return [
+            f"{label}: timeline.json has no interlude/caption pair to measure "
+            f"pacing over — verbs recorded: "
+            f"{[b.get('verb') for b in beats]}"
+        ]
+
+    # The long clip outlasts its beat's hold, so the *next* beat cannot begin
+    # until the clip has finished. This is the only observable the pacing has:
+    # `_finish_line` idles between beats, so the wait lands in the gap rather
+    # than inside either one.
+    line, following = long_pair
+    elapsed = float(following["t_start"]) - float(line["t_start"])
+    if elapsed < NARRATION_LONG_S:
+        failures.append(
+            f"{label}: the beat after a {NARRATION_LONG_S}s line started "
+            f"{elapsed:.2f}s after it began — the recorder cut its own "
+            f"narration off, and the mp4 carries a clip that outlives the "
+            f"caption it belongs to"
+        )
+
+    # The control, and the reason the bar above is not "everything is slow":
+    # the short clip finishes inside its hold, so nothing is added. A recorder
+    # that idled a fixed amount after every line would pass the assertion above
+    # and fail this one.
+    line, following = short_pair
+    elapsed = float(following["t_start"]) - float(line["t_start"])
+    if elapsed >= NARRATION_LONG_S:
+        failures.append(
+            f"{label}: the beat after a {NARRATION_SHORT_S}s line was held "
+            f"{elapsed:.2f}s, past even the long line's clip — the wait is not "
+            f"the clip's length, so the assertion above grades nothing"
+        )
+    return failures
+
+
+def check_narration_audio(out_dir: Path, lines: list) -> list[str]:
+    """The mp4 carries audio where a line is, and silence where none is."""
+    label = "narration"
+    failures: list[str] = []
+    mp4 = out_dir / "demo.mp4"
+
+    probe = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=codec_name,channels,sample_rate,duration",
+            "-of",
+            "json",
+            str(mp4),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    streams = json.loads(probe.stdout or "{}").get("streams", [])
+    if len(streams) != 1:
+        return [
+            f"{label}: demo.mp4 carries {len(streams)} audio streams, expected "
+            f"exactly 1 — a take with narration on and no track is a silent "
+            f"demo that every other artifact reports as healthy"
+        ]
+    stream = streams[0]
+    for field, wanted in (
+        ("codec_name", NARRATION_CODEC),
+        ("channels", NARRATION_CHANNELS),
+        ("sample_rate", str(NARRATION_SAMPLE_RATE)),
+    ):
+        if str(stream.get(field)) != str(wanted):
+            failures.append(
+                f"{label}: demo.mp4's audio {field} is {stream.get(field)!r}, "
+                f"expected {wanted!r} — stitch() concatenates segments with "
+                f"-c copy and cannot join streams that disagree"
+            )
+
+    # The first line's offset, as the recorder logged it. Measured from the
+    # recorder's own `_lines` rather than from the beat log, because that list
+    # is what `_convert` turns into `adelay` values — grading the mix against
+    # anything else would grade agreement between two records instead of
+    # whether the audio is where the recorder said it put it.
+    if not lines:
+        return failures + [f"{label}: the recorder logged no narration lines"]
+    first_offset = float(lines[0][0])
+
+    loud = mean_dbfs(mp4, first_offset + 0.1, NARRATION_WINDOW_S)
+    if loud is None:
+        failures.append(
+            f"{label}: ffmpeg reported no volume for the window at "
+            f"{first_offset + 0.1:.2f}s — the measurement itself failed, which "
+            f"is not the same as a silent window"
+        )
+    elif loud < NARRATION_LOUD_DBFS:
+        failures.append(
+            f"{label}: the {NARRATION_WINDOW_S}s window inside the first "
+            f"narration line measures {loud:.1f} dBFS, under the "
+            f"{NARRATION_LOUD_DBFS} dBFS this grades — the track is there and "
+            f"silent, which every other assertion in this suite reads as a "
+            f"healthy take"
+        )
+
+    # The control. Before the first line there is nothing to hear, and a mix
+    # that smeared one clip across the whole track — or a track of noise —
+    # passes the bar above everywhere.
+    if first_offset < NARRATION_WINDOW_S + 0.1:
+        failures.append(
+            f"{label}: the first line starts at {first_offset:.2f}s, too early "
+            f"to measure a silent window before it — this take's storyboard is "
+            f"supposed to leave room, so the control is missing"
+        )
+    else:
+        quiet = mean_dbfs(mp4, 0.0, NARRATION_WINDOW_S)
+        if quiet is None:
+            failures.append(
+                f"{label}: ffmpeg reported no volume for the opening window"
+            )
+        elif quiet > NARRATION_QUIET_DBFS:
+            failures.append(
+                f"{label}: the {NARRATION_WINDOW_S}s window *before* the first "
+                f"line measures {quiet:.1f} dBFS, over the "
+                f"{NARRATION_QUIET_DBFS} dBFS this grades — audio is playing "
+                f"where no line was spoken, so 'loud inside a line' says "
+                f"nothing about the mix"
+            )
+    return failures
+
+
+def run_narration(out_root: Path) -> list[str]:
+    """Speech end to end, from a seeded cache: pacing and the audio mix."""
+    out_dir = fresh_take_dir(out_root, "narration")
+    with fixture_server() as base_url:
+        try:
+            problems, info = record_narration(out_dir, base_url)
+        except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+            return [f"narration: Recorder raised {type(exc).__name__}: {exc}"]
+    mp4 = out_dir / "demo.mp4"
+    if not mp4.is_file():
+        return problems + [f"narration: {mp4} was never written"]
+    failures = (
+        problems
+        + check_narration_pacing(out_dir)
+        + check_narration_audio(out_dir, info["lines"])
+        + check_healthy("narration", out_dir)
+    )
+    if not failures:
+        offsets = ", ".join(f"{off:.2f}s" for off, _ in info["lines"])
+        print(
+            f"smoke: narration ok ({len(info['lines'])} lines spoken from a "
+            f"seeded cache at {offsets}, no key sent, audio present where a "
+            f"line is and silent before the first)"
+        )
+    return failures
+
+
 def run_terminal(out_root: Path) -> list[str]:
     if os.name != "posix":
         print(
@@ -8264,6 +8633,11 @@ def main() -> int:
         help="record only the per-beat evidence take (issue #9)",
     )
     parser.add_argument(
+        "--narration-only",
+        action="store_true",
+        help="record only the speech take, from a seeded cache (issue #157)",
+    )
+    parser.add_argument(
         "--failure-only",
         action="store_true",
         help="record only the takes that do not finish (issues #11/#20/#24/#46)",
@@ -8315,6 +8689,7 @@ def main() -> int:
             ("--determinism-only", args.determinism_only),
             ("--segments-only", args.segments_only),
             ("--evidence-only", args.evidence_only),
+            ("--narration-only", args.narration_only),
             ("--failure-only", args.failure_only),
             ("--polish-only", args.polish_only),
             ("--content-only", args.content_only),
@@ -8406,6 +8781,11 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
         failures += run_strict_web(out_root)
     if only in (None, "--web-only", "--evidence-only"):
         failures += run_evidence(out_root)
+    # Speech end to end (issue #157). A web take, so it is reachable from
+    # --web-only as well as its own flag — whoever changes the narration path
+    # is running one of the two.
+    if only in (None, "--web-only", "--narration-only"):
+        failures += run_narration(out_root)
     if only in (None, "--terminal-only"):
         failures += run_terminal_problems(out_root)
         failures += run_terminal_race(out_root)

--- a/tests/unit
+++ b/tests/unit
@@ -68,6 +68,11 @@ from demo_recording.coverage import (  # noqa: E402
     _merged_coverage,
     coverage_report,
 )
+from demo_recording.narration import (  # noqa: E402
+    TTS_KEY_CHARS,
+    TTS_KEY_SEP,
+    _tts_key,
+)
 from demo_recording.timeline import (  # noqa: E402
     _coverage_md,
     _fmt_t,
@@ -556,6 +561,100 @@ class MergeContent(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# narration.py — the cache key (issue #157)
+# --------------------------------------------------------------------------
+#
+# The whole speech path was ungraded until #157. It had been graded by accident:
+# the redaction axis swept everything a take wrote for a registered value, and
+# `.tts/` was one of those things, so some take had to really synthesize speech
+# for that sweep to mean anything. #150 deleted the sweep and with it the only
+# reason any take ran the synthesizer at all.
+#
+# What is graded here is the key, because the key is where a wrong answer is
+# **invisible**. Every other failure in this path announces itself: no clip
+# means no audio, a broken mix means ffmpeg exits non-zero. A key that drops
+# the voice hands a take recorded in one voice the clips of another, and the
+# mp4 comes out with a full, correctly-timed, entirely wrong-sounding track —
+# which no assertion downstream of it can tell from a right one.
+#
+# The pacing and the audio mix are graded end to end in `tests/smoke`, against
+# a seeded cache: `tts_clip` returns a cached clip before it reads `api_key`,
+# so a take whose lines are all hits runs the real path with no network. What
+# stays ungraded is the HTTP call itself and its retry ladder.
+
+
+class TtsKey(unittest.TestCase):
+    LINE = "The queue can be filtered to one status."
+    VOICE = "EXAVITQu4vr4xnSDxMaL"
+    MODEL = "eleven_multilingual_v2"
+
+    def key(self, text=None, voice=None, model=None) -> str:
+        return _tts_key(
+            self.LINE if text is None else text,
+            self.VOICE if voice is None else voice,
+            self.MODEL if model is None else model,
+        )
+
+    def test_the_same_line_in_the_same_voice_is_the_same_clip(self):
+        # The point of the cache: a retake of an unchanged storyboard hits the
+        # API zero times. Without this the key is a cache that never hits.
+        self.assertEqual(self.key(), self.key())
+
+    def test_each_of_the_three_inputs_changes_the_key_on_its_own(self):
+        # Named separately in the failure message, because "the key changed"
+        # is satisfied by a key that varies on text alone — which is the exact
+        # bug: switching voice would then replay the previous voice's audio.
+        base = self.key()
+        for label, other in (
+            ("text", self.key(text=self.LINE + " ")),
+            ("voice", self.key(voice="21m00Tcm4TlvDq8ikWAM")),
+            ("model", self.key(model="eleven_turbo_v2")),
+        ):
+            with self.subTest(input=label):
+                self.assertNotEqual(base, other, f"{label} is not in the key")
+
+    def test_the_separator_is_one_no_voice_or_model_id_can_hold(self):
+        # Joining three fields is only unambiguous because the separator
+        # cannot occur in the first two. Voice and model ids are alphanumeric,
+        # so the contract is exactly "not alphanumeric" — asserted here rather
+        # than left to the comment that states it.
+        #
+        # Graded on the property, not on the character: `assertEqual(SEP, "|")`
+        # would pass for any separator somebody typed, including `a`, which is
+        # the break this is here to catch.
+        self.assertTrue(TTS_KEY_SEP, "there is no separator at all")
+        self.assertFalse(
+            any(c.isalnum() for c in TTS_KEY_SEP),
+            f"{TTS_KEY_SEP!r} can occur in a voice or model id, so two "
+            f"different takes can hash the same string",
+        )
+
+    def test_moving_a_field_boundary_changes_the_key(self):
+        # The separator's job, stated as behaviour: these two triples have the
+        # same naive concatenation, and must not share a clip. Holds for any
+        # separator; fails for none at all.
+        self.assertNotEqual(
+            _tts_key(text="c", voice_id="a", model_id="b"),
+            _tts_key(text="", voice_id="ab", model_id="c"),
+        )
+
+    def test_the_key_is_a_filename_stem_and_not_a_path(self):
+        # It is interpolated straight into `cache_dir / f"{key}.mp3"`. A key
+        # holding a slash or a dot would write outside the cache directory or
+        # collide with the `.part` file the atomic rename uses.
+        #
+        # **20 is written out, not read from `TTS_KEY_CHARS`.** The code slices
+        # by that constant, so comparing the length against it would be the
+        # catalogue's environment-agreeing assertion: it holds for any value
+        # either of them takes, and grades nothing. Shortening the key is a
+        # decision about collision odds, and it should cost an edit here.
+        key = self.key()
+        self.assertEqual(len(key), 20)
+        self.assertEqual(TTS_KEY_CHARS, 20)
+        self.assertTrue(all(c in "0123456789abcdef" for c in key), key)
+
+
+# --------------------------------------------------------------------------
 # SKILL.md and its reference/ files (issue #140)
 # --------------------------------------------------------------------------
 #
@@ -884,6 +983,45 @@ INJECTIONS = [
         "| [reference/narration.md](reference/narration.md) | When",
         "| reference/narration.md | When",
         ["SkillDocs.test_every_reference_file_is_linked_from_skill_md"],
+    ),
+    (
+        "the narration cache keys on the line alone, ignoring the voice",
+        "narration.py",
+        "TTS_KEY_SEP.join((voice_id, model_id, text))",
+        "text",
+        ["TtsKey.test_each_of_the_three_inputs_changes_the_key_on_its_own"],
+    ),
+    (
+        # Same search string as the entry above, different break: that one
+        # drops voice *and* model, this one drops the model alone. The pair is
+        # the difference between "the key varies" and "the key varies with
+        # each input", which is the claim the test actually makes.
+        "the narration cache key drops the model but keeps the voice",
+        "narration.py",
+        "TTS_KEY_SEP.join((voice_id, model_id, text))",
+        "TTS_KEY_SEP.join((voice_id, text))",
+        ["TtsKey.test_each_of_the_three_inputs_changes_the_key_on_its_own"],
+    ),
+    (
+        "the three fields are joined with nothing between them",
+        "narration.py",
+        "TTS_KEY_SEP.join((voice_id, model_id, text))",
+        '"".join((voice_id, model_id, text))',
+        ["TtsKey.test_moving_a_field_boundary_changes_the_key"],
+    ),
+    (
+        "the key's separator becomes a character a voice id can hold",
+        "narration.py",
+        'TTS_KEY_SEP = "|"',
+        'TTS_KEY_SEP = "a"',
+        ["TtsKey.test_the_separator_is_one_no_voice_or_model_id_can_hold"],
+    ),
+    (
+        "the cache key is shortened, raising the collision odds silently",
+        "narration.py",
+        "TTS_KEY_CHARS = 20",
+        "TTS_KEY_CHARS = 12",
+        ["TtsKey.test_the_key_is_a_filename_stem_and_not_a_path"],
     ),
     (
         "a deletion leaves a constant in tests/smoke that nothing reads",


### PR DESCRIPTION
## Acceptance

> At least the cache key and the audio-mix presence have an assertion that has
> been seen to fail. Whatever is left ungraded after that is named explicitly in
> `tests/README.md` with the reason.

Met, with two more than asked for: pacing and the stream shape. The issue
scoped grading the real synthesizer to a separate piece of work needing "a
binary and a network" — it turns out not to.

## The seeded cache

`tts_clip` returns a cached clip **before it reads `api_key`**, and the
constructor only requires the env var to be non-empty. So a take whose every
line is already in `.tts/` runs the entire real path — pacing, the line log,
`media_duration`, the ffmpeg mix — with no key, no network, and none of the
non-determinism a remote service brings.

The clips are tones of a known length rather than speech, which is what makes
the pacing bar exact. A real clip's duration is whatever ElevenLabs decided, and
a bar you cannot predict is one you end up widening until it passes.

**The cache is seeded by a key `tests/smoke` computes by hand**, not by calling
`_tts_key`. A harness that seeded itself through the function under test would
agree with that function's bugs by construction — a key that dropped the voice
would still find every clip. Here a divergence is a cache miss, and a miss fails
the take. Same separation the deleted `TTS_VOICE_ID` / `TTS_MODEL_ID` constants
had, restored deliberately.

## `tts_clip` moves to `narration.py`

It has no Playwright dependency and never did — it was lazily exported only
because it lived in `core`, which imports Playwright at module scope. A cache
key is a function of three strings and should not cost a browser to check.
`_LAZY` is now down to the two recorders.

Two seams came out of the move:

- **`TTS_KEY_SEP`** — so the separator's contract is checkable rather than only
  asserted in a comment. It must be a character no voice or model id can hold
  (they are alphanumeric), and that is what makes the concatenation unambiguous.
- **`TTS_API_BASE`** — so a caller that must not reach the real service can say
  so. See the last injection below for why this is not optional.

## What is graded

**`tests/unit`** — 52 tests, no browser: the key is stable; each of the three
inputs changes it on its own; moving a field boundary changes it; the separator
cannot occur in an id; the key is a filename stem.

**`tests/smoke`** — a new ~10 s take:

| | |
|---|---|
| nothing was synthesized | `.tts/` holds exactly the seeded files |
| a beat cannot start mid-line | the next beat's `t_start` is ≥ the 1.6 s clip's length after the line began |
| the mix carries audio where a line is | ≥ −60 dBFS inside the first line |
| …and silence where none is | ≤ −80 dBFS in the window before it |
| the stream is what `stitch()` needs | `aac`, 2ch, 44100 Hz |

**Both halves have controls, and that is the point of each pair.** The second
line's clip (0.3 s) finishes inside its hold, so a recorder that idled a fixed
amount after every line passes the pacing bar and fails the control. And a
silent track passes every *other* assertion in this suite — present, `aac`,
stereo, 44.1 kHz, exactly as long as the video — which is why "loud inside a
line" is paired with "quiet before the first". Measured: **−25 dBFS inside a
line against −91 before one**, so both bars sit a long way from either number.

## Injected — nine new entries, all watched to fail

```
_finish_line stops idling   the beat after a 1.6s line started 0.56s after
                            it began — the recorder cut its own narration off
the mix lays down silence   the window inside the first line measures
                            -91.0 dBFS, under the -60.0 this grades
adelay pinned to 0          the window *before* the first line measures
                            -19.4 dBFS — audio is playing where no line was
aformat dropped             audio channels is 1, expected 2 — stitch() cannot
                            join streams that disagree
the key stops matching      ElevenLabs TTS failed: Connection refused
```

Plus four in `narration.py` against `tests/unit`. **26 of 26 injections caught.**

### The last injection is why `TTS_API_BASE` exists

Before it, that break put the harness's fake key **on the wire to
`api.elevenlabs.io`** and read a 401 back. An outbound request carrying a
fabricated credential to a third party, on a path somebody breaking things
deliberately is *expected* to take, from a test whose whole claim is that it
needs no network. The take now pins the endpoint to a closed local port for its
duration, so a miss dies against a dead socket in milliseconds and cannot leave
the machine.

## Two corrections to my own assertions before they shipped

- **The key-length test was tautological.** It compared `len(key)` against
  `TTS_KEY_CHARS` — the constant the code slices by — so it held for any value
  either took. Now pinned to a literal `20`.
- **The separator test defended the wrong property.** Its injection changed `|`
  to `a` and the test stayed green, because the collision I constructed only
  collides under `|`. The contract is "not a character an id can hold", so that
  is what it asserts now.

## Stated limits

- **Nothing calls the ElevenLabs API.** By construction — the take never takes
  the miss path. So the request, the 429/5xx retry ladder, and the
  `.part`-then-rename that keeps a truncated download out of the cache are
  unexercised. A regression there costs a take at record time with a legible
  exception, which is the mildest failure in this file. Closing it needs a local
  HTTP stub; `TTS_API_BASE` is the seam that would take one.
- **The no-lines `anullsrc` branch is ungraded.** A speech-enabled segment that
  narrated nothing gets a silent track so `stitch()`'s `-c copy` sees uniform
  streams. Every take here either narrates or disables speech. It is exactly
  what the mix injection *produces*, so we know the silence is well formed — but
  nothing asserts a line-less segment gets it.
- **The take adds ~10 s to smoke.** It is a web take and reachable from
  `--web-only` as well as `--narration-only`.

Both limits are in `tests/README.md`'s Known gaps, not only here.

## Verification

- full `tests/smoke`: **PASSED**, 98 reported checks (up from 95)
- `tests/unit`: 52 tests; `--fault-inject`: 26/26
- `ruff==0.14.2` check + format, `mypy==1.18.2` over 11 files: clean

Fixes #157
