### PR TITLE
Make timeline.json say what was true of the screen (#134, #177)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -247,7 +247,7 @@ exception, or a non-zero exit. Both are
 |---|---|
 | `goto(path)` | Navigate (relative to base_url); waits for networkidle, but gives up after 10 s for apps that poll |
 | `pause(s)` / `shot(name)` | Hold the frame / capture `images/<name>.png` |
-| `caption(text)` | Narrator line at the bottom; `""` clears; dies on full page loads, survives SPA routing — clear before navigating either way |
+| `caption(text)` | Narrator line at the bottom; `""` clears; dies on full page loads and the beat log clears with it, survives SPA routing — re-caption after a load |
 | `caption(text, ac="AC-3")` / `shot(name, ac="AC-3")` | Tag this beat with the acceptance criterion it is there to demonstrate. Needs `Recorder(criteria={...})`; a tag naming an undeclared criterion is refused. See [reference/review.md](reference/review.md). |
 | `hold(min_s=1.5)` | Keep the current frame up until the current caption's narration finishes (min `min_s`). Use after a spotlight/action so the emphasis rides the whole spoken line instead of flashing. See **Pacing and perception** below. |
 | `move_to` / `click` / `click_fast` / `scroll_to` | Visible cursor motion; `click_fast` for elements that re-render continuously |

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import functools
+import inspect
 import json
 import os
 import re
@@ -447,20 +448,51 @@ def _env_flag(name: str) -> bool | None:
     return value.lower() in ("1", "true", "yes", "on")
 
 
-def _verb_target(args: tuple, kwargs: dict) -> str | None:
-    """The string a verb acted on, dug out of how it happened to be called."""
-    if args and isinstance(args[0], str):
-        return args[0]
-    for name in ("selector", "path", "command", "text", "pattern", "name"):
-        value = kwargs.get(name)
-        if isinstance(value, str):
-            return value
-    return None
+def _verb_target(fn: Callable) -> Callable[[tuple, dict], str | None]:
+    """Build the default beat-target extractor for one storyboard verb.
+
+    The target is the verb's **first parameter after `self`**, whatever it is
+    named, and it is read the same way whether the caller passed it by
+    position or by keyword: `click("#go")` and `click(selector="#go")` are one
+    call written two ways, and a beat log that describes only one of them is
+    describing something that did not happen.
+
+    This used to be a fixed allowlist of keyword names — `selector`, `path`,
+    `command`, `text`, `pattern`, `name` — so a verb whose first parameter was
+    called anything else logged `selector: null` the moment somebody passed it
+    by keyword (issue #177). Nothing noticed: the beat was recorded, the
+    timeline was well-formed, and the only symptom was a null in a committed
+    artifact. Reading the signature removes the list rather than lengthening
+    it, so the next verb is right without anyone remembering this.
+
+    A verb that wants something else — `key(*names)`, whose target is the
+    whole chord — passes its own extractor to `_beat_verb`.
+    """
+    try:
+        params = list(inspect.signature(fn).parameters.values())[1:]  # drop self
+    except (TypeError, ValueError):  # pragma: no cover - callables without one
+        params = []
+    first = params[0] if params else None
+
+    def target(args: tuple, kwargs: dict) -> str | None:
+        # Positionally the first argument *is* the first parameter, so this
+        # branch is what the allowlist version did and stays byte-identical.
+        if args:
+            return args[0] if isinstance(args[0], str) else None
+        if first is None or first.kind in (
+            inspect.Parameter.VAR_POSITIONAL,
+            inspect.Parameter.VAR_KEYWORD,
+        ):
+            return None
+        value = kwargs.get(first.name)
+        return value if isinstance(value, str) else None
+
+    return target
 
 
 def _beat_verb(
     verb: str,
-    target: Callable[[tuple, dict], str | None] = _verb_target,
+    target: Callable[[tuple, dict], str | None] | None = None,
 ) -> Callable:
     """Decorate a storyboard verb so calling it records one beat.
 
@@ -468,18 +500,26 @@ def _beat_verb(
     recorders' method bodies untouched, which is the difference between a
     one-line diff per verb and re-indenting three files.
 
-    `target` extracts the beat's `selector` from the call; the default takes
-    the first string argument (so `click("#go")`, `run("ls")` and
-    `goto("/app")` all self-describe) and yields null for verbs called with
-    none (`pause(2)`, `spotlight()`).
+    `target` extracts the beat's `selector` from the call; left out, the verb's
+    own signature supplies it (see `_verb_target`), so `click("#go")`,
+    `run("ls")`, `goto("/app")` and `goto(path="/app")` all self-describe, and
+    a verb called with nothing to name (`pause(2)`, `spotlight()`) yields null.
     """
 
     def decorate(fn: Callable) -> Callable:
+        extract = _verb_target(fn) if target is None else target
+
         @functools.wraps(fn)
         def wrapper(self, *args, **kwargs):
-            with self._beat(verb, selector=target(args, kwargs)):
+            with self._beat(verb, selector=extract(args, kwargs)):
                 return fn(self, *args, **kwargs)
 
+        # The verb name, on the method. `tests/unit` sweeps every verb on both
+        # recorders and calls each one twice — once positionally, once by
+        # keyword — to hold #177 shut for verbs nobody has written yet, and a
+        # sweep that has to guess which methods are verbs would quietly stop
+        # covering the one somebody adds next.
+        wrapper._demo_verb = verb  # type: ignore[attr-defined]
         return wrapper
 
     return decorate

--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -45,9 +45,10 @@ from .timeline import timeline_paths
 #     no signal at all, so whatever else repainted in the window wins;
 #   * an app that keeps repainting under the bar supplies a stronger edge than
 #     the caption does, at a time of its own choosing;
-#   * a mid-take `goto()` destroys the caption bar with the document and logs
-#     no caption change at all, so there is nothing to measure and every later
-#     frame is captioned with a line that is not on screen.
+#   * a mid-take `goto()` destroys the caption bar with the document. The beat
+#     log no longer keeps the dead line (#134), but it clears from the *next*
+#     beat, so the bar leaves the screen a beat before the log says so and
+#     there is still nothing in the picture to measure the moment against.
 #
 # All three are the same mistake — guessing which pixel change was the caption.
 # The sound fix is for the recorder to *state* the mapping rather than have it

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -453,17 +453,27 @@ class Recorder(_DemoBase):
         )
 
     def _watch_page(self, page) -> None:
-        """Subscribe to the page events this recorder reacts to.
+        """Everything `_DemoBase` watches, plus what a *document* being
+        replaced means to a web take.
 
