### PR TITLE
Give a form demo a way to empty a field and press a key (#130)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -251,13 +251,15 @@ exception, or a non-zero exit. Both are
 | `caption(text, ac="AC-3")` / `shot(name, ac="AC-3")` | Tag this beat with the acceptance criterion it is there to demonstrate. Needs `Recorder(criteria={...})`; a tag naming an undeclared criterion is refused. See [reference/review.md](reference/review.md). |
 | `hold(min_s=1.5)` | Keep the current frame up until the current caption's narration finishes (min `min_s`). Use after a spotlight/action so the emphasis rides the whole spoken line instead of flashing. See **Pacing and perception** below. |
 | `move_to` / `click` / `click_fast` / `scroll_to` | Visible cursor motion; `click_fast` for elements that re-render continuously |
-| `type_into(selector, text)` | Click a field and type visibly, key by key — form demos (checkout, login, search) |
+| `type_into(selector, text)` | Click a field and type visibly, key by key — form demos (checkout, login, search). Types at the caret: it appends to what is already there, so `clear()` first to replace it |
+| `clear(selector)` | Empty a field, visibly — click, select what is in it, delete. Its own beat, because emptying a field is something the viewer watches happen |
+| `press(key, hold_s=0.5)` | Press one named key wherever the focus already is — `"Enter"` to submit, `"Escape"` to dismiss, `"Tab"` to move on, `"Control+A"`. Playwright's key names; an unknown one raises. Selector-free on purpose: `Tab` *is* the focus demo and `Escape` acts on whatever is up, and `type_into`/`clear` leave the caret where they put it. Holds `hold_s` so the change is on screen long enough to read |
 | `wait_for(selector)` | Wait for something the app does on its own |
 | `spotlight(selector)` | Ring + enlarge the element the caption discusses; `spotlight()` clears. It eases in *and out* over 250 ms, and the verb waits out its own exit, so the element is back exactly as it was found before the next beat starts (~250 ms per clear on an ordinary take, ~0 under `deterministic=True`, which flattens the transition) |
 | `terminal(cmd)` / `terminal_output(text)` / `terminal_close()` | A *decorative* on-screen terminal card for off-browser actions **inside a web demo** — a prop, not a real shell. To record an actual CLI/TUI use `TerminalRecorder` (below). |
 | `interlude(text, hold=2.8, style=…)` | Bridge a jump; `hold` is how long the card stays before the storyboard moves on. `style="card"` (default) is a full-screen title card, for real time-skips; `style="light"` is a centered label over a soft scrim with the scene still visible, for short transitions. **`interlude("")` fades out whatever is up, whichever style raised it** — the clear takes no `style` and ignores the one it is given. Leave one up and the take says so on stderr and in `content.warnings`; nothing else will notice (see [reference/limits.md](reference/limits.md)). |
 | `stitch(out_dir, [segments])` | Lossless concat of segment recordings into demo.mp4, **and** merge their beat logs into one `timeline.json` / `timeline.md` beside it. `keep_parts=True` leaves each `.seg.mp4` and its `.seg.timeline.*` on disk for a re-stitch |
-| `rec.page` | The live Playwright page — the escape hatch for anything the verbs don't cover (iframes, keyboard shortcuts, drag) |
+| `rec.page` | The live Playwright page — the escape hatch for anything the verbs don't cover (iframes, drag, hover-only menus) |
 
 ## Pacing and perception
 

--- a/skills/demo-video/helpers/demo_recording/content.py
+++ b/skills/demo-video/helpers/demo_recording/content.py
@@ -259,11 +259,13 @@ CONTENT_STATIC_WARN_S = 15.0
 # copied it out of here into a shipped table of beat verbs.
 CONTENT_ACTING_VERBS = frozenset(
     {
+        "clear",
         "click",
         "click_fast",
         "goto",
         "key",
         "move_to",
+        "press",
         "run",
         "scroll_to",
         "send",

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -155,6 +155,31 @@ window.__demoTerminalHide = () => {
 };
 """
 
+# How long `press()` holds the frame after the key goes down (issue #130).
+#
+# A key press is instantaneous in a way typing is not: the list refilters, the
+# dialog closes, the focus ring jumps, and it is over inside one frame. A verb
+# that returned the moment Playwright did would put the change and the *next*
+# verb's action in the same frame of video, which is the jump cut `type_into`'s
+# per-character delay exists to avoid — the whole reason the storyboard is not
+# just driving Playwright.
+#
+# 0.5 s is a floor with a reason rather than a round number: SKILL.md's
+# "Pacing and perception" puts a saccade at ~200 ms and says a change needs a
+# fixation after it to be recognised rather than merely noticed. It is
+# deliberately *below* the 1.5 s emphasis floor, because a press is a beat in
+# the middle of an interaction and not the emphasis itself — a storyboard that
+# wants the result dwelt on says `hold()` after it, as it does after a click.
+PRESS_HOLD_S = 0.5
+
+# How long `clear()` leaves the selection highlight up before deleting it.
+#
+# The highlight is the only thing on screen that explains where the text went.
+# Without the pause the field goes from a value to nothing between two frames
+# with no cursor, no keystroke and no selection visible — exactly the "jump
+# cut" reading issue #130 filed against `page.keyboard.press("Backspace")`.
+CLEAR_SELECT_HOLD_S = 0.4
+
 # How long the spotlight's enter and exit take. One constant, used as the
 # element's `transition` and as the shape of the timer that backs the exit up,
 # so the two cannot drift apart.
@@ -771,11 +796,73 @@ class Recorder(_DemoBase):
         demos (checkout, login, search). For anything the verbs don't
         cover, `self.page` is the live Playwright page.
 
+        **Types at the caret; it does not empty the field first.** A second
+        term typed into a box that already holds one appends to it. `clear()`
+        is the verb for emptying it, and it is a separate beat on purpose —
+        see its docstring.
+
         Type example values. Nothing here hides what it types — see "What this
         records, and what it does not defend against" in SKILL.md.
         """
         self.click(selector)
         self.page.keyboard.type(text, delay=delay_ms)
+
+    @_beat_verb("clear")
+    def clear(self, selector: str) -> None:
+        """Empty a field, visibly — click it, select what is in it, delete.
+
+        The counterpart to `type_into`, which appends (issue #130). A search
+        demo empties the box between terms as a matter of course, and before
+        this verb existed the only way to do it was `rec.page.keyboard`, which
+        records no beat at all: `timeline.json` showed the click and then the
+        next caption, and the two keystrokes that actually emptied the field
+        happened in the gap between them.
+
+        **A verb rather than an argument on `type_into`.** Emptying a field is
+        something the viewer watches happen, so it is a thing with its own
+        beat, its own frame and its own evidence file; folding it into
+        `type_into` would give one beat that did two visible things and named
+        only the second. And the case that settles it takes no text at all —
+        the demo that clears the search box to show the unfiltered list
+        restored has no `type_into` call for the argument to hang on.
+
+        **Selects and deletes rather than animating one backspace per
+        character.** The selection highlight is a frame a viewer can read, it
+        costs the same whether the field holds four characters or forty, and it
+        is what a person actually does. The delete is a real `Backspace`, so an
+        app listening on `keydown` sees what a keyboard would send —
+        `fill("")` sends no key events at all.
+        """
+        self.click(selector)
+        self.page.locator(selector).first.select_text()
+        self.pause(CLEAR_SELECT_HOLD_S)
+        self.page.keyboard.press("Backspace")
+        self.pause(0.3)
+
+    @_beat_verb("press", lambda args, kwargs: args[0] if args else kwargs.get("key"))
+    def press(self, key: str, hold_s: float = PRESS_HOLD_S) -> None:
+        """Press one named key wherever the focus already is — `"Enter"` to
+        submit, `"Escape"` to dismiss, `"Tab"` to move on, `"Control+A"`.
+
+        Playwright's key names (`Enter`, `Escape`, `Tab`, `ArrowDown`,
+        `Control+A`, `Shift+Tab`); an unknown one raises rather than typing its
+        letters. One key per call, so each press is its own beat with its own
+        frame — the beat records the key by name, which is the whole of what
+        `rec.page.keyboard.press` could not do (issue #130).
+
+        **Cursor-free and selector-free, deliberately.** The keys a form demo
+        needs are about the thing that already has focus: `Tab` is a demo *of*
+        the focus order and clicking a target first would destroy it, and
+        `Escape` dismisses whatever is up rather than acting on an element.
+        `type_into()` and `clear()` leave the caret in the field they drove, so
+        a press straight after either one lands where the viewer is looking.
+
+        Holds `hold_s` afterwards so the effect is on screen long enough to
+        read — see PRESS_HOLD_S. Shorten it when touring several fields with
+        `Tab`; lengthen it, or say `hold()`, when the press is the point.
+        """
+        self.page.keyboard.press(key)
+        self.pause(hold_s)
 
     @_beat_verb("scroll_to")
     def scroll_to(self, selector: str) -> None:

--- a/tests/fixture/index.html
+++ b/tests/fixture/index.html
@@ -65,6 +65,13 @@
     background: var(--accent); border: 0; border-radius: 10px; cursor: pointer;
   }
   #refresh:hover { filter: brightness(1.06); }
+  /* Keyboard focus, made unmistakable. Chromium draws its own ring on a
+     Tab-focused button, but its colour and width are the UA's to change; this
+     is the fixture stating what `press("Tab")` is supposed to look like.
+     `:focus-visible`, not `:focus`, so a mouse click on Refresh — which the
+     web take does, and photographs — still draws no ring at all. `outline`
+     takes no space, so nothing on the page moves. */
+  #refresh:focus-visible { outline: 3px solid var(--ink); outline-offset: 3px; }
 
   /* Table ------------------------------------------------------------ */
   .card {
@@ -173,6 +180,16 @@
  * screen, no animations. Every element the smoke test (and the queued
  * feature work) drives has a stable id.
  *
+ * Keyboard behaviour, always on (issue #130 — the recorder's `press()` and
+ * `clear()` verbs need something to drive that a mouse cannot reach):
+ *   Enter in #search   submits the toolbar, which here means what the Refresh
+ *                      button means — advance to the next snapshot
+ *   Escape anywhere    empties #search and takes focus off it, the way a
+ *                      search field's dismiss key does
+ *   Tab from #search   moves focus to #refresh, which draws a ring (CSS above)
+ * None of them is a query-string hook: a form demo is the ordinary case, not
+ * a broken-app case.
+ *
  * Query-string hooks, inert unless asked for:
  *   ?console-error=1  page logs a console error and throws on load (issue #3)
  *   ?bad-fetch=<url>  page fetches a missing path and <url>, both on load,
@@ -273,10 +290,32 @@ function render() {
   renderRows();
 }
 
-el("search").addEventListener("input", renderRows);
-el("refresh").addEventListener("click", function () {
+function advance() {
   snapshotIndex = (snapshotIndex + 1) % SNAPSHOTS.length;
   render();
+}
+
+el("search").addEventListener("input", renderRows);
+el("refresh").addEventListener("click", advance);
+
+// Enter in the search box does what the toolbar's button does. Deliberately
+// the same code path, so a demo that submits with the keyboard and one that
+// clicks are demonstrably the same action and not two things that agree.
+el("search").addEventListener("keydown", function (e) {
+  if (e.key !== "Enter") { return; }
+  e.preventDefault();
+  advance();
+});
+
+// Escape dismisses the search, from wherever the focus happens to be — which
+// is the point of a dismiss key, and the reason the recorder's press() takes
+// no selector. Blurring as well as emptying is what separates this from what
+// clear() does, so neither can pass an assertion meant for the other.
+document.addEventListener("keydown", function (e) {
+  if (e.key !== "Escape") { return; }
+  el("search").value = "";
+  el("search").blur();
+  renderRows();
 });
 
 render();

--- a/tests/smoke
+++ b/tests/smoke
@@ -391,10 +391,16 @@ OVERLAY_CLEARED_MAX_RATIO = 0.2
 # Duration windows, in seconds. Wide on purpose: the lower bound catches a
 # take that died early, the upper one catches a hang, and everything in
 # between is legitimate variation between a laptop and a cold CI runner.
-WEB_DURATION_S = (6.0, 32.0)
+#
+# The web ceiling went 32 -> 45 when the form verbs' eight beats joined this
+# storyboard (issue #130): the take measured 20.6 s before them and 27.6 s
+# after, so 32 was no longer a bound on a hang, it was a bound on a loaded
+# machine. A hang is minutes, not seconds, and the lower bound is what catches
+# the failure this suite actually sees.
+WEB_DURATION_S = (6.0, 45.0)
 TERMINAL_DURATION_S = (4.0, 32.0)
 
-WEB_SHOTS = ["01-dashboard", "02-filtered", "03-refreshed"]
+WEB_SHOTS = ["01-dashboard", "02-filtered", "03-refreshed", "04-cleared"]
 TERMINAL_SHOTS = ["01-echo", "02-listing"]
 
 # Two stills every take ends with: the same frame with the caption cleared and
@@ -629,6 +635,18 @@ WEB_BEATS = [
     ("click", "#refresh"),
     ("pause", None),
     ("shot", "03-refreshed"),
+    # The form verbs (issue #130). `press` records the key it pressed in the
+    # beat's target field, which is the issue's acceptance criterion: before
+    # this, the keystrokes that emptied a field happened in the gap between two
+    # beats and appeared in no artifact at all.
+    ("caption", None),
+    ("clear", "#search"),
+    ("shot", "04-cleared"),
+    ("press", "Enter"),
+    ("press", "Tab"),
+    ("type_into", "#search"),
+    ("pause", None),
+    ("press", "Escape"),
     ("caption", None),
     ("shot", "90-caption-off"),
     ("pause", None),
@@ -636,6 +654,13 @@ WEB_BEATS = [
     ("shot", "91-caption-on"),
     ("caption", None),
 ]
+
+# The keys the web storyboard presses, in order. Written out separately from
+# WEB_BEATS because it answers a different question: WEB_BEATS asks whether the
+# beat is there, this asks whether the beat *names the key*, which is issue
+# #130's acceptance criterion and the one thing `rec.page.keyboard.press` could
+# never do. check_form_pacing() reads it.
+WEB_PRESS_KEYS = ["Enter", "Tab", "Escape"]
 
 TERMINAL_BEATS = [
     ("pause", None),
@@ -665,6 +690,7 @@ WEB_CAPTIONS = [
     "A small dashboard.",
     "Filter by city.",
     "Refresh reloads it.",
+    "Keys, not just clicks.",
     "",
     PROBE_CAPTION,
     "",
@@ -1242,6 +1268,32 @@ WEB_EVIDENCE = [
         "03-refreshed",
         ["$134,950", "snapshot 2 of 3", "Refresh reloads it."],
         ["$128,400", "snapshot 1 of 3"],
+    ),
+    # The two form verbs, graded in the artifact issue #130 is actually about.
+    # `find()` above locates these by (verb, target), so each entry asserts
+    # three things at once: the beat exists, its target is the selector the
+    # storyboard cleared or the key it pressed by name, and the evidence file
+    # written for *that beat* describes the screen the verb produced. A verb
+    # that drove the page through `rec.page.keyboard` would fail at the first.
+    (
+        "clear",
+        "#search",
+        # The filter came off: the three rows "harbor" had hidden are back in
+        # the account of the screen, not merely on it.
+        [
+            "Harbor Supply Co.",
+            "Ferrari Logistics",
+            "Redwood Kitchens",
+            "Blue Ridge Foods",
+            "Keys, not just clicks.",
+        ],
+        ["Pine & Poplar", "Cascade Outfitters"],
+    ),
+    (
+        "press",
+        "Enter",
+        ["snapshot 3 of 3", "$119,180", "Pine & Poplar", "Cascade Outfitters"],
+        ["snapshot 2 of 3", "$134,950"],
     ),
 ]
 
@@ -2131,6 +2183,17 @@ def check_determinism(b: Beats, page, when: str, on: bool = True) -> dict:
     return state
 
 
+# What has the focus, as a name a failure message can print: the element's id
+# when it has one, and its tag when it does not — `blur()` hands focus back to
+# `<body>`, which has no id and would otherwise read as the empty string beside
+# every other unfocusable answer.
+_FOCUSED_JS = """() => {
+  const el = document.activeElement;
+  if (!el) return '(none)';
+  return el.id || el.tagName.toLowerCase();
+}"""
+
+
 # Records every mousemove the page sees, so move_to()'s 30-step glide can be
 # told apart from the single move Playwright's own click() dispatches.
 _TRAIL_JS = """() => {
@@ -2272,6 +2335,102 @@ def record_web(
             "$134,950",
         )
         rec.shot("03-refreshed")
+
+        # -- the form verbs (issue #130) --------------------------------------
+        #
+        # Every assertion here reads the *app*, not the beat log: a verb that
+        # logged a beautiful beat and pressed nothing fails each one. The beat
+        # log is graded separately, by WEB_BEATS and by the two WEB_EVIDENCE
+        # entries keyed on ("clear", "#search") and ("press", "Enter") — which
+        # is the half of the issue no post-condition can see, since
+        # `rec.page.keyboard` would satisfy everything below and write nothing.
+        rec.caption("Keys, not just clicks.")
+        check_caption(b, rec.page, "Keys, not just clicks.")
+
+        # The pre-condition is asserted, not assumed: "the field is empty" is
+        # not news about a field that was already empty, which is the vacuous
+        # sweep in wip/verified-review with a different haystack.
+        b.expect(
+            "before clear('#search'), #search value",
+            rec.page.input_value("#search"),
+            "seattle",
+        )
+        rec.clear("#search")
+        b.expect(
+            "clear('#search'), field value",
+            rec.page.input_value("#search"),
+            "",
+        )
+        b.expect(
+            "clear('#search'), #rows row count (all four rows are back)",
+            rec.page.locator("#rows tr").count(),
+            4,
+        )
+        # The caret stays where the viewer last saw it, which is what lets the
+        # press() below be selector-free rather than careless — and it is the
+        # post-condition Escape does *not* produce, so neither verb can pass an
+        # assertion meant for the other.
+        b.expect(
+            "clear('#search'), the focused element (the caret stays in the box)",
+            rec.page.evaluate(_FOCUSED_JS),
+            "search",
+        )
+        rec.shot("04-cleared")
+
+        # Enter submits from inside the field clear() left the caret in.
+        rec.press("Enter")
+        b.expect(
+            "press('Enter'), #status text",
+            rec.page.locator("#status").inner_text(),
+            "snapshot 3 of 3",
+        )
+        b.expect(
+            "press('Enter'), #kpi-rev text",
+            rec.page.locator("#kpi-rev").inner_text(),
+            "$119,180",
+        )
+
+        rec.press("Tab")
+        b.expect(
+            "press('Tab'), the focused element",
+            rec.page.evaluate(_FOCUSED_JS),
+            "refresh",
+        )
+        # ...and the half of Tab a viewer can see. `:focus-visible` in the
+        # fixture draws this ring for keyboard focus only, so the mouse click
+        # on #refresh above leaves it 'none' and this cannot pass on that.
+        b.expect(
+            "press('Tab'), #refresh computed outline-style (the ring)",
+            rec.page.eval_on_selector("#refresh", outline),
+            "solid",
+        )
+
+        # Escape last, with a term in the box for it to dismiss — and a row
+        # count that says the box really holds one, because an Escape that
+        # emptied nothing would satisfy the value check below on its own.
+        rec.type_into("#search", "harbor")
+        rec.pause(0.6)
+        b.expect(
+            "type_into('#search', 'harbor'), #rows row count",
+            rec.page.locator("#rows tr").count(),
+            1,
+        )
+        rec.press("Escape")
+        b.expect(
+            "press('Escape'), #search value",
+            rec.page.input_value("#search"),
+            "",
+        )
+        b.expect(
+            "press('Escape'), #rows row count (all six rows are back)",
+            rec.page.locator("#rows tr").count(),
+            6,
+        )
+        b.expect(
+            "press('Escape'), the focused element (the dismiss let the box go)",
+            rec.page.evaluate(_FOCUSED_JS),
+            "body",
+        )
 
         # Two stills back to back with the page frozen and only the caption
         # changing. Their difference in the caption band is pixel proof that
@@ -5144,6 +5303,124 @@ def _same_frame(mp4: Path, at: float, png: Path) -> bool:
         )
 
 
+# -- how long the form verbs hold the frame (issue #130) ----------------------
+#
+# The post-conditions in `record_web` grade *that* the key was pressed and the
+# field emptied. Nothing in them grades the pacing, and pacing is half of why
+# these are verbs at all: `rec.page.keyboard.press("Backspace")` also emptied
+# the field, in about ten milliseconds, and the complaint in the issue is that
+# a viewer could not see it happen. So both holds get a bar, and both bars are
+# **hand-written here rather than imported from the recorder** — a bound read
+# off the code it grades agrees with that code whatever the code says, which is
+# the same reason WEB_BEATS is written out by hand.
+#
+# Measured on this box, over the web take: the three press beats span 0.514,
+# 0.518 and 0.515 s against the recorder's 0.5 s hold, and the same three with
+# the hold injected out span 0.013, 0.013 and 0.012 s. The bar sits at 0.35 —
+# 32% under the healthy reading and 27x over the broken one. A lower bound on a
+# deliberate wait is the one timing bar contention cannot turn red: a loaded
+# machine only ever makes it larger.
+MIN_PRESS_BEAT_SPAN_S = 0.35
+
+# `clear()`'s own pacing, measured as what it costs **over** a plain `click()`
+# in the same take. Its beat starts with a click — the same 30-step glide, the
+# same 0.4 s settle — so an absolute bar on its span would be satisfied by the
+# glide alone and would say nothing about the selection hold. The difference
+# is: 0.4 s for the highlight to be readable, plus the 0.3 s tail after the
+# delete, plus `select_text`.
+#
+# Measured on this box: the clear beat spans 0.70-0.71 s more than the click
+# beat, and a clear stripped of both pauses spans 0.009 s more (1.665 s against
+# 0.956 s healthy; 0.965 s against 0.956 s injected). Both glides inflate
+# together under load, so the difference is stable rather than merely large;
+# the bar is at 0.40, leaving 0.30 s of noise room against the healthy reading
+# and sitting 78x over the broken one.
+MIN_CLEAR_OVER_CLICK_S = 0.40
+
+
+def _beat_span(beats: list[dict], verb: str, target: str | None) -> float | None:
+    """How long the single (verb, target) beat took, or None if there is not
+    exactly one of them."""
+    hits = [
+        b
+        for b in beats
+        if b.get("verb") == verb
+        and b.get("selector") == target
+        and isinstance(b.get("t_start"), (int, float))
+        and isinstance(b.get("t_end"), (int, float))
+    ]
+    if len(hits) != 1:
+        return None
+    return float(hits[0]["t_end"]) - float(hits[0]["t_start"])
+
+
+def check_form_pacing(label: str, out_dir: Path) -> list[str]:
+    """The form verbs hold the frame long enough to be watched (issue #130).
+
+    Reads `timeline.json`, which is also the artifact the issue is about: a
+    storyboard that drove the page through `rec.page.keyboard` writes no beat
+    here at all, so the first thing this fails on is the beat being missing.
+    """
+    doc = json.loads((out_dir / "timeline.json").read_text(encoding="utf-8"))
+    beats = doc.get("beats") or []
+    failures: list[str] = []
+
+    presses = [b for b in beats if b.get("verb") == "press"]
+    if len(presses) != len(WEB_PRESS_KEYS):
+        failures.append(
+            f"{label}: timeline.json holds {len(presses)} `press` beat(s), "
+            f"expected {len(WEB_PRESS_KEYS)} — either the storyboard changed "
+            f"or press() stopped recording a beat, which is the whole of what "
+            f"issue #130 asked for"
+        )
+    for beat, key in zip(presses, WEB_PRESS_KEYS, strict=False):
+        # The key by name, in the log. `rec.page.keyboard.press` could not do
+        # this, and it is the issue's acceptance criterion word for word.
+        if beat.get("selector") != key:
+            failures.append(
+                f"{label}: beat {beat.get('index')} is a `press` whose target "
+                f"is {beat.get('selector')!r}, expected {key!r} — the beat does "
+                f"not name the key it pressed"
+            )
+        # `or 0.0` rather than a default: a beat whose verb raised carries a
+        # null `t_end`, and reading that as zero is the honest answer here —
+        # a press that did not finish did not hold anything.
+        span = float(beat.get("t_end") or 0.0) - float(beat.get("t_start") or 0.0)
+        if span < MIN_PRESS_BEAT_SPAN_S:
+            failures.append(
+                f"{label}: the `press` beat for {key!r} spans {span:.3f}s, "
+                f"under the {MIN_PRESS_BEAT_SPAN_S}s bar — the key went down "
+                f"and the verb returned in the same frame, so the change it "
+                f"caused is on screen for less time than a saccade takes"
+            )
+
+    cleared = _beat_span(beats, "clear", "#search")
+    clicked = _beat_span(beats, "click", "#refresh")
+    if cleared is None or clicked is None:
+        failures.append(
+            f"{label}: timeline.json does not hold exactly one "
+            f"clear('#search') beat and one click('#refresh') beat "
+            f"(spans {cleared!r} and {clicked!r}), so what clear() costs over "
+            f"a plain click cannot be measured"
+        )
+    elif cleared - clicked < MIN_CLEAR_OVER_CLICK_S:
+        failures.append(
+            f"{label}: the clear('#search') beat spans {cleared:.3f}s against "
+            f"{clicked:.3f}s for click('#refresh'), a difference of "
+            f"{cleared - clicked:.3f}s under the {MIN_CLEAR_OVER_CLICK_S}s bar "
+            f"— clear() is doing no more than a click and a delete, so the "
+            f"field empties between two frames with no selection on screen to "
+            f"say where the text went"
+        )
+    if not failures:
+        print(
+            f"smoke: {label} form verbs hold the frame "
+            f"({len(presses)} press beats, "
+            f"clear costs {cleared - clicked:+.2f}s over a click)"
+        )
+    return failures
+
+
 def check_beat_frames(
     label: str,
     out_dir: Path,
@@ -6516,6 +6793,9 @@ def run_web(out_root: Path) -> list[str]:
         + check_timeline("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
         + check_beat_frames("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
         + check_evidence("web", out_dir, WEB_EVIDENCE, WEB_EVIDENCE_SCOPE)
+        # The form verbs' pacing (issue #130), read off the same beat log the
+        # two checks above read for their contents.
+        + check_form_pacing("web", out_dir)
         # Here rather than in its own phase: the opening hold has to leave every
         # beat where it was, and this is the take whose beat/frame alignment is
         # already graded above (issue #119).

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -5,7 +5,7 @@
 # ///
 """An executed injection manifest for `tests/smoke` (issue #136).
 
-    tests/smoke-inject               # the whole manifest, ~14 minutes
+    tests/smoke-inject               # the whole manifest, ~31 minutes
     tests/smoke-inject --list        # what it covers, and what each entry costs
     tests/smoke-inject --self-test   # prove the harness refuses a bad entry (0s)
     tests/smoke-inject --arm coverage      # one arm's entries
@@ -23,8 +23,8 @@ this file is what notices.
 going to be maintained. But smoke has per-arm flags, and an injection aimed at
 one arm costs that arm: measured on this box, `--coverage-only` is 8 s,
 `--strict-only` 13 s, `--overlay-only` 31 s, `--failure-only` 48 s,
-`--content-only` 148 s. Every entry below names the arm it needs, and nothing
-else runs.
+`--web-only` 123 s, `--content-only` 148 s. Every entry below names the arm it
+needs, and nothing else runs.
 
 **The contract, per entry** — the same one `tests/unit`'s `INJECTIONS` uses,
 with the arm added:
@@ -51,7 +51,7 @@ an aborted run cannot leave a broken recorder behind.
 
 **What this does not do** is in `tests/README.md`, under "What the injection
 manifest covers". Read it before treating a green run here as coverage of
-`tests/smoke`: 16 entries against 9 of smoke's 32 check functions is a floor
+`tests/smoke`: 22 entries against 11 of smoke's 33 check functions is a floor
 under the assertions that would be worst to lose, not a statement about the
 rest. Every check function with no entry is printed as `ungraded` at the end of
 a run, so the gap is in the output rather than in somebody's memory.
@@ -271,6 +271,141 @@ INJECTIONS = [
         arm="--failure-only",
         sites=("check_crash_take",),
         must_contain=(" does not name the ", " does not say whether demo.mp4 is"),
+    ),
+    # -- the form verbs clear() and press() (issue #130), 123 s an entry ------
+    #
+    # The six breaks PR #178 measured by hand. Its driver no longer exists, so
+    # until these entries their whole record was a table in a pull request
+    # body — the shape this file was built to stop.
+    #
+    # Two checks grade the pair, and neither can cover for the other.
+    # `check_form_pacing` reads `timeline.json`: it sees a verb that stopped
+    # recording a beat or stopped holding the frame, and is blind to a verb
+    # that logged a beautiful beat and touched nothing. `check_evidence` reads
+    # what the page said when the verb returned: it sees exactly the opposite.
+    # Every entry below names whichever of the two can actually notice its
+    # break, which is why the three `press` entries do not all name the same
+    # site.
+    Injection(
+        # The one line that presses the key, and nothing else. press() still
+        # logs its beat, still names 'Enter' as its target and still holds the
+        # frame for 0.5 s, so every assertion that reads the log passes — the
+        # only thing left that disagrees is the account of the screen the
+        # recorder wrote when the verb returned.
+        #
+        # Both halves of `check_evidence`'s per-beat claim have to fire: the
+        # facts Enter should have produced are missing *and* the ones the
+        # previous screen showed are still there. Either alone is a weaker
+        # statement than "this beat's screen never changed". Neither names the
+        # beat, because the beat is interpolated into the message rather than
+        # written in it — the arm passing clean is what makes these failures
+        # attributable to the break.
+        name="press logs the key it names and never presses it",
+        module="web.py",
+        old="        self.page.keyboard.press(key)\n",
+        new="",
+        arm="--web-only",
+        sites=("check_evidence",),
+        must_contain=(
+            " was on screen. A reviewer holding only this file cannot state ",
+            " was on screen, which belongs to an earlier state of the page ",
+        ),
+    ),
+    Injection(
+        # The pause *after* the key, which is the whole of press()'s pacing.
+        # The key still goes down, the app still changes and the beat still
+        # names the key, so nothing about the effect is disturbed: three beats
+        # spanning 0.013 s where they spanned 0.515 s is the only trace left,
+        # and the 0.35 s bar is the only assertion that reads it. Targeted as
+        # the two lines together rather than `self.pause(hold_s)` alone so the
+        # search string cannot drift onto another verb's hold.
+        name="press returns in the same frame the key went down in",
+        module="web.py",
+        old="        self.page.keyboard.press(key)\n        self.pause(hold_s)\n",
+        new="        self.page.keyboard.press(key)\n",
+        arm="--web-only",
+        sites=("check_form_pacing",),
+        must_contain=(
+            "s bar — the key went down and the verb returned in the same frame",
+        ),
+    ),
+    Injection(
+        # The decorator, not the body: the page is driven exactly as before, so
+        # every post-condition in the storyboard still passes and only the log
+        # is poorer. That is issue #130 reproduced — `rec.page.keyboard.press`
+        # also pressed the key and also wrote nothing to `timeline.json` — and
+        # it is why WEB_EVIDENCE grew an entry keyed on ('press', 'Enter').
+        # Both logs must notice: the pacing check counts the press beats, the
+        # evidence check cannot find the one it is keyed to.
+        name="press drives the page and writes no beat",
+        module="web.py",
+        old=(
+            '    @_beat_verb("press", lambda args, kwargs: args[0] if args '
+            'else kwargs.get("key"))\n'
+        ),
+        new="",
+        arm="--web-only",
+        sites=("check_form_pacing", "check_evidence"),
+        must_contain=(
+            " — either the storyboard changed or press() stopped recording a beat",
+            "), so the evidence facts written for it cannot be checked against one",
+        ),
+    ),
+    Injection(
+        # The delete. `select_text()` still runs and both pauses still run, so
+        # the beat is logged, the highlight is on screen for its full 0.4 s and
+        # the pacing bar below is satisfied — the field simply still holds
+        # "seattle" when the verb returns. Aimed at `check_evidence` for the
+        # same reason as the first entry, and with the same limit: the message
+        # says a beat's facts went missing without naming which beat, so what
+        # rules out an unrelated red is the clean baseline, not the wording.
+        name="clear selects the text and never deletes it",
+        module="web.py",
+        old='        self.page.keyboard.press("Backspace")\n',
+        new="",
+        arm="--web-only",
+        sites=("check_evidence",),
+        must_contain=(
+            " was on screen. A reviewer holding only this file cannot state ",
+        ),
+    ),
+    Injection(
+        # Both pauses, which are all clear() has to make the selection
+        # readable. The field still empties and the beat is still logged; what
+        # is left is a highlight that appears and is gone inside one frame.
+        # Graded as what the beat costs *over* the click('#refresh') beat in
+        # the same take: clear() opens with the same 30-step glide a click
+        # does, so an absolute bar would be satisfied by the glide alone and
+        # would grade nothing.
+        name="clear empties the field between two frames",
+        module="web.py",
+        old=(
+            "        self.pause(CLEAR_SELECT_HOLD_S)\n"
+            '        self.page.keyboard.press("Backspace")\n'
+            "        self.pause(0.3)\n"
+        ),
+        new='        self.page.keyboard.press("Backspace")\n',
+        arm="--web-only",
+        sites=("check_form_pacing",),
+        must_contain=("s bar — clear() is doing no more than a click and a delete",),
+    ),
+    Injection(
+        # clear()'s half of the decorator pair, and the one the issue was
+        # actually filed about: the search box empties on screen exactly as
+        # before and `timeline.json` shows the click and then the next caption,
+        # with the emptying in the gap between them. The pacing check loses the
+        # beat it measures the click against; the evidence check loses the beat
+        # keyed ('clear', '#search').
+        name="clear empties the field and writes no beat",
+        module="web.py",
+        old='    @_beat_verb("clear")\n',
+        new="",
+        arm="--web-only",
+        sites=("check_form_pacing", "check_evidence"),
+        must_contain=(
+            ": timeline.json does not hold exactly one clear('#search') beat",
+            "), so the evidence facts written for it cannot be checked against one",
+        ),
     ),
     # -- whether the recorder notices a recording nobody can watch (#97), 148 s
     Injection(


### PR DESCRIPTION
Closes #130.

Two verbs, `clear(selector)` and `press(key)`, so a form demo stops reaching past
the recorder into `rec.page.keyboard`. The full reasoning is in the commit
message; this body covers only the evidence and the limits.

## Acceptance criterion

A storyboard can empty a field and press a named key, **and both appear in
`timeline.json`**. The second half is the whole point: the reference demo for
#129 reached past the recorder four times, and the beat log recorded a click and
then the next caption, with the two keystrokes that emptied the box happening in
the gap between them.

## What was measured

Six injections, one per claim, each run against the real fixture:

| injection | separation |
|---|---|
| `press` does not press | post-conditions go red |
| `press` does not hold | 0.514 / 0.518 / 0.515 s → 0.013 / 0.013 / 0.012 s |
| `press` loses its `@_beat_verb` | app still changes, **only** the beat-log assertions go red |
| `clear` does not clear | post-conditions go red |
| `clear` loses its pauses | +0.71 s over a click → +0.009 s |
| `clear` loses its `@_beat_verb` | app still changes, **only** the beat-log assertions go red |

The two decorator rows are the filed issue reproduced exactly, and they are the
reason `WEB_EVIDENCE` grew entries keyed on `("clear", "#search")` and
`("press", "Enter")`: every post-condition in this take passes for a storyboard
that drives the page through `rec.page.keyboard` and writes nothing to the log.

`check_form_pacing()` grades the press bar absolutely and the clear bar as what
it costs **over a plain click in the same take**. An absolute bar on clear would
have been satisfied by the cursor glide alone — an assertion that grades nothing.

The first run of the harness reported all six caught for the wrong reason: every
one died on `ModuleNotFoundError` before recording anything, because the driver
had not put the package on `sys.path` the way the suite's own `main()` does.
That is the injection that silently does nothing wearing a red hat, and it is why
the driver now prints the diff it applied and runs an uninjected control first.

## Verified on this branch

- `tests/unit` — 100 tests, OK
- `tests/unit --fault-inject` — all **58** injections caught
- `tests/unit --budget` — SKILL.md 599 lines against a 600 budget
- `tests/smoke` — PASSED (whole suite)
- `tests/smoke --web-only` — `web form verbs hold the frame (3 press beats, clear costs +0.74s over a click)`; the web take is 31 beats, up from 23
- `tests/smoke-inject --self-test` — all 16 registered entries still match
- ruff, ruff format, mypy (12 modules) — clean

## Stated limits

- **The six injections above are not in `tests/smoke-inject`.** They were run by
  an ad-hoc driver, so their evidence lives in this body and not in the
  executable manifest #174 built for exactly this purpose. Six assertions whose
  only record is prose is the thing that manifest exists to prevent. Being fixed
  on this branch before merge.
- **`examples/ticket-queue` still carries its `clear_search` helper.** Dropping
  it means re-recording that take, because its committed `timeline.json` would
  otherwise describe a storyboard that no longer exists.
- **Nothing here discourages `rec.page` in general**, which #130 explicitly did
  not ask for. `rec.page`'s row lost "keyboard shortcuts" from its examples,
  since that is now a verb, and gained "hover-only menus", which is not.
- **`press` takes no selector**, by design — `Tab` *is* the focus demo and
  clicking a target first would destroy it. The safety comes from `type_into`
  and `clear` leaving the caret where they put it. A `press` far from either one
  is the author's responsibility and nothing checks it.
