### PR TITLE
Move the failure dump's rendering out of _DemoBase, and grade it (#147 narrow slice)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -51,6 +51,11 @@ from .failure import (
     FAILURE_MARKER,
     FAILURE_MESSAGE_CHARS,
     FAILURE_SCHEMA,
+    clear_failure_dir,
+    clear_failure_marker,
+    failed_beat,
+    failure_summary,
+    render_failure_md,
 )
 from .frames import _FRAME_EDGE_S, _extract, write_beat_frames
 from .narration import tts_clip
@@ -67,8 +72,6 @@ from .timeline import (
     TIMELINE_SCHEMA,
     StrictTakeFailed,
     _cap_text,
-    _fmt_t,
-    _md_cell,
     evidence_name,
     write_timeline,
 )
@@ -809,7 +812,7 @@ class _DemoBase:
         # write carries an `evidence` path, so writing that timeline while
         # skipping this would point every beat at a file that is not there.
         failure: dict | None = (
-            None if exc_type is None else self._failure_summary(exc_type, exc)
+            None if exc_type is None else failure_summary(exc_type, exc, self._beats)
         )
         self._build_evidence()
         if failure is not None:
@@ -919,8 +922,8 @@ class _DemoBase:
                 if failure is not None:
                     self._report_failure(failure, wrote_dump=True)
             else:
-                self._clear_failure_marker()
-                self._clear_failure_dir()
+                clear_failure_marker(self.out_dir)
+                clear_failure_dir(self.out_dir)
             # Always, strict or not, crashed or not: the problems a take
             # recorded are the one thing nobody thinks to go looking for, so
             # they have to arrive unasked.
@@ -1424,35 +1427,6 @@ take with fewer beats than the last one would otherwise leave the
                 f"this take — {type(exc).__name__}: {exc}]"
             )
 
-    def _failed_beat(self) -> dict | None:
-        """The beat whose verb raised, or None if the failure was between beats.
-
-        Reads `error`, which `_beat` stamps (issue #24), rather than assuming
-        the last beat is the culprit — a storyboard can raise in its own code
-        between two verbs, and blaming the last beat that *worked* is exactly
-        the confidently-wrong attribution `_attributed_beat` refuses to make
-        for issues.
-        """
-        for beat in reversed(self._beats):
-            if "error" in beat:
-                return beat
-        return None
-
-    def _failure_summary(self, exc_type: type, exc: BaseException | None) -> dict:
-        """What came out of the `with`, and which beat it came out of.
-
-        Unscrubbed: every consumer (`_timeline_doc`, the dump, the marker)
-        masks it on the way to its own file, and each has a different mask.
-        """
-        beat = self._failed_beat()
-        message = str(exc) if exc is not None else ""
-        return {
-            "type": exc_type.__name__,
-            "message": message[:FAILURE_MESSAGE_CHARS],
-            "beat": None if beat is None else beat.get("index"),
-            "verb": None if beat is None else beat.get("verb"),
-        }
-
     def _failure_doc(self, failure: dict) -> dict:
         """The machine-readable half of `failure/`, masked and checked.
 
@@ -1462,7 +1436,7 @@ take with fewer beats than the last one would otherwise leave the
         issues and the beats have been in memory since they happened, and the
         media is named rather than opened.
         """
-        beat = self._failed_beat()
+        beat = failed_beat(self._beats)
         doc: dict = {
             "schema": FAILURE_SCHEMA,
             "generated_by": "demo-video",
@@ -1486,83 +1460,6 @@ take with fewer beats than the last one would otherwise leave the
             "screen_captured": self._failure_screen_text is not None,
         }
         return doc
