### PR TITLE
Narrow the package's front door to the six names the documentation imports (#148)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -312,7 +312,8 @@ return.
    of real background work, don't record the wait — record **segments**:
    `Recorder(out_dir, segment="part1")`, poll between segments until the
    work is done, open the next segment with `rec.interlude("…a few minutes
-   later…")` on `about:blank` before navigating, and `stitch()` into
+   later…")` on `about:blank` before navigating, and
+   `from demo_recording import stitch` to concatenate them into
    demo.mp4. A **terminal** segment takes its opening card as
    `TerminalRecorder(interlude="…")` instead — see
    [reference/terminal.md](reference/terminal.md). `stitch()` also merges the segments' beat logs into one

--- a/skills/demo-video/helpers/demo_recording/__init__.py
+++ b/skills/demo-video/helpers/demo_recording/__init__.py
@@ -6,13 +6,42 @@ Storyboards import from here:
     from demo_recording import TerminalRecorder   # CLIs / TUIs
     from demo_recording import stitch             # concat segments -> demo.mp4
 
-**The two recorders are imported lazily, and that is load-bearing rather than
-an optimisation.** Everything else this package exposes — the timeline schema
-and its two renderings, the coverage report, the content and opening
-measurements, the review-frame manifest, `stitch` — is a function of documents
-and files, with no third-party dependency at all. Importing any of it used to
-require Playwright, because this file imported both recorders eagerly and
-`core` imports Playwright at module scope.
+## What this package promises, and what it does not
+
+**`__all__` is the storyboard surface, and nothing else** (issue #148). Six
+names: the two recorders, `stitch`, the exception a strict take raises, and the
+two helpers the documentation tells you to re-run on a demo you already have —
+`beat_frames` to regenerate review frames, `content_report` to re-measure the
+picture. Those six are what SKILL.md and `reference/` describe, and they are the
+contract.
+
+It used to be fifty. The package re-exported every threshold, schema constant
+and writer the recorder owns, because `tests/smoke` read the recorder's own
+internals back through the front door to grade itself — the shallow module in
+its plainest form, an interface as wide as its implementation. A storyboard
+author opening this file met `CONTENT_MOVED_PIXELS` before `Recorder`.
+
+**Nothing became unreachable.** Every one of those names still lives in the
+module that owns it and is imported from there:
+
+    from demo_recording.timeline import TIMELINE_SCHEMA, render_timeline_md
+    from demo_recording.content import media_duration, merge_content
+    from demo_recording.frames import scene_times
+
+That is the distinction being drawn, and it is the only one: **a test may reach
+into the module it is testing; a storyboard may not.** `tests/smoke` and
+`tests/unit` both import through the owning module now. If you are consuming
+`timeline.json` programmatically from outside this repository, its schema and
+its renderer are `demo_recording.timeline`'s and always were — they are not
+private, they are simply not part of the storyboard surface, and this package
+does not promise them a stable front door.
+
+## Why the recorders are imported lazily
+
+Everything else this package exposes is a function of documents and files, with
+no third-party dependency at all. Importing any of it used to require Playwright,
+because this file imported both recorders eagerly and `core` imports Playwright
+at module scope.
 
 Two consequences followed, and both were bugs:
 
@@ -33,65 +62,20 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .content import (
-    CONTENT_ACTING_VERBS,
-    CONTENT_BLANK_FLOOR,
-    CONTENT_MOVED_PIXELS,
-    CONTENT_PASSIVE_VERBS,
-    CONTENT_PIXEL_DELTA,
-    CONTENT_SAMPLE_FPS,
-    CONTENT_STATIC_WARN_S,
-    OPENING_HOLD_LIMIT_S,
-    OPENING_SAMPLE_FPS,
-    OPENING_SEARCH_S,
-    OPENING_WARN_S,
-    content_rect,
-    content_report,
-    media_duration,
-    merge_content,
-    opening_gap,
-    opening_report,
-    opening_warning,
-    print_content_summary,
-)
-from .coverage import coverage_report
-from .failure import FAILURE_DIR, FAILURE_MARKER, FAILURE_SCHEMA
-from .frames import (
-    FRAMES_SCHEMA,
-    SCENE_MIN_SPAN_S,
-    beat_frames,
-    frames_paths,
-    render_frames_md,
-    scene_times,
-    write_beat_frames,
-)
-from .narration import tts_clip
+from .content import content_report
+from .frames import beat_frames
 from .stitching import stitch
-from .timeline import (
-    EVIDENCE_DIR,
-    EVIDENCE_LIMITS,
-    EVIDENCE_SCHEMA,
-    EVIDENCE_TRUNCATED,
-    ISSUE_KINDS,
-    MAX_ISSUES,
-    STRICT_KINDS,
-    TIMELINE_SCHEMA,
-    StrictTakeFailed,
-    evidence_name,
-    render_timeline_md,
-    timeline_paths,
-    write_timeline,
-)
+from .timeline import StrictTakeFailed
 
 if TYPE_CHECKING:  # the real classes, for type checkers and editors only
     from .terminal import TerminalRecorder
     from .web import Recorder
 
-# Everything that cannot be reached without Playwright — which is now only the
-# two recorders. `tts_clip` used to be here too, for the same reason: it lived
-# in `core`, which imports Playwright at module scope. It does not need one
-# (a cache key is a function of three strings), so #157 moved it to
-# `narration` and it is imported eagerly above like everything else.
+# Everything that cannot be reached without Playwright — which is only the two
+# recorders. `tts_clip` used to be here too, for the same reason: it lived in
+# `core`, which imports Playwright at module scope. It does not need one (a
+# cache key is a function of three strings), so #157 moved it to `narration`,
+# where `tests/unit` reaches it directly.
 _LAZY = {
     "Recorder": ".web",
     "TerminalRecorder": ".terminal",
@@ -118,51 +102,10 @@ def __dir__() -> list[str]:
 
 
 __all__ = [
-    "CONTENT_ACTING_VERBS",
-    "CONTENT_BLANK_FLOOR",
-    "CONTENT_MOVED_PIXELS",
-    "CONTENT_PASSIVE_VERBS",
-    "CONTENT_PIXEL_DELTA",
-    "CONTENT_SAMPLE_FPS",
-    "CONTENT_STATIC_WARN_S",
-    "EVIDENCE_DIR",
-    "EVIDENCE_LIMITS",
-    "EVIDENCE_SCHEMA",
-    "EVIDENCE_TRUNCATED",
-    "FAILURE_DIR",
-    "FAILURE_MARKER",
-    "FAILURE_SCHEMA",
-    "FRAMES_SCHEMA",
-    "ISSUE_KINDS",
-    "MAX_ISSUES",
-    "OPENING_HOLD_LIMIT_S",
-    "OPENING_SAMPLE_FPS",
-    "OPENING_SEARCH_S",
-    "OPENING_WARN_S",
     "Recorder",
-    "SCENE_MIN_SPAN_S",
-    "STRICT_KINDS",
     "StrictTakeFailed",
-    "TIMELINE_SCHEMA",
     "TerminalRecorder",
     "beat_frames",
     "content_report",
-    "content_rect",
-    "coverage_report",
-    "evidence_name",
-    "frames_paths",
-    "media_duration",
-    "merge_content",
-    "opening_gap",
-    "opening_report",
-    "opening_warning",
-    "print_content_summary",
-    "render_frames_md",
-    "render_timeline_md",
-    "scene_times",
     "stitch",
-    "timeline_paths",
-    "tts_clip",
-    "write_beat_frames",
-    "write_timeline",
 ]

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -74,9 +74,15 @@ record in parts is a demo nobody wants to review by scrubbing.
 
 `frames/` is a review artifact, not documentation: **gitignore it** along with
 `demo.mp4` — it is in the file table at the top for the same reason. Nothing
-downstream reads it; `beat_frames(out_dir)` from `demo_recording` regenerates
-it from `demo.mp4` and `timeline.json` without re-recording, and clears the
-previous run's frames first.
+downstream reads it; `beat_frames(out_dir)` regenerates it from `demo.mp4` and
+`timeline.json` without re-recording, and clears the previous run's frames
+first:
+
+```python
+from demo_recording import beat_frames
+
+beat_frames(Path("demos/2026-07-26-x"))
+```
 
 ## Per-beat evidence (`evidence/beat-NN.json`)
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -2831,7 +2831,7 @@ def _check_video(
     duration_range: tuple[float, float],
     video_rect: Rect,
 ) -> list[str]:
-    from demo_recording import media_duration
+    from demo_recording.content import media_duration
 
     failures: list[str] = []
     size = mp4.stat().st_size
@@ -3405,7 +3405,8 @@ def check_coverage_refusals(out_root: Path) -> list[str]:
     """Tagging and declaring are refused where they would produce a wrong
     report. No browser: `Recorder(...)` does not launch one until `__enter__`.
     """
-    from demo_recording import Recorder, coverage_report
+    from demo_recording import Recorder
+    from demo_recording.coverage import coverage_report
 
     failures: list[str] = []
     out = out_root / "coverage-refusals"
@@ -3589,7 +3590,7 @@ def check_opening_gap(out_root: Path) -> list[str]:
     frame to last must measure a 0.0 gap. Delete the floor and this is the
     assertion that goes red.
     """
-    from demo_recording import opening_gap
+    from demo_recording.content import opening_gap
 
     failures: list[str] = []
     root = out_root / "opening-gap"
@@ -3653,7 +3654,7 @@ def check_verb_classification() -> list[str]:
     the arm quietly stops noticing a whole class of demo. Free to check, and it
     needs no recording.
     """
-    from demo_recording import CONTENT_ACTING_VERBS, CONTENT_PASSIVE_VERBS
+    from demo_recording.content import CONTENT_ACTING_VERBS, CONTENT_PASSIVE_VERBS
 
     declared = declared_verbs()
     if len(declared) < 15:
@@ -4398,7 +4399,8 @@ def check_timeline(
     segment each beat was recorded in (all None for a single take), and
     `expected_interludes` the lines any `interlude` beats show.
     """
-    from demo_recording import TIMELINE_SCHEMA, media_duration
+    from demo_recording.content import media_duration
+    from demo_recording.timeline import TIMELINE_SCHEMA
 
     failures: list[str] = []
     json_path = out_dir / "timeline.json"
@@ -4841,7 +4843,7 @@ def check_beat_frames(
         neither of them can see it. This one looks at the pixels, against the
         hand-written storyboard, and says so.
     """
-    from demo_recording import FRAMES_SCHEMA
+    from demo_recording.frames import FRAMES_SCHEMA
 
     failures: list[str] = []
     frames_dir = out_dir / "frames"
@@ -5226,7 +5228,7 @@ def _check_scene_fallback(label: str, out_dir: Path, doc: dict) -> list[str]:
     At a threshold separating those, an ordinary terminal repaint would be
     reported as a cut. Issue #57.
     """
-    from demo_recording import SCENE_MIN_SPAN_S, scene_times
+    from demo_recording.frames import SCENE_MIN_SPAN_S, scene_times
 
     failures: list[str] = []
     mp4 = out_dir / "demo.mp4"
@@ -5356,7 +5358,7 @@ def check_issues(
     that was running when it fired. "The take broke" is not a bug report; "the
     take broke during `click('#refresh')`" is.
     """
-    from demo_recording import ISSUE_KINDS, STRICT_KINDS
+    from demo_recording.timeline import ISSUE_KINDS, STRICT_KINDS
 
     failures: list[str] = []
     json_path = out_dir / "timeline.json"
@@ -6448,7 +6450,8 @@ def check_strict_failure(
     somebody wants to look at; failing it by destroying the evidence would be
     worse than not failing it.
     """
-    from demo_recording import STRICT_KINDS, StrictTakeFailed
+    from demo_recording import StrictTakeFailed
+    from demo_recording.timeline import STRICT_KINDS
 
     failures: list[str] = []
     if exc is None:
@@ -6551,7 +6554,7 @@ def last_frame(mp4: Path, rect: Rect) -> bytes | None:
     """The final second of a recording, reduced over `rect`, last frame first
     available. Both takes end on the same static page, so this is the frame
     they should agree on."""
-    from demo_recording import media_duration
+    from demo_recording.content import media_duration
 
     try:
         seconds = media_duration(mp4)
@@ -6957,7 +6960,8 @@ def stitch_segments(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
     function that grades a single take. What is here is only what is true of a
     merge and of nothing else.
     """
-    from demo_recording import media_duration, stitch
+    from demo_recording import stitch
+    from demo_recording.content import media_duration
 
     failures: list[str] = []
     demo = out_dir / "demo.mp4"
@@ -7222,7 +7226,8 @@ def run_evidence(out_root: Path) -> list[str]:
        reached it through the mask.
     3. **truncation is marked, never silent**, on all three text fields.
     """
-    from demo_recording import EVIDENCE_LIMITS, EVIDENCE_SCHEMA, Recorder
+    from demo_recording import Recorder
+    from demo_recording.timeline import EVIDENCE_LIMITS, EVIDENCE_SCHEMA
 
     label = "evidence"
     failures: list[str] = []
@@ -7914,7 +7919,8 @@ def check_crash_take(
     arm that fails between beats — where the requirement is the opposite one:
     no beat may claim it.
     """
-    from demo_recording import FAILURE_MARKER, media_duration
+    from demo_recording.content import media_duration
+    from demo_recording.failure import FAILURE_MARKER
 
     failures: list[str] = []
     if raised is None:
@@ -8346,7 +8352,9 @@ def run_stale_media(out_root: Path, base_url: str) -> list[str]:
     second, `duration: null` would also be true of a broken fix, and the
     assertion would grade nothing.
     """
-    from demo_recording import FAILURE_MARKER, Recorder, media_duration
+    from demo_recording import Recorder
+    from demo_recording.content import media_duration
+    from demo_recording.failure import FAILURE_MARKER
 
     out_dir = fresh_take_dir(out_root, "stale-media")
     mp4 = out_dir / "demo.mp4"
@@ -8480,7 +8488,8 @@ def run_marker_cleared(out_root: Path, base_url: str) -> list[str]:
     it is a plaintext dump of a page, which may hold exactly the value the new
     take was rewritten to hide.
     """
-    from demo_recording import FAILURE_MARKER, Recorder
+    from demo_recording import Recorder
+    from demo_recording.failure import FAILURE_MARKER
 
     out_dir = fresh_take_dir(out_root, "marker-cleared")
     marker = out_dir / FAILURE_MARKER

--- a/tests/unit
+++ b/tests/unit
@@ -753,6 +753,99 @@ class SkillDocs(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# The package's front door is the storyboard surface (issue #148)
+# --------------------------------------------------------------------------
+#
+# `__all__` published 50 names for a storyboard that imports three, because
+# `tests/smoke` read the recorder's own thresholds back through the front door
+# to grade itself. An interface as wide as its implementation is not an
+# interface, and a storyboard author opening `__init__.py` met
+# `CONTENT_MOVED_PIXELS` before `Recorder`.
+#
+# **The bar is the documentation, not a second copy of the list.** Asserting
+# `__all__ == [six literals]` would be the catalogue's ungraded constant: it
+# would pass for whatever list somebody typed, and the interesting failure —
+# `__all__` and the docs drifting apart — is invisible to it. So the test reads
+# every `from demo_recording import ...` out of SKILL.md and reference/ and
+# requires the two to agree.
+#
+# Its limit, stated: prose that *names* a helper without showing the import is
+# not counted. `stitch()` is discussed all over SKILL.md, and only one line
+# imports it.
+
+SKILL_IMPORT_RE = re.compile(r"from demo_recording import ([A-Za-z_, ]+)")
+
+
+class PublicSurface(unittest.TestCase):
+    def documented(self) -> set[str]:
+        names: set[str] = set()
+        docs = [SKILL_DIR / "SKILL.md", *sorted((SKILL_DIR / "reference").glob("*.md"))]
+        for doc in docs:
+            for match in SKILL_IMPORT_RE.finditer(doc.read_text(encoding="utf-8")):
+                names |= {n.strip() for n in match.group(1).split(",") if n.strip()}
+        return names
+
+    def test_every_name_the_documentation_imports_is_exported(self):
+        import demo_recording
+
+        documented = self.documented()
+        # The haystack first: a docs sweep that found no imports would make the
+        # subset check below hold over an empty set.
+        self.assertGreaterEqual(len(documented), 3, "no documented imports found")
+        missing = sorted(documented - set(demo_recording.__all__))
+        self.assertEqual(
+            missing, [], f"SKILL.md/reference tell an author to import {missing}"
+        )
+
+    def test_nothing_is_exported_that_no_caller_needs(self):
+        # The other direction, and the one #148 is about. `StrictTakeFailed` is
+        # named in reference/failures.md as the exception a strict take raises
+        # but never shown in an import line, so it is allowed explicitly rather
+        # than by widening the regex to catch prose.
+        import demo_recording
+
+        allowed = self.documented() | {"StrictTakeFailed"}
+        extra = sorted(set(demo_recording.__all__) - allowed)
+        self.assertEqual(
+            extra,
+            [],
+            f"{len(extra)} name(s) on the front door that no documented "
+            f"storyboard imports: {extra}. Internals belong to the module that "
+            f"owns them — a test may reach in, a storyboard may not.",
+        )
+
+    def test_every_exported_name_resolves(self):
+        # `__all__` is hand-written and the recorders are resolved by PEP 562,
+        # so a typo in it is not a syntax error anywhere — it surfaces as an
+        # ImportError in somebody's storyboard.
+        #
+        # The two lazy names are checked by reading the module they point at
+        # rather than by importing it. `getattr(demo_recording, "Recorder")`
+        # would resolve `.web`, which imports Playwright — and this file's
+        # `dependencies = []` is the thing that split bought. Parsing the
+        # module for a definition of that name proves the same fact and keeps
+        # the suite browser-free.
+        import ast
+
+        import demo_recording
+
+        for name in demo_recording.__all__:
+            with self.subTest(name=name):
+                lazy = demo_recording._LAZY.get(name)
+                if lazy is None:
+                    getattr(demo_recording, name)
+                    continue
+                module = _PKG_PARENT / "demo_recording" / f"{lazy.lstrip('.')}.py"
+                self.assertTrue(module.is_file(), f"{name} points at {module}")
+                defined = {
+                    node.name
+                    for node in ast.parse(module.read_text(encoding="utf-8")).body
+                    if isinstance(node, (ast.ClassDef, ast.FunctionDef))
+                }
+                self.assertIn(name, defined, f"{module.name} defines no {name}")
+
+
+# --------------------------------------------------------------------------
 # tests/smoke carries nothing it does not read (issue #156)
 # --------------------------------------------------------------------------
 #
@@ -1022,6 +1115,27 @@ INJECTIONS = [
         "TTS_KEY_CHARS = 20",
         "TTS_KEY_CHARS = 12",
         ["TtsKey.test_the_key_is_a_filename_stem_and_not_a_path"],
+    ),
+    (
+        "an internal threshold drifts back onto the package's front door",
+        "__init__.py",
+        '__all__ = [\n    "Recorder",',
+        '__all__ = [\n    "CONTENT_MOVED_PIXELS",\n    "Recorder",',
+        ["PublicSurface.test_nothing_is_exported_that_no_caller_needs"],
+    ),
+    (
+        "a name the documentation tells an author to import is dropped",
+        "__init__.py",
+        '    "beat_frames",\n',
+        "",
+        ["PublicSurface.test_every_name_the_documentation_imports_is_exported"],
+    ),
+    (
+        "a lazily-resolved export names a module that does not define it",
+        "__init__.py",
+        '"TerminalRecorder": ".terminal",',
+        '"TerminalRecorder": ".stitching",',
+        ["PublicSurface.test_every_exported_name_resolves"],
     ),
     (
         "a deletion leaves a constant in tests/smoke that nothing reads",


### PR DESCRIPTION
## Acceptance

> `__all__` becomes the storyboard surface. `tests/smoke` imports thresholds
> from the module that owns them. Delete the ones with no caller.

Met. `__all__` goes **47 → 6**.

The issue counted 50 names and 23 unused; today's numbers are 47 and 27,
because #142/#144 deleted `Secret`/`SecretLeak` and #157 moved `tts_clip`. The
shape is unchanged.

## The surface

`Recorder`, `TerminalRecorder`, `stitch`, `beat_frames`, `content_report`,
`StrictTakeFailed`.

The last three are there on evidence rather than taste:

| name | where the docs tell you to use it |
|---|---|
| `beat_frames` | reference/review.md — how to get `frames/` back after gitignoring it |
| `content_report` | reference/timeline.md — a worked example for re-measuring an existing demo |
| `StrictTakeFailed` | reference/failures.md — what a strict take raises, so somebody catches it |

## Nothing became unreachable

```python
from demo_recording.timeline import TIMELINE_SCHEMA, render_timeline_md
from demo_recording.content import media_duration, merge_content
```

That is the distinction #148 draws, and the only one: **a test may reach into
the module it is testing; a storyboard may not.** `tests/smoke`'s 18 internal
imports moved onto owning modules, as `tests/unit`'s already were. The suite's
reach is unchanged — only the door.

The issue asked for a deliberate decision on external consumers. It is now in
the module docstring: `timeline.json`'s schema and its renderer are
`demo_recording.timeline`'s and always were. Not private, not part of the
storyboard surface, and not promised a stable front door.

## The check is graded against the documentation

`assertEqual(__all__, [six literals])` would be the catalogue's **ungraded
constant** — it passes for whatever list somebody typed, and the failure that
matters, `__all__` and the docs drifting apart, is invisible to it.

So `PublicSurface` parses every `from demo_recording import …` out of SKILL.md
and `reference/*.md` and requires the two to agree in both directions.

**It found a real gap on its first run.** `stitch` and `beat_frames` were
described everywhere and never once shown being imported — SKILL.md discusses
`stitch()` in five places without saying where it comes from. Fixed in the
documentation rather than by widening the test.

## A note on the lazy pair

`test_every_exported_name_resolves` cannot `getattr` the two recorders: that
imports Playwright, and `dependencies = []` is exactly what the #139 split
bought. It parses the target module for a definition of the name instead —
same fact, no browser. The injection pointing `TerminalRecorder` at
`.stitching` confirms it can fail.

## Injected

```
PASS  break: an internal threshold drifts back onto the package's front door
PASS  break: a name the documentation tells an author to import is dropped
PASS  break: a lazily-resolved export names a module that does not define it
All 29 injections were caught.
```

## Stated limit

The docs sweep counts **import lines, not prose**. A helper named in a sentence
but never shown being imported reads as undocumented — which is what surfaced
the two above. A false negative, not a false positive.

## Verification

- full `tests/smoke`: **PASSED**, 98 reported checks
- `tests/unit`: 55 tests; `--fault-inject`: 29/29
- `ruff==0.14.2`, `mypy==1.18.2` over 11 files: clean

Fixes #148