### PR TITLE
Let step 6 say "the app is wrong" instead of "record it again" (#131, #95, #172)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -106,10 +106,11 @@ behind every one, are in [reference/limits.md](reference/limits.md).
   an issue and is fatal under `strict=True`, with no way to say it was the
   point — so leave strict off for that demo, and say in the pull request which
   recorded issue is the demo's subject.
-- **A stitched demo's attribution is unproven.** An issue recorded in segment
-  two can name a beat of segment one, and a coverage row can lose the segment
-  it belongs to. Check both against the parts before handing them to a
-  reviewer.
+- **A stitched demo's issue attribution is unproven.** An issue recorded in
+  segment two can name a beat of segment one — `stitch()` re-points every
+  issue's beat while merging, and no take exercises it. Check it against the
+  parts before handing them to a reviewer. A coverage row keeping its segment
+  *is* now graded ([#137](https://github.com/rogvid/skills/issues/137)).
 - **CI does less for a fork.** A pull request from a fork gets no demo comment;
   its beat table and artifact link are on the workflow run's summary page
   instead.

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -416,30 +416,41 @@ return.
    frame is aimed at its beat, which is what decides how much weight a
    reviewer's reading of one can carry.
 
-   Give them the pictures and nothing else — no storyboard, no feature
-   name, no captions. `frames.md` is built that way on purpose (see
-   [reference/review.md](reference/review.md)): a `click('#refresh')` in the
-   margin answers the question you are asking before they look at anything.
+   Give them the pictures and nothing else — no storyboard, no feature name,
+   no captions; `frames.md` is built that way on purpose. A tmpdir, or
+   `frames/` beside `demo.mp4` if the reviewer needs a stable path; either way
+   it is a working file, gitignored with the mp4 it came out of (step 8).
 
-   A tmpdir, or `frames/` beside `demo.mp4` if the reviewer needs a stable
-   path. Either way they are working files — `frames/` is gitignored for the
-   same reason `evidence/` is, and for the same reason the mp4 they came out
-   of is.
+   Dispatch a subagent told NOTHING about the feature (a fresh session or
+   process fed only `frames/` works too) and ask it, in these words:
 
-   Dispatch a subagent told NOTHING about the feature (any context-free
-   reviewer works: a fresh session or process fed only `frames/`, if the
-   harness has no subagents): read the frames in order; reply with
-   (1) NARRATION — the story as understood purely from the frames,
-   (2) CONFUSIONS — anything unclear, unreadable, or contradictory, and
-   (3) VERDICT — CLEAR or UNCLEAR with the reason, plus whether the demo
-   is CONVINCING: did they see evidence of the claims on screen, or take
-   the captions' word for it. If the narration misses the intended story
-   or the verdict is UNCLEAR, fix the storyboard and re-record. Each round
-   needs a NEW subagent — the previous one is no longer fresh. Ship only
-   on CLEAR with the headline claim evidenced on screen. Reviewers
-   converge in ~2 rounds; cap at 3 and surface remaining findings to the
-   user instead of looping. Findings that need a different feature demoed
-   are future demos, not blockers.
+   > Read the frames in order and reply with:
+   > (1) NARRATION — the story as understood purely from the frames.
+   > (2) CONFUSIONS — anything unclear, unreadable, or that you could not follow.
+   > (3) CONTRADICTIONS — a caption whose claim a later frame shows the opposite
+   > of, or that no frame ever shows. Captions are written *before* the action
+   > they introduce, so a caption normally appears a frame or two ahead of the
+   > picture that evidences it — that lead is by design, and a caption still
+   > waiting for its evidence is not a contradiction. Report one only when its
+   > claim never arrives in any later frame, or when a later frame shows the
+   > opposite. Quote the caption and name the frames you checked.
+   > (4) VERDICT — CLEAR or UNCLEAR, on one question only: could you follow the
+   > story from the pictures? Anything you listed under (3) is reported there and
+   > judged elsewhere; it does not by itself make the verdict UNCLEAR. Say
+   > separately whether the demo is CONVINCING: did you see evidence of the
+   > claims on screen, or take the captions' word for it?
+
+   **The verdict and the contradictions have different owners.** A narration
+   that misses the intended story, or UNCLEAR, is the storyboard's fault — fix
+   it and re-record, with a NEW subagent each round. A CONTRADICTIONS entry
+   may not be: check the app first. If the caption overstates the storyboard,
+   fix the caption; **if the app does not do what the caption says, the demo
+   has caught a bug** — that goes in the pull request, and into 6b when the
+   take declared `criteria=`. It is not a re-record, and deleting the beat or
+   softening the caption launders the finding the demo exists to deliver
+   ([reference/review.md](reference/review.md)). Ship on CLEAR. Reviewers
+   converge in ~2 rounds; cap at 3 and surface the rest to the user instead of
+   looping. Findings that need a different feature demoed are future demos.
 
    **6b. Conformance review (only when the take declared `criteria=`).** A
    *second* reviewer, run alongside the one above and never instead of it —

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -85,6 +85,64 @@ from demo_recording import beat_frames
 beat_frames(Path("demos/2026-07-26-x"))
 ```
 
+## Why the comprehension review reports contradictions separately
+
+Step 6's reviewer answers four questions, not three, and the fourth — the
+CLEAR/UNCLEAR verdict — is deliberately narrowed to *could you follow the
+story*. Two failures made that necessary, and both are worth knowing about
+before you write the prompt differently.
+
+### A caption leads its evidence, by design
+
+The pacing rules tell a storyboard author to set the caption **first** and then
+perform the action it introduces, so the eye is already pointed where the change
+will happen. That is right for a viewer, who experiences the caption as a
+sentence spanning several seconds with the click as an event inside it. It is
+wrong for a frame reviewer, who sees one instant per beat and finds the caption
+asserting something the pixels under it do not yet show.
+
+Asked "name any caption that asserts something the picture does not show", a
+reviewer given no warning can answer *"all of the ones written the way the skill
+prescribes"* — and a gate whose output is mostly artifact gets skimmed, taking
+the real entry with it ([#95](https://github.com/rogvid/skills/issues/95)
+measured a list of four, of which three were this).
+
+So the prompt states the lead. It does **not** tell the reviewer to ignore
+caption/picture mismatches, which would remove the finding the section exists
+for. The discriminator is *does the evidence ever arrive*: a caption still
+waiting for its picture is the house style; a caption whose claim no later frame
+shows, or that a later frame shows the opposite of, is a finding. That is a
+question about the whole sheet rather than one frame, which is exactly why the
+reviewer is asked to name the frames it checked.
+
+### A caption the app contradicts is not a recording defect
+
+The verdict used to carry this too, and it was unstable. On the reference take
+at `examples/ticket-queue/demos/2026-07-28-queue-search/` — recorded against a
+ticket one of whose criteria the app does not satisfy, with the beat claiming it
+kept and captioned in the ticket's own words — two independent reviewers given
+the same frames and the same instructions returned **UNCLEAR** and **CLEAR**.
+Both named the same beat, correctly, in the same terms. The finding was stable;
+the ship/no-ship field was a coin flip
+([#131](https://github.com/rogvid/skills/issues/131)).
+
+The reason is that one verdict was being asked to carry two different faults:
+
+- **"I could not follow this."** The storyboard is at fault, and re-recording is
+  the fix.
+- **"I followed it, and the screen disagrees with the words."** The *app* is at
+  fault. Re-recording cannot help, and the three things that would make the
+  contradiction go away — delete the beat, editorialise the caption, choose an
+  input that does not look like the unimplemented case — all hide the finding
+  the demo exists to deliver. Followed honestly, the old rule launders the
+  result.
+
+Splitting them means the verdict now grades the thing re-recording can repair,
+and the contradiction is routed where it can be acted on: the pull request, and
+the conformance pass below when the take declared `criteria=`. On a take with
+`criteria=` this is sharper still — a caption/picture contradiction on a tagged
+beat is 6b's call by construction, and 6b answers it with citations.
+
 ## Per-beat evidence (`evidence/beat-NN.json`)
 
 A reviewing agent handed frames has to infer what the page said from pixels.


### PR DESCRIPTION
Step 6 hands a fresh agent the review frames and asks whether the demo lands.
Two defects in what it asks, both of which waste the reviewer's answer.

**This was graded by running it, not by reasoning about it.** Four fresh
`general-purpose` reviewers, same frames, no shared context, on
`examples/ticket-queue/demos/2026-07-28-queue-search` — whose AC-3 caption says
*"Search matches the requester as well as the title."* while the app searches
only title and id. The exact #131 case.

## #131 — the verdict was unstable on the one case that matters most

**Current prompt, two runs, verbatim:**

> **run 1** — "VERDICT — **UNCLEAR**, specifically on the requester-matching
> claim … CONVINCING for everything except that one claim"

> **run 2** — "**CLEAR** for the core feature … CONVINCING for most claims, but
> **not fully convincing** on one"

Same take, same instructions, **opposite answers on the ship/no-ship field.**

The cause: SKILL.md said fix the storyboard, re-record, ship only on CLEAR. When
the *app* contradicts the caption, re-recording cannot help — the instruction
sends an author in a loop, and the reviewer has nowhere to put a finding that is
neither "the recording is unclear" nor "everything is fine".

**Fixed:** step 6 now asks for four sections. `CONTRADICTIONS` is its own bucket,
and the verdict answers one question — *could you follow the story*. The routing
paragraph says UNCLEAR is the storyboard's fault and gets a re-record, but a
contradiction goes to the app first, and if the app is what disagrees it goes to
the pull request, **not into another take**. That case is arguably the most
valuable thing a demo review can produce: the demo just caught a real bug.

**Revised prompt, both runs, verbatim (3) and (4):**

> **(3) CONTRADICTIONS** — Caption: **"Search matches the requester as well as
> the title."** … I checked every later frame (`beat-14` through `beat-42`) …
> it returns **zero** results … asserted by caption only and never positively
> demonstrated
>
> **(4) VERDICT** — CLEAR — the sequence of actions … is easy to follow purely
> from the screenshots

Stable across both, and the finding now quotes the caption and names the frames
checked — auditable in a way "UNCLEAR" is not.

## #95 — the premise has decayed, and this says so

The issue claims frame reviewers flag the caption-first rule as a false claim
**every time**. Three runs of the *current* prompt, across two demos, produced
**zero** instances. One reviewer raised the pairing question and dismissed it
itself, citing `frames.md`'s existing clock caveat.

The caption-lead sentence ships anyway, but **for a narrower reason, stated**:
`CONTRADICTIONS` is a *new* question, and without the rule the honest answer to
it would be "every caption written the way the skill prescribes". It guards the
new section rather than repairing an observed failure.

It does not license waving a false caption through, and that was checked: the
revised prompt on a clean take returned **"CONTRADICTIONS: None found"** with all
eleven captions enumerated against their evidence frames, while the queue-search
runs caught the real one.

## #172 — SKILL.md was the last place still describing a closed defect

#174 closed the coverage-segment gap and graded it. `reference/limits.md` was
rewritten in that PR from "here is the hole" to "closed, and now graded";
SKILL.md's own limits bullet was not, leaving the always-loaded file as the only
one of three that lies.

The bullet's *other* half stands and stays: `stitch()` re-points every issue's
beat while merging and no take exercises that path, which is #51.

**Worth recording:** the agent that fixed #131/#95 **declined** to touch this,
because at the time it ran #174 had not merged — so the bullet, `limits.md` and
the code all agreed, and editing it would have made SKILL.md the only liar. It
re-ran the injection to confirm and posted the measurement. Applied here now
that #174 is on `main`.

## No unit check for the prompt, deliberately

The artifact this change produces is a reviewer's verdict. A string-presence
check over the prompt text would be the catalogue's decoration — it would pass
for any wording. It was graded by running it four times instead, which is what
the verdicts above are.

## Found, not fixed

`frames.md` — the document the reviewer actually *reads* — does not carry the
caption-lead rule; it lives only in the prompt an agent composes at step 6. A
reviewer driven by a harness that does not use step 6's wording would not have
it. That is `helpers/frames.py`, out of scope for this branch.

## Verification

- `tests/unit`: 82 tests; `--fault-inject`: **45/45**
- `--budget`: **597/600** — budget not raised; the argued detail went to
  `reference/review.md`
- `tests/smoke` **not run**, and the reasoning is stated: two markdown files
  changed, nothing in smoke reads either, and the doc-facing assertions
  (`SkillDocs`, `DocPointers`, `DocSymbols`) are all in `tests/unit` and green

Fixes #131
Fixes #95
Fixes #172