### PR TITLE
Stop shipping documents that name things the code does not have (#115)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
         run: uv run --with playwright playwright install --with-deps chromium
 
       # Writes outside the checkout, at a path the upload step below knows.
-      - name: Record web, redaction and terminal demos
+      - name: Record the web and terminal demo takes
         run: tests/smoke --out-dir "$RUNNER_TEMP/smoke-out"
 
       # Only on failure: a green run's recordings are noise, a red run's are

--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -33,7 +33,7 @@ and a real terminal session (voice on):
   storyboard did rather than at a stopwatch, so nothing is missed and a held
   frame is photographed once. A stitched demo gets them too, off the merged
   timeline. Deliberately uncaptioned, and aimed to within a beat or so rather
-  than exactly — SKILL.md says how far and why.
+  than exactly — `reference/review.md` says how far and why.
 - **`record.py`** — the storyboard that produced the media, and the thing
   that actually gets committed: re-runnable after the UI changes, so the
   video stays out of git history and is regenerated rather than archived.
@@ -45,7 +45,8 @@ and a real terminal session (voice on):
   `srcdoc` document, an attribute nothing renders, an input's `value` — because
   a string that reached none of the frames should not have evidence as the one
   place it exists. It clears what a previous take left behind. It is **not
-  committed**; `SKILL.md` explains those decisions and where they stop.
+  committed**; `reference/review.md` explains those decisions and where they
+  stop.
 - **A statement about the frames, not only the storyboard** — `content` in
   `timeline.json`, plus a line on stderr, saying whether the recording shows
   anything at all: how much picture there is where the app sits, and the
@@ -59,8 +60,8 @@ and a real terminal session (voice on):
   additionally freezes the page's clock and flattens animations, so the same
   storyboard gives you the same stills rather than a new set of timestamps.
   Opt-in because a stopped clock changes what a debounce, a token check or an
-  elapsed-time bar does, usually without saying so; `SKILL.md` shows the five
-  shapes that break and what the recorder cannot pin at all.
+  elapsed-time bar does, usually without saying so; `reference/determinism.md`
+  shows the five shapes that break and what the recorder cannot pin at all.
 - **Spoken narration (optional)** — with `ELEVENLABS_API_KEY` set, every
   caption line is synthesized via ElevenLabs and mixed onto the mp4 at the
   moment it appears. Clips are cached; pacing self-adjusts so speech is
@@ -117,6 +118,7 @@ win over env vars.
 | `DEMO_VIDEO_TIMEZONE` | browser timezone (always applied) | `UTC` |
 | `DEMO_VIDEO_LOCALE` | browser locale (always applied) | `en-US` |
 | `DEMO_VIDEO_SPEECH` | force narration on/off (`1`/`0`) | auto by API key |
+| `DEMO_VIDEO_STRICT` | raise `StrictTakeFailed` if the take recorded a fatal issue (`1`/`0`) | **off** |
 | `DEMO_VIDEO_EVIDENCE` | write `evidence/beat-NN.json` per beat (`1`/`0`) | **on** |
 | `DEMO_VIDEO_VOICE_ID` | ElevenLabs voice | Sarah (premade) |
 | `DEMO_VIDEO_SPEECH_MODEL` | ElevenLabs model | `eleven_multilingual_v2` |
@@ -139,24 +141,31 @@ demo-video/
 ├── README.md                      # this file — humans read this
 └── helpers/
     ├── demo_recording/            # package: the recorders, and what reads their output
-    │   ├── __init__.py            #   exports Recorder, TerminalRecorder, stitch
+    │   ├── __init__.py            #   exports Recorder, TerminalRecorder, stitch,
+    │   │                          #   beat_frames, content_report, StrictTakeFailed
     │   ├── core.py                #   _DemoBase: the browser, narration, ffmpeg
     │   ├── web.py                 #   Recorder (Playwright web apps)
     │   ├── terminal.py            #   TerminalRecorder (PTY + xterm.js)
-    │   ├── timeline.py            #   ── everything below this line is
-    │   ├── coverage.py            #      browser-free: no Playwright, no ffmpeg
-    │   ├── content.py             #      import, importable and unit-testable
-    │   ├── frames.py              #      on its own. tests/unit grades it in
-    │   ├── failure.py             #      0.07 s; tests/smoke owns the rest.
-    │   ├── secrets.py             #
-    │   └── stitching.py           #
+    │   │                          #   ── everything below this line is browser-free:
+    │   │                          #      no Playwright, no ffmpeg import, importable
+    │   │                          #      and unit-testable on its own. tests/unit
+    │   │                          #      grades it in 0.07 s; tests/smoke the rest.
+    │   ├── timeline.py            #   the beat log: schema and its two renderings
+    │   ├── coverage.py            #   acceptance criteria, and what claimed them
+    │   ├── content.py             #   whether the picture showed anything
+    │   ├── frames.py              #   review frames, off a demo already recorded
+    │   ├── failure.py             #   the dump a take that did not finish leaves
+    │   ├── narration.py           #   ElevenLabs synthesis and its content cache
+    │   ├── markdown.py            #   escaping a value into a markdown table
+    │   └── stitching.py           #   joining segments into one demo, losslessly
     └── assets/xterm/              # vendored xterm.js (terminal rendering)
 ```
 
 **SKILL.md is loaded whole into an agent's context whenever the skill triggers;
 `reference/` is read on demand.** That is why the split exists and why it is
-worth keeping: the entry point costs ~11k tokens instead of ~40k, and nothing
-was deleted to get there.
+worth keeping: the entry point is 33 kB (~12k tokens) against the 90 kB (~33k)
+of SKILL.md plus `reference/` together, and nothing was deleted to get there.
+`tests/unit --budget` prints the current figure.
 
 The package and every generated storyboard carry PEP 723 metadata, so the
 dependency declaration travels with the files. Each storyboard embeds

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1251,9 +1251,11 @@ class _DemoBase:
         """What this medium can say about the screen right now.
 
         Overridden per medium (`Recorder` -> ARIA + outerHTML, `TerminalRecorder`
-        -> the rendered screen). A payload of `{"omitted": reason}` is the
-        medium refusing to hand over page text it cannot vouch for; the file is
-        still written, and says so.
+        -> the rendered screen). Every medium answers with the text it read;
+        there is no refusal path here any more — the one that existed, an
+        `{"omitted": reason}` payload for text the mask could not vouch for,
+        went with the mask in #144. A capture that *raises* still gets a file,
+        carrying `error`; see `_capture_evidence`.
         """
         return {}
 
@@ -1283,8 +1285,18 @@ class _DemoBase:
 
 
     def _evidence_doc(self, beat: dict, payload: dict) -> dict:
-        """One evidence document: masked, then capped, then checked.
+        """One evidence document: the envelope, the payload, then the caps.
 
+        The envelope names the take — schema, recorder, segment, media — and
+        copies the beat this evidence belongs to, so a file read on its own
+        says which moment of which recording it is of. The medium's payload
+        (ARIA and the spotlight's markup, or the rendered screen) is merged in
+        as it came back: nothing is removed from it here, because there is no
+        masking anywhere in this recorder.
+
+        Only the caps act. Each field named in `EVIDENCE_LIMITS` is cut to its
+        budget and listed in `truncated`, so a field that was shortened is
+        never read as a page that was short.
         """
         doc: dict = {
             "schema": EVIDENCE_SCHEMA,
@@ -1536,19 +1548,19 @@ take with fewer beats than the last one would otherwise leave the
     def _write_failure_marker(self, failure: dict) -> None:
         """Say, in the demo folder itself, that this take failed (issue #46).
 
-        The one artifact that is written on **every** abnormal exit, including
-        the one where nothing else is: a take that could not verify its mask
-        writes no mp4 and no timeline, and what it does not touch is what a
-        *previous* run left in the same directory. A folder holding a watchable
-        `demo.mp4`, an empty `images/`, and a `timeline.json` from the run
-        before reads as a successful take with missing stills — and the video
-        is a recording of different code. In a review gate that produces a
-        confident approval of something that was never recorded.
+        Written on **every** abnormal exit, and the case it exists for is the
+        one where the artifacts left behind disagree with each other: ffmpeg
+        failing to convert writes this take's `timeline.json` beside whatever
+        `demo.mp4` a *previous* run left in the same directory. That reads as a
+        successful take, and the video is a recording of different code — in a
+        review gate, a confident approval of something that was never recorded.
+        `stale` below is exactly that condition, and the marker names it rather
+        than leaving a reader to notice.
 
         Never raises, and that is deliberate: the absence of this file means
         "the last take succeeded", so failing to write it is itself the lie it
-        exists to prevent. Text that cannot be masked is dropped from it rather
-        than allowed to stop it.
+        exists to prevent. The exception's message is trimmed to fit rather
+        than allowed to stop the write.
         """
         marker = self.out_dir / FAILURE_MARKER
         mp4 = self._media_path()
@@ -1907,7 +1919,6 @@ take with fewer beats than the last one would otherwise leave the
         reviewer — a committed picture of the moment, at a known timestamp.
         """
         claims = self._checked_ac(ac, "shot()")
-        # Scrubbed here rather than only in the beat record, so the file on
         path = self.images_dir / f"{name}.png"
         rel = path.relative_to(self.out_dir).as_posix()
         with self._beat("shot", selector=name, still=rel, **_ac_field(claims)):

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -739,10 +739,11 @@ class TerminalRecorder(_DemoBase):
 
     @_beat_verb("wait_for_text")
     def wait_for_text(self, pattern: str, timeout_s: float = 60) -> None:
-        """Wait until the rendered screen (visible text + scrollback,
-        ANSI-stripped) matches `pattern` (a regex, searched). `^` and `$`
-        anchor to individual screen lines (re.MULTILINE). Robust for TUIs,
-        which repaint continuously and emit no clean 'done' line."""
+        """Wait until the rendered screen (visible text + scrollback, ANSI
+        resolved by xterm.js rather than stripped by a regex) matches `pattern`
+        (a regex, searched). `^` and `$` anchor to individual screen lines
+        (re.MULTILINE). Robust for TUIs, which repaint continuously and emit no
+        clean 'done' line."""
         rx = re.compile(pattern, re.MULTILINE)
         deadline = time.monotonic() + timeout_s
         while True:

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -542,7 +542,7 @@ class Recorder(_DemoBase):
             # In a finally because `.hold.png` is a frame of the *app*, not of
             # the recorder's chrome: if ffmpeg raises, leaving it on disk leaves
             # a full-size picture of whatever the app was showing sitting beside
-            # the demo. `_discard_artifacts` names it too, for the same reason.
+            # the demo.
             self._frame_png.unlink(missing_ok=True)
             if hold is not None:
                 hold.unlink(missing_ok=True)

--- a/skills/demo-video/reference/failures.md
+++ b/skills/demo-video/reference/failures.md
@@ -115,15 +115,23 @@ The original exception still propagates, unchanged — it is the message that
 says what to fix, and the recorder does not replace it. What the recorder adds
 is a line on stderr naming the beat and pointing at `failure/`.
 
-**`demo-video-FAILED.md` is the one file written on every abnormal exit**,
-including the refusal path that keeps nothing else. That path is the reason it
-exists: a take that cannot verify its mask writes no mp4 and no timeline, and
-what it does *not* touch is what a previous run left in the same folder — so
-the folder ends up holding a watchable `demo.mp4`, an emptied `images/`, and a
-`timeline.json` from the run before. That reads as a successful take with
-missing stills, and the video is a recording of different code. The next take
-that writes its own artifacts deletes the marker, so its presence always
-describes the most recent run.
+**`demo-video-FAILED.md` is written whenever a take did not write its own
+complete set of artifacts**, and there are exactly two ways to get there. One is
+the storyboard raising, above — the mp4 beside the marker is this take's, cut
+short. The other is the reason the marker exists:
+**ffmpeg failing to convert the recording.** The storyboard finished, so the
+beat log is written and is this take's, but nothing was encoded — and what sits
+in the folder under `demo.mp4` is then whatever a *previous* run left there. A
+watchable video next to a current `timeline.json` reads as a take that
+succeeded, and the video is a recording of different code. Three things keep it
+from being believed: `duration` is `null` rather than that file's length, no
+review frames are extracted off it, and the marker says in the folder itself
+which of the two happened. The next take that writes its own artifacts deletes
+the marker, so its presence always describes the most recent run.
+
+A `strict=True` refusal is neither of those. It writes every artifact and all of
+them are current, so its marker is cleared exactly like a success's — the
+`StrictTakeFailed` it raises is the report, not a hole in the folder.
 
 **`failure/screen.txt` is a text dump of the page, and nothing in it is
 hidden.** It is the ARIA tree (or the rendered terminal buffer) exactly as the

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -24,12 +24,13 @@ static one twice. Each frame is taken at its beat's **midpoint** — `t_start` i
 is whatever Chromium's screencast managed to record, and it drops wall time
 during idle stretches ([#18](https://github.com/rogvid/skills/issues/18)). So a
 frame cut at a beat's midpoint shows a moment slightly *ahead* of that beat in
-the demo's own story — measured at **40–120 ms** on instrumented takes, and up
-to **~600 ms** on a take that loses the browser's start-up window whole (about
-1 in 12). The practical consequence: for a beat comfortably longer than that,
-the frame is of that beat; **for a beat shorter than the drift — a bare
-`shot()`, a `wait_for()` that returned immediately — the frame can be of the
-beat after it.** `tests/smoke` measures exactly this and shows it: with the
+the demo's own story — measured at **80–200 ms** on instrumented takes, and up
+to the **~0.7 s** of browser start-up no test code can cover, on a take that
+loses that window whole (about 1 in 12, which is why `tests/smoke` bounds this
+direction at 750 ms). The practical consequence: for a beat comfortably longer
+than that, the frame is of that beat; **for a beat shorter than the drift — a
+bare `shot()`, a `wait_for()` that returned immediately — the frame can be of
+the beat after it.** `tests/smoke` measures exactly this and shows it: with the
 drift allowance removed, the frame for a 50 ms `shot()` beat that sits against
 a caption change is already showing the next beat's screen.
 
@@ -115,18 +116,7 @@ off.
 | `scope` / `scope_aria` / `html` | the current `spotlight()` target: its selector, its own ARIA tree, and its `outerHTML` with every value-bearing attribute stripped. All three are null when no spotlight is up |
 | `screen` | **`TerminalRecorder`**: the rendered screen, ANSI resolved by xterm.js, scrollback included — the same text `wait_for_text()` matches against |
 | `truncated` / `limits` | which fields were cut, and at what budget. A cut field also says so inline where it stops |
-| `omitted` | present *instead of* the page text when the recorder would have had to guess — see below. `timeline.json` is unaffected |
-
-**`outerHTML` is only ever the spotlight target's, never the page's.** A whole
-document's markup is an order of magnitude bigger than its ARIA tree and
-carries two things nobody put on screen: the text of every inline `<script>`,
-and `srcdoc` attributes — i.e. source code and whole embedded documents. The
-clone that gets serialized drops both, along with `<style>`, the recorder's own
-overlays.
-
-Fields are capped (12 000 characters of ARIA or screen text, 8 000 of markup)
-and truncation is **marked, never silent** — a TUI's scrollback is 5 000 lines,
-and an uncapped `evidence/` outgrows the mp4 it describes.
+| `error` | present *instead of* the page text when reading the screen raised. Capturing evidence is a diagnostic and must not cost an otherwise fine take, so the file is written anyway, saying what went wrong — which keeps every beat's `evidence` pointer resolving. `timeline.json` is unaffected |
 
 ### What evidence does and does not carry
 

--- a/skills/demo-video/reference/terminal.md
+++ b/skills/demo-video/reference/terminal.md
@@ -14,7 +14,7 @@
 | `send(text, enter=True)` | Type a response to the running program (answer a prompt, a REPL expression). The PTY echoes it, so it is on camera; a program that turns echo off shows nothing either way. |
 | `key(*names)` | Send keys: `"Up" "Down" "Left" "Right" "Enter" "Tab" "Escape" "Home" "End" "PageUp" "PageDown" "Backspace" "Delete" "Space"`, `"C-<letter>"` (e.g. `"C-c"`), or any single literal char (`"q"`, `"/"`). |
 | `wait_for_prompt(timeout_s=60)` | Wait until the shell prompt returns — i.e. the command finished. |
-| `wait_for_text(pattern, timeout_s=60)` | **The universal sync.** Wait until the rendered screen (visible text + scrollback, ANSI-stripped) matches `pattern`; `^`/`$` anchor to screen lines. |
+| `wait_for_text(pattern, timeout_s=60)` | **The universal sync.** Wait until the rendered screen (visible text + scrollback, ANSI resolved by xterm.js rather than stripped by a regex) matches `pattern`; `^`/`$` anchor to screen lines. |
 | `rec.page` | The live Playwright page (escape hatch). `rec._write(str)` sends raw bytes to the PTY. |
 
 ### Opening a terminal segment on a title card
@@ -70,11 +70,12 @@ painted before that first `goto()` would be destroyed by it.
   echoes each key, so it appears typed. Programs that turn echo off
   (password prompts, raw-mode TUIs) correctly show nothing.
 - **A secret a command prints is on screen, and nothing here hides it.**
-  There is no scrubber on the output path and no `redact()` for a terminal —
-  what a program writes to the PTY is what the recording shows, and what
-  `evidence/` dumps. Demo against example data; see "What this records, and
-  what it does not defend against" at the top of
-  [SKILL.md](../SKILL.md).
+  Not "not yet for terminals" — the skill has **no masking, no scrubbing and no
+  redaction at all**, on either recorder or on any artifact either one writes.
+  There is no verb, no flag and no setting that changes that. What a program
+  writes to the PTY is what the recording shows, and what `evidence/` dumps.
+  Demo against example data; see "What this records, and what it does not
+  defend against" at the top of [SKILL.md](../SKILL.md).
 - **Keep the prompt distinctive.** The default `❯ ` rarely collides with
   output. If you theme it via `terminal_prompt`, keep it a string unlikely
   to appear as the last line of a command's output.

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -181,8 +181,11 @@ inside the stretch?**
 
 | beats inside the held stretch | verdict |
 |---|---|
-| `caption`, `interlude`, `bridge`, `hold`, `pause`, `shot`, `wait_for*` | narrated hold — silent |
+| `caption`, `interlude`, `hold`, `pause`, `shot`, `wait_for*` | narrated hold — silent |
 | `run`, `send`, `key`, `click`, `type_into`, `goto`, `scroll_to`, `spotlight`, `move_to` | worth looking at — warns |
+
+Both interlude styles log as the verb `interlude`, with `selector` carrying the
+style (`"card"` or `"light"`) — there is no separate verb for the light one.
 
 A `run()` that printed nothing visible, a `click()` that moved nothing: those
 are the shapes worth a human's two minutes. A caption change over a screen

--- a/tests/unit
+++ b/tests/unit
@@ -762,6 +762,252 @@ class SkillDocs(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# No shipped document names a symbol the package does not have
+# --------------------------------------------------------------------------
+#
+# Every defect a documentation audit of this skill turned up was one shape: a
+# document naming something the code does not have. `secrets.py` sat in
+# README's layout tree as a module of the package — there has never been such a
+# module. `redact()` was in reference/terminal.md as a function this recorder
+# does not offer "for a terminal", which reads as one it offers elsewhere. An
+# `omitted` evidence key was documented that no code path emits. Three of the
+# four were about **secret handling**, which is the subject where a reader
+# believing the document is worst: SKILL.md's first section says there is no
+# masking, no scrubbing and no redaction, and the layout tree said otherwise.
+#
+# Prose cannot be graded. A backticked identifier can: it is the author saying
+# "this is a name in the code", and whether the code has that name is a
+# decidable question. Two sweeps, because the two claims have different
+# strengths of answer:
+#
+#   * **A `module.py`** is a claim about a file, and it is checked against the
+#     directory listing. Swept out of the whole document rather than out of
+#     backticks, because the place these appear is the README's layout tree —
+#     ASCII art inside a fence, where nothing is backticked. `secrets.py` was
+#     there, unquoted, for as long as the tree was.
+#   * **A backticked symbol-shaped span** — a `foo()` call, a `CONSTANT_NAME`,
+#     a CapWords or snake_case identifier — has to appear somewhere in the
+#     package's source text.
+#
+# **What this does not check**, stated plainly because it is the difference
+# between a check and a reassurance:
+#
+#   * The second sweep's haystack is the *text* of the package's modules,
+#     comments and docstrings included. A document kept alive by a stale
+#     docstring passes, which is exactly how `omitted` survived — it was in a
+#     `core.py` docstring describing a path deleted in #144. This catches the
+#     name that was never there or is now entirely gone, not the one that
+#     rotted in two places at once.
+#
+#     How much slack that is, measured rather than assumed: of the 89 symbols
+#     graded today, 85 occur in the modules' *code* tokens with comments and
+#     docstrings stripped. The four that do not are `http_error`,
+#     `request_failed`, `warn` and `DEMO_VIDEO_SPEECH_MODEL` — issue kinds and
+#     an env suffix that reach the code as pieces of an f-string.
+#   * Only symbol-shaped spans are taken. A bare lowercase word in backticks is
+#     indistinguishable from ordinary prose — `caption`, `screen`, `card` and
+#     `hold` are all legitimate — so the `omitted` and `bridge` defects would
+#     not have been caught here even in a fresh package. Widening to bare words
+#     was tried and rejected: it moves ~90 further spans into the sweep and
+#     almost all of them are English.
+#   * `helpers/assets/` is not searched. It is vendored, minified xterm.js, and
+#     a haystack that size finds anything — `expect`, `random` and `showModal`
+#     all occur in it. Searching it would make this check pass for reasons that
+#     have nothing to do with the recorder.
+
+DOC_SPAN_RE = re.compile(r"`([^`\n]+)`")
+DOC_MODULE_RE = re.compile(r"\b[A-Za-z_][A-Za-z0-9_]*\.py\b")
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+# Below this many symbol-shaped spans, the docs were not read — an extraction
+# that matches nothing makes "every name exists" hold over an empty set, the
+# catalogue's vacuous sweep. It is 95 today across SKILL.md, README.md and
+# reference/. This is a floor on "the documents were parsed", not a bar on how
+# many names they may carry, so it does not move when a document is added.
+DOC_SYMBOL_FLOOR = 70
+
+# The same floor for the module sweep, which is much smaller: 13 distinct
+# filenames today, twelve package modules plus `record.py`.
+DOC_MODULE_FLOOR = 8
+
+# `.py` filenames the docs name that are not modules of this package.
+DOC_MODULE_ALLOWED = {
+    "record.py": "the storyboard the skill writes into the user's project",
+}
+
+# Symbol-shaped spans that are legitimately not names in this package. Each
+# entry carries why, because an allowlist without reasons is how a check stops
+# grading anything — eleven entries against the 95 spans swept, and six of them
+# are what the 95 actually contains. The other five (the two GitHub Actions
+# triggers, `showModal`, and the two `tests/smoke` functions) are named by
+# reference/limits.md, which is landing alongside this and is the one document
+# here that talks about CI and the browser rather than about the recorder.
+DOC_SYMBOL_ALLOWED = {
+    # Read by the *generated storyboard*, not by the package: the storyboard
+    # resolves the skill's location before it can import anything from it.
+    "DEMO_VIDEO_SKILL_DIR": "env var the generated storyboard reads, not the package",
+    "_DEFAULT_SKILL_DIR": "constant SKILL.md's storyboard template defines",
+    # Shells, not Python.
+    "PROMPT_SUBST": "a zsh shell option",
+    # Third-party and browser APIs, named in prose to say what they are.
+    "expect": "Playwright's assertion API (expect(...).toMatchAriaSnapshot)",
+    "random": "the browser's Math.random()",
+    "randomUUID": "the browser's crypto.randomUUID()",
+    "showModal": "the DOM's <dialog>.showModal()",
+    # GitHub Actions vocabulary.
+    "pull_request": "a GitHub Actions workflow trigger",
+    "pull_request_target": "a GitHub Actions workflow trigger",
+    # Test harness functions. `tests/smoke` is a sibling of the package, not
+    # part of it, and reference/ names its checks when explaining what is
+    # graded where.
+    "check_coverage": "a function in tests/smoke",
+    "check_coverage_merge": "a function in tests/smoke",
+}
+
+
+def doc_symbol(span: str) -> str | None:
+    """The code symbol a backticked span claims, or None if it claims none.
+
+    Deliberately narrow. Everything it returns is a shape an author only writes
+    when they mean a name in the code:
+
+        `redact()`          a call            -> redact
+        `rec.wait_for_text` an attribute      -> wait_for_text
+        `TTS_KEY_CHARS`     a constant        -> TTS_KEY_CHARS
+        `TerminalRecorder`  CapWords/camel    -> TerminalRecorder
+
+    A bare lowercase word (`caption`, `bridge`) is not one of them, and neither
+    is a bare acronym (`ARIA`, `UTC`) — both are ordinary prose in backticks.
+    A `module.py` is not one either: filenames are the other sweep's, which
+    answers a stronger question than "does this string occur".
+    """
+    text = span.strip()
+    called = "(" in text
+    head = text.split("(", 1)[0].strip() if called else text
+    if DOC_MODULE_RE.fullmatch(head):
+        return None
+    if "." in head:  # rec.page, demo_recording.timeline, Path.exists
+        head = head.rsplit(".", 1)[-1]
+    if not _IDENT_RE.fullmatch(head):
+        return None
+    if called or "_" in head:
+        return head
+    if head.isupper():  # a bare acronym; a constant has an underscore
+        return None
+    return None if head.islower() else head
+
+
+def doc_files() -> list[Path]:
+    """The documents this skill ships. README.md is one: it is what a human
+    reads on the repository page, and the layout tree that named a module the
+    package never had lived in it, not in SKILL.md."""
+    return [
+        SKILL_DIR / "SKILL.md",
+        SKILL_DIR / "README.md",
+        *sorted((SKILL_DIR / "reference").glob("*.md")),
+    ]
+
+
+def doc_symbols() -> dict[str, set[str]]:
+    """Every symbol-shaped backticked span in the shipped docs -> where.
+
+    Fenced blocks are swept too. Measured: including them changes neither the
+    count nor the result today, because Python and shell samples carry no
+    backticks of their own — so there is no exclusion rule here to go stale.
+    """
+    found: dict[str, set[str]] = {}
+    for doc in doc_files():
+        for match in DOC_SPAN_RE.finditer(doc.read_text(encoding="utf-8")):
+            name = doc_symbol(match.group(1))
+            if name:
+                found.setdefault(name, set()).add(doc.name)
+    return found
+
+
+def doc_modules() -> dict[str, set[str]]:
+    """Every `<name>.py` the shipped docs mention -> where.
+
+    Backticks are not required, and that is the point: the README's layout tree
+    is ASCII art inside a fence, where `secrets.py` sat unquoted next to eleven
+    real modules for as long as the tree existed.
+    """
+    found: dict[str, set[str]] = {}
+    for doc in doc_files():
+        for match in DOC_MODULE_RE.finditer(doc.read_text(encoding="utf-8")):
+            found.setdefault(match.group(0), set()).add(doc.name)
+    return found
+
+
+class DocSymbols(unittest.TestCase):
+    def test_every_module_the_docs_name_is_a_file_in_the_package(self):
+        found = doc_modules()
+        # The haystack, before anything is claimed about it.
+        self.assertGreaterEqual(
+            len(found),
+            DOC_MODULE_FLOOR,
+            f"only {len(found)} .py filenames found in the docs — the "
+            f"extraction is broken, and 'they all exist' would hold trivially",
+        )
+        package = _PKG_PARENT / "demo_recording"
+        missing = sorted(
+            f"{name} (in {', '.join(sorted(where))})"
+            for name, where in found.items()
+            if name not in DOC_MODULE_ALLOWED and not (package / name).is_file()
+        )
+        self.assertEqual(
+            missing,
+            [],
+            f"{len(missing)} module(s) the documentation names that "
+            f"helpers/demo_recording/ does not contain: {missing}",
+        )
+
+    def test_every_symbol_the_docs_name_exists_in_the_package(self):
+        found = doc_symbols()
+        # The haystack, before anything is claimed about it.
+        self.assertGreaterEqual(
+            len(found),
+            DOC_SYMBOL_FLOOR,
+            f"only {len(found)} symbol-shaped spans found in the docs — the "
+            f"extraction is broken, and 'they all exist' would hold trivially",
+        )
+
+        source = "\n".join(
+            path.read_text(encoding="utf-8")
+            for path in sorted((_PKG_PARENT / "demo_recording").glob("*.py"))
+        )
+        missing = []
+        for name in sorted(found):
+            if name in DOC_SYMBOL_ALLOWED:
+                continue
+            # `DEMO_VIDEO_*` names are assembled at runtime from a prefix and a
+            # suffix (`_env("BASE_URL")`), so the full name never appears
+            # literally. Searching for the suffix still grades the claim: an
+            # env var the recorder does not read has no `_env` call either.
+            needle = name.removeprefix("DEMO_VIDEO_")
+            # Word-bounded, not a substring: `redact` must not be satisfied by
+            # the word "redaction" in a comment about the feature's removal,
+            # which is precisely what sits in core.py today.
+            if not re.search(rf"\b{re.escape(needle)}\b", source):
+                missing.append(f"{name} (in {', '.join(sorted(found[name]))})")
+        self.assertEqual(
+            missing,
+            [],
+            f"{len(missing)} symbol(s) the documentation names that no module "
+            f"under helpers/demo_recording/ has: {missing}. Either the name is "
+            f"wrong, or the document is describing something that was removed. "
+            f"If it is genuinely not a package symbol — a shell command, an "
+            f"env var, a browser API — add it to DOC_SYMBOL_ALLOWED with the "
+            f"reason.",
+        )
+
+    def test_no_allowlist_entry_is_unexplained(self):
+        # An allowlist is how this check stops grading anything. The reason is
+        # what a reviewer weighs, so an empty one is a defect in itself.
+        entries = {**DOC_MODULE_ALLOWED, **DOC_SYMBOL_ALLOWED}
+        self.assertEqual(sorted(k for k, v in entries.items() if not v.strip()), [])
+
+
+# --------------------------------------------------------------------------
 # failure.py — the dump a take that did not finish leaves behind (issue #147)
 # --------------------------------------------------------------------------
 #
@@ -1441,6 +1687,47 @@ INJECTIONS = [
         ["PublicSurface.test_every_exported_name_resolves"],
     ),
     (
+        # The defect verbatim: `secrets.py` sat in this tree for as long as the
+        # tree did, and it was the only place in the docs implying the recorder
+        # has a secret-handling module at all.
+        "a shipped document names a module of the package that does not exist",
+        "README.md",
+        "    │   ├── markdown.py            #   escaping a value into a markdown table",
+        "    │   ├── markdown.py            #   escaping a value into a markdown table\n"
+        "    │   ├── secrets.py             #   masking, before a take writes anything",
+        ["DocSymbols.test_every_module_the_docs_name_is_a_file_in_the_package"],
+    ),
+    (
+        # The other defect, in the other sweep: prose naming a function that
+        # exists nowhere. `redact()` was in reference/terminal.md phrased as a
+        # scope limit — "no `redact()` for a terminal" — which reads as a
+        # promise that the web recorder has one.
+        "a shipped document names a function that exists nowhere",
+        "reference/terminal.md",
+        "  redaction at all**, on either recorder or on any artifact either one writes.",
+        "  redaction at all** — there is no `redact()` on either recorder.",
+        ["DocSymbols.test_every_symbol_the_docs_name_exists_in_the_package"],
+    ),
+    (
+        # The half the catalogue is about: each sweep above is worth something
+        # only while its extraction still extracts. Matching nothing makes
+        # "every name the docs use exists" true over an empty set, and the
+        # suite goes green *because* the check stopped working. Two entries,
+        # because the two sweeps have two extractions and one floor each.
+        "the doc-symbol extraction matches nothing, so that sweep goes vacuous",
+        "tests/unit",
+        'DOC_SPAN_RE = re.compile(r"`([^`\\n]+)`")',
+        'DOC_SPAN_RE = re.compile(r"`([^`\\n]{400,})`")',
+        ["DocSymbols.test_every_symbol_the_docs_name_exists_in_the_package"],
+    ),
+    (
+        "the doc-module extraction matches nothing, so that sweep goes vacuous",
+        "tests/unit",
+        'DOC_MODULE_RE = re.compile(r"\\b[A-Za-z_][A-Za-z0-9_]*\\.py\\b")',
+        'DOC_MODULE_RE = re.compile(r"\\b[A-Za-z_][A-Za-z0-9_]{80,}\\.py\\b")',
+        ["DocSymbols.test_every_module_the_docs_name_is_a_file_in_the_package"],
+    ),
+    (
         "a deletion leaves a constant in tests/smoke that nothing reads",
         "tests/smoke",
         # Modelled on what #138 actually left behind: a name defined beside a
@@ -1459,18 +1746,31 @@ def fault_inject() -> int:
     failures = 0
     for name, module, old, new, must_fail in INJECTIONS:
         with tempfile.TemporaryDirectory() as tmp:
-            # The whole skill, not just the package: two injections break
-            # SKILL.md, and the documentation assertions are as much a check
-            # as the behavioural ones. `tests/smoke` is copied alongside it
-            # because one assertion reads that file rather than the package —
+            # The whole skill, not just the package: several injections break a
+            # shipped document, and the documentation assertions are as much a
+            # check as the behavioural ones. `tests/smoke` is copied alongside
+            # it because one assertion reads that file rather than the package —
             # residue in the *harness* is the defect it grades.
+            #
+            # This file is copied too, and the copy is what runs. One assertion
+            # — the doc-symbol sweep — has an *extraction step* of its own, and
+            # an extraction that quietly matches nothing is the vacuous sweep
+            # the floor exists to catch. Proving that floor fires means breaking
+            # code that lives here, so the inner run cannot be this file. It
+            # reads nothing from `REPO`: every path it uses comes from the three
+            # environment variables below, so a copy under /tmp behaves exactly
+            # as the original does.
             skill = Path(tmp) / "demo-video"
             shutil.copytree(REPO / "skills" / "demo-video", skill)
             root = skill / "helpers"
             smoke = Path(tmp) / "smoke"
             shutil.copy(REPO / "tests" / "smoke", smoke)
+            unit = Path(tmp) / "unit"
+            shutil.copy(Path(__file__).resolve(), unit)
             if module == "tests/smoke":
                 target = smoke
+            elif module == "tests/unit":
+                target = unit
             elif module == "__init__.py" or module.endswith(".py"):
                 target = root / "demo_recording" / module
             elif module.endswith(".md"):
@@ -1491,7 +1791,7 @@ def fault_inject() -> int:
             target.write_text(text.replace(old, new), encoding="utf-8")
 
             done = subprocess.run(
-                [sys.executable, str(Path(__file__).resolve()), "--_inner"],
+                [sys.executable, str(unit), "--_inner"],
                 capture_output=True,
                 text=True,
                 env={


### PR DESCRIPTION
An audit of every statement in `SKILL.md`, `README.md` and `reference/*.md`
against the code at 6b99fdd. **This skill is about to be shared publicly**, and
the repo treats an artifact that lies as a blocking defect — three of these
would have told a reader the opposite of the truth about what the recorder does
with secrets.

## Blocking — false statements about safety

| where | said | truth |
|---|---|---|
| `README.md:151` | lists **`secrets.py`** in the module tree | no such file; 140 lines after SKILL.md says there is no masking |
| `reference/failures.md:118` | the FAILED marker exists because *"a take that cannot verify its mask writes no mp4 and no timeline"* | no mask, no verifier, and that path cannot be reached (`core.py:828-830`) |
| `reference/terminal.md:73` | *"no `redact()` **for a terminal**"* | phrased as a scope limit, implying the web recorder has one. `redact()` does not exist anywhere |

`failures.md`'s paragraph is rewritten around the two paths that survive —
`exc_type is not None` and `convert_error is not None` — with ffmpeg-convert
failure as the case the marker is actually for.

**Note what was deliberately *not* written back:** the lead now says the marker
is written "whenever a take did not write its own complete set of artifacts",
not "on any abnormal exit". The latter is the overclaim #115 item 1 tracks, and
fixing one stale sentence by copying another known-wrong one is not a fix.

## Misleading

- `reference/review.md` documented an **`omitted`** evidence key. No code path
  emits it. Replaced with the `error` key `_capture_evidence` really writes,
  which was undocumented.
- Caption drift figures were **40–120 ms / ~600 ms**; the harness that produced
  them says **80–200 ms** and a ~0.7 s window bounded at **750 ms**.
- Three README pointers said "SKILL.md says/explains/shows" for content that
  moved into `reference/` during the #146 split. Retargeted.
- README's Configuration table omitted `DEMO_VIDEO_STRICT`, which is real.

## Nits

Layout tree gained `narration.py` and `markdown.py` and now lists all six
`__all__` names; the token-cost claim is measured (**33 kB / ~11.9k tokens for
SKILL.md against 90 kB / ~33k with `reference/`**) rather than guessed; two
paragraph pairs duplicated within 40 lines of `review.md` reduced to one each;
`bridge` removed from the verb table; ANSI is "resolved by xterm.js" in both
places that describe it, including the code docstring the doc copied it from.

## Five severed comments in the code

`core.py:1250` (`_evidence_payload` still describing the `omitted` refusal —
**the source of the bogus doc row**, found and repaired rather than only its
symptom), `core.py:1286`, `core.py:1540`, `core.py:1910`, `web.py:545`, plus
`ci.yml`'s step name still advertising redaction takes.

## The durable fix

Every defect above is one class: **a shipped document naming something that
does not exist.** `tests/unit` gains `DocSymbols`, two sweeps:

- **`<name>.py` → must be a file in `helpers/demo_recording/`**, checked against
  the directory listing. Swept from the whole document, not just backticks —
  `secrets.py` sat **unquoted** inside a fenced ASCII tree, so a backtick-only
  sweep could never have caught the worst defect here.
- **Backticked symbol-shaped spans → must occur in the package source**, word-
  bounded so `redact` is not satisfied by "redaction" in a comment.

**Haystack floors** of 70 spans and 8 filenames against 95 and 13 today, so a
broken extractor cannot pass vacuously.

This required `fault_inject` to copy `tests/unit` and run the copy: an assertion
with its own extraction step cannot have that extraction broken while the
original file is what executes.

### Injected — 4 new, manifest now 38 of 38

```
AssertionError: ['secrets.py (in README.md)'] != []
  : 1 module(s) the documentation names that helpers/demo_recording/ does not contain
AssertionError: ['redact (in terminal.md)'] != []
AssertionError: 0 not greater than or equal to 70 : only 0 symbol-shaped spans found —
  the extraction is broken, and 'they all exist' would hold trivially
AssertionError: 0 not greater than or equal to 8 : only 0 .py filenames found in the docs
```

## Stated limits of the new check

- **The haystack includes comments and docstrings**, so a doc kept alive by a
  stale docstring passes. That is exactly how the `omitted` row survived, and it
  is why `core.py:1250` had to be repaired by hand. Measured: 85 of 89 graded
  symbols occur in code tokens with comments stripped.
- **Bare lowercase words are not swept.** The `omitted` and `bridge` defects
  would not have been caught here even in a clean package. Widening pulls in
  ~90 further spans, nearly all English.
- **Five allowlist entries are for symbols named only by `reference/limits.md`**,
  which arrives in the PR stacked on this one. If that never lands they are five
  dead entries.

## Also filed

**#165** — `bridge` genuinely exists as a member of `CONTENT_PASSIVE_VERBS`, but
no beat has ever carried that verb. Dead data the docs copied, and proof of the
sweep's second stated limit.

## Verification

- `tests/unit`: 76 tests; `--fault-inject`: 38/38
- full `tests/smoke`: **PASSED**, 98 reported checks (run on this branch with
  the stacked boundary work, so the union is covered)
- `ruff==0.14.2` check + format, `mypy==1.18.2` over 12 modules: clean

Refs #115