### PR TITLE
interlude("") could not take down a light scrim, and the check meant to catch it scored it backwards (#162, #163)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -249,7 +249,7 @@ exception, or a non-zero exit. Both are
 | `wait_for(selector)` | Wait for something the app does on its own |
 | `spotlight(selector)` | Ring + enlarge the element the caption discusses; `spotlight()` clears. It eases in *and out* over 250 ms, and the verb waits out its own exit, so the element is back exactly as it was found before the next beat starts (~250 ms per clear on an ordinary take, ~0 under `deterministic=True`, which flattens the transition) |
 | `terminal(cmd)` / `terminal_output(text)` / `terminal_close()` | A *decorative* on-screen terminal card for off-browser actions **inside a web demo** — a prop, not a real shell. To record an actual CLI/TUI use `TerminalRecorder` (below). |
-| `interlude(text, style=…)` | Bridge a jump. `style="card"` (default) is a full-screen title card, for real time-skips; `style="light"` is a centered label over a soft scrim with the scene still visible, for short transitions. `""` fades it out. |
+| `interlude(text, hold=2.8, style=…)` | Bridge a jump; `hold` is how long the card stays before the storyboard moves on. `style="card"` (default) is a full-screen title card, for real time-skips; `style="light"` is a centered label over a soft scrim with the scene still visible, for short transitions. **`interlude("")` fades out whatever is up, whichever style raised it** — the clear takes no `style` and ignores the one it is given. Leave one up and the take says so on stderr and in `content.warnings`; nothing else will notice (see [reference/limits.md](reference/limits.md)). |
 | `stitch(out_dir, [segments])` | Lossless concat of segment recordings into demo.mp4, **and** merge their beat logs into one `timeline.json` / `timeline.md` beside it. `keep_parts=True` leaves each `.seg.mp4` and its `.seg.timeline.*` on disk for a re-stitch |
 | `rec.page` | The live Playwright page — the escape hatch for anything the verbs don't cover (iframes, keyboard shortcuts, drag) |
 
@@ -541,6 +541,13 @@ return.
   timeline over a recording nobody can watch. Check `content` in the same file
   — that is the field that describes the frames
   ([reference/timeline.md](reference/timeline.md)).
+- **Reading `content.score` as "the app was visible".** It is luma variance
+  over the app rect, so a translucent overlay *adds* to it: a scrim left over
+  the app measured **32.94** against a clean take's **26.74**, and both printed
+  `demo.mp4 shows a picture`. `warnings` is the field that answers the
+  question. An interlude *this recorder* raised and you did not clear is named
+  there by element id; an app's own modal is named by nothing
+  ([reference/limits.md](reference/limits.md)).
 - **Reading `content.static_for` as a score.** It is not one. A healthy demo
   that narrates a rendered screen holds it for 20s or more, which is what a
   covering card also measures. Read `warnings`; the number alone means nothing

--- a/skills/demo-video/helpers/demo_recording/content.py
+++ b/skills/demo-video/helpers/demo_recording/content.py
@@ -499,6 +499,58 @@ def opening_warning(opening: dict | None) -> str | None:
     )
 
 
+# -- the recorder's own overlay, still up (issue #163) ------------------------
+#
+# Everything above measures the *picture*, and on a full-viewport overlay with
+# internal variance the picture measurement runs backwards. Three takes of one
+# storyboard against one app, from a clean install:
+#
+#   scrim over the app for the last ~17 s of 48 s        score 32.94
+#   "cleared" per the docs, still covered (issue #162)   score 32.95
+#   clean, nothing covering the app                      score 26.74
+#
+# The two broken takes scored 23% *higher*, and stderr printed "demo.mp4 shows
+# a picture" for all three. The scrim is a soft gradient; a gradient across the
+# measured rect adds luma variance, and luma variance is what the score arm is.
+# No floor separates 26.74 from 32.94 in the right direction, so this is not a
+# threshold to retune — it needs a different question.
+#
+# The question this asks is deliberately the narrow one: **was the recorder's
+# own overlay still up when the take ended?** The recorder created those
+# elements and knows their ids, so that is exact rather than heuristic, and it
+# is the case an author is most likely to hit because the recorder's own API
+# put the occluder there. It is *not* occlusion detection — an app's own modal
+# is still invisible to this, and to everything else here (see
+# reference/limits.md).
+#
+# The probe itself lives in `core`, because it is the only part that needs a
+# page. What is here is the sentence it produces, which is the part that ends
+# up in `timeline.json` and on stderr — and the part that can be graded without
+# a browser.
+
+
+def overlay_warning(ids: list[str]) -> str | None:
+    """The warning for overlays still showing at the end of a take, or None.
+
+    `ids` are the element ids the page reported as visible. An empty list is
+    the healthy answer and must stay silent: a warning that fires on every take
+    is a warning nobody reads, which is the whole reason `opening_warning` and
+    the held-picture arm are as narrow as they are.
+    """
+    if not ids:
+        return None
+    names = ", ".join(f"#{i}" for i in ids)
+    return (
+        f"the recorder's own overlay ({names}) was still on screen when this "
+        f"take ended, so from the moment it went up the frames are that "
+        f"overlay and not the app. Read off the page by element id at the end "
+        f"of the take, not from the frames: the score above cannot see this — "
+        f"a scrim has internal variance and reads as picture, so an occluded "
+        f"take can score higher than a clean one. `interlude(\"\")` takes down "
+        f"whichever overlay is up."
+    )
+
+
 def _beats_within(beats: list[dict], start: float, end: float) -> list[dict]:
     """The beats that **began** inside [start, end], classified.
 

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -43,6 +43,7 @@ from .content import (
     opening_gap,
     opening_report,
     opening_warning,
+    overlay_warning,
     print_content_summary,
 )
 from .coverage import _ac_field, _checked_criteria, coverage_report
@@ -135,12 +136,13 @@ window.__demoInterlude = (text) => {
 # Lightweight bridge: a centered label over a soft scrim, with the scene
 # still visible behind it. For short segment transitions where a full-screen
 # interlude card would feel heavy.
+BRIDGE_ID = "__demo_bridge"
 _BRIDGE_JS = """
 window.__demoBridge = (text) => {
-  let el = document.getElementById('__demo_bridge');
+  let el = document.getElementById('__ID__');
   if (!el) {
     el = document.createElement('div');
-    el.id = '__demo_bridge';
+    el.id = '__ID__';
     el.style.cssText = `
       position: fixed; inset: 0; display: flex; align-items: center;
       justify-content: center; z-index: 2147483647; opacity: 0;
@@ -160,6 +162,38 @@ window.__demoBridge = (text) => {
   document.getElementById('__demo_bridge_t').textContent = text;
   el.style.opacity = text ? '1' : '0';
 };
+"""
+
+# The two overlays this module puts on the page, by element id.
+#
+# One tuple because three separate things now need the same answer: the scripts
+# above create these elements, `interlude("")` takes **both** down whatever
+# style raised them (issue #162), and `_note_overlays_up()` asks the page at the
+# end of a take whether either is still showing (issue #163). Written here rather
+# than duplicated at each site, because a fourth id that only two of the three
+# knew about is exactly how the clear came to be style-dependent in the first
+# place.
+OVERLAY_IDS = (INTERLUDE_ID, BRIDGE_ID)
+
+# Which of `OVERLAY_IDS` is still *visible*, not merely present in the tree.
+#
+# Visibility, because a cleared overlay is not removed — both scripts above
+# toggle `opacity`, and `terminal.py`'s opening card leaves a fully faded
+# element behind on every healthy terminal take. Asking "does the element
+# exist" would warn on all of them.
+#
+# `getComputedStyle` rather than the inline style, so an in-flight fade reads
+# as the number it is actually painting at. Both callers of the clear pause
+# well past the 0.4-0.45 s transition before the take ends, so a cleared
+# overlay reads 0 rather than an interpolated value.
+_OVERLAY_PROBE_JS = """
+(ids) => ids.filter((id) => {
+  const el = document.getElementById(id);
+  if (!el) return false;
+  const style = getComputedStyle(el);
+  if (style.display === 'none' || style.visibility === 'hidden') return false;
+  return parseFloat(style.opacity || '1') > 0.01;
+})
 """
 
 
@@ -607,6 +641,11 @@ class _DemoBase:
         # rather than the storyboard. See the "did the recording show
         # anything?" section.
         self._content: dict | None = None
+        # Whether the recorder's own overlays were still on screen when the
+        # take ended (issue #163), read off the page in `__exit__` and folded
+        # into `content.warnings` by `_measure_content`. None means "nothing
+        # was up", which is what a healthy take reads.
+        self._overlay_note: str | None = None
         # Seconds of blank opening this take's encode covered over, or None for
         # a recorder that does not do that at all (issue #119). Null and 0.0 are
         # different answers here — "never claimed to" against "had nothing to
@@ -742,7 +781,7 @@ class _DemoBase:
                 _INTERLUDE_JS.replace("__ID__", INTERLUDE_ID)
                 .replace("__CSS__", INTERLUDE_CSS)
             )
-            self._context.add_init_script(_BRIDGE_JS)
+            self._context.add_init_script(_BRIDGE_JS.replace("__ID__", BRIDGE_ID))
             # Medium-specific init scripts (cursor, spotlight, ...).
             self._init_context(self._context)
             self.page = self._context.new_page()
@@ -796,6 +835,15 @@ class _DemoBase:
         #     the `with` that carries an exception, for exactly that reason.
         if exc_type is None:
             self._finish_line(tail=0.5)  # don't end mid-sentence
+        # The last thing asked of the live page, and it has to be here rather
+        # than beside the rest of the picture check: `_measure_content` runs
+        # after the browser is gone, off a file, and the one occlusion nothing
+        # in a file can be asked about is the recorder's *own* (issue #163).
+        # Before `_stop()` so a medium that kills its child process cannot take
+        # the page with it, and outside the `exc_type is None` guard because a
+        # storyboard that raised under an overlay is still a take somebody has
+        # to be told about.
+        self._note_overlays_up()
         self._stop()
         # Buffered in memory here and turned into a file by `_build_failure`
         # below — see that split, which survives #144 for a reason unrelated
@@ -1654,6 +1702,38 @@ take with fewer beats than the last one would otherwise leave the
         name = f"{self.segment}.seg.mp4" if self.segment else "demo.mp4"
         return self.out_dir / name
 
+    def _note_overlays_up(self) -> None:
+        """Ask the page whether this recorder's own overlays are still showing.
+
+        **Exact, not heuristic, and that is the whole scope.** The recorder
+        created these elements and knows their ids, so "is the interlude card
+        still up" is a question with an answer rather than something to infer
+        from luma. It says nothing about an app's own modal, a `<dialog>` the
+        page opened, or anything else covering the app — that is unbounded and
+        is declared in `reference/limits.md`, not attempted here.
+
+        It exists because the measurement that should have caught this scored
+        it backwards. On three takes of one storyboard, one clean and two with
+        a `light` scrim over the app for the last 17 s of 48, `content.score`
+        read 26.74 for the clean take and 32.94/32.95 for the covered ones: the
+        scrim is a gradient, gradient inside the measured rect is variance, and
+        variance is what the score arm measures. No threshold separates those
+        numbers in the right direction, so this asks a different question.
+
+        Lives in the base rather than in either recorder: the overlays are
+        `_DemoBase`'s own init scripts, and both media record the same page.
+
+        Never raises. A page that is already gone is the ordinary state of a
+        failing take, and losing the take over a diagnostic would be worse than
+        the diagnostic being absent.
+        """
+        try:
+            up = self.page.evaluate(_OVERLAY_PROBE_JS, list(OVERLAY_IDS))
+        except Exception:  # noqa: BLE001 - a diagnostic must not kill a take
+            return
+        if isinstance(up, list):
+            self._overlay_note = overlay_warning([str(i) for i in up])
+
     def _measure_content(self) -> None:
         """Fill in `self._content` off the mp4 this take just encoded.
 
@@ -1674,20 +1754,31 @@ take with fewer beats than the last one would otherwise leave the
                 f"frame ({type(exc).__name__}: {exc}), so nothing about the "
                 f"picture was measured"
             )
-            return
-        # The beat log goes in, and it is what makes the held-picture arm mean
-        # anything: without it a demo narrating over a rendered screen and a
-        # demo nobody can see are the same number. See CONTENT_ACTING_VERBS.
-        self._content = content_report(self._media_path(), rect, self._beats)
-        # What the take opened on, measured off the **encoded** mp4 — the file
-        # a reviewer watches, and the one the opening hold has already been
-        # applied to. That ordering is the whole check: a hold that silently
-        # did nothing leaves a non-zero gap right here (issue #119).
-        gap, note = opening_gap(self._media_path(), rect)
-        self._content["opening"] = opening_report(gap, note, self._opening_held)
-        warning = opening_warning(self._content["opening"])
-        if warning:
-            self._content["warnings"].append(warning)
+        else:
+            # The beat log goes in, and it is what makes the held-picture arm
+            # mean anything: without it a demo narrating over a rendered screen
+            # and a demo nobody can see are the same number. See
+            # CONTENT_ACTING_VERBS.
+            self._content = content_report(self._media_path(), rect, self._beats)
+            # What the take opened on, measured off the **encoded** mp4 — the
+            # file a reviewer watches, and the one the opening hold has already
+            # been applied to. That ordering is the whole check: a hold that
+            # silently did nothing leaves a non-zero gap right here (#119).
+            gap, note = opening_gap(self._media_path(), rect)
+            self._content["opening"] = opening_report(gap, note, self._opening_held)
+            warning = opening_warning(self._content["opening"])
+            if warning:
+                self._content["warnings"].append(warning)
+        # On **both** paths above, and last. An overlay this recorder left up is
+        # a fact about the picture whether or not the rect could be worked out,
+        # and it is a `content` warning rather than an issue on purpose: it
+        # answers the question `content` exists to answer, `stitch()` already
+        # carries a segment's content warnings into the merged demo tagged with
+        # the segment they came from, and `print_content_summary` suppresses
+        # "shows a picture" when the list is non-empty — which is exactly the
+        # line issue #163 measured being printed over an occluded take.
+        if self._overlay_note:
+            self._content["warnings"].append(self._overlay_note)
 
     def _timeline_doc(self, failure: dict | None = None) -> dict:
         """This take's beat log as a timeline document (see TIMELINE_SCHEMA).
@@ -1885,17 +1976,36 @@ take with fewer beats than the last one would otherwise leave the
         return min(6.0, max(1.4, 0.6 + words * 0.34))
 
     def interlude(self, text: str, hold: float = 2.8, style: str = "card") -> None:
-        """Bridge a jump in the demo; "" fades it out. With speech enabled the
-        line is spoken too.
+        """Bridge a jump in the demo; "" takes it down, whichever style is up.
+
+        With speech enabled the line is spoken too, and `hold` is how long the
+        card stays before the storyboard moves on (a clear always takes 0.6 s,
+        long enough for the fade).
 
         style="card" (default) is a full-screen title card — right for real
         time-skips (minutes of background work) between segments. style="light"
         is a centered label over a soft scrim with the scene still visible —
-        lighter, for short transitions where a full takeover feels heavy."""
+        lighter, for short transitions where a full takeover feels heavy.
+
+        **Raising dispatches on `style`; clearing does not** (issue #162).
+        `style` describes how a label *appears*, and making it load-bearing on
+        the way out gave `interlude("")` — the call this docstring and SKILL.md
+        both document — a silent no-op against a `light` scrim, because the
+        default `style="card"` sent the clear at the other element. Measured
+        cost of that: a scrim and a stale label over the app for the last 17 s
+        of a 48 s demo, with `warnings: []`, `issues: []` and
+        "demo.mp4 shows a picture" on stderr. So a clear takes down whatever is
+        up: both overlays, unconditionally, and it is cheap because taking down
+        an overlay that was never raised does nothing visible either way."""
         clip = self._prepare_line(text)
-        fn = "__demoBridge" if style == "light" else "__demoInterlude"
         with self._beat("interlude", selector=style, caption=text):
-            self.page.evaluate(f"t => window.{fn}(t)", text)
+            if text:
+                fn = "__demoBridge" if style == "light" else "__demoInterlude"
+                self.page.evaluate(f"t => window.{fn}(t)", text)
+            else:
+                self.page.evaluate(
+                    "() => { window.__demoInterlude(''); window.__demoBridge(''); }"
+                )
             self._start_line(clip)
             self.pause(hold if text else 0.6)
 

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -153,6 +153,10 @@ explains what it measures and lists five limits of the held-picture arm. Three
 of those five can hide a real occlusion; two of the three are worth an author's
 attention before recording, and both are here with their numbers.
 
+The third limit below is the *score* arm's rather than the held-picture arm's,
+and it is the sharpest measured thing in this group: an overlay does not merely
+hide from the score, it can push the score **up**.
+
 ### An occluder that spans only narration is never reported
 
 A held stretch warns only when a verb that *acts on the app* began inside it —
@@ -201,6 +205,57 @@ documented rather than graded
 
 What to do: keep captions to one line if you want `static_for` to mean what it
 says.
+
+### A full-viewport overlay can raise the content score, not lower it
+
+The score arm is the median luma standard deviation over the app rect, so it
+answers "is there variance here" and nothing more. A translucent overlay with
+internal variance — the `style="light"` scrim is a radial gradient — **adds**
+variance across the whole measured region. Three takes of one storyboard
+against one app, from a clean standalone install:
+
+| take | state | `content.score` |
+|---|---|---:|
+| 1 | scrim over the app for the last ~17 s of 48 s | 32.94 |
+| 2 | "cleared" per the docs, still covered ([#162](https://github.com/rogvid/skills/issues/162)) | 32.95 |
+| 3 | clean, nothing covering the app | **26.74** |
+
+The two broken takes scored **23% higher** than the correct one, and stderr
+printed `demo.mp4 shows a picture` for all three. `tests/smoke`'s own overlay
+pair reproduces it harder against the fixture app: **28.07** with the scrim up
+against **17.02** without, 65% the wrong way round. There is no threshold that
+separates those numbers in the right direction, and restricting the rect cannot
+help — the overlay is exactly where the app is. This is the same
+anti-correlation issue #17 found at whole-frame level, one level in.
+
+What was added instead is narrow and exact rather than a better metric: at the
+end of every take, before teardown, the recorder asks the **page** whether
+`#__demo_interlude` or `#__demo_bridge` is still visible. It built those
+elements and knows their ids, so the answer is a fact rather than an inference.
+A take that ends with one up gets a `content.warnings` entry naming it, a
+`WARNING` on stderr, and — because a non-empty warning list suppresses the
+healthy line — no `shows a picture` claim.
+
+**What it does not cover**, and this is the boundary rather than a to-do:
+
+- **Only the recorder's own two overlays.** An app's own modal, a cookie
+  banner, a `<dialog>.showModal()`, a stuck loading veil: all invisible to it,
+  and to everything else here. General occlusion detection is unbounded and is
+  declared out of scope alongside
+  [#123](https://github.com/rogvid/skills/issues/123) and
+  [#124](https://github.com/rogvid/skills/issues/124).
+- **Only the end of the take.** An overlay raised at 10 s and cleared at 40 s of
+  a 45 s take covered two thirds of the recording and reports nothing here. The
+  held-picture arm is what might see that, with the limits above.
+- **Only a take that encoded an mp4.** The finding rides in `content`, which is
+  null when no mp4 was written, so a take whose ffmpeg conversion failed loses
+  it. Such a take already carries `failure/` and `demo-video-FAILED.md`.
+- **The score is left alone.** It still reads high on an occluded take. The two
+  answers sit side by side in `timeline.json` on purpose; the warning says why
+  they disagree ([#163](https://github.com/rogvid/skills/issues/163)).
+
+What to do: nothing, if you use `interlude("")`. If you build your own overlay
+in page script, take it down yourself — no check here will notice it.
 
 ### If your app paints slowly, you are the first to run that path
 

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -118,7 +118,8 @@ the encoded frame, and writes down what it found:
   is what decides whether the stretch is worth a warning. See below.
 - `warnings` is empty on a healthy take, and each entry is one sentence saying
   what to go and look at. They are also printed on stderr as the take ends, so
-  an author who never opens this file is still told.
+  an author who never opens this file is still told. One entry does not come
+  from the frames at all — see *An overlay the recorder left up* below.
 - `measured` is `false`, with `note` saying why, when the check could not run.
   `content` itself is `null` only when the take encoded no mp4.
 - `opening` says what the take opened on — and, on a web take, what the
@@ -161,6 +162,27 @@ covering seconds of it would be inventing a demo rather than repairing one.
 inside the page, so it has no equivalent gap; open a terminal segment on a title
 card if you want its first frame to be deliberate (see *Opening a terminal
 segment on a title card*).
+
+### An overlay the recorder left up is reported exactly
+
+Every other number in `content` is measured off the encoded mp4. One warning is
+not: at the end of a take, while the page is still alive, the recorder asks it
+whether `#__demo_interlude` or `#__demo_bridge` — the two elements `interlude()`
+creates — is still visible. It built them, so this is a fact rather than an
+inference, and the warning names the id.
+
+It exists because the score arm gets this case *backwards*. A `style="light"`
+scrim is a radial gradient, and a gradient across the measured rect adds
+variance — which is what `score` is. Measured on three takes of one storyboard:
+**32.94** and **32.95** with the scrim over the app against **26.74** clean.
+The covered takes scored 23% higher, and all three printed
+`demo.mp4 shows a picture`.
+
+A take that ends with an overlay up now gets the warning, on stderr and in this
+file, and no `shows a picture` line. What it does **not** cover: an app's own
+modal (it only knows its own two elements), an overlay raised and cleared in the
+middle of a take (only the end is checked), and a take that encoded no mp4
+(`content` is null there). See [limits.md](limits.md).
 
 ### A long held stretch is not a problem, and this is the part to understand
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -328,6 +328,65 @@ CONTENT_COVERED_FRACTION = 0.75
 # 8 dB is a sixfold difference in mean squared error and sits under both.
 CONTENT_PSNR_GAP_DB = 8.0
 
+# -- the recorder's own overlay (issues #162 and #163) ------------------------
+#
+# The pair above records the *card* style and grades the held-picture arm. This
+# pair records the **light** style and grades two things that arm cannot see.
+#
+# `interlude("")` used to dispatch its clear on `style`, which defaults to
+# "card" — so the documented call took down the card overlay while a `light`
+# scrim stayed up (#162). Found from a clean standalone install: a scrim and a
+# stale label over the app for the last ~17 s of a 48 s demo, with
+# `warnings: []`, `issues: []` and "demo.mp4 shows a picture" on stderr.
+#
+# And the check that exists to catch that scored it backwards (#163). Three
+# takes of that storyboard: 32.94 and 32.95 for the two covered ones against
+# **26.74** for the clean one — the covered takes scored 23% *higher*, because
+# the scrim is a gradient and gradient inside the measured rect is exactly what
+# the score arm measures. This pair reproduces it against the fixture app,
+# harder: **28.07** with the scrim up against **17.02** without, 65% the wrong
+# way. So nothing here is asserted against `content.score`: that number is the
+# thing that was broken, and an assertion witnessed only by it would be grading
+# the defect with the defect. The two takes' scores are printed, not gated.
+#
+#   overlay-cleared   raise a `light` interlude, take it down with the
+#                     documented `interlude("")`. The scrim must be gone from
+#                     the recording, and the recorder must say nothing.
+#   overlay-left-up   the same storyboard without that one line. The scrim must
+#                     be visible in the recording, and the recorder must report
+#                     its own overlay by id, in timeline.json and on stderr.
+#
+# Each direction is the other's control. "The scrim is gone" is satisfied by a
+# recorder that never draws one; "the recorder warns" by one that warns on
+# everything; and the frame comparison by a measurement pointed somewhere the
+# scrim never covers. One storyboard, one line apart, both graded.
+OVERLAY_TAKES = ("overlay-cleared", "overlay-left-up")
+OVERLAY_LABEL = "Ten minutes later…"
+
+# How long the scrim is held, and how long the quiet stretches either side of
+# it are. Both are sized against the beat/video clock skew this file already
+# measures (MAX_CAPTURE_LOSS_S = 0.75): each sampled frame is taken from the
+# middle of a beat at least 3 s long, so a three-quarter-second slide in either
+# direction still lands inside the beat, and past the overlay's own 0.4-0.45 s
+# fade. A shorter hold would make these readings a measurement of luck.
+OVERLAY_HOLD_S = 3.2
+OVERLAY_QUIET_S = 3.0
+
+# How much of the frame the scrim has to move before "the scrim is gone" is a
+# claim worth making, in mean absolute luma over the app rect. This is the
+# **control**: it is asserted on the take that leaves the scrim up, and without
+# it a harness sampling the wrong rect would report "no scrim" for both takes
+# and call that a pass. Measured on this box: **63.90** for the left-up take
+# against **0.13** for the cleared one, so the bar sits an order of magnitude
+# under the first and well over an order above the second.
+OVERLAY_SCRIM_MIN_DIFF = 6.0
+
+# ...and how much of that the cleared take is allowed to keep. A ratio rather
+# than an absolute, for the reason CONTENT_PSNR_GAP_DB is one: the two takes
+# are recorded in the same run on the same encoder against the same app, so
+# comparing them claims nothing about either number on its own.
+OVERLAY_CLEARED_MAX_RATIO = 0.2
+
 # Duration windows, in seconds. Wide on purpose: the lower bound catches a
 # take that died early, the upper one catches a hang, and everything in
 # between is legitimate variation between a laptop and a cold CI runner.
@@ -2708,6 +2767,53 @@ def record_content_toured(out_dir: Path) -> tuple[list[str], dict]:
     return b.problems, {"app": app, "size": size}
 
 
+def record_overlay(
+    out_dir: Path, base_url: str, cleared: bool
+) -> tuple[list[str], dict]:
+    """A `light` interlude, taken down with the documented call — or left up.
+
+    The A/B of issues #162 and #163, and the only difference between the two
+    takes is the `interlude("")` on the line below.
+
+    **Web rather than terminal, and `light` rather than `card`.** The pair
+    above already records a card over a terminal; what neither of them reaches
+    is the style whose clear was broken, over an app with enough painted colour
+    for a translucent scrim to be measurable at all. A card is opaque, so "the
+    card is gone" and "the card is a different picture" are the same reading; a
+    scrim is not, which is the case the picture check scores backwards.
+
+    Quiet stretches either side of the scrim rather than beats that act on the
+    app: the frames compared below are of *the same screen*, once with the
+    scrim over it and once without, so nothing but the scrim can explain a
+    difference between them.
+    """
+    from demo_recording import Recorder
+
+    label = OVERLAY_TAKES[0] if cleared else OVERLAY_TAKES[1]
+    b = Beats(label)
+
+    with Recorder(
+        out_dir, base_url=base_url, speech=False, strict=True, deterministic=True
+    ) as rec:
+        rec.goto("/")
+        rec.wait_for("#kpi-rev")
+        # Without it the page goes idle behind the scrim, the screencast stops
+        # emitting frames, and every timestamp below drifts (issue #18).
+        start_ticker(b, rec.page)
+        rec.pause(OVERLAY_QUIET_S)
+        rec.interlude(OVERLAY_LABEL, hold=OVERLAY_HOLD_S, style="light")
+        if cleared:
+            # The call SKILL.md documents, with the default style. Before the
+            # fix this cleared the *card* overlay and left the scrim standing.
+            rec.interlude("")
+        rec.pause(OVERLAY_QUIET_S)
+
+        g = rec._geom
+        app: Rect = (g["appx"], g["appy"], g["appw"], g["apph"])
+
+    return b.problems, {"app": app}
+
+
 class EntropyTake(NamedTuple):
     """One recording of the entropy storyboard, and what it rendered."""
 
@@ -3937,6 +4043,31 @@ def check_content_pair(takes: dict[str, dict]) -> list[str]:
 
     # 6. The anti-correlated metric (issue #17), as a standing regression test.
     failures += _check_scored_region(shown, shown_c)
+
+    # 7. The card is this recorder's own element, and it is still up when the
+    #    take ends — so the recorder can report it by id rather than inferring
+    #    it from luma (#163). `check_overlay_pair` grades the same reading on
+    #    `#__demo_bridge`; this is the other overlay, on the other medium, and
+    #    it is free because this take already exists. The *silent* direction is
+    #    assertion 1 above: the shown take must carry no warning at all.
+    if "#__demo_interlude" not in still:
+        failures.append(
+            f"{CONTENT_TAKES[1]}: this take ends with the recorder's own "
+            f"interlude card on screen and `content.warnings` does not name it. "
+            f"The held-picture arm reports a stretch and cannot say what caused "
+            f"it; the element id is the one thing here that is exact (#163). "
+            f"warnings: {covered_c.get('warnings')!r}"
+        )
+    if "__demo_interlude" not in err:
+        failures.append(
+            f"{CONTENT_TAKES[1]}: nothing on stderr named the overlay left up. "
+            f"Captured stderr: {err[-400:]!r}"
+        )
+    if "__demo_" in shown["stderr"]:
+        failures.append(
+            f"{CONTENT_TAKES[0]}: stderr reported an overlay still up on the "
+            f"take that took its card down: {shown['stderr'][-400:]!r}"
+        )
     return failures
 
 
@@ -4012,6 +4143,195 @@ def check_content_toured(out_dir: Path, stderr: str) -> list[str]:
                 f"{[b.get('verb') for b in spanned]} — and the recorder said "
                 f"nothing, which is correct"
             )
+    return failures
+
+
+def _overlay_frame(mp4: Path, at: float, rect: Rect) -> bytes | None:
+    """One reduced frame of `rect` at `at` seconds, or None."""
+    try:
+        frames = gray_frames(mp4, rect, sample_fps=2, start=at, duration=0.6)
+    except RuntimeError:
+        return None
+    return frames[0] if frames else None
+
+
+def _overlay_scrim_delta(
+    out_dir: Path, label: str, rect: Rect
+) -> tuple[list[str], float | None]:
+    """How much the app rect moved between the two quiet stretches of a take.
+
+    The take pauses before the scrim goes up and again after it would have come
+    down, on a screen nothing else touches. So the difference between those two
+    moments **is** the scrim, and nothing else: no command ran, no caption was
+    set, the clock is frozen and the only other moving thing in the frame is
+    the 8x8 ticker in a corner the app rect includes and the gradient barely
+    reaches.
+
+    Sampled from `demo.mp4`, not from a still: a `shot()` is a screenshot of
+    the page and would be true of a DOM nobody recorded. Issue #162's
+    acceptance is about the frame.
+    """
+    pauses = beat_midpoints(out_dir, "pause")
+    if len(pauses) != 2:
+        return (
+            [
+                f"{label}: the take recorded {len(pauses)} pause beats, expected "
+                f"2 — the two quiet stretches this reading is taken from"
+            ],
+            None,
+        )
+    mp4 = out_dir / "demo.mp4"
+    before = _overlay_frame(mp4, pauses[0][1], rect)
+    after = _overlay_frame(mp4, pauses[1][1], rect)
+    if before is None or after is None:
+        return ([f"{label}: could not sample {mp4.name} at the two pause beats"], None)
+    # A control on the control: two frames of a black recording differ by 0 and
+    # would read as "the scrim is gone" for the cleared take. Both frames have
+    # to show something first.
+    for when, frame in (("before", before), ("after", after)):
+        score = contrast(frame)
+        if score < MIN_CONTENT_STDDEV["web"]:
+            return (
+                [
+                    f"{label}: the frame sampled {when} the scrim scores "
+                    f"{score:.1f} luma stddev over {rect}, under the "
+                    f"{MIN_CONTENT_STDDEV['web']} floor — there is no picture "
+                    f"there to have been covered, so comparing the two says "
+                    f"nothing"
+                ],
+                None,
+            )
+    return [], frame_difference(before, after)
+
+
+def check_overlay_pair(takes: dict[str, dict]) -> list[str]:
+    """The two `light`-interlude takes, against each other (#162 and #163).
+
+    Two claims, each with the other take as its control:
+
+    1. **The documented clear works.** `interlude("")` takes down a `light`
+       scrim, so the cleared take's two quiet stretches are the same picture
+       while the left-up take's are not. Neither reading means anything alone —
+       "no difference" is also what a harness measuring the wrong rect reports,
+       and "a difference" is also what a recorder that never cleared anything
+       produces — so the bar is the ratio between them, with an absolute floor
+       under the left-up take so the pair cannot both go quiet.
+    2. **The recorder notices its own overlay.** The left-up take must name
+       `#__demo_bridge` in `content.warnings` and on stderr, and must *not*
+       print that the recording shows a picture; the cleared take must say
+       nothing about any overlay. `content.score` is not consulted: it is the
+       measurement #163 is about, and it runs the wrong way here.
+    """
+    failures: list[str] = []
+    cleared, left_up = takes[OVERLAY_TAKES[0]], takes[OVERLAY_TAKES[1]]
+
+    # 1. The frames.
+    deltas: dict[str, float | None] = {}
+    for name, take in takes.items():
+        found, deltas[name] = _overlay_scrim_delta(
+            take["out_dir"], name, keep_top(take["info"]["app"])
+        )
+        failures += found
+    up_delta, clear_delta = deltas[OVERLAY_TAKES[1]], deltas[OVERLAY_TAKES[0]]
+    if up_delta is None or clear_delta is None:
+        failures.append("overlay: one of the two takes yielded no scrim reading")
+    elif up_delta < OVERLAY_SCRIM_MIN_DIFF:
+        failures.append(
+            f"{OVERLAY_TAKES[1]}: leaving the scrim up moved the app rect by "
+            f"only {up_delta:.2f} mean luma between the two quiet stretches, "
+            f"under the {OVERLAY_SCRIM_MIN_DIFF} floor. This harness cannot see "
+            f"the scrim at all, so the cleared take reading small proves "
+            f"nothing about the clear"
+        )
+    elif clear_delta > up_delta * OVERLAY_CLEARED_MAX_RATIO:
+        failures.append(
+            f'{OVERLAY_TAKES[0]}: after the documented `interlude("")` the app '
+            f"rect is still {clear_delta:.2f} mean luma from where it was "
+            f"before the scrim went up — {clear_delta / up_delta:.0%} of the "
+            f"{up_delta:.2f} the take that never cleared it keeps, over the "
+            f"{OVERLAY_CLEARED_MAX_RATIO:.0%} bar. The scrim is still in the "
+            f"recording, which is issue #162: the clear dispatched on `style`, "
+            f'so the default `style="card"` took down the other overlay'
+        )
+    else:
+        print(
+            f"smoke: {OVERLAY_TAKES[0]} scrim cleared — the app rect moved "
+            f"{clear_delta:.2f} mean luma across the clear against "
+            f"{up_delta:.2f} for {OVERLAY_TAKES[1]}"
+        )
+
+    # 2. What the recorder said about it.
+    reports = {}
+    for name, take in takes.items():
+        content = content_of(take["out_dir"])
+        if content is None or not content.get("measured"):
+            failures.append(
+                f"{name}: no measured `content` in timeline.json "
+                f"({None if content is None else content.get('note')})"
+            )
+        else:
+            reports[name] = content
+    if len(reports) != 2:
+        return failures
+    up_warnings = " ".join(
+        str(w) for w in reports[OVERLAY_TAKES[1]].get("warnings") or []
+    )
+    clear_warnings = " ".join(
+        str(w) for w in reports[OVERLAY_TAKES[0]].get("warnings") or []
+    )
+    if "#__demo_bridge" not in up_warnings:
+        failures.append(
+            f"{OVERLAY_TAKES[1]}: this take ended with the recorder's own scrim "
+            f"on screen and `content.warnings` does not name it. The recorder "
+            f"built that element and knows its id, so this is the one occlusion "
+            f"it can report exactly (#163). warnings: "
+            f"{reports[OVERLAY_TAKES[1]].get('warnings')!r}"
+        )
+    if "__demo_" in clear_warnings:
+        failures.append(
+            f"{OVERLAY_TAKES[0]}: the recorder reported an overlay still up on "
+            f"the take that took its scrim down: {clear_warnings!r}"
+        )
+    if "__demo_bridge" not in left_up["stderr"]:
+        failures.append(
+            f"{OVERLAY_TAKES[1]}: nothing on stderr said the scrim was still up. "
+            f"An author who never opens timeline.json gets no signal at all, "
+            f"which is half of #163's acceptance. Captured stderr: "
+            f"{left_up['stderr'][-400:]!r}"
+        )
+    # The line #163 measured being printed over three occluded takes, on the
+    # stream `print_content_summary` prints it to. Both directions, because
+    # "the covered take does not say it" is satisfied by a recorder that stopped
+    # saying it about anything — which would cost every healthy take its only
+    # unasked account of its own picture.
+    if "shows a picture" not in cleared["stdout"]:
+        failures.append(
+            f"{OVERLAY_TAKES[0]}: the take that cleared its scrim never said "
+            f"the recording shows a picture, so the covered take not saying it "
+            f"proves nothing. Captured stdout: {cleared['stdout'][-400:]!r}"
+        )
+    if "shows a picture" in left_up["stdout"]:
+        failures.append(
+            f"{OVERLAY_TAKES[1]}: the recorder still says the recording shows a "
+            f"picture, over a take whose last frames are its own scrim: "
+            f"{left_up['stdout'][-400:]!r}"
+        )
+    if "__demo_" in cleared["stderr"]:
+        failures.append(
+            f"{OVERLAY_TAKES[0]}: stderr warned about an overlay on the take "
+            f"that cleared it: {cleared['stderr'][-400:]!r}"
+        )
+
+    if not failures:
+        # Printed, never asserted: this is the anti-correlation of #163, and a
+        # bar in this direction would be the defect written down as a check.
+        print(
+            f"smoke: content.score reads "
+            f"{reports[OVERLAY_TAKES[1]].get('score')} for the covered take "
+            f"against {reports[OVERLAY_TAKES[0]].get('score')} for the clear "
+            f"one — the picture score does not separate these, which is why "
+            f"the overlay is reported by element id instead (#163)"
+        )
     return failures
 
 
@@ -6236,29 +6556,46 @@ def run_terminal_opening(out_root: Path) -> list[str]:
 
 
 def _record_content_take(out_root: Path, name: str, record) -> tuple[list[str], dict]:
-    """Record one content take, capturing its stderr.
+    """Record one content take, capturing what it printed.
 
-    stderr is captured rather than merely inspected afterwards, because half
-    the acceptance criterion is that the verdict arrives *unasked*: an author
-    who never opens timeline.json still has to be told, and — for the healthy
-    takes — must not be told something untrue. `print` resolves `sys.stderr` at
-    call time, so redirecting here catches the recorder's own output and
-    nothing else's.
+    The streams are captured rather than merely inspected afterwards, because
+    half the acceptance criterion is that the verdict arrives *unasked*: an
+    author who never opens timeline.json still has to be told, and — for the
+    healthy takes — must not be told something untrue. `print` resolves
+    `sys.stderr`/`sys.stdout` at call time, so redirecting here catches the
+    recorder's own output and nothing else's.
+
+    **Both streams, and the split is the recorder's, not this file's.**
+    `print_content_summary` puts a *warning* on stderr and the healthy
+    "demo.mp4 shows a picture" line on stdout. Issue #163's acceptance is that
+    an occluded take reports the overlay *rather than* printing that line, so
+    grading it needs the stream that line goes to; capturing only stderr made
+    "it no longer says it shows a picture" an assertion that could never fail.
+
+    Shared with the overlay pair (#162/#163), which grades the same "it has to
+    arrive unasked" half against the other overlay style.
     """
     out_dir = fresh_take_dir(out_root, name)
-    captured = io.StringIO()
+    err, out = io.StringIO(), io.StringIO()
     try:
-        with contextlib.redirect_stderr(captured):
+        with contextlib.redirect_stderr(err), contextlib.redirect_stdout(out):
             found, info = record(out_dir)
     except Exception as exc:  # noqa: BLE001 - a raising take is a failure
-        sys.stderr.write(captured.getvalue())
-        return [f"{name}: TerminalRecorder raised {type(exc).__name__}: {exc}"], {}
-    # Put it back on the real stderr: a run that fails later should not also
+        sys.stdout.write(out.getvalue())
+        sys.stderr.write(err.getvalue())
+        return [f"{name}: the recorder raised {type(exc).__name__}: {exc}"], {}
+    # Put them back on the real streams: a run that fails later should not also
     # have swallowed the recorder's own account of itself.
-    sys.stderr.write(captured.getvalue())
+    sys.stdout.write(out.getvalue())
+    sys.stderr.write(err.getvalue())
     if not (out_dir / "demo.mp4").is_file():
         found = [*found, f"{name}: demo.mp4 was never written"]
-    return found, {"out_dir": out_dir, "info": info, "stderr": captured.getvalue()}
+    return found, {
+        "out_dir": out_dir,
+        "info": info,
+        "stderr": err.getvalue(),
+        "stdout": out.getvalue(),
+    }
 
 
 def run_content(out_root: Path) -> list[str]:
@@ -6305,6 +6642,28 @@ def run_content(out_root: Path) -> list[str]:
         + check_content_pair(takes)
         + check_content_toured(toured["out_dir"], toured["stderr"])
     )
+
+
+def run_overlay(out_root: Path) -> list[str]:
+    """Two takes: a `light` scrim taken down with the documented call, and one
+    left up (issues #162 and #163)."""
+    problems: list[str] = []
+    takes: dict[str, dict] = {}
+    with fixture_server() as base_url:
+        for name, cleared in zip(OVERLAY_TAKES, (True, False), strict=True):
+            found, take = _record_content_take(
+                out_root,
+                name,
+                lambda out_dir, cleared=cleared: record_overlay(
+                    out_dir, base_url, cleared=cleared
+                ),
+            )
+            problems += found
+            if take:
+                takes[name] = take
+    if problems:
+        return problems
+    return check_overlay_pair(takes)
 
 
 def run_coverage(out_root: Path) -> list[str]:
@@ -8664,6 +9023,12 @@ def main() -> int:
         "recording showing nothing (issue #97)",
     )
     parser.add_argument(
+        "--overlay-only",
+        action="store_true",
+        help="record only the pair that grades clearing a light interlude and "
+        "reporting one left up (issues #162 and #163)",
+    )
+    parser.add_argument(
         "--coverage-only",
         action="store_true",
         help="record only the take that grades acceptance-criterion coverage "
@@ -8702,6 +9067,7 @@ def main() -> int:
             ("--failure-only", args.failure_only),
             ("--polish-only", args.polish_only),
             ("--content-only", args.content_only),
+            ("--overlay-only", args.overlay_only),
             ("--coverage-only", args.coverage_only),
         )
         if on
@@ -8780,6 +9146,11 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
     # take, and the card it leaves up is the terminal recorder's card.
     if only in (None, "--terminal-only", "--content-only"):
         failures += run_content(out_root)
+    # Clearing a `light` interlude, and noticing one left up (#162/#163). A web
+    # take, and reachable from --content-only as well as its own flag: it
+    # grades the other half of the same question the pair above does.
+    if only in (None, "--web-only", "--content-only", "--overlay-only"):
+        failures += run_overlay(out_root)
     # Acceptance-criterion coverage (issue #12). Reachable from --web-only as
     # well as its own flag: it is a web take, and whoever is changing the
     # recorder's beat record is running --web-only.

--- a/tests/unit
+++ b/tests/unit
@@ -61,6 +61,7 @@ from demo_recording.content import (  # noqa: E402
     merge_content,
     opening_report,
     opening_warning,
+    overlay_warning,
 )
 from demo_recording.coverage import (  # noqa: E402
     _checked_criteria,
@@ -465,6 +466,46 @@ class OpeningWarning(unittest.TestCase):
 
     def test_a_healthy_take_whose_hold_landed_is_silent(self):
         self.assertIsNone(opening_warning(opening_report(0.0, None, 0.42)))
+
+
+class OverlayWarning(unittest.TestCase):
+    """issue #163 — the recorder noticing its own overlay is still up.
+
+    Deliberately *not* graded against `content.score`: the score is the thing
+    that is broken here (26.74 clean against 32.94 covered, the wrong way
+    round), so an assertion whose only witness was that number would be
+    grading the defect with the defect. What these grade is the sentence, and
+    whether it stays silent when nothing is up. That the probe finds the right
+    elements needs a page and is `tests/smoke`'s.
+    """
+
+    def test_a_take_with_nothing_up_says_nothing(self):
+        # The direction that costs the most if it breaks: a warning that fires
+        # on every take stops being read, and every healthy take in the suite
+        # ends with the interlude element present at opacity 0.
+        self.assertIsNone(overlay_warning([]))
+
+    def test_the_overlay_that_was_up_is_named(self):
+        # "An overlay was up" is not actionable; #__demo_bridge against
+        # #__demo_interlude is the difference between a `light` scrim and a
+        # full-screen card, and it is the whole of issue #162's symptom.
+        warning = overlay_warning(["__demo_bridge"])
+        self.assertIsNotNone(warning)
+        self.assertIn("#__demo_bridge", warning)
+        self.assertNotIn("#__demo_interlude", warning)
+
+    def test_both_overlays_up_are_both_named(self):
+        warning = overlay_warning(["__demo_interlude", "__demo_bridge"])
+        self.assertIn("#__demo_interlude", warning)
+        self.assertIn("#__demo_bridge", warning)
+
+    def test_the_warning_says_the_score_cannot_see_this(self):
+        # The reader most likely to see this line is the one reading it beside
+        # a healthy-looking `score`, so it has to say why the two disagree —
+        # otherwise it reads as the check contradicting itself.
+        warning = overlay_warning(["__demo_bridge"])
+        self.assertIn("score", warning)
+        self.assertIn('interlude("")', warning)
 
 
 class BeatsWithin(unittest.TestCase):
@@ -1524,6 +1565,39 @@ INJECTIONS = [
         [
             "OpeningWarning.test_the_warning_bar_is_graded_at_its_boundary",
             "OpeningWarning.test_a_healthy_take_whose_hold_landed_is_silent",
+        ],
+    ),
+    (
+        # The pre-#163 behaviour exactly: nothing is ever said about an
+        # overlay left up, and the take reports that it shows a picture.
+        "the overlay check goes silent whatever the page reported",
+        "content.py",
+        "    if not ids:\n        return None",
+        "    if True:\n        return None",
+        [
+            "OverlayWarning.test_the_overlay_that_was_up_is_named",
+            "OverlayWarning.test_both_overlays_up_are_both_named",
+            "OverlayWarning.test_the_warning_says_the_score_cannot_see_this",
+        ],
+    ),
+    (
+        # The opposite direction, and the more expensive one: every healthy
+        # take in this repo ends with a faded interlude element in the tree,
+        # so a check that warns unconditionally warns on all of them.
+        "the overlay check warns on a take with nothing up",
+        "content.py",
+        "    if not ids:\n        return None",
+        "    if not ids:\n        ids = ['__demo_interlude']",
+        ["OverlayWarning.test_a_take_with_nothing_up_says_nothing"],
+    ),
+    (
+        "the overlay warning stops naming which overlay was up",
+        "content.py",
+        '    names = ", ".join(f"#{i}" for i in ids)',
+        '    names = "an overlay"',
+        [
+            "OverlayWarning.test_the_overlay_that_was_up_is_named",
+            "OverlayWarning.test_both_overlays_up_are_both_named",
         ],
     ),
     (


### PR DESCRIPTION
Two defects, one story. Both were found by an agent following `SKILL.md` from a
**clean standalone install** — the first time this skill has been exercised the
way a user gets it rather than from inside the repo.

## #162 — the documented clear did nothing

`core.py`: `fn = "__demoBridge" if style == "light" else "__demoInterlude"`.

The clear dispatched on `style`, which defaults to `"card"`. So the documented
`interlude("")` took down the *card* overlay while a `style="light"` scrim
stayed up. `SKILL.md` said `""` fades it out.

**Fixed:** `style` now dispatches only when *raising*. `interlude("")` evaluates
both clears and takes down whatever is up. `terminal.py`'s direct
`__demoInterlude('')` for its opening card is untouched and still correct.

What it cost the agent who hit it: a scrim and a stale label over the app for
the last **~17s of a 48s demo**, with `warnings: []`, `issues: []`, stderr
saying `demo.mp4 shows a picture`, and a `timeline.md` row that reads exactly
like a successful clear. `images/04-filtered.png` — a file SKILL.md tells you to
**commit to git** — came out byte-identical across takes with the scrim baked in.

## #163 — and the check that exists to catch that scored it *backwards*

| take | state | `content` |
|---|---|---:|
| scrim up | covered | 32.94 |
| "cleared" per the docs | still covered | 32.95 |
| clean | fine | **26.74** |

The broken takes scored **23% higher**. The scrim is a gradient; gradient inside
the measured rect reads as picture. This is the catalogue's *anti-correlated
metric*, and this repo already learned it one level up — `tests/smoke`'s
docstring explains why the whole frame is not scored.

**Against the fixture the effect is worse still: 28.07 covered against 17.02
clean, 65% the wrong way.** That is printed by the new arm and deliberately
**not asserted** — asserting it would write the defect down as a check.

**Fixed narrowly.** Not general occlusion detection, which is unbounded and
stays declared in `reference/limits.md`. The winnable claim: *the recorder
notices its own overlay is still up when the take ends.* It built those elements
and knows their ids, so this is exact rather than heuristic.

`_note_overlays_up()` runs in `__exit__` after `_finish_line()` and **before
`_stop()`**, on both the clean and the exception path, and asks the live page
which of `OVERLAY_IDS` is *visible* — `getComputedStyle`, opacity > 0.01, plus
`display`/`visibility`. Visibility rather than existence, because the terminal's
opening card leaves a faded element in the tree on every healthy take.

### Why a warning and not an issue

1. **#163's acceptance is "reports it *rather than* reporting that the demo
   shows a picture."** `print_content_summary` returns early when `warnings` is
   non-empty, so a warning suppresses that line. An issue would print the
   reassurance underneath the warning.
2. **An issue would be attributed wrongly.** `_note_issue` at teardown gets
   `beat: None`, which `_issue_where` renders as *"before the first beat"* — a
   confidently wrong location for something observed at the end, which is the
   artifact-lie class this repo blocks on.
3. **Zero schema surface.** No `ISSUE_KINDS`/`STRICT_KINDS` entry, nothing for
   `stitching.py` to learn, no smoke schema assertion touched.

Rejected: a threshold change (no floor separates 26.74 from 32.94 in the right
direction) and excluding the overlay from the scored rect (the overlay is
exactly where the app is).

## Watched to fail — four breaks

1. **The pre-fix `interlude` restored verbatim.** The new arm reports the app
   rect still 63.91 mean luma from where it was, *100% of what the take that
   never cleared keeps*, over a 20% bar — and names #162 as the cause.
2. **The probe returns nothing (pre-#163).** Three assertions fire across two
   arms: the warning is absent, stderr is silent, and the recorder still says
   the recording shows a picture over a take ending in its own scrim.
3. **The probe over-reports** (`up = list(OVERLAY_IDS)`): four healthy arms go
   red, including two that legitimately take their card down.
4. **A vacuity control.** `"shows a picture"` → `"was measured"` in
   `print_content_summary`, and the covered take's assertion collapses — proving
   the covered take *not* saying it means something only because the clean take
   *does*.

Plus **three registered `tests/unit` injections** on the browser-free
`overlay_warning()`. Manifest **41 of 41**.

## Docs

`reference/limits.md` gains "A full-viewport overlay can raise the content
score, not lower it" in the picture-measurement group, with both measurements
and four stated non-coverages. `reference/timeline.md` gains a short subsection.
`SKILL.md` documents `interlude`'s `hold=` (#164 item 4), states the clear is
style-agnostic, and gains a Common-mistakes bullet against reading
`content.score` as "the app was visible".

## Two filed, not fixed here

- **#168** — `tests/smoke`'s own narration fixture leaves its interlude card up
  for most of its take; the new check reports it on an arm the suite calls
  healthy. Fixing it touches `check_narration_pacing`'s beat pairing.
- **#169** — `print_content_summary` puts warnings on stderr and the healthy
  line on **stdout**, while the docs say stderr for the whole summary. Found
  because the first version of an assertion here searched the wrong stream and
  therefore could not fail.

## Verification

- full `tests/smoke`: **PASSED**, 101 reported checks (was 98)
- `tests/unit`: 80 tests; `--fault-inject`: 41/41
- `--budget`: 578/600 lines
- `ruff==0.14.2` check + format, `mypy==1.18.2` over 12 modules: clean

Fixes #162
Fixes #163