### PR TITLE
Send a first-time user somewhere that exists, and ship a template that parses (#164)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -180,7 +180,7 @@ from pathlib import Path
 
 # Filled in by the writing agent with the skill's real location;
 # DEMO_VIDEO_SKILL_DIR takes precedence.
-_DEFAULT_SKILL_DIR = <the demo-video skill folder, as known when writing this file>
+_DEFAULT_SKILL_DIR = "<fill in: the demo-video skill folder>"
 SKILL_DIR = Path(os.environ.get("DEMO_VIDEO_SKILL_DIR") or _DEFAULT_SKILL_DIR)
 if not (SKILL_DIR / "helpers" / "demo_recording" / "__init__.py").exists():
     sys.exit(f"demo-video skill not found at {SKILL_DIR} — set DEMO_VIDEO_SKILL_DIR")
@@ -201,37 +201,42 @@ call — see **Terminal demos** below.
 Every `Recorder` parameter resolves **explicit parameter → `DEMO_VIDEO_*`
 env var → built-in default**, so projects can put defaults in their
 `.env` (load with `set -a; source .env; set +a`) and storyboards stay
-clean:
+clean. **The Sets column names the parameter behind each variable** — for
+three it is not the variable lowercased, so do not infer it:
 
-| Variable | Sets | Default |
+| Variable | Sets (parameter — what it does) | Default |
 |---|---|---|
-| `DEMO_VIDEO_OUT_DIR` | where demo files land (`out_dir`) | — (required one way or the other) |
-| `DEMO_VIDEO_BASE_URL` | app under demo | `http://localhost:8000` |
-| `DEMO_VIDEO_ACCENT_RGB` | cursor/spotlight color, `"235,110,20"` | orange |
-| `DEMO_VIDEO_TERMINAL_TITLE` | web `terminal()` card title | `terminal` |
-| `DEMO_VIDEO_TERMINAL_PROMPT` | prompt string — web card, and `TerminalRecorder`'s shell PS1 | `$ ` (web card); `❯ ` (`TerminalRecorder`) |
-| `DEMO_VIDEO_TERMINAL_SHELL` | shell `TerminalRecorder` launches | `/bin/bash` |
-| `DEMO_VIDEO_TERMINAL_FONT_SIZE` | `TerminalRecorder` font px | `15` |
-| `DEMO_VIDEO_VIEWPORT` | recording size, `"1280x720"` | 1280×720 |
-| `DEMO_VIDEO_DETERMINISTIC` | freeze the page clock and flatten motion (`1`/`0`) — **read [reference/determinism.md](reference/determinism.md) first** | **off** |
-| `DEMO_VIDEO_CLOCK` | the instant the page's clock is frozen at, when it is (ISO 8601) | `2025-01-01T09:00:00Z` |
-| `DEMO_VIDEO_TIMEZONE` | browser timezone (`timezone_id`), always applied | `UTC` |
-| `DEMO_VIDEO_LOCALE` | browser locale (`locale`), always applied | `en-US` |
-| `DEMO_VIDEO_SPEECH` | force narration on/off (`1`/`0`) | auto by API key |
-| `DEMO_VIDEO_STRICT` | fail the take on console errors / non-zero exits (`1`/`0`) | off |
-| `DEMO_VIDEO_EVIDENCE` | write `evidence/beat-NN.json` per beat (`1`/`0`) — see [reference/review.md](reference/review.md) | **on** |
-| `DEMO_VIDEO_VOICE_ID` | ElevenLabs voice | Sarah (premade) |
-| `DEMO_VIDEO_SPEECH_MODEL` | ElevenLabs model | `eleven_multilingual_v2` |
-| `DEMO_VIDEO_SKILL_DIR` | where storyboards find this skill | the constant baked into each storyboard |
-| `ELEVENLABS_API_KEY` | enables speech narration | off |
+| `DEMO_VIDEO_OUT_DIR` | `out_dir` — where demo files land | — (required one way or the other) |
+| `DEMO_VIDEO_BASE_URL` | `base_url` — app under demo | `http://localhost:8000` |
+| `DEMO_VIDEO_ACCENT_RGB` | `accent_rgb` — cursor/spotlight color, `"235,110,20"` | orange |
+| `DEMO_VIDEO_TERMINAL_TITLE` | `terminal_title` — web `terminal()` card title | `terminal` |
+| `DEMO_VIDEO_TERMINAL_PROMPT` | `terminal_prompt` — prompt string: web card, and `TerminalRecorder`'s shell PS1 | `$ ` (web card); `❯ ` (`TerminalRecorder`) |
+| `DEMO_VIDEO_TERMINAL_SHELL` | `shell` — shell `TerminalRecorder` launches | `/bin/bash` |
+| `DEMO_VIDEO_TERMINAL_FONT_SIZE` | `font_size` — `TerminalRecorder` font px | `15` |
+| `DEMO_VIDEO_VIEWPORT` | `viewport` — recording size, `"1280x720"` | 1280×720 |
+| `DEMO_VIDEO_DETERMINISTIC` | `deterministic` — freeze the page clock and flatten motion (`1`/`0`) — **read [reference/determinism.md](reference/determinism.md) first** | **off** |
+| `DEMO_VIDEO_CLOCK` | `clock` — the instant the page's clock is frozen at, when it is (ISO 8601) | `2025-01-01T09:00:00Z` |
+| `DEMO_VIDEO_TIMEZONE` | `timezone_id` — browser timezone, always applied | `UTC` |
+| `DEMO_VIDEO_LOCALE` | `locale` — browser locale, always applied | `en-US` |
+| `DEMO_VIDEO_SPEECH` | `speech` — force narration on/off (`1`/`0`). **`speech=False` records silently even with a key set**; with no key it is off already, and forcing it *on* without one refuses the take | auto by API key |
+| `DEMO_VIDEO_STRICT` | `strict` — fail the take on console errors / non-zero exits (`1`/`0`) | off |
+| `DEMO_VIDEO_EVIDENCE` | `evidence` — write `evidence/beat-NN.json` per beat (`1`/`0`) — see [reference/review.md](reference/review.md) | **on** |
+| `DEMO_VIDEO_VOICE_ID` | `voice_id` — ElevenLabs voice | Sarah (premade) |
+| `DEMO_VIDEO_SPEECH_MODEL` | `speech_model` — ElevenLabs model | `eleven_multilingual_v2` |
+| `DEMO_VIDEO_SKILL_DIR` | *no parameter* — where storyboards find this skill | the constant baked into each storyboard |
+| `ELEVENLABS_API_KEY` | *no parameter* — enables speech narration | off |
 
 `DEMO_VIDEO_BASE_URL` applies to the web `Recorder` only; the terminal
-`*` variables to `TerminalRecorder`. All the rest apply to both.
+`*` variables to `TerminalRecorder`. All the rest apply to both. The
+parameters with **no** env var are per-storyboard by nature: `segment`
+and `criteria` on both recorders, plus `TerminalRecorder`'s `interlude`,
+`interlude_hold` and `type_delay_ms`.
 
 ## Recorder API (storyboard verbs)
 
 `Recorder(out_dir, base_url=..., segment=None, strict=False, ...)` as a context
-manager; exiting the `with` converts the recording to mp4 and writes the beat
+manager — the `...` is the Configuration table above, which names every
+parameter. Exiting the `with` converts the recording to mp4 and writes the beat
 log. A storyboard that *raises* gets the same treatment plus a `failure/` dump.
 `strict=True` refuses a take that recorded a console error, an uncaught
 exception, or a non-zero exit. Both are
@@ -392,7 +397,9 @@ return.
    `timeline.md` too — it is the take's own account of what ran and when, so
    a beat that fired at the wrong moment or a caption that never changed
    shows up there without decoding a frame. **Read the problem summary the
-   recorder prints on stderr**, and the Issues section of `timeline.md`: a
+   recorder prints on stderr**, and the Issues section of `timeline.md` if it
+   has one — both appear only when there was something to report, so a take
+   with neither is the all-clear, not a malformed file. A
    demo of an app throwing on every render looks exactly like a demo of a
    working one, and this is the only place it shows
    ([reference/failures.md](reference/failures.md)). To check what a *specific*

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -693,7 +693,8 @@ class _DemoBase:
                 f"plausible wrong screen rather than failing loudly — check the "
                 f"stills against the app by hand this once, and pass "
                 f"deterministic=False (or DEMO_VIDEO_DETERMINISTIC=0) if "
-                f"anything looks off. See SKILL.md, 'Determinism'.",
+                f"anything looks off. See the skill's "
+                f"reference/determinism.md.",
                 file=sys.stderr,
             )
         else:
@@ -703,8 +704,8 @@ class _DemoBase:
                 f"are still pinned, but the page's clock runs, so anything the "
                 f"app renders from it differs between takes and two recordings "
                 f"of this storyboard will not match. Recorder("
-                f"deterministic=True) freezes it; read SKILL.md's 'Determinism' "
-                f"section first, it changes what some apps do.",
+                f"deterministic=True) freezes it; read the skill's "
+                f"reference/determinism.md first, it changes what some apps do.",
                 file=sys.stderr,
             )
 

--- a/tests/unit
+++ b/tests/unit
@@ -35,6 +35,8 @@ before treating a green run as coverage of the recorder.
 from __future__ import annotations
 
 import argparse
+import ast
+import io
 import os
 import re
 import shutil
@@ -42,6 +44,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import tokenize
 import unittest
 from pathlib import Path
 
@@ -1049,6 +1052,224 @@ class DocSymbols(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# No shipped file points at a place in the documentation that is not there
+# --------------------------------------------------------------------------
+#
+# The sibling defect of the sweep above, and the one this repo keeps re-making:
+# not a document naming a symbol the code lacks, but **code naming a place in
+# the documentation that a move deleted**. `core.py` told every take with
+# determinism off to "read SKILL.md's 'Determinism' section first" for the four
+# releases after #146 moved that section to `reference/determinism.md`. It was
+# on stderr, on the ordinary successful path, and a fresh agent did exactly what
+# it said and found nothing (issue #164). Same shape as the four stale comments
+# #155 repaired and the module name #166 removed — a move that left a pointer.
+#
+# Two kinds of pointer, because a pointer names a place two ways:
+#
+#   * **A quoted SKILL.md section name** — `SKILL.md's 'Determinism'`, or
+#     `"What this records…" in SKILL.md` — has to be a heading in SKILL.md.
+#   * **A `reference/<name>.md` path** has to be a file.
+#
+# Swept out of the package's *prose* — comments, docstrings and the strings it
+# prints — and out of the shipped documents, because the same pointer rots in
+# both and the reader cannot tell which file it came from.
+#
+# **What this does not check**, so nobody reads it as more than it is:
+#
+#   * Unquoted pointers. `reference/determinism.md` says "the Process section of
+#     [SKILL.md](../SKILL.md), step 2" and README's layout tree annotates
+#     `reference/` in prose; neither is quoted, and a rule loose enough to catch
+#     them matches ordinary English. Quoting is the author saying "this is a
+#     name in that document", which is the decidable half.
+#   * Anchors and step numbers. "step 2 of Process" resolving to the right step
+#     is not decidable from the heading list.
+#   * That a section still *says* what the pointer claims. A heading that
+#     survived a rewrite of everything under it passes here.
+#   * SKILL.md's own `](reference/…)` links are graded twice, here and by
+#     `SkillDocs`. That overlap is deliberate and not the point of this sweep:
+#     of the 59 path sites today, 52 are SKILL.md's links and 7 are what
+#     `SkillDocs` cannot see — README's three bare prose mentions, and the four
+#     the *package* prints or comments (`core.py` ×3, `content.py` ×1). #164
+#     was in that second group, and until #170 it had no members at all.
+#
+# The section sweep's haystack is small and stated rather than implied: **3
+# sites naming 1 heading**, all of them pointing at the secret-boundary section
+# at the top of SKILL.md. That is worth guarding — it is the section a reader
+# is sent to before pointing the recorder at anything, from two docstrings and
+# a reference file — but it is not a broad check, and the floor below is at
+# today's exact count so that thinning it further is somebody's explicit
+# decision rather than a drift.
+
+# A quoted span. No quote characters inside, so it stops at the first closer;
+# newlines are allowed because a docstring wraps its section names across lines.
+POINTER_QUOTED = r"['\"]([^'\"]{3,120}?)['\"]"
+# `SKILL.md's 'Determinism'` / `SKILL.md, 'Determinism'` — name after the file.
+# Nothing in the skill is phrased this way *today*, because the two sites that
+# were are what #164 fixed. It stays because that is the phrasing the defect
+# took, and the injection that reproduces #164 verbatim is what exercises it.
+POINTER_AFTER_RE = re.compile(r"SKILL\.md(?:'s)?[^\n]{0,24}?" + POINTER_QUOTED)
+# `"What this records…" in SKILL.md` / `… at the top of [SKILL.md]` — before it.
+POINTER_BEFORE_RE = re.compile(POINTER_QUOTED + r"[^\n]{0,30}?\[?SKILL\.md")
+POINTER_PATH_RE = re.compile(r"\breference/[A-Za-z0-9_-]+\.md\b")
+
+# Below these many *sites*, the extraction stopped extracting and "every
+# pointer resolves" holds over an empty set — the catalogue's vacuous sweep.
+# Today: 3 section sites (`web.py`, `terminal.py`, `reference/terminal.md`) and
+# 59 path sites. The path floor is a floor and has room; the section floor is
+# at today's count for the reason above.
+POINTER_SECTION_FLOOR = 3
+POINTER_PATH_FLOOR = 40
+
+
+def _py_prose(path: Path) -> list[str]:
+    """A module's human-readable text: comments, docstrings, printed strings.
+
+    Read through `ast` and `tokenize` rather than off the raw file, because
+    Python's own quoting is in the way of the question. A message the recorder
+    prints is four adjacent f-string literals in the source and one sentence on
+    the user's terminal, and the section name inside it is single-quoted only
+    because the literal around it is double-quoted. The parser joins the pieces
+    and strips the delimiters, so what is searched is what the user reads.
+    """
+    src = path.read_text(encoding="utf-8")
+    units = [
+        tok.string.lstrip("#")
+        for tok in tokenize.generate_tokens(io.StringIO(src).readline)
+        if tok.type == tokenize.COMMENT
+    ]
+    tree = ast.parse(src)
+    # An f-string's literal pieces are Constants *inside* the JoinedStr, so
+    # walking naively yields every message twice — once whole, once in pieces.
+    in_fstring = {
+        id(part)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.JoinedStr)
+        for part in node.values
+    }
+    for node in ast.walk(tree):
+        if isinstance(node, ast.JoinedStr):
+            units.append(
+                "".join(
+                    part.value
+                    if isinstance(part, ast.Constant) and isinstance(part.value, str)
+                    else "{}"
+                    for part in node.values
+                )
+            )
+        elif (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and id(node) not in in_fstring
+        ):
+            units.append(node.value)
+    return units
+
+
+def pointer_sources() -> dict[str, list[str]]:
+    """Every shipped file that can carry a pointer -> its prose, by unit."""
+    sources = {
+        f"helpers/demo_recording/{py.name}": _py_prose(py)
+        for py in sorted((_PKG_PARENT / "demo_recording").glob("*.py"))
+    }
+    for doc in doc_files():
+        sources[doc.name] = [doc.read_text(encoding="utf-8")]
+    return sources
+
+
+def skill_headings() -> set[str]:
+    """SKILL.md's headings, whitespace-normalised.
+
+    Fenced blocks are skipped: the storyboard template is Python whose comments
+    and PEP 723 metadata start with `#`, and counting `# /// script` as a
+    heading would let a pointer at a section that does not exist pass by
+    matching a line of sample code.
+    """
+    headings, fenced = set(), False
+    for line in (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8").splitlines():
+        if line.startswith("```"):
+            fenced = not fenced
+        elif not fenced and line.startswith("#"):
+            headings.add(" ".join(line.lstrip("#").split()))
+    return headings
+
+
+def section_pointers() -> list[tuple[str, str]]:
+    """(section name, file) for every quoted SKILL.md section name shipped."""
+    sites = []
+    for where, units in pointer_sources().items():
+        for unit in units:
+            seen: set[tuple[int, int]] = set()
+            for pattern in (POINTER_AFTER_RE, POINTER_BEFORE_RE):
+                for match in pattern.finditer(unit):
+                    if match.span(1) in seen:  # both patterns hit one pointer
+                        continue
+                    seen.add(match.span(1))
+                    sites.append((" ".join(match.group(1).split()), where))
+    return sites
+
+
+def path_pointers() -> list[tuple[str, str]]:
+    """(reference path, file) for every `reference/*.md` the skill names."""
+    return [
+        (match.group(0), where)
+        for where, units in pointer_sources().items()
+        for unit in units
+        for match in POINTER_PATH_RE.finditer(unit)
+    ]
+
+
+class DocPointers(unittest.TestCase):
+    def test_every_skill_md_section_the_skill_quotes_is_a_heading(self):
+        sites = section_pointers()
+        # The haystack, before anything is claimed about it.
+        self.assertGreaterEqual(
+            len(sites),
+            POINTER_SECTION_FLOOR,
+            f"only {len(sites)} quoted SKILL.md section names found — the "
+            f"extraction is broken, and 'they all resolve' would hold trivially",
+        )
+        # No floor on the heading set: a scan returning too few makes pointers
+        # look dead, which the assertion below already catches, and one
+        # returning too many is what skipping fenced blocks prevents. A count
+        # here would be the catalogue's dominated assertion.
+        headings = skill_headings()
+        dead = sorted(
+            {f"{name!r} (in {where})" for name, where in sites if name not in headings}
+        )
+        self.assertEqual(
+            dead,
+            [],
+            f"{len(dead)} pointer(s) at a SKILL.md section that does not "
+            f"exist: {dead}. The section was renamed or moved out to "
+            f"reference/, and the pointer stayed. Point at wherever the "
+            f"material went — a reader who is told to look in SKILL.md and "
+            f"finds nothing concludes the skill is wrong about itself.",
+        )
+
+    def test_every_reference_document_the_skill_names_exists(self):
+        sites = path_pointers()
+        # The haystack, before anything is claimed about it.
+        self.assertGreaterEqual(
+            len(sites),
+            POINTER_PATH_FLOOR,
+            f"only {len(sites)} reference/*.md paths found — the extraction "
+            f"is broken, and 'they all resolve' would hold trivially",
+        )
+        dead = sorted(
+            {
+                f"{path} (in {where})"
+                for path, where in sites
+                if not (SKILL_DIR / path).is_file()
+            }
+        )
+        self.assertEqual(
+            dead,
+            [],
+            f"{len(dead)} pointer(s) at a reference document that is not there: {dead}",
+        )
+
+
+# --------------------------------------------------------------------------
 # failure.py — the dump a take that did not finish leaves behind (issue #147)
 # --------------------------------------------------------------------------
 #
@@ -1800,6 +2021,46 @@ INJECTIONS = [
         'DOC_MODULE_RE = re.compile(r"\\b[A-Za-z_][A-Za-z0-9_]*\\.py\\b")',
         'DOC_MODULE_RE = re.compile(r"\\b[A-Za-z_][A-Za-z0-9_]{80,}\\.py\\b")',
         ["DocSymbols.test_every_module_the_docs_name_is_a_file_in_the_package"],
+    ),
+    (
+        # Issue #164 verbatim: this is the string the recorder printed on every
+        # take with determinism off for the four releases after #146 moved that
+        # section out to reference/determinism.md.
+        "the recorder's stderr points at a SKILL.md section that was moved out",
+        "core.py",
+        '                f"deterministic=True) freezes it; read the skill\'s "\n'
+        '                f"reference/determinism.md first, it changes what some apps do.",',
+        '                f"deterministic=True) freezes it; read SKILL.md\'s "\n'
+        "                f\"'Determinism' section first, it changes what some apps do.\",",
+        ["DocPointers.test_every_skill_md_section_the_skill_quotes_is_a_heading"],
+    ),
+    (
+        # The other half of the same defect, in the sweep that grades a path
+        # rather than a heading — and in README's *prose*, which is one of the
+        # seven sites `SkillDocs`'s link check structurally cannot see.
+        "a shipped document names a reference file that is not there",
+        "README.md",
+        "than exactly — `reference/review.md` says how far and why.",
+        "than exactly — `reference/reviews.md` says how far and why.",
+        ["DocPointers.test_every_reference_document_the_skill_names_exists"],
+    ),
+    (
+        # Both sweeps above are worth something only while their extraction
+        # still extracts, and each has an extraction of its own. Matching
+        # nothing makes "every pointer resolves" true over an empty set and the
+        # suite goes green *because* the check stopped working.
+        "the section-pointer extraction matches nothing, so that sweep goes vacuous",
+        "tests/unit",
+        'POINTER_BEFORE_RE = re.compile(POINTER_QUOTED + r"[^\\n]{0,30}?\\[?SKILL\\.md")',
+        'POINTER_BEFORE_RE = re.compile(POINTER_QUOTED + r"[^\\n]{300,}?\\[?SKILL\\.md")',
+        ["DocPointers.test_every_skill_md_section_the_skill_quotes_is_a_heading"],
+    ),
+    (
+        "the reference-path extraction matches nothing, so that sweep goes vacuous",
+        "tests/unit",
+        'POINTER_PATH_RE = re.compile(r"\\breference/[A-Za-z0-9_-]+\\.md\\b")',
+        'POINTER_PATH_RE = re.compile(r"\\breference/[A-Za-z0-9_-]{80,}\\.md\\b")',
+        ["DocPointers.test_every_reference_document_the_skill_names_exists"],
     ),
     (
         "a deletion leaves a constant in tests/smoke that nothing reads",


### PR DESCRIPTION
Issue #164, from an agent following `SKILL.md` on a **clean standalone install**.
Every item is something a first-time user hits and nobody working inside the
repo can see.

## 1. The recorder pointed at a section that does not exist

On every take with determinism off, the recorder printed:

> `read SKILL.md's 'Determinism' section first, it changes what some apps do.`

**SKILL.md has no Determinism section** — it moved to
`reference/determinism.md` in #146, and the two banners in `core.py` kept
pointing at the old home. This reaches a *user*, on stderr, on a normal
successful run.

**A sweep of the whole package** — comments, docstrings and printed strings,
read through `ast`/`tokenize` so the haystack is the sentence a user sees rather
than the four adjacent f-string fragments that build it — found these were the
only two. `web.py` and `terminal.py` quote *"What this records, and what it does
not defend against"*, which is a real heading; the four `reference/*.md` paths
#170 added all resolve.

## 2. The storyboard template was a SyntaxError

```python
_DEFAULT_SKILL_DIR = <the demo-video skill folder, as known when writing this file>
```

A `SyntaxError` **at parse time**, so the friendly `sys.exit` guard three lines
below — which explains exactly what to do — could never run. A placeholder that
fails at parse time cannot be caught by a runtime guard.

**Proved fixed**, template extracted programmatically from the edited SKILL.md
fence and run unmodified:

```
$ python3 record.py
demo-video skill not found at <fill in: the demo-video skill folder> — set DEMO_VIDEO_SKILL_DIR
exit=1
```

...and the old placeholder restored, for contrast:

```
    _DEFAULT_SKILL_DIR = <the demo-video skill folder, as known when writing this file>
                         ^
SyntaxError: invalid syntax
```

## 3. The `Recorder` parameter list — and the shortcut that does not work

SKILL.md said parameters resolve *explicit parameter → `DEMO_VIDEO_*` env var*
but named the parameter for only two of them, leaving a reader to strip the
prefix and lowercase.

**That rule is wrong three times**, verified against `__init__` in `core.py`,
`web.py` and `terminal.py`:

| variable | naive guess | actual |
|---|---|---|
| `DEMO_VIDEO_TERMINAL_SHELL` | `terminal_shell` | **`shell`** |
| `DEMO_VIDEO_TERMINAL_FONT_SIZE` | `terminal_font_size` | **`font_size`** |
| `DEMO_VIDEO_TIMEZONE` | `timezone` | **`timezone_id`** |

The Configuration table's **Sets** column now names the parameter for all 17
variables that have one (two say *no parameter*), the intro says not to infer
it, and a sentence names the five parameters with no env var at all — `segment`,
`criteria`, `interlude`, `interlude_hold`, `type_delay_ms`.

**`speech=False` is now documented.** It is the first parameter a user without
an ElevenLabs key needs and it appeared nowhere.

## 4. "the Issues section of timeline.md"

Did not exist on a clean take, so it read as *the file is malformed* rather than
*nothing was wrong*. Now: "if it has one — both appear only when there was
something to report, so a take with neither is the all-clear, not a malformed
file."

## The assertion

`DocPointers` sweeps the shipped skill for two pointer shapes: a **quoted
SKILL.md section name** (must be a real heading) and a **`reference/<name>.md`
path** (must be a file). Both assert their haystack first.

Pointed at the pre-fix code it names the defect:

```
AssertionError: 1 pointer(s) at a SKILL.md section that does not exist:
  ["'Determinism' (in helpers/demo_recording/core.py)"]
```

**Its limit, stated rather than implied:** the section haystack is *small* —
3 sites naming 1 heading — and the floor sits at today's exact count so thinning
it is an explicit decision rather than a silent one. The path sweep is broad
(59 sites), and **7 of those are invisible to the existing `SkillDocs` check**,
which only reads SKILL.md's `](reference/…)` links. That group is exactly where
#164 lived, and it had no members at all until #170.

Two things deliberately not shipped: a floor on the heading set (dominated — a
short scan already fails the main assertion), and any rule for unquoted pointers
like "the Process section of SKILL.md, step 2", which is loose enough to match
ordinary English.

**The injection aborted on its first run** — the search literal collided with the
constant it was breaking and matched twice, so the exactly-once guard refused to
proceed rather than reporting a pass. That is the fifth time that guard has
caught a mis-targeted break in this repo.

## Not covered by any check

The template still parsing, the Sets column pairing each variable with the
*correct* parameter (`DocSymbols` grades that the names exist somewhere in the
package, not that they sit opposite the right row), and the Issues wording. All
prose, all stated here rather than left to be assumed.

## Left open from #164

`reference/review.md` argues twice from "`tests/smoke` measures exactly this and
shows it", and `tests/` is not shipped with the skill. That is a judgement about
how the reference docs argue rather than an onboarding blocker; it stays
recorded in #164.

## Verification

- `tests/unit`: 82 tests; `--fault-inject`: **45/45** (was 41)
- full `tests/smoke`: **PASSED** — run despite no assertion matching the changed
  strings, because `core.py` is on the recording path
- `--budget`: 585/600 lines
- `ruff==0.14.2` check + format, `mypy==1.18.2` over 12 modules: clean

Fixes #164