-
-    def _failure_md(self, doc: dict) -> str:
-        """The human half. Pure function of the document above, so it inherits
-        its masking rather than re-deriving it."""
-        failure = doc.get("failure") or {}
-        beat = doc.get("beat") or {}
-        where = (
-            f"beat {failure.get('beat')} (`{_md_cell(failure.get('verb'))}`"
-            + (f", target `{_md_cell(beat.get('selector'))}`" if beat.get("selector") else "")
-            + ")"
-            if failure.get("beat") is not None
-            else "between beats — no verb was running when it happened"
-        )
-        out = [
-            "# This take did not finish",
-            "",
-            f"`{doc.get('recorder')}` · {doc.get('when')} · "
-            f"{doc.get('beats_recorded')} beats recorded",
-            "",
-            f"**{_md_cell(failure.get('type'))}** at {where}.",
-            "",
-            f"> {_md_cell(failure.get('message')) or '(no message)'}",
-            "",
-            "## What is here",
-            "",
-            "| file | what it is |",
-            "|---|---|",
-            "| `failure.json` | this, machine-readable: the failing beat in "
-            "full, every issue the take recorded, and what was written |",
-        ]
-        if doc.get("media_written_by_this_take"):
-            out.append(
-                f"| `last-frame.png` | the final frame of "
-                f"`{doc.get('media')}` — what was on screen when it stopped |"
-            )
-        if doc.get("screen_captured"):
-            out.append(
-                "| `screen.txt` | the page's accessibility tree (web) or the "
-                "rendered terminal buffer, read at the end of the take |"
-            )
-        out += ["", "## What the app said", ""]
-        issues = doc.get("issues") or []
-        if not issues:
-            out.append(
-                "Nothing. No console errors, failed requests or non-zero exits "
-                "were recorded, so the app did not announce this."
-            )
-        else:
-            for issue in issues:
-                seat = (
-                    "before the first beat"
-                    if issue.get("beat") is None
-                    else f"beat {issue['beat']} (`{_md_cell(issue.get('verb'))}`)"
-                )
-                out.append(
-                    f"- **{_md_cell(issue.get('kind'))}** — {seat} at "
-                    f"{_fmt_t(issue.get('t'))}s: {_md_cell(issue.get('message'))}"
-                )
-            total = doc.get("issue_count", len(issues))
-            if total > len(issues):
-                out.append(f"- …and {total - len(issues)} more, not recorded.")
-        out += [
-            "",
-            "## The recording",
-            "",
-            (
-                f"`{doc.get('media')}` beside this folder is **this** take's "
-                f"partial recording — the webm the browser had in hand when the "
-                f"storyboard gave up, converted rather than discarded."
-                if doc.get("media_written_by_this_take")
-                else f"**This take encoded no mp4.** Any `{doc.get('media')}` in "
-                f"the folder above is a *previous* run's and is not a recording "
-                f"of this failure — see `{FAILURE_MARKER}`."
-            ),
-            "",
-        ]
-        return "\n".join(out).rstrip() + "\n"
 
     def _build_failure(self, failure: dict) -> None:
         """Turn the crash into documents. Writes nothing.
@@ -1611,7 +1508,7 @@ take with fewer beats than the last one would otherwise leave the
         written = 0
         for path, text in [
             (out / "failure.json", json.dumps(doc, indent=2, ensure_ascii=False) + "\n"),
-            (out / "failure.md", self._failure_md(doc)),
+            (out / "failure.md", render_failure_md(doc)),
             *self._failure_docs,
         ]:
             path.write_text(text)
@@ -1708,64 +1605,6 @@ take with fewer beats than the last one would otherwise leave the
             print(
                 f"demo-video: WARNING — could not write {marker} ({exc}), so "
                 f"nothing in this folder says the take failed",
-                file=sys.stderr,
-            )
-
-    def _clear_failure_dir(self) -> list[str]:
-        """Take a previous run's `failure/` off disk. Returns what went.
-
-        Same reasoning as `_clear_stale_evidence`, and the same hazard: this
-        directory holds a text dump of the page — an ARIA tree or a terminal
-        buffer — so a stale one sitting beside a *fresh* take is both a lie
-        about which run failed and a file that may hold the very value this
-        take was rewritten to hide. Bounded to the names `_write_failure`
-        writes, never the directory, so nothing anybody put here is touched.
-        """
-        directory = self.out_dir / FAILURE_DIR
-        gone: list[str] = []
-        if not directory.is_dir():
-            return gone
-        for name in ("failure.json", "failure.md", "screen.txt", "last-frame.png"):
-            path = directory / name
-            try:
-                if path.is_file():
-                    path.unlink()
-                    gone.append(f"{FAILURE_DIR}/{name}")
-            except OSError:  # noqa: PERF203 - report what could not be removed
-                print(
-                    f"demo-video: WARNING — could not delete {path}, which is "
-                    f"a previous take's failure dump and describes a run "
-                    f"this one is not",
-                    file=sys.stderr,
-                )
-        try:
-            next(directory.iterdir())
-        except StopIteration:
-            directory.rmdir()
-        except OSError:
-            pass
-        return gone
-
-    def _clear_failure_marker(self) -> None:
-        """Take a previous run's marker off disk once a take succeeds.
-
-        The other half of #46 and not an optional one: a marker left beside a
-        freshly-written demo.mp4 is the same lie inverted, and it is the one
-        that makes people stop believing the marker at all.
-        """
-        marker = self.out_dir / FAILURE_MARKER
-        try:
-            if marker.is_file():
-                marker.unlink()
-                print(
-                    f"demo-video: this take wrote its own artifacts, so the "
-                    f"{FAILURE_MARKER} a previous run left here is gone",
-                    file=sys.stderr,
-                )
-        except OSError as exc:
-            print(
-                f"demo-video: WARNING — could not delete {marker} ({exc}). It "
-                f"describes a previous run, not this one.",
                 file=sys.stderr,
             )
 

--- a/skills/demo-video/helpers/demo_recording/failure.py
+++ b/skills/demo-video/helpers/demo_recording/failure.py
@@ -1,12 +1,28 @@
 """Where a take that did not finish writes itself down.
 
-Only the constants live here — the paths, the schema and the message budget.
-The documents themselves are built by the recorder, because building them
-means reading a live page, and they are built in memory and refused whole if
-the mask cannot be vouched for.
+The constants — paths, schema, message budget — and the half of the dump that is
+a function of documents rather than of a live recorder: rendering `failure.md`,
+naming the beat that raised, and taking a previous run's dump off disk.
+
+**What is not here is what needs the recorder.** `_failure_doc` reads the
+buffered page text, the issue log and the media path off `self`;
+`_failure_screen` is the hook a medium overrides to say what its screen holds;
+`_write_failure` needs to know whether the encode happened. Those stay in
+`core`, and the split is drawn exactly where the state stops: everything below
+takes its inputs as arguments and can be checked without a browser (#147).
+
+The docstring used to say the documents "are built in memory and refused whole
+if the mask cannot be vouched for". There is no mask (#138); a document is built
+and written.
 """
 
 from __future__ import annotations
+
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from .markdown import _fmt_t, _md_cell
 
 # -- failure artifacts (issues #11, #20, #24, #32, #46) ----------------------
 #
@@ -67,3 +83,178 @@ FAILURE_MARKER = "demo-video-FAILED.md"
 # per-beat `error.message` is **not** capped — it is the machine-readable copy
 # and something may want to match on it — so nothing is lost by capping here.
 FAILURE_MESSAGE_CHARS = 2_000
+
+
+def failed_beat(beats: Sequence[dict]) -> dict | None:
+    """The beat whose verb raised, or None if the failure was between beats.
+
+    Reads `error`, which `_beat` stamps (issue #24), rather than assuming
+    the last beat is the culprit — a storyboard can raise in its own code
+    between two verbs, and blaming the last beat that *worked* is exactly
+    the confidently-wrong attribution `_attributed_beat` refuses to make
+    for issues.
+    """
+    for beat in reversed(list(beats)):
+        if "error" in beat:
+            return beat
+    return None
+
+
+def failure_summary(
+    exc_type: type, exc: BaseException | None, beats: Sequence[dict]
+) -> dict:
+    """What came out of the `with`, and which beat it came out of.
+
+    Unscrubbed: every consumer (`_timeline_doc`, the dump, the marker)
+    masks it on the way to its own file, and each has a different mask.
+    """
+    beat = failed_beat(beats)
+    message = str(exc) if exc is not None else ""
+    return {
+        "type": exc_type.__name__,
+        "message": message[:FAILURE_MESSAGE_CHARS],
+        "beat": None if beat is None else beat.get("index"),
+        "verb": None if beat is None else beat.get("verb"),
+    }
+
+
+def render_failure_md(doc: dict) -> str:
+    """The human half. Pure function of the document above, so it inherits
+    its masking rather than re-deriving it."""
+    failure = doc.get("failure") or {}
+    beat = doc.get("beat") or {}
+    where = (
+        f"beat {failure.get('beat')} (`{_md_cell(failure.get('verb'))}`"
+        + (
+            f", target `{_md_cell(beat.get('selector'))}`"
+            if beat.get("selector")
+            else ""
+        )
+        + ")"
+        if failure.get("beat") is not None
+        else "between beats — no verb was running when it happened"
+    )
+    out = [
+        "# This take did not finish",
+        "",
+        f"`{doc.get('recorder')}` · {doc.get('when')} · "
+        f"{doc.get('beats_recorded')} beats recorded",
+        "",
+        f"**{_md_cell(failure.get('type'))}** at {where}.",
+        "",
+        f"> {_md_cell(failure.get('message')) or '(no message)'}",
+        "",
+        "## What is here",
+        "",
+        "| file | what it is |",
+        "|---|---|",
+        "| `failure.json` | this, machine-readable: the failing beat in "
+        "full, every issue the take recorded, and what was written |",
+    ]
+    if doc.get("media_written_by_this_take"):
+        out.append(
+            f"| `last-frame.png` | the final frame of "
+            f"`{doc.get('media')}` — what was on screen when it stopped |"
+        )
+    if doc.get("screen_captured"):
+        out.append(
+            "| `screen.txt` | the page's accessibility tree (web) or the "
+            "rendered terminal buffer, read at the end of the take |"
+        )
+    out += ["", "## What the app said", ""]
+    issues = doc.get("issues") or []
+    if not issues:
+        out.append(
+            "Nothing. No console errors, failed requests or non-zero exits "
+            "were recorded, so the app did not announce this."
+        )
+    else:
+        for issue in issues:
+            seat = (
+                "before the first beat"
+                if issue.get("beat") is None
+                else f"beat {issue['beat']} (`{_md_cell(issue.get('verb'))}`)"
+            )
+            out.append(
+                f"- **{_md_cell(issue.get('kind'))}** — {seat} at "
+                f"{_fmt_t(issue.get('t'))}s: {_md_cell(issue.get('message'))}"
+            )
+        total = doc.get("issue_count", len(issues))
+        if total > len(issues):
+            out.append(f"- …and {total - len(issues)} more, not recorded.")
+    out += [
+        "",
+        "## The recording",
+        "",
+        (
+            f"`{doc.get('media')}` beside this folder is **this** take's "
+            f"partial recording — the webm the browser had in hand when the "
+            f"storyboard gave up, converted rather than discarded."
+            if doc.get("media_written_by_this_take")
+            else f"**This take encoded no mp4.** Any `{doc.get('media')}` in "
+            f"the folder above is a *previous* run's and is not a recording "
+            f"of this failure — see `{FAILURE_MARKER}`."
+        ),
+        "",
+    ]
+    return "\n".join(out).rstrip() + "\n"
+
+
+def clear_failure_dir(out_dir: Path) -> list[str]:
+    """Take a previous run's `failure/` off disk. Returns what went.
+
+    Same reasoning as `_clear_stale_evidence`, and the same hazard: this
+    directory holds a text dump of the page — an ARIA tree or a terminal
+    buffer — so a stale one sitting beside a *fresh* take is both a lie
+    about which run failed and a file that may hold the very value this
+    take was rewritten to hide. Bounded to the names `_write_failure`
+    writes, never the directory, so nothing anybody put here is touched.
+    """
+    directory = out_dir / FAILURE_DIR
+    gone: list[str] = []
+    if not directory.is_dir():
+        return gone
+    for name in ("failure.json", "failure.md", "screen.txt", "last-frame.png"):
+        path = directory / name
+        try:
+            if path.is_file():
+                path.unlink()
+                gone.append(f"{FAILURE_DIR}/{name}")
+        except OSError:  # noqa: PERF203 - report what could not be removed
+            print(
+                f"demo-video: WARNING — could not delete {path}, which is "
+                f"a previous take's failure dump and describes a run "
+                f"this one is not",
+                file=sys.stderr,
+            )
+    try:
+        next(directory.iterdir())
+    except StopIteration:
+        directory.rmdir()
+    except OSError:
+        pass
+    return gone
+
+
+def clear_failure_marker(out_dir: Path) -> None:
+    """Take a previous run's marker off disk once a take succeeds.
+
+    The other half of #46 and not an optional one: a marker left beside a
+    freshly-written demo.mp4 is the same lie inverted, and it is the one
+    that makes people stop believing the marker at all.
+    """
+    marker = out_dir / FAILURE_MARKER
+    try:
+        if marker.is_file():
+            marker.unlink()
+            print(
+                f"demo-video: this take wrote its own artifacts, so the "
+                f"{FAILURE_MARKER} a previous run left here is gone",
+                file=sys.stderr,
+            )
+    except OSError as exc:
+        print(
+            f"demo-video: WARNING — could not delete {marker} ({exc}). It "
+            f"describes a previous run, not this one.",
+            file=sys.stderr,
+        )

--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -17,7 +17,8 @@ import sys
 from pathlib import Path
 
 from .content import media_duration
-from .timeline import _fmt_t, _md_cell, timeline_paths
+from .markdown import _fmt_t, _md_cell
+from .timeline import timeline_paths
 
 # -- beat-aligned review frames ----------------------------------------------
 #

--- a/skills/demo-video/helpers/demo_recording/markdown.py
+++ b/skills/demo-video/helpers/demo_recording/markdown.py
@@ -1,0 +1,35 @@
+"""Two helpers for writing a value into a markdown document.
+
+**A leaf: this module imports nothing from the package**, and that is its whole
+job. Three modules render markdown — `timeline`, `frames` and `failure` — and
+these two functions were in `timeline`, which is fine until `failure` needs them
+too: `timeline` imports `failure` for its paths, so `failure` importing back was
+a cycle (#147).
+
+Keeping them here rather than duplicating them matters more than the tidiness.
+`_md_cell` is the only thing standing between an exception message holding a
+pipe and a markdown table gaining a column, and a second copy is a second place
+to forget the backslash.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+
+def _md_cell(value: object) -> str:
+    """A value made safe to drop into a markdown table cell."""
+    if value is None:
+        return ""
+    return str(value).replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def _fmt_t(value: object) -> str:
+    # The `cast` is erased at run time, so this is byte-for-byte the behaviour
+    # it had inside core.py — including the TypeError `float()` raises on a
+    # beat whose timestamp is not a number. What changed is only that the
+    # diagnostic is now visible: `[mypy-demo_recording.core]` disables
+    # `arg-type` wholesale for one *stated* reason (a ViewportSize TypedDict),
+    # and it was silencing this second, unrelated one for free. Moving the
+    # function out from under a blanket suppression is how that surfaced.
+    return "" if value is None else f"{float(cast('float', value)):.2f}"

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import cast
 
 from .failure import FAILURE_DIR, FAILURE_MARKER
+from .markdown import _fmt_t, _md_cell
 
 # -- beat timeline -----------------------------------------------------------
 #
@@ -330,29 +330,6 @@ def timeline_paths(out_dir: Path | str, segment: str | None = None) -> tuple[Pat
     stem = f"{segment}.seg.timeline" if segment else "timeline"
     out_dir = Path(out_dir)
     return out_dir / f"{stem}.json", out_dir / f"{stem}.md"
-
-
-def _md_cell(value: object) -> str:
-    """A value made safe to drop into a markdown table cell."""
-    if value is None:
-        return ""
-    return (
-        str(value)
-        .replace("\\", "\\\\")
-        .replace("|", "\\|")
-        .replace("\n", " ")
-    )
-
-
-def _fmt_t(value: object) -> str:
-    # The `cast` is erased at run time, so this is byte-for-byte the behaviour
-    # it had inside core.py — including the TypeError `float()` raises on a
-    # beat whose timestamp is not a number. What changed is only that the
-    # diagnostic is now visible: `[mypy-demo_recording.core]` disables
-    # `arg-type` wholesale for one *stated* reason (a ViewportSize TypedDict),
-    # and it was silencing this second, unrelated one for free. Moving the
-    # function out from under a blanket suppression is how that surfaced.
-    return "" if value is None else f"{float(cast('float', value)):.2f}"
 
 
 def _coverage_md(coverage: object) -> list[str]:

--- a/tests/unit
+++ b/tests/unit
@@ -68,6 +68,17 @@ from demo_recording.coverage import (  # noqa: E402
     _merged_coverage,
     coverage_report,
 )
+from demo_recording.failure import (  # noqa: E402
+    FAILURE_DIR,
+    FAILURE_MARKER,
+    FAILURE_MESSAGE_CHARS,
+    clear_failure_dir,
+    clear_failure_marker,
+    failed_beat,
+    failure_summary,
+    render_failure_md,
+)
+from demo_recording.markdown import _fmt_t, _md_cell  # noqa: E402
 from demo_recording.narration import (  # noqa: E402
     TTS_KEY_CHARS,
     TTS_KEY_SEP,
@@ -75,8 +86,6 @@ from demo_recording.narration import (  # noqa: E402
 )
 from demo_recording.timeline import (  # noqa: E402
     _coverage_md,
-    _fmt_t,
-    _md_cell,
     render_timeline_md,
     timeline_paths,
 )
@@ -753,6 +762,260 @@ class SkillDocs(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# failure.py — the dump a take that did not finish leaves behind (issue #147)
+# --------------------------------------------------------------------------
+#
+# `failure.md` is what a person opens when a take crashed, and until #147 it was
+# written by a 76-line method on `_DemoBase` that used no instance state at all —
+# a pure function of one document, unreachable without a browser, and therefore
+# graded only by `tests/smoke`'s four crash takes. Those grade that the file
+# *exists* and holds a marker string. Nothing graded what it says.
+#
+# The distinction that matters for this artifact: **it is read at the moment
+# somebody's demo just broke.** A dump that attributes the crash to the wrong
+# beat, or claims a `demo.mp4` beside it is this take's when it is a previous
+# run's, is worse than no dump — it is the artifact-lies failure this repo
+# treats as blocking, on the one path where a reader has no working recording
+# to check it against.
+
+
+class FailedBeat(unittest.TestCase):
+    def test_the_beat_that_raised_is_named_not_the_last_one(self):
+        # `_beat` stamps `error` on the beat whose verb raised. Blaming the last
+        # beat instead is the confidently-wrong attribution the issue log
+        # already refuses to make; a dump gets the same rule.
+        beats = [
+            beat(0, "goto", 0.1),
+            beat(1, "click", 1.0, error={"type": "TimeoutError", "message": "x"}),
+            beat(2, "caption", 2.0),
+        ]
+        self.assertEqual(failed_beat(beats)["index"], 1)
+
+    def test_a_failure_between_beats_blames_no_beat(self):
+        # A storyboard can raise in its own code between two verbs. `None` here
+        # is what makes `failure.md` say "between beats" instead of picking one.
+        self.assertIsNone(failed_beat([beat(0, "goto", 0.1), beat(1, "click", 1.0)]))
+
+    def test_the_last_raising_beat_wins_when_more_than_one_did(self):
+        beats = [
+            beat(0, "click", 0.1, error={"type": "A", "message": ""}),
+            beat(1, "click", 1.0, error={"type": "B", "message": ""}),
+        ]
+        self.assertEqual(failed_beat(beats)["index"], 1)
+
+
+class FailureSummary(unittest.TestCase):
+    def test_the_summary_carries_the_verb_that_was_running(self):
+        # A beat is appended *after* the failing one on purpose: `_beat` stamps
+        # `error` and the take can go on to record a teardown beat, so "the
+        # last beat" and "the beat that raised" are different rows. With one
+        # beat they coincide, and the injection that returns `beats[-1]` stays
+        # green — measured, which is why this list has three entries.
+        beats = [
+            beat(2, "goto", 1.0),
+            beat(3, "wait_for", 2.0, error={"type": "TimeoutError", "message": "x"}),
+            beat(4, "caption", 3.0),
+        ]
+        summary = failure_summary(TimeoutError, TimeoutError("no such element"), beats)
+        self.assertEqual(
+            summary,
+            {
+                "type": "TimeoutError",
+                "message": "no such element",
+                "beat": 3,
+                "verb": "wait_for",
+            },
+        )
+
+    def test_a_long_message_is_cut_to_the_budget(self):
+        # A `wait_for_text()` timeout quotes a thousand characters of terminal
+        # screen, and a Playwright error quotes a call log and a page snippet.
+        # Graded at the boundary rather than comfortably past it.
+        exc = RuntimeError("y" * (FAILURE_MESSAGE_CHARS + 500))
+        summary = failure_summary(RuntimeError, exc, [])
+        self.assertEqual(len(summary["message"]), FAILURE_MESSAGE_CHARS)
+        exact = RuntimeError("z" * FAILURE_MESSAGE_CHARS)
+        self.assertEqual(
+            len(failure_summary(RuntimeError, exact, [])["message"]),
+            FAILURE_MESSAGE_CHARS,
+        )
+
+    def test_an_exception_with_no_message_still_names_its_type(self):
+        # `KeyboardInterrupt` on a hung demo is exactly the take somebody is
+        # about to go looking at, and it carries no message at all.
+        self.assertEqual(
+            failure_summary(KeyboardInterrupt, KeyboardInterrupt(), []),
+            {"type": "KeyboardInterrupt", "message": "", "beat": None, "verb": None},
+        )
+
+
+class FailureMd(unittest.TestCase):
+    def doc(self, **over) -> dict:
+        base = {
+            "schema": 1,
+            "generated_by": "demo-video",
+            "recorder": "Recorder",
+            "when": "2026-07-29T09:00:00Z",
+            "beats_recorded": 4,
+            "failure": {
+                "type": "TimeoutError",
+                "message": "waiting for #save",
+                "beat": 2,
+                "verb": "click",
+            },
+            "beat": {"index": 2, "verb": "click", "selector": "#save"},
+            "issues": [],
+            "issue_count": 0,
+            "media": "demo.mp4",
+            "media_written_by_this_take": True,
+            "screen_captured": True,
+        }
+        base.update(over)
+        return base
+
+    def test_the_failing_beat_and_its_target_are_named(self):
+        md = render_failure_md(self.doc())
+        self.assertIn("**TimeoutError** at beat 2 (`click`, target `#save`).", md)
+        self.assertIn("> waiting for #save", md)
+
+    def test_a_failure_between_beats_says_so_instead_of_naming_one(self):
+        # The document this renders from has `beat: None`, and the sentence has
+        # to change rather than render "beat None".
+        md = render_failure_md(
+            self.doc(
+                failure={
+                    "type": "ValueError",
+                    "message": "bad",
+                    "beat": None,
+                    "verb": None,
+                },
+                beat=None,
+            )
+        )
+        self.assertIn("between beats — no verb was running", md)
+        self.assertNotIn("beat None", md)
+
+    def test_a_take_that_encoded_nothing_disowns_the_mp4_beside_it(self):
+        # The whole of issue #46 in one sentence: a failed re-record leaves the
+        # previous run's demo.mp4 looking current, and in a review gate that
+        # produces a confident approval of something never recorded.
+        md = render_failure_md(self.doc(media_written_by_this_take=False))
+        self.assertIn("**This take encoded no mp4.**", md)
+        self.assertIn(FAILURE_MARKER, md)
+        self.assertNotIn("last-frame.png", md)
+
+    def test_a_take_that_did_encode_claims_its_own_recording(self):
+        # The other side of the same sentence. Without this the assertion above
+        # passes on a renderer that always disowns the media.
+        md = render_failure_md(self.doc())
+        self.assertIn("is **this** take's", md)
+        self.assertIn("last-frame.png", md)
+        self.assertNotIn("encoded no mp4", md)
+
+    def test_no_issues_says_the_app_did_not_announce_it(self):
+        md = render_failure_md(self.doc())
+        self.assertIn("Nothing. No console errors", md)
+
+    def test_every_issue_is_listed_with_where_it_landed(self):
+        md = render_failure_md(
+            self.doc(
+                issues=[
+                    {
+                        "kind": "console_error",
+                        "beat": 1,
+                        "verb": "goto",
+                        "t": 0.5,
+                        "message": "boom",
+                    },
+                    {
+                        "kind": "failed_request",
+                        "beat": None,
+                        "verb": None,
+                        "t": 0.1,
+                        "message": "404 /x",
+                    },
+                ],
+                issue_count=2,
+            )
+        )
+        self.assertIn("**console_error** — beat 1 (`goto`) at 0.50s: boom", md)
+        self.assertIn("**failed_request** — before the first beat at 0.10s: 404 /x", md)
+
+    def test_issues_past_the_cap_are_counted_not_dropped_silently(self):
+        # `issue_count` is the uncapped total. A dump that listed ten of two
+        # hundred and said nothing would read as a take with ten problems.
+        md = render_failure_md(
+            self.doc(
+                issues=[
+                    {
+                        "kind": "console_error",
+                        "beat": 0,
+                        "verb": "goto",
+                        "t": 0.1,
+                        "message": "one",
+                    }
+                ],
+                issue_count=201,
+            )
+        )
+        self.assertIn("…and 200 more, not recorded.", md)
+
+    def test_a_pipe_in_a_message_does_not_break_the_table(self):
+        # The same `_md_cell` contract the timeline has: this renderer emits a
+        # markdown table, and an unescaped pipe in an exception message adds a
+        # column to it.
+        md = render_failure_md(
+            self.doc(
+                failure={
+                    "type": "RuntimeError",
+                    "message": "a | b",
+                    "beat": 2,
+                    "verb": "click",
+                }
+            )
+        )
+        self.assertIn(r"a \| b", md)
+
+
+class FailureCleanup(unittest.TestCase):
+    def test_only_the_files_the_dump_writes_are_removed(self):
+        # Bounded to known names, never the directory: a reader's own notes in
+        # `failure/` are not this function's to delete.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            directory = out / FAILURE_DIR
+            directory.mkdir()
+            for name in ("failure.json", "failure.md", "screen.txt", "last-frame.png"):
+                (directory / name).write_text("stale")
+            (directory / "my-notes.md").write_text("mine")
+            gone = clear_failure_dir(out)
+            self.assertEqual(len(gone), 4)
+            self.assertTrue((directory / "my-notes.md").is_file())
+
+    def test_an_emptied_directory_is_removed_but_a_used_one_stays(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / FAILURE_DIR).mkdir()
+            (out / FAILURE_DIR / "failure.md").write_text("stale")
+            clear_failure_dir(out)
+            self.assertFalse((out / FAILURE_DIR).exists())
+
+    def test_nothing_to_clear_is_not_an_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(clear_failure_dir(Path(tmp)), [])
+
+    def test_a_successful_take_removes_a_previous_runs_marker(self):
+        # The other half of #46: a marker beside a freshly-written demo.mp4 is
+        # the same lie inverted, and it is the one that makes people stop
+        # believing the marker at all.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            (out / FAILURE_MARKER).write_text("a previous run failed")
+            clear_failure_marker(out)
+            self.assertFalse((out / FAILURE_MARKER).exists())
+
+
+# --------------------------------------------------------------------------
 # The package's front door is the storyboard surface (issue #148)
 # --------------------------------------------------------------------------
 #
@@ -961,9 +1224,9 @@ INJECTIONS = [
     ),
     (
         "the table cell stops escaping pipes",
-        "timeline.py",
-        '        .replace("|", "\\\\|")',
-        '        .replace("|", "|")',
+        "markdown.py",
+        '.replace("|", "\\\\|")',
+        '.replace("|", "|")',
         [
             "Cell.test_a_pipe_in_a_caption_does_not_add_a_column",
             "TimelineMd.test_the_beat_table_survives_a_caption_holding_a_pipe",
@@ -971,7 +1234,7 @@ INJECTIONS = [
     ),
     (
         "a beat with no timestamp renders as time zero",
-        "timeline.py",
+        "markdown.py",
         '    return "" if value is None else f"{float(cast(\'float\', value)):.2f}"',
         "    return f\"{float(cast('float', value or 0)):.2f}\"",
         ["FmtT.test_a_beat_with_no_timestamp_renders_empty_not_zero"],
@@ -1117,6 +1380,46 @@ INJECTIONS = [
         ["TtsKey.test_the_key_is_a_filename_stem_and_not_a_path"],
     ),
     (
+        "the failure dump blames the last beat instead of the one that raised",
+        "failure.py",
+        'for beat in reversed(list(beats)):\n        if "error" in beat:\n            return beat\n    return None',
+        "return list(beats)[-1] if beats else None",
+        [
+            "FailedBeat.test_a_failure_between_beats_blames_no_beat",
+            "FailureSummary.test_the_summary_carries_the_verb_that_was_running",
+        ],
+    ),
+    (
+        "an exception message reaches the dump uncapped",
+        "failure.py",
+        '"message": message[:FAILURE_MESSAGE_CHARS],',
+        '"message": message,',
+        ["FailureSummary.test_a_long_message_is_cut_to_the_budget"],
+    ),
+    (
+        "a take that encoded no mp4 stops disowning the one beside it (#46)",
+        "failure.py",
+        'if doc.get("media_written_by_this_take")\n            else f"**This take encoded no mp4.** Any `{doc.get(\'media\')}` in "',
+        "if True\n            else f\"**This take encoded no mp4.** Any `{doc.get('media')}` in \"",
+        [
+            "FailureMd.test_a_take_that_encoded_nothing_disowns_the_mp4_beside_it",
+        ],
+    ),
+    (
+        "the dump stops saying how many issues it left out",
+        "failure.py",
+        'out.append(f"- …and {total - len(issues)} more, not recorded.")',
+        "pass",
+        ["FailureMd.test_issues_past_the_cap_are_counted_not_dropped_silently"],
+    ),
+    (
+        "clearing a previous run's dump takes the whole directory with it",
+        "failure.py",
+        'for name in ("failure.json", "failure.md", "screen.txt", "last-frame.png"):',
+        "for name in [p.name for p in directory.iterdir()]:",
+        ["FailureCleanup.test_only_the_files_the_dump_writes_are_removed"],
+    ),
+    (
         "an internal threshold drifts back onto the package's front door",
         "__init__.py",
         '__all__ = [\n    "Recorder",',
@@ -1168,6 +1471,8 @@ def fault_inject() -> int:
             shutil.copy(REPO / "tests" / "smoke", smoke)
             if module == "tests/smoke":
                 target = smoke
+            elif module == "__init__.py" or module.endswith(".py"):
+                target = root / "demo_recording" / module
             elif module.endswith(".md"):
                 target = skill / module
             else:


### PR DESCRIPTION
The narrow slice of #147, **re-cut against today's numbers**. The full
re-measurement is [on the issue](https://github.com/rogvid/skills/issues/147);
in short, #138 closed most of the leak it was filed about.

| | as filed | today |
|---|---:|---:|
| `_DemoBase` lines | 2,408 | **1,700** |
| `Recorder` base private methods called | 4 | **0** |
| `TerminalRecorder` base private methods called | 10 | 5 |
| `__exit__` lines | ~280 | 173 |

Two of the six proposed collaborators no longer exist (`SecretRegistry` went
with #144, `NarrationTrack` half-moved in #157), and the "watch out for" note is
spent — `__exit__`'s ordering was load-bearing *because the redaction check had
to run last*, and there is no redaction check.

**#147 stays open**, re-scoped to the stateful remainder.

## What moved, and why these five

Chosen by how much recorder state each method touches, not by name:

| method | lines | `self.*` used |
|---|---:|---:|
| `_failure_md` | 76 | **0** |
| `_failure_summary` | 14 | 1 |
| `_failed_beat` | 13 | 1 |
| `_clear_failure_dir` | 34 | 1 |
| `_clear_failure_marker` | 22 | 1 |

`_failure_md` was a 76-line pure function written as a method. `failure.py`
already owned the constants, so the rendering half had a home waiting.

**`_DemoBase`: 1,700 → 1,536 lines, 56 → 51 methods.**

### Two exclusions, stated

- **`_failure_screen` is not in that list**, though the issue's sketch implies
  it. It returns `None` and both subclasses override it — it is the seam itself,
  not rendering.
- **The stateful half stays**: `_failure_doc`, `_write_failure`,
  `_write_failure_marker`, `_build_failure`, `_report_failure` read `_converted`,
  `_media_path`, `_beats`, `_issues` and `out_dir`. That is a refactor with real
  risk, not a code move, and it belongs in its own change.

## The move is proven, not asserted

Old and new ASTs compared statement by statement, with only the four
substitutions the move is *allowed* to make applied to the original:

```
_failure_md              -> render_failure_md       IDENTICAL
_failure_summary         -> failure_summary         IDENTICAL
_failed_beat             -> failed_beat             IDENTICAL
_clear_failure_dir       -> clear_failure_dir       IDENTICAL
_clear_failure_marker    -> clear_failure_marker    IDENTICAL
```

## markdown.py — one thing expanded scope, correctly

`render_failure_md` needs `_md_cell`, which lived in `timeline.py`. But
`timeline` imports `failure` for its paths, so importing back was a cycle. The
two markdown helpers moved to a new **leaf** module that imports nothing from
the package.

Three modules render markdown, and `_md_cell` is the only thing between an
exception message holding a pipe and a table gaining a column. Shared rather
than duplicated: a second copy is a second place to forget the backslash.

## What is graded now

**18 tests, the first this artifact has ever had.** `tests/smoke`'s four crash
takes grade that `failure.md` *exists* and holds a marker string. Nothing graded
what it says.

That matters more here than for most files: it is read at the moment somebody's
demo just broke. A dump that blames the wrong beat, or claims a `demo.mp4`
beside it is this take's when it is a previous run's, is the artifact-lies
failure this repo treats as blocking — on the one path where the reader has no
working recording to check it against.

Both directions of the #46 sentence are graded, which is the point of the pair:
a take that encoded nothing disowns the mp4 and names the marker; a take that
did encode claims its own recording. Either alone passes on a renderer stuck in
one mode.

## Injected

```
PASS  the dump blames the last beat, not the one that raised
PASS  an exception message reaches the dump uncapped
PASS  a take that encoded no mp4 stops disowning the one beside it (#46)
PASS  the dump stops saying how many issues it left out
PASS  clearing a previous run's dump takes the whole directory with it
All 34 injections were caught.
```

Two **pre-existing** entries had to be retargeted from `timeline.py` at
`markdown.py`. The exactly-once guard refused to proceed on both rather than
reporting a pass — which is what it is for, and worth noting as a case where it
earned its keep on somebody else's assertions.

### One of my own tests was too weak, and the manifest said so

The summary test had a single beat, so "the last beat" and "the beat that
raised" were the same row and the `beats[-1]` injection stayed green. It now
records a beat *after* the failing one, which is what a take does when it logs a
teardown beat. Fixed the test, not the injection.

## Verification

- full `tests/smoke`: **PASSED**, 98 reported checks
- `tests/unit`: 73 tests; `--fault-inject`: 34/34
- `ruff==0.14.2`, `mypy==1.18.2` over 12 files: clean

Refs #147