-        Its own method so the subscription is reachable without a browser:
-        `tests/unit` hands this a page that records what was subscribed and
-        then fires it, which is the only way to grade the handlers below
-        without ten minutes of Chromium.
+        **`super()` first, and it is load-bearing.** The base subscribes
+        `console`, `pageerror`, `requestfailed` and `response` — every problem
+        this recorder exists to write down, and what `strict=True` refuses a
+        take over. An override that forgot the call would silently unsubscribe
+        all four for web takes only, which is the one shape of bug that leaves
+        `timeline.json` looking healthy because the problems never reach it.
+        `tests/unit` holds that shut behaviourally, and it is registered as an
+        injection because it is a mistake this file has already made once.
 
-        Both callbacks only set an attribute. Playwright delivers page events
-        on the same thread that is blocked in a Playwright call, so calling
-        back into the API from one of them is a way to deadlock a take.
+        `__enter__` calls this before `_start()`, so the first navigation is
+        watched too. Do not call it again from `_start`: two subscriptions
+        record every console error twice.
+
+        Both callbacks below only set an attribute. Playwright delivers page
+        events on the same thread that is blocked in a Playwright call, so
+        calling back into the API from one of them is a way to deadlock a take.
         """
+        super()._watch_page(page)
         # **Kept deliberately when the masking went** — #142's carve-out.
         # Written for the paint gate, which is gone; nothing reads the flag.
         #
@@ -481,7 +491,6 @@ class Recorder(_DemoBase):
         page.on("domcontentloaded", self._note_document_replaced)
 
     def _start(self) -> None:
-        self._watch_page(self.page)
         # Render the window+background frame once (on a throwaway page, so the
         # app page stays clean for goto). ffmpeg composites the recording into
         # it in _postprocess.

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -403,8 +403,8 @@ class Recorder(_DemoBase):
         # page: `window.__spotEl` is an element handle, not a selector, and the
         # selector is the thing worth writing down.
         self._spotlit: str | None = None
-        # Set by the retained `framenavigated` listener. Nothing reads it yet;
-        # see `_note_navigation` and #134.
+        # Set by the retained `framenavigated` listener. Nothing reads it;
+        # see `_note_navigation` for why the listener is kept anyway.
         self._navigated = False
 
     def _frame_geometry(self) -> dict:
@@ -452,24 +452,36 @@ class Recorder(_DemoBase):
             .replace("__SLACK_MS__", str(SPOTLIGHT_EXIT_SLACK_MS))
         )
 
-    def _start(self) -> None:
+    def _watch_page(self, page) -> None:
+        """Subscribe to the page events this recorder reacts to.
+
+        Its own method so the subscription is reachable without a browser:
+        `tests/unit` hands this a page that records what was subscribed and
+        then fires it, which is the only way to grade the handlers below
+        without ten minutes of Chromium.
+
+        Both callbacks only set an attribute. Playwright delivers page events
+        on the same thread that is blocked in a Playwright call, so calling
+        back into the API from one of them is a way to deadlock a take.
+        """
         # **Kept deliberately when the masking went** — #142's carve-out.
-        # This listener was written for the paint gate, and the gate is gone;
-        # but it is also the recorder's *only* reaction to a document being
-        # replaced. A link click, go_back(), a form submit, location.href and
-        # a meta refresh all land here and nowhere else, and #134 — a mid-take
-        # goto() leaving `self._caption` stale, so every later beat logs a
-        # caption that is not on screen, into files this skill says to commit —
-        # cannot be fixed without knowing that a navigation happened.
+        # Written for the paint gate, which is gone; nothing reads the flag.
         #
         # `frameattached` went with the rest: it existed because a frame that
         # attached after the parent's checkpoint had never been verified, which
         # is a statement about a mask and about nothing else.
-        #
-        # The callback only sets a flag. Playwright delivers page events on the
-        # same thread that is blocked in a Playwright call, so calling back
-        # into the API from here is a way to deadlock a take.
-        self.page.on("framenavigated", self._note_navigation)
+        page.on("framenavigated", self._note_navigation)
+        # The caption bar is a DOM element, so a document replacing the one it
+        # lives in takes it off the screen (#134). This is the signal for that
+        # and `framenavigated` is not: Playwright fires `framenavigated` for
+        # same-document history navigation too, so an SPA route change would
+        # clear a caption that is still on screen — the same lie in the other
+        # direction. `domcontentloaded` is fired once per new document, and
+        # only for the main frame, so an iframe loading does not touch it.
+        page.on("domcontentloaded", self._note_document_replaced)
+
+    def _start(self) -> None:
+        self._watch_page(self.page)
         # Render the window+background frame once (on a throwaway page, so the
         # app page stays clean for goto). ffmpeg composites the recording into
         # it in _postprocess.
@@ -605,19 +617,34 @@ class Recorder(_DemoBase):
 
 
     def _note_navigation(self, frame) -> None:
-        """A frame navigated. Nothing reads this yet, and that is deliberate.
+        """A frame navigated. Nothing reads this, and that is deliberate.
 
         The flag used to mean "the next checkpoint must re-inject and re-verify
         the mask". There is no mask, so nothing consumes it. The *listener* is
-        what #142 keeps: it is the only way this recorder learns that a
-        document was replaced, and #134 needs precisely that. Keeping the hook
-        and dropping its consumer is a smaller thing to get wrong than
-        re-deriving the hook later.
+        what #142 keeps, and it fires for any frame and for same-document
+        history navigation as well, which is why it is not what invalidates the
+        caption — see `_note_document_replaced`.
 
-        Deliberately does nothing else — see `_start` for why touching
+        Deliberately does nothing else — see `_watch_page` for why touching
         Playwright from an event callback is not safe here.
         """
         self._navigated = True
+
+    def _note_document_replaced(self, page) -> None:
+        """A new document is in the main frame, so the caption bar is gone.
+
+        `_CAPTION_JS` builds `#__demo_caption` inside the document, and a full
+        page load destroys it. `self._caption` — which every beat that does not
+        carry its own caption is stamped with — is a Python attribute and
+        survives, so without this a mid-take `goto()` leaves every later beat
+        reporting a line that is not on screen, in a `timeline.json` this skill
+        says to commit (issue #134).
+
+        Clearing it here rather than in `goto()` covers a link click,
+        `go_back()`, a form submit, `location.href` and a meta refresh too:
+        they all replace the document and none of them goes through `goto`.
+        """
+        self._caption = ""
 
     # -- evidence (issue #9) ------------------------------------------------
 

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -49,8 +49,8 @@ worse review material than no caption at all. An earlier version tried to
 recover the mapping by finding caption transitions in the video; it mislabelled
 frames on ordinary storyboards (two captions of the same length give it no
 signal, an app that repaints under the bar gives it a stronger edge than the
-caption does, and a mid-take `goto()` destroys the bar while logging no caption
-change at all). [#60](https://github.com/rogvid/skills/issues/60) is how the
+caption does, and a mid-take `goto()` destroys the bar a beat before the log
+says so — see [#134](https://github.com/rogvid/skills/issues/134)). [#60](https://github.com/rogvid/skills/issues/60) is how the
 pairing gets earned back: have the recorder render the beat index into the
 frame so extraction reads it rather than infers it.
 

--- a/tests/unit
+++ b/tests/unit
@@ -140,7 +140,7 @@ _pw.sync_api = _pw_sync  # type: ignore[attr-defined]
 sys.modules["playwright"] = _pw
 sys.modules["playwright.sync_api"] = _pw_sync
 
-from demo_recording.core import _beat_verb  # noqa: E402
+from demo_recording.core import _beat_verb, _DemoBase  # noqa: E402
 from demo_recording.terminal import TerminalRecorder  # noqa: E402
 from demo_recording.web import Recorder  # noqa: E402
 
@@ -2249,12 +2249,65 @@ class CaptionTruth(unittest.TestCase):
         rec.pause(0)
         self.assertEqual(rec._beats[-1]["caption"], "The order was accepted.")
 
-    def test_the_take_subscribes_its_page_when_the_recording_starts(self):
-        # `_start` needs Chromium, so what is graded is that it delegates to
-        # the seam every test above exercises. Without this, the handlers
-        # could be perfect and subscribed by nothing on a real take.
-        source = inspect.getsource(Recorder._start)
+    def test_a_take_watches_its_page_before_the_medium_starts(self):
+        # `__enter__` needs Chromium, so what is graded is that it reaches the
+        # seam every test above exercises, and reaches it *before* `_start` —
+        # a page that throws on load is the whole point of watching it.
+        source = inspect.getsource(_DemoBase.__enter__)
         self.assertIn("self._watch_page(self.page)", source)
+        self.assertLess(
+            source.index("self._watch_page(self.page)"),
+            source.index("self._start()"),
+            "the medium starts before its page is watched, so the first "
+            "navigation's problems are recorded by nobody",
+        )
+
+
+class WatchedEvents(unittest.TestCase):
+    """What subscribing a recorder's page subscribes.
+
+    Written after the first version of #134's fix shipped `Recorder`'s two
+    handlers as a **new** `_watch_page`, when `_DemoBase._watch_page` — the
+    subscription for `console`, `pageerror`, `requestfailed` and `response` —
+    already existed under exactly that name. Python resolved the override, the
+    base's four listeners were never attached on a web take, and every problem
+    the recorder exists to record went unrecorded: `timeline.json` was
+    well-formed and empty of issues, and `strict=True` stopped refusing
+    anything. `tests/unit` could not see it, because no test here enters the
+    context manager that calls the shadowed method — the catalogue's
+    config-hidden path, in the suite rather than in the code.
+    """
+
+    def subscribed(self, cls) -> dict[str, int]:
+        """{event: how many handlers} after one subscription pass."""
+        rec = recorder(self, cls=cls)
+        rec._watch_page(rec.page)
+        return {event: len(h) for event, h in rec.page.subscribed.items()}
+
+    def test_a_web_take_watches_the_problems_every_take_watches(self):
+        # Spelled out rather than derived from the base class: a list read out
+        # of the code under test agrees with that code by construction, and
+        # these four names are what `timeline.json`'s issue log is made of.
+        self.assertLessEqual(
+            {"console", "pageerror", "requestfailed", "response"},
+            set(self.subscribed(WebRec)),
+        )
+
+    def test_the_web_recorder_only_adds_to_what_the_base_watches(self):
+        # The same claim from the other side, and the one that survives a
+        # listener being renamed: the terminal recorder does not override
+        # `_watch_page`, so what it subscribes *is* the base's set.
+        base = set(self.subscribed(TermRec))
+        self.assertEqual(
+            set(self.subscribed(WebRec)),
+            base | {"framenavigated", "domcontentloaded"},
+        )
+
+    def test_no_page_event_is_subscribed_twice(self):
+        # `__enter__` already calls `_watch_page`; a medium calling it again
+        # from `_start` would log every console error the page emits twice.
+        doubled = {e: n for e, n in self.subscribed(WebRec).items() if n != 1}
+        self.assertEqual(doubled, {})
 
 
 class VerbTarget(unittest.TestCase):
@@ -2906,13 +2959,37 @@ INJECTIONS = [
         ["CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption"],
     ),
     (
-        # …and the subscription can be right and never made, because `_start`
-        # needs Chromium and no test here runs it.
-        "a take starts without subscribing to its page's events",
+        # …and the subscription can be right and never made, because
+        # `__enter__` needs Chromium and no test here runs it.
+        "a take starts the medium before it watches the page",
+        "core.py",
+        "            self._watch_page(self.page)\n            self._start()",
+        "            self._start()\n            self._watch_page(self.page)",
+        ["CaptionTruth.test_a_take_watches_its_page_before_the_medium_starts"],
+    ),
+    (
+        # The regression the first version of this change shipped, and the one
+        # `tests/smoke` caught after `tests/unit` went green: `Recorder`
+        # declaring `_watch_page` without delegating shadows the base's four
+        # problem listeners, so a web take records no console error, no
+        # pageerror, no failed request — and `strict=True` refuses nothing.
+        "the web recorder's page subscription shadows the base's",
         "web.py",
-        "        self._watch_page(self.page)",
-        "        pass  # the page is watched by nobody",
-        ["CaptionTruth.test_the_take_subscribes_its_page_when_the_recording_starts"],
+        "        super()._watch_page(page)",
+        "        pass  # the base's problem listeners are on their own",
+        [
+            "WatchedEvents.test_a_web_take_watches_the_problems_every_take_watches",
+            "WatchedEvents.test_the_web_recorder_only_adds_to_what_the_base_watches",
+        ],
+    ),
+    (
+        # And the mirror: subscribing twice logs every problem the page emits
+        # twice, which is the shape the fix for the above invites.
+        "a medium subscribes its page a second time",
+        "web.py",
+        "        super()._watch_page(page)",
+        "        super()._watch_page(page)\n        super()._watch_page(page)",
+        ["WatchedEvents.test_no_page_event_is_subscribed_twice"],
     ),
     (
         # The naive fix, and the reason the clear is not on `framenavigated`:

--- a/tests/unit
+++ b/tests/unit
@@ -2240,9 +2240,7 @@ class CaptionTruth(unittest.TestCase):
         before = len(rec._beats)
         self.assertGreaterEqual(rec.page.fire("framenavigated", None), 1)
         rec.pause(0)
-        self.assertEqual(
-            [b["caption"] for b in rec._beats[before:]], [STALE_CAPTION]
-        )
+        self.assertEqual([b["caption"] for b in rec._beats[before:]], [STALE_CAPTION])
 
     def test_a_caption_set_after_the_load_is_reported_again(self):
         rec = self.prepared()
@@ -2269,8 +2267,9 @@ class VerbTarget(unittest.TestCase):
 
     def target_of(self, cls, name, *args, **kwargs):
         """The `selector` the beat log records for one call of one verb."""
-        rec = recorder(self, cls=WebRec if cls is Recorder else TermRec,
-                       page=DeadPage())
+        rec = recorder(
+            self, cls=WebRec if cls is Recorder else TermRec, page=DeadPage()
+        )
         with contextlib.suppress(Exception):
             getattr(rec, name)(*args, **kwargs)
         self.assertTrue(
@@ -2291,8 +2290,7 @@ class VerbTarget(unittest.TestCase):
             self.assertEqual(
                 positional,
                 VERB_SENTINEL,
-                f"{cls.__name__}.{name}({VERB_SENTINEL!r}) logged "
-                f"{positional!r}",
+                f"{cls.__name__}.{name}({VERB_SENTINEL!r}) logged {positional!r}",
             )
             self.assertEqual(
                 keyword,

--- a/tests/unit
+++ b/tests/unit
@@ -37,7 +37,9 @@ from __future__ import annotations
 import argparse
 import ast
 import contextlib
+import inspect
 import io
+import json
 import os
 import re
 import shutil
@@ -45,7 +47,9 @@ import subprocess
 import sys
 import tempfile
 import textwrap
+import time
 import tokenize
+import types
 import unittest
 from pathlib import Path
 
@@ -99,6 +103,46 @@ from demo_recording.timeline import (  # noqa: E402
     render_timeline_md,
     timeline_paths,
 )
+
+# --------------------------------------------------------------------------
+# The recorders, without a browser
+# --------------------------------------------------------------------------
+#
+# `core` imports `playwright.sync_api` at module scope, so importing either
+# recorder needs the name to resolve. A stand-in is installed for it here and
+# `dependencies = []` at the top of this file stays true.
+#
+# What is being stood in for is *only* the import. `Page` is an annotation and
+# nothing here evaluates it; `sync_playwright` is reached from `__enter__`,
+# which no test in this file enters — both raise if anything ever does, so a
+# test that quietly started driving a browser would say so rather than hang.
+#
+# Installed unconditionally rather than only when Playwright is missing: a
+# suite that runs different code on the author's box than on CI grades the box
+# (the catalogue's environment-agreeing assertion). This is the same code
+# either way.
+_pw = types.ModuleType("playwright")
+_pw_sync = types.ModuleType("playwright.sync_api")
+
+
+class _NoBrowser:
+    """Whatever reached for Playwright, this suite does not have one."""
+
+    def __init__(self, *args, **kwargs):
+        raise RuntimeError(
+            "tests/unit does not start a browser — this belongs in tests/smoke"
+        )
+
+
+_pw_sync.Page = _NoBrowser  # type: ignore[attr-defined]
+_pw_sync.sync_playwright = _NoBrowser  # type: ignore[attr-defined]
+_pw.sync_api = _pw_sync  # type: ignore[attr-defined]
+sys.modules["playwright"] = _pw
+sys.modules["playwright.sync_api"] = _pw_sync
+
+from demo_recording.core import _beat_verb  # noqa: E402
+from demo_recording.terminal import TerminalRecorder  # noqa: E402
+from demo_recording.web import Recorder  # noqa: E402
 
 # --------------------------------------------------------------------------
 # Helpers — deliberately hand-written
@@ -1992,6 +2036,302 @@ class VendoredAssets(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# The beat log says what was true of the screen (issues #134, #177)
+# --------------------------------------------------------------------------
+#
+# Both defects have the same shape: a beat that reads well, a timeline that
+# validates, and a field that describes something other than what happened.
+# Nothing downstream can notice — `timeline.json` and `timeline.md` are
+# committed, so the wrong value is what a reviewing agent reads once the video
+# is gone.
+#
+# These tests are written from the **reader's** side. None of them asks the
+# recorder what it thinks its caption is: `self._caption` is the stale field
+# in #134, so a check that consulted it would share the bug's blind spot
+# exactly. What is read is the beat record — the object that becomes a row of
+# `timeline.json` — and, for the caption, the serialized text of it, so a
+# stale line reappearing under any key is a failure rather than a near miss.
+
+# One string, distinctive enough that finding it in a beat is not a
+# coincidence and that a stale copy of it is unmistakable.
+STALE_CAPTION = "The dashboard shows every open order."
+
+# Below this many verbs, "every verb names its target both ways" holds over
+# almost nothing — the catalogue's vacuous sweep. It is 13 today (web 10,
+# terminal 4, shared 2, minus the three whose first parameter is not a
+# string and the one that takes *names).
+VERB_TARGET_FLOOR = 10
+
+# The sentinel a swept verb is handed as its target. A string, because that is
+# what the beat log records; distinctive, so an assertion cannot be satisfied
+# by a default value that happened to be lying around.
+VERB_SENTINEL = "#unit-sweep-target"
+
+
+class _VerbBodyStopped(RuntimeError):
+    """A swept verb reached for the browser it does not have."""
+
+
+class _NoWait:
+    """Hold no frames. These tests grade the beat log, not the wall clock."""
+
+    def _idle(self, seconds: float) -> None:
+        return None
+
+
+class WebRec(_NoWait, Recorder):
+    pass
+
+
+class TermRec(_NoWait, TerminalRecorder):
+    pass
+
+
+class PressRec(WebRec):
+    """#177's own example: a verb whose first parameter is named `key`.
+
+    `key` is outside the six-name allowlist `_verb_target` used to consult, so
+    `press(key="Enter")` recorded `selector: null` while `press("Enter")`
+    recorded it fine. Declared here rather than waited for in the package,
+    because the defect is about the verb somebody adds *next*.
+    """
+
+    @_beat_verb("press")
+    def press(self, key: str) -> None:
+        return None
+
+
+class FakePage:
+    """A page that remembers what was subscribed to it, and can fire it.
+
+    `Recorder._watch_page` is the production subscription and this is handed
+    to it verbatim, so the tests below fire the same callbacks Playwright
+    would, under the same event names. Getting the event name wrong is
+    therefore a test failure and not a silently unexercised handler.
+    """
+
+    def __init__(self) -> None:
+        self.subscribed: dict[str, list] = {}
+
+    def on(self, event: str, handler) -> None:
+        self.subscribed.setdefault(event, []).append(handler)
+
+    def fire(self, event: str, *args) -> int:
+        """Deliver `event`; returns how many handlers took it."""
+        handlers = self.subscribed.get(event, [])
+        for handler in handlers:
+            handler(*args)
+        return len(handlers)
+
+    def evaluate(self, *args, **kwargs):
+        return None
+
+
+class DeadPage:
+    """A page whose every call fails at once.
+
+    The verb sweep wants each verb's *beat*, not its effect; the beat is
+    opened before the body runs, so stopping the body on first contact with
+    the browser is what makes the sweep runnable here at all.
+    """
+
+    def __getattr__(self, name: str):
+        def refuse(*args, **kwargs):
+            raise _VerbBodyStopped(name)
+
+        return refuse
+
+
+def recorder(test: unittest.TestCase, cls=WebRec, page=None):
+    """A recorder wired to `page`, with the clock started and no browser."""
+    tmp = tempfile.TemporaryDirectory()
+    test.addCleanup(tmp.cleanup)
+    # The constructor's advisory notices about determinism and narration are
+    # for someone recording a take; several hundred of them would bury this
+    # suite's own output, and `--fault-inject` prints a tail of stderr.
+    with contextlib.redirect_stderr(io.StringIO()):
+        rec = cls(
+            tmp.name,
+            # Pinned, not inherited: speech reads ELEVENLABS_API_KEY and
+            # evidence reads the page, and a suite whose behaviour depends on
+            # either grades the box it runs on.
+            speech=False,
+            evidence=False,
+        )
+    rec.page = page if page is not None else FakePage()
+    rec._t0 = time.monotonic()
+    return rec
+
+
+def beat_verbs() -> list[tuple[type, str]]:
+    """(class, attribute) for every `@_beat_verb` method on both recorders."""
+    found = []
+    for cls in (Recorder, TerminalRecorder):
+        for name in dir(cls):
+            attr = getattr(cls, name, None)
+            if getattr(attr, "_demo_verb", None) is not None:
+                found.append((cls, name))
+    return found
+
+
+def first_string_parameter(cls: type, name: str) -> str | None:
+    """The name of the verb's first parameter after `self`, when it takes a
+    string there — the parameter #177 is about. None for the rest."""
+    fn = getattr(cls, name)
+    params = list(inspect.signature(fn).parameters.values())
+    # `signature` on a bound-less function still lists `self`; drop it, then
+    # anything that cannot be passed by keyword (`key(*names)`).
+    params = [p for p in params[1:] if p.kind is p.POSITIONAL_OR_KEYWORD]
+    if not params:
+        return None
+    annotation = str(params[0].annotation)
+    return params[0].name if "str" in annotation else None
+
+
+class CaptionTruth(unittest.TestCase):
+    """What a beat reports was on screen, across a navigation (issue #134).
+
+    The caption bar is a DOM element (`#__demo_caption`), so a document
+    replacing the one it lives in takes it off the screen. `self._caption` is
+    a Python attribute and does not notice, and every beat that does not carry
+    its own caption is stamped with it.
+    """
+
+    def prepared(self):
+        """A recorder with `STALE_CAPTION` up and one beat proving it."""
+        rec = recorder(self)
+        rec._watch_page(rec.page)
+        rec.caption(STALE_CAPTION)
+        rec.pause(0)
+        # The control. Everything below is a claim about a caption going
+        # *away*, and none of it means anything unless a beat was carrying the
+        # caption in the first place — a recorder that stamped "" on every
+        # beat would satisfy the assertions and record nothing true.
+        self.assertEqual(
+            rec._beats[-1]["caption"],
+            STALE_CAPTION,
+            "the beat before the navigation does not carry the caption, so "
+            "this test is not exercising the stamping it grades",
+        )
+        return rec
+
+    def test_a_beat_after_a_document_load_reports_no_caption(self):
+        rec = self.prepared()
+        before = len(rec._beats)
+        self.assertGreaterEqual(
+            rec.page.fire("domcontentloaded", rec.page),
+            1,
+            "no handler took the document-load event, so nothing was tested",
+        )
+        rec.pause(0)
+        after = rec._beats[before:]
+        self.assertEqual([b["caption"] for b in after], [""])
+        # Broader than the field, deliberately: the claim is that a reader of
+        # this take's timeline cannot recover the pre-navigation line from a
+        # beat recorded after it, whichever key it might have travelled under.
+        self.assertNotIn(STALE_CAPTION, json.dumps(after))
+
+    def test_an_spa_route_change_keeps_the_caption(self):
+        # The bar survives history navigation, so clearing on every
+        # `framenavigated` — which Playwright also fires for same-document
+        # navigation — would be the same lie pointing the other way: a beat
+        # reporting no caption while one is on screen.
+        rec = self.prepared()
+        before = len(rec._beats)
+        self.assertGreaterEqual(rec.page.fire("framenavigated", None), 1)
+        rec.pause(0)
+        self.assertEqual(
+            [b["caption"] for b in rec._beats[before:]], [STALE_CAPTION]
+        )
+
+    def test_a_caption_set_after_the_load_is_reported_again(self):
+        rec = self.prepared()
+        rec.page.fire("domcontentloaded", rec.page)
+        rec.caption("The order was accepted.")
+        rec.pause(0)
+        self.assertEqual(rec._beats[-1]["caption"], "The order was accepted.")
+
+    def test_the_take_subscribes_its_page_when_the_recording_starts(self):
+        # `_start` needs Chromium, so what is graded is that it delegates to
+        # the seam every test above exercises. Without this, the handlers
+        # could be perfect and subscribed by nothing on a real take.
+        source = inspect.getsource(Recorder._start)
+        self.assertIn("self._watch_page(self.page)", source)
+
+
+class VerbTarget(unittest.TestCase):
+    """Which target a verb's beat names, by position and by keyword (#177).
+
+    `rec.press("Enter")` and `rec.press(key="Enter")` are one action written
+    two ways. Until this, the second recorded `selector: null` — an action
+    that happened on screen and is absent from the artifact a reviewer reads.
+    """
+
+    def target_of(self, cls, name, *args, **kwargs):
+        """The `selector` the beat log records for one call of one verb."""
+        rec = recorder(self, cls=WebRec if cls is Recorder else TermRec,
+                       page=DeadPage())
+        with contextlib.suppress(Exception):
+            getattr(rec, name)(*args, **kwargs)
+        self.assertTrue(
+            rec._beats, f"{name} recorded no beat at all, so it names nothing"
+        )
+        self.assertEqual(rec._beats[-1]["verb"], getattr(cls, name)._demo_verb)
+        return rec._beats[-1]["selector"]
+
+    def test_every_verb_names_its_target_the_same_way_called_either_way(self):
+        swept = []
+        for cls, name in beat_verbs():
+            parameter = first_string_parameter(cls, name)
+            if parameter is None:
+                continue
+            swept.append(f"{cls.__name__}.{name}")
+            positional = self.target_of(cls, name, VERB_SENTINEL)
+            keyword = self.target_of(cls, name, **{parameter: VERB_SENTINEL})
+            self.assertEqual(
+                positional,
+                VERB_SENTINEL,
+                f"{cls.__name__}.{name}({VERB_SENTINEL!r}) logged "
+                f"{positional!r}",
+            )
+            self.assertEqual(
+                keyword,
+                VERB_SENTINEL,
+                f"{cls.__name__}.{name}({parameter}={VERB_SENTINEL!r}) logged "
+                f"{keyword!r} — the same action, written the other way, is "
+                f"missing from the beat log (#177)",
+            )
+        # The haystack, before anything is claimed about it: an empty sweep
+        # satisfies "every verb names its target" trivially.
+        self.assertGreaterEqual(
+            len(swept),
+            VERB_TARGET_FLOOR,
+            f"only {len(swept)} verbs were swept ({sorted(swept)}) — the "
+            f"enumeration is broken, not the verbs",
+        )
+
+    def test_a_verb_whose_parameter_is_outside_the_old_allowlist_names_it(self):
+        # The general property, on a verb the package does not have. The sweep
+        # above can only be as general as the verbs that exist today, and
+        # every one of *their* first parameters happens to be an allowlist
+        # name — so on its own it would go green against the old code for all
+        # but one verb.
+        rec = recorder(self, cls=PressRec)
+        rec.press(key="Enter")
+        rec.press("Enter")
+        self.assertEqual([b["selector"] for b in rec._beats], ["Enter", "Enter"])
+
+    def test_a_verb_given_no_string_names_nothing(self):
+        # The other direction: null is the honest answer when there is no
+        # target, and an extractor that invented one would be worse than the
+        # bug it replaced.
+        rec = recorder(self)
+        rec.pause(0)
+        rec.hold(min_s=0)
+        self.assertEqual([b["selector"] for b in rec._beats], [None, None])
+
+
+# --------------------------------------------------------------------------
 # Fault injection
 # --------------------------------------------------------------------------
 
@@ -2521,6 +2861,72 @@ INJECTIONS = [
         "",
         ["VendoredAssets.test_the_manifest_names_exactly_what_the_directory_holds"],
     ),
+    (
+        # Issue #177, exactly as it shipped: the six-name allowlist back in
+        # place of reading the verb's own signature.
+        "a verb's target is dug out of a fixed keyword allowlist again",
+        "core.py",
+        "        value = kwargs.get(first.name)\n"
+        "        return value if isinstance(value, str) else None",
+        '        for name in ("selector", "path", "command", "text", "pattern", "name"):\n'
+        "            if isinstance(kwargs.get(name), str):\n"
+        "                return str(kwargs[name])\n"
+        "        return None",
+        [
+            "VerbTarget.test_every_verb_names_its_target_the_same_way_called_either_way",
+            "VerbTarget.test_a_verb_whose_parameter_is_outside_the_old_allowlist_names_it",
+        ],
+    ),
+    (
+        # The other half of the same claim. A sweep that only ever checked the
+        # keyword side would go green against a verb that names nothing at all.
+        "a verb called positionally stops naming its target",
+        "core.py",
+        "            return args[0] if isinstance(args[0], str) else None",
+        "            return None",
+        [
+            "VerbTarget.test_every_verb_names_its_target_the_same_way_called_either_way",
+            "VerbTarget.test_a_verb_whose_parameter_is_outside_the_old_allowlist_names_it",
+        ],
+    ),
+    (
+        # Issue #134: the caption bar dies with the document, the recorder's
+        # copy of it does not, and every later beat reports a line that is not
+        # on screen into a committed timeline.
+        "a document load stops invalidating the caption",
+        "web.py",
+        '        self._caption = ""',
+        "        pass  # the recorder keeps a caption the document took away",
+        ["CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption"],
+    ),
+    (
+        # The handler can be right and reachable by nothing.
+        "nothing subscribes to the document being replaced",
+        "web.py",
+        '        page.on("domcontentloaded", self._note_document_replaced)',
+        "        pass  # no subscription",
+        ["CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption"],
+    ),
+    (
+        # …and the subscription can be right and never made, because `_start`
+        # needs Chromium and no test here runs it.
+        "a take starts without subscribing to its page's events",
+        "web.py",
+        "        self._watch_page(self.page)",
+        "        pass  # the page is watched by nobody",
+        ["CaptionTruth.test_the_take_subscribes_its_page_when_the_recording_starts"],
+    ),
+    (
+        # The naive fix, and the reason the clear is not on `framenavigated`:
+        # Playwright fires that for same-document history navigation too, so
+        # this reports no caption while one is on screen — #134 pointing the
+        # other way.
+        "an SPA route change clears a caption that is still on screen",
+        "web.py",
+        "        self._navigated = True",
+        '        self._navigated = True\n        self._caption = ""',
+        ["CaptionTruth.test_an_spa_route_change_keeps_the_caption"],
+    ),
 ]
 
 
@@ -2622,10 +3028,19 @@ def fault_inject() -> int:
 # Stated plainly rather than implied by silence:
 #
 # - **Anything that drives a browser or a PTY.** `_DemoBase`, `Recorder` and
-#   `TerminalRecorder` — every storyboard verb, per-beat evidence capture, the
-#   failure dump, narration pacing and the ffmpeg composite — are
+#   `TerminalRecorder` — every storyboard verb's *effect*, per-beat evidence
+#   capture, the failure dump, narration pacing and the ffmpeg composite — are
 #   `tests/smoke`'s, and this suite does not reduce what smoke has to run. It
 #   runs the half that never needed one.
+#
+#   Two things about the recorders *are* graded here, both with a stand-in for
+#   `playwright.sync_api` and a page that records rather than paints (#134,
+#   #177): what a beat writes down about a call, and what a document load does
+#   to the caption the beat log stamps. Neither needs a browser to be true, and
+#   both are read off the beat record — the row that becomes `timeline.json` —
+#   rather than off the screen. What a real Chromium does with the same events
+#   is still smoke's: that `domcontentloaded` fires when this claims it does is
+#   Playwright's contract, not an assertion made here.
 # - **Anything measured off real frames.** `content_report`'s ffmpeg sampling,
 #   `opening_gap`, `_luma_stddev` and `_moved_pixels` need a video to be true
 #   about. What is graded here is the logic *around* them: the warning


### PR DESCRIPTION
Closes #134 and #177. One acceptance criterion for both: **`timeline.json` must
not record something that was not true of the screen.**

## What each fix is

**#134 — a mid-take `goto()` left the caption behind.** The caption bar is
`#__demo_caption`, a DOM element, and a full page load destroys it.
`self._caption` — which `_beat` stamps onto every beat that does not carry its
own — is a Python attribute and did not notice, so every beat after the
navigation reported a line that was not on screen, into a file this skill says
to commit.

`Recorder._note_document_replaced` clears it, subscribed to
**`domcontentloaded`**. That event fires once per new document and only for the
main frame, so a link click, `go_back()`, a form submit, `location.href` and a
meta refresh are all covered in one place, and an iframe loading is not.

It is deliberately **not** `framenavigated`, which the issue suggested.
Playwright dispatches `framenavigated` for same-document history navigation
too — `frameCommittedSameDocumentNavigation` builds its event with
`isPublic: true` and `frameDispatcher` forwards it — so clearing there would
take the caption off the beat log while it is still on screen during SPA
routing. That is the same lie pointing the other way, and #134 says explicitly
that "SPA routing keeps the bar and must keep the string". The `framenavigated`
listener and its `_navigated` flag are left exactly as #142 left them.

**#177 — a keyword-called verb named no target.** `_verb_target` read a beat's
target out of `args[0]`, else out of a fixed allowlist of six keyword names, so
a verb whose first parameter was called anything else logged `selector: null`
the moment somebody passed it by keyword. It now builds a per-verb extractor
from the verb's own signature: the first parameter after `self`, whatever it is
named. The positional branch is unchanged — positionally `args[0]` *is* the
first parameter — so this only generalizes the keyword side.

## How the assertions were graded

`tests/unit` had no way to reach the recorders: `core` imports
`playwright.sync_api` at module scope, and the import was the only thing that
needed a browser. A stand-in module is installed for it (unconditionally, so
the author's box and CI run the same code), `Page` and `sync_playwright` both
raise if anything ever evaluates them, and `dependencies = []` stays true.

Seven tests, six registered injections, `All 64 injections were caught`.

Every assertion reads the **beat record** — the row that becomes
`timeline.json` — and never `self._caption`. Consulting the stale field to
check whether the stale field is stale is the catalogue's *check that shares
the bug's blind spot*, and it is the trap this change is most exposed to. The
caption assertion is also broader than the field it grades: it searches the
serialized post-navigation beats for the pre-navigation line, so a stale copy
surfacing under any key fails rather than passing narrowly.

Controls against the vacuous sweep: `CaptionTruth.prepared` refuses to proceed
unless a beat *before* the navigation carries the caption (a recorder stamping
`""` on everything would otherwise satisfy every assertion below it); the
document-load test asserts at least one handler took the event; the verb sweep
asserts it swept at least 10 verbs and names them when it did not.

### Pasted failure output

```
==============================================================================
break: a verb's target is dug out of a fixed keyword allowlist again
  in core.py: value = kwargs.get(first.name)
==============================================================================
FAIL: test_every_verb_names_its_target_the_same_way_called_either_way (__main__.VerbTarget.test_every_verb_names_its_target_the_same_way_called_either_way)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/tmpcee21di_/unit", line 2295, in test_every_verb_names_its_target_the_same_way_called_either_way
    self.assertEqual(
AssertionError: None != '#unit-sweep-target' : Recorder.terminal_close(stamp='#unit-sweep-target') logged None — the same action, written the other way, is missing from the beat log (#177)

======================================================================
FAIL: test_a_verb_whose_parameter_is_outside_the_old_allowlist_names_it (__main__.VerbTarget.test_a_verb_whose_parameter_is_outside_the_old_allowlist_names_it)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/tmpcee21di_/unit", line 2320, in test_a_verb_whose_parameter_is_outside_the_old_allowlist_names_it
    self.assertEqual([b["selector"] for b in rec._beats], ["Enter", "Enter"])
AssertionError: Lists differ: [None, 'Enter'] != ['Enter', 'Enter']
```

```
==============================================================================
break: a verb called positionally stops naming its target
  in core.py: return args[0] if isinstance(args[0], str) else None
==============================================================================
FAIL: test_every_verb_names_its_target_the_same_way_called_either_way (__main__.VerbTarget.test_every_verb_names_its_target_the_same_way_called_either_way)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/tmpt29gooj3/unit", line 2290, in test_every_verb_names_its_target_the_same_way_called_either_way
    self.assertEqual(
AssertionError: None != '#unit-sweep-target' : Recorder.click('#unit-sweep-target') logged None

======================================================================
FAIL: test_a_verb_whose_parameter_is_outside_the_old_allowlist_names_it (__main__.VerbTarget.test_a_verb_whose_parameter_is_outside_the_old_allowlist_names_it)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/tmpt29gooj3/unit", line 2320, in test_a_verb_whose_parameter_is_outside_the_old_allowlist_names_it
    self.assertEqual([b["selector"] for b in rec._beats], ["Enter", "Enter"])
AssertionError: Lists differ: ['Enter', None] != ['Enter', 'Enter']
```

```
==============================================================================
break: a document load stops invalidating the caption
  in web.py: self._caption = ""
==============================================================================
FAIL: test_a_beat_after_a_document_load_reports_no_caption (__main__.CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/tmp1hbcvaii/unit", line 2228, in test_a_beat_after_a_document_load_reports_no_caption
    self.assertEqual([b["caption"] for b in after], [""])
AssertionError: Lists differ: ['The dashboard shows every open order.'] != ['']

First differing element 0:
'The dashboard shows every open order.'
''

- ['The dashboard shows every open order.']
+ ['']
```

```
==============================================================================
break: nothing subscribes to the document being replaced
  in web.py: page.on("domcontentloaded", self._note_document_replaced)
==============================================================================
FAIL: test_a_beat_after_a_document_load_reports_no_caption (__main__.CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/tmppfxgb8ed/unit", line 2221, in test_a_beat_after_a_document_load_reports_no_caption
    self.assertGreaterEqual(
AssertionError: 0 not greater than or equal to 1 : no handler took the document-load event, so nothing was tested
```

```
==============================================================================
break: a take starts without subscribing to its page's events
  in web.py: self._watch_page(self.page)
==============================================================================
FAIL: test_the_take_subscribes_its_page_when_the_recording_starts (__main__.CaptionTruth.test_the_take_subscribes_its_page_when_the_recording_starts)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/tmptqgy56o6/unit", line 2257, in test_the_take_subscribes_its_page_when_the_recording_starts
    self.assertIn("self._watch_page(self.page)", source)
AssertionError: 'self._watch_page(self.page)' not found in '    def _start(self) -> None:\n        pass  # the page is watched by nobody\n ...
```

```
==============================================================================
break: an SPA route change clears a caption that is still on screen
  in web.py: self._navigated = True
==============================================================================
FAIL: test_an_spa_route_change_keeps_the_caption (__main__.CaptionTruth.test_an_spa_route_change_keeps_the_caption)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/tmp09eu4tkf/unit", line 2243, in test_an_spa_route_change_keeps_the_caption
    self.assertEqual([b["caption"] for b in rec._beats[before:]], [STALE_CAPTION])
AssertionError: Lists differ: [''] != ['The dashboard shows every open order.']

First differing element 0:
''
'The dashboard shows every open order.'
```

## Verification

Run at CI's scope, with CI's pinned ruff (`RUFF_VERSION` from `ci.yml`):

```
./tests/unit                    Ran 110 tests — OK   (100 before, +10)
./tests/unit --fault-inject     All 66 injections were caught   (58 before, +8)
./tests/unit --budget           SKILL.md: 597 lines (~13,793 tokens), budget 600
./tests/ci-unit                 Ran 49 tests — OK
uv run --with ruff==0.14.2 ruff check .          All checks passed!
uv run --with ruff==0.14.2 ruff format --check . 12 files already formatted
uv run --with mypy==1.13.0 --with playwright mypy skills/demo-video/helpers/
                                Success: no issues found in 12 source files
./tests/smoke --web-only        PASSED  (web-problems 8 problems / 6 fatal,
./tests/smoke --strict-only     PASSED   web-strict refused at beat 0 with 4)
./tests/smoke --segments-only   PASSED
./tests/smoke --determinism-only PASSED
./tests/smoke (full)            FAILED on determinism — and fails identically
                                on main @ 5b7cc16, see below and #185
```

The first push of this branch was verified with `ruff format --check` pointed at
`skills/demo-video/helpers/` only, and CI runs it over the repo root — so the
one file the change actually adds code to, `tests/unit`, was outside the path
that graded it, and the lint job failed on three formatting nits in the new
tests. That is the catalogue's *wrong-scope search*, on the verification rather
than in it. Both ruff steps are now run from the repo root at the pinned
version.

## The regression this shipped, and what now holds it shut

The first version of the #134 fix gave `Recorder` a `_watch_page` method for
the two new handlers. `_DemoBase._watch_page` already existed under that exact
name and is what subscribes `console`, `pageerror`, `requestfailed` and
`response` — every problem a take writes into `timeline.json`, and everything
`strict=True` refuses a take over. Python resolved the override, and on a web
take the base's four listeners were never attached: `timeline.json` came out
well-formed with no issues at all, and strict mode refused nothing.

`tests/unit` went green through all of it, because no test here enters the
context manager that calls the shadowed method — the catalogue's
**config-hidden path**, in the verification rather than in the change.
`tests/smoke` caught it (`web-problems`, `web-strict`).

The override now calls `super()` first, `_start` no longer calls it at all
(`__enter__` already does, before `_start`), and three behavioural assertions
hold it shut: that a web take's subscription contains the four problem events,
that it is exactly the base's set plus the two added here, and that nothing is
subscribed twice. All three are registered injections, including the shadowing
itself and the double subscription the fix invites.

Verified against a browser this time, not only in `tests/unit`:
`./tests/smoke --web-only` passes, with `web-problems` recording 8 problems (6
fatal) and `web-strict` refusing at beat 0 with 4.

## CI's smoke job fails on something older than this branch

`smoke` is red on this PR, three runs running, on the determinism arm:
`01-entropy.png` and `02-entropy.png` differ between two takes of the same
storyboard — at **0.00 mean luma over the panel being graded**, with all four
clocks frozen identically and `demo.mp4` reproducing.

It is not this change. A full local `tests/smoke` run on `main` @ `5b7cc16`
fails the identical assertion with the **identical pair of hashes**, take order
swapped:

```
main:   01-entropy.png  e3d8a91b4beaa6e6 vs 6f95a864aa645e46
branch: 01-entropy.png  6f95a864aa645e46 vs e3d8a91b4beaa6e6
```

This branch changes no pixel, no still and no encoder setting. Filed as **#185**
with the full measurement, including why `--determinism-only` passes while the
full suite fails and why CI's own pair is stable across all three runs.

## Stated limits

- **No real-browser arm.** #134's acceptance names a `tests/smoke` arm; smoke is
  out of this change's scope and was not run here. The unit arm fires
  `domcontentloaded` itself, so it proves the handler and the subscription and
  takes Playwright's contract for *when* that event fires on trust. Filed as
  **#179** with the specific unverified claims listed (ordering against a real
  `goto()`, coverage of link clicks / `go_back()` / form submits / meta
  refresh, and that an SPA route change does not deliver it).
- **A lost caption is silent.** The beat log stops lying, and nothing tells the
  author a line was dropped — a storyboard that captions, navigates and then
  holds now records honest empty captions where it meant to have one. #134
  excluded this explicitly; filed as **#180** with its measurement.
- **The `goto` beat itself still carries the pre-navigation caption.** It is
  stamped when the beat opens, which is before the document is replaced, and
  the caption genuinely was on screen then. Beats *after* it are what #134's
  acceptance is about. The one-beat lag is now stated in `frames.py`'s note on
  why review frames ship uncaptioned, which previously claimed a `goto()` logs
  "no caption change at all" — true before this change, false after it.
- **The interlude and terminal-card overlays are not covered.** They are DOM
  elements too and die with the same document, but neither is stamped onto a
  beat, so neither can make an artifact disagree with the screen. Not measured.
- **`_verb_target` still infers.** #177 listed "make the target explicit at
  every `@_beat_verb` and delete the inference" as an alternative; this takes
  the signature-reading option and keeps the third (assert against it, over
  every verb on both recorders) as the check that would have caught the
  original.

## The SKILL.md row that this change made false

Line 250 used to put the obligation on the author — "clear before navigating
either way" — which was correct only because the recorder did not. It now
reads:

```
| `caption(text)` | Narrator line at the bottom; `""` clears; dies on full page loads and the beat log clears with it, survives SPA routing — re-caption after a load |
```

One line for one line: `./tests/unit --budget` reports 597 of 600.

## Files

`core.py` (`_verb_target`, `_beat_verb`), `web.py` (`_watch_page`,
`_note_document_replaced`), `frames.py` (a comment this change made false),
`reference/review.md` (the same sentence), `tests/unit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


