### PR TITLE
Counts that check themselves, and a ruff pin that reaches the local command (#184, #189)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,18 @@ jobs:
         with:
           enable-cache: true
 
-      - name: ruff check
-        run: uv run --with "ruff==$RUFF_VERSION" ruff check --output-format github .
+      # The guards on the pin itself: that RUFF_VERSION above is the only one,
+      # that tests/lint reads it rather than remembering a version, and that no
+      # workflow reaches ruff any other way. Runs no ruff and costs nothing.
+      - name: tests/lint --self-test
+        run: tests/lint --self-test
 
-      - name: ruff format --check
-        run: uv run --with "ruff==$RUFF_VERSION" ruff format --check .
+      # ruff, at RUFF_VERSION above — which tests/lint parses out of this file,
+      # so `tests/lint` locally is this step, at this version. Running ruff
+      # here by hand instead would be a second pin; issue #189 is what that
+      # cost, and tests/lint --self-test above refuses it.
+      - name: ruff check + ruff format --check
+        run: tests/lint --github
 
       # shellcheck comes from PyPI rather than apt so this is the same binary
       # a contributor gets from the same command locally.
@@ -116,14 +123,19 @@ jobs:
       - name: tests/unit --fault-inject
         run: tests/unit --fault-inject
 
-      # `tests/smoke`'s injection manifest costs ~14 minutes of recording and
-      # runs nightly (.github/workflows/smoke-inject.yml). Its *guards* cost
-      # nothing and belong on every push: this proves the harness still aborts
-      # on an injection that would not land, still refuses an expected failure
-      # no named assertion can print, and still reads a red suite that never
+      # `tests/smoke`'s injection manifest costs ~32 minutes of recording
+      # (`tests/smoke-inject --list`) and runs nightly
+      # (.github/workflows/smoke-inject.yml). Its *guards* cost nothing and
+      # belong on every push: this proves the harness still aborts on an
+      # injection that would not land, still refuses an expected failure no
+      # named assertion can print, and still reads a red suite that never
       # named the assertion as a miss. A harness that reports PASS on no
       # evidence would certify the whole smoke suite, so it is checked here
       # rather than only where it runs.
+      #
+      # It also reads tests/README.md's figures about the manifest back out of
+      # the file and compares them with what the manifest computes (#184), so
+      # the next drift fails this step instead of waiting to be noticed.
       - name: tests/smoke-inject --self-test
         run: tests/smoke-inject --self-test
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -19,6 +19,7 @@ extend-include = [
     "tests/smoke-inject",
     "tests/ci-unit",
     "tests/unit",
+    "tests/lint",
     ".github/scripts/*",   # the CI workflow's PEP 723 executables
     "skills/*/scripts/*",  # every skill's PEP 723 executables
     "examples/*/serve",    # the example app's PEP 723 executables

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,9 +38,10 @@ below for what it covers and what it does not.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~14 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~32 min, nightly)
 ├── unit               # the browser-free half (~0.07 s, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
+├── lint               # ruff, at exactly the version ci.yml pins (~0.3 s)
 └── fixture/
     └── index.html     # the app smoke records: static, dependency-free, deterministic
 ```
@@ -62,7 +63,19 @@ tests/unit                        # the browser-free half of the recorder
 tests/unit --fault-inject         # break each thing an assertion watches
 tests/ci-unit                     # the CI workflow's three helper scripts
 tests/ci-unit --fault-inject
+tests/lint                        # ruff check + ruff format --check, as CI runs them
 ```
+
+**Lint with `tests/lint`, not with `uvx ruff`.** They are not the same command.
+`uvx ruff` resolves to whatever ruff is current, which on this tree sees a
+different set of files and disagrees about them — in the direction where you
+reformat files CI was happy with and land an unrelated diff. `tests/lint` reads
+the `RUFF_VERSION:` line out of `.github/workflows/ci.yml` and runs *that*
+ruff, and CI's `lint` job runs `tests/lint --github`, so there is one command
+and one pin. Change the pin and the local command changes with it;
+`tests/lint --self-test` is what keeps that true, and refuses a workflow that
+reaches ruff any other way.
+[#189](https://github.com/rogvid/skills/issues/189) is what this cost before.
 
 Then the recorder itself:
 
@@ -91,8 +104,12 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~48 s)
-tests/smoke-inject                # all 15, ~14 min
+tests/smoke-inject                # all 25 entries, ~32 min
 ```
+
+Those three figures, and every number in **The injection manifest** below, are
+checked against the manifest by `tests/smoke-inject --self-test` on every push.
+Editing one by hand turns a run red; see that section for why.
 
 **One suite at a time, per machine.** The script takes an exclusive `flock` on
 `$TMPDIR/demo-video-smoke.lock` and refuses to start while another run holds
@@ -1352,26 +1369,49 @@ refusal as an assertion that failed.
 
 ### What it covers
 
-Sixteen entries, chosen by *what a silent failure would cost* rather than by
-what is easy to break. Measured end to end, twice, on the box the arm table
-above was measured on: **16.3 and 16.4 minutes**, five clean baselines
-included.
+Entries are chosen by *what a silent failure would cost* rather than by what is
+easy to break. This is what `tests/smoke-inject --list` reports today, quoted
+rather than remembered:
+
+```
+25 entries, 7 arms, ~31.9 min of takes
+```
+
+That figure is `--list`'s **estimate** — each entry's arm from the table above,
+plus one clean baseline per arm — not a stopwatch reading. The last measured
+end-to-end pair, 16.3 and 16.4 minutes, was taken when the manifest held
+sixteen entries and is not comparable; nobody has sat through the current one,
+and the nightly job's budget is set from the estimate.
+
+Every number in this section is read back out of this file and compared against
+the manifest by `tests/smoke-inject --self-test`, which runs on every push. It
+is checked rather than maintained because it was maintained: by
+[#184](https://github.com/rogvid/skills/issues/184) this section claimed sixteen
+entries over five arms and "23 of 32 check functions have no entry" against a
+real 22 of 35 — a coverage claim reading *better* than the truth, in the one
+paragraph whose job is to say what this manifest does not cover.
 
 | arm | entries | what a miss would mean |
 |---|---|---|
 | `--coverage-only` | 5 | the report flatters the storyboard: nothing reported unclaimed, a claim pointing at the wrong beat or forgetting its segment, an undeclared tag accepted, the finding dropped from `timeline.md` |
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
+| `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
+| `--web-only` | 6 | the form verbs lie about what they did: `press` logging a key it never sent or returning before the page saw it, `clear` selecting without deleting or emptying the field between two frames, either of them driving the page and writing no beat |
 | `--content-only` | 3 | the recorder stops noticing a recording nobody can watch, starts warning about honest demos that hold still, or goes back to scoring the whole frame (issue #17's anti-correlated metric) |
 
 ### What it does **not** cover
 
-- **23 of `tests/smoke`'s 32 check functions have no entry**, and the harness
+- **22 of `tests/smoke`'s 35 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
-  leaving the boundary to somebody's memory. The large ones are there for cost:
-  `check_take`, `check_timeline`, `check_beat_frames`, `check_issues`,
-  `check_evidence` and `check_caption` live on `--web-only`/`--terminal-only`
+  leaving the boundary to somebody's memory. Every check function this bullet
+  names in backticks is checked against that list too, not just the count —
+  one of them stayed written here as uncovered for as long as it had six
+  entries aimed at it, and a count would never have said so. The large ones
+  are there for cost:
+  `check_take`, `check_timeline`, `check_beat_frames`, `check_issues`
+  and `check_caption` live on `--web-only`/`--terminal-only`
   (123 s and 186 s an injection), and `check_determinism`, `check_merge_offset`
   and the narration pair each carry their own arm nobody has aimed an entry at
   yet. Adding one is cheap in effort and expensive in wall clock; that trade is
@@ -1405,7 +1445,9 @@ included.
 - **Every push** — `tests/smoke-inject --self-test`, in ci.yml's `unit` job. It
   records nothing and costs nothing, and it is what stops the harness itself
   from reporting PASS on no evidence: each guard is handed the input it exists
-  to refuse and has to refuse it.
+  to refuse and has to refuse it. It also reads the figures above back out of
+  this file and compares them with the manifest, so a stale count here is a red
+  run and not a discovery.
 - **Nightly, and on demand** — the whole manifest, in
   `.github/workflows/smoke-inject.yml`. Not per-push: CI already pays ~10
   minutes for `smoke` on every commit, and what rots here is an *assertion*,

--- a/tests/lint
+++ b/tests/lint
@@ -1,0 +1,198 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Ruff, at exactly the version CI pins (issue #189).
+
+    tests/lint                # ruff check + ruff format --check, from the root
+    tests/lint --github       # ...with GitHub annotations; what ci.yml runs
+    tests/lint --self-test    # prove the pin is live and single-sourced (0 s)
+
+**Why this file exists rather than a line in a README.** `.github/workflows/
+ci.yml` pins ruff and runs it as `uv run --with "ruff==$RUFF_VERSION" ruff …`.
+The obvious local equivalent, `uvx ruff …`, resolves to whatever ruff is
+current, and on this tree the two disagreed by 33 files — in the bad direction,
+where the local run demands reformatting CI was happy with. That cost a cycle
+in PR #181: an agent correcting a *scope* mistake reached for the obvious
+command, which answers a different question.
+
+**The pin lives in exactly one place**, the `RUFF_VERSION:` line of ci.yml, and
+this script reads it out of that file as text. CI runs this script too, so
+there is one command and one version. Changing `RUFF_VERSION` changes what a
+local `tests/lint` runs — that is the measurement issue #189 asked for, and
+`--self-test` is what keeps it true.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CI = REPO / ".github" / "workflows" / "ci.yml"
+WORKFLOWS = REPO / ".github" / "workflows"
+
+# The one line the pin lives on. Anchored to the key so a `ruff==` written
+# anywhere else in the file cannot stand in for it.
+PIN = re.compile(r'^\s*RUFF_VERSION:\s*"([^"]+)"\s*$', re.MULTILINE)
+
+# A workflow running ruff by hand instead of through this script: the exact
+# drift #189 is about, since such a step carries its own version.
+INLINE_RUFF = re.compile(r"^\s*run:.*\bruff\b.*$", re.MULTILINE)
+
+
+class Refused(Exception):
+    """The pin cannot be read, or has stopped being the only one."""
+
+
+def pinned_version(text: str) -> str:
+    """The ruff version a workflow file pins. Exactly one line may say so."""
+    found = PIN.findall(text)
+    if len(found) != 1:
+        raise Refused(
+            f"{len(found)} `RUFF_VERSION:` lines in the workflow, expected "
+            f"exactly 1 — with none there is no pin, and with two the local "
+            f"command and CI can run different ruffs."
+        )
+    version = found[0]
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        raise Refused(f"RUFF_VERSION is {version!r}, which is not a pinned version")
+    return version
+
+
+def ruff(version: str, *args: str) -> subprocess.CompletedProcess[str]:
+    """Ruff, resolved by uv at `version`, run from the repository root."""
+    return subprocess.run(
+        ["uv", "run", "--with", f"ruff=={version}", "ruff", *args],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+
+
+def run(github: bool) -> int:
+    version = pinned_version(CI.read_text(encoding="utf-8"))
+    print(f"lint: ruff {version}, pinned by .github/workflows/ci.yml")
+
+    # What actually ran, not what was asked for. A `--with` that silently
+    # stopped applying would otherwise lint the tree with the ambient ruff and
+    # print the pinned version above it — a report that is confidently wrong.
+    reported = ruff(version, "--version")
+    if reported.stdout.split() != ["ruff", version]:
+        print(
+            f"lint: asked for ruff {version} and got {reported.stdout.strip()!r} "
+            f"— the pin is not reaching the binary, so this run does not "
+            f"answer what CI would say.",
+            file=sys.stderr,
+        )
+        return 3
+
+    failed = 0
+    check = ["check", "--output-format", "github", "."] if github else ["check", "."]
+    for label, args in (
+        ("ruff check", check),
+        ("ruff format --check", ["format", "--check", "."]),
+    ):
+        done = ruff(version, *args)
+        sys.stdout.write(done.stdout)
+        sys.stderr.write(done.stderr)
+        if done.returncode != 0:
+            failed += 1
+            print(f"lint: {label} failed")
+    return 1 if failed else 0
+
+
+def self_test() -> int:
+    """The guards that keep the pin from becoming decorative. Runs no ruff."""
+    bad = 0
+
+    # 1. The pin is readable from the file CI reads it from.
+    try:
+        version = pinned_version(CI.read_text(encoding="utf-8"))
+        print(f"OK       the pin is {version}, read out of .github/workflows/ci.yml")
+    except Refused as exc:
+        bad += 1
+        print(f"BROKEN   {exc}")
+        version = ""
+
+    # 2. It is *read*, not remembered. The same parser over a workflow that
+    #    says something else must say something else — if it does not, the
+    #    version in ci.yml is decorative and the two can drift apart again,
+    #    which is the state #189 is about.
+    other = CI.read_text(encoding="utf-8").replace(
+        f'RUFF_VERSION: "{version}"', 'RUFF_VERSION: "9.9.9"'
+    )
+    try:
+        got = pinned_version(other)
+    except Refused as exc:
+        got = f"refused: {exc}"
+    if got == "9.9.9":
+        print("OK       changing RUFF_VERSION changes the version this script runs")
+    else:
+        bad += 1
+        print(f"DEAD PIN a ci.yml pinning 9.9.9 still resolved to {got!r}")
+
+    # 3. Malformed pins are refused rather than passed to uv, where they would
+    #    surface as a resolver error nobody reads as "the pin is wrong".
+    for what, text in (
+        ("no RUFF_VERSION line at all", 'env:\n  MYPY_VERSION: "1.18.2"\n'),
+        (
+            "two RUFF_VERSION lines",
+            '  RUFF_VERSION: "0.1.0"\n  RUFF_VERSION: "0.2.0"\n',
+        ),
+        ("a version that is not pinned", '  RUFF_VERSION: "latest"\n'),
+    ):
+        try:
+            pinned_version(text)
+        except Refused as exc:
+            print(f"REFUSED  {what}")
+            print(f"         {str(exc).splitlines()[0][:120]}")
+            continue
+        bad += 1
+        print(f"ACCEPTED {what} — the guard is not guarding")
+
+    # 4. No workflow runs ruff by hand. Such a step brings its own version with
+    #    it, and then there are two pins again.
+    for path in sorted(WORKFLOWS.glob("*.yml")):
+        for line in INLINE_RUFF.findall(path.read_text(encoding="utf-8")):
+            if "tests/lint" in line:
+                continue
+            bad += 1
+            print(
+                f"TWO PINS {path.name} runs ruff without going through "
+                f"tests/lint:{line.strip()[:90]}"
+            )
+    if not bad:
+        print("OK       every workflow reaches ruff through tests/lint")
+
+    if bad:
+        print(f"\n{bad} guard(s) did not hold: the pin cannot be trusted.")
+        return 1
+    print("\nOne pin, one command: tests/lint runs exactly what CI runs.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--github", action="store_true", help="GitHub annotations (what ci.yml runs)"
+    )
+    parser.add_argument(
+        "--self-test", action="store_true", help="prove the pin is live and singular"
+    )
+    args = parser.parse_args()
+    if args.self_test:
+        return self_test()
+    try:
+        return run(args.github)
+    except Refused as exc:
+        print(f"lint: {exc}", file=sys.stderr)
+        return 3
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -62,6 +62,7 @@ from __future__ import annotations
 import argparse
 import ast
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -940,11 +941,213 @@ def self_test() -> int:
         bad += 1
         print(f"STALE    {exc}")
 
+    # And what tests/README.md says this manifest covers, against what it
+    # covers (#184). Read as text: the README is the claim, `INJECTIONS` and
+    # the AST of tests/smoke are the truth.
+    readme = README.read_text(encoding="utf-8")
+    problems = readme_problems(readme)
+    if problems:
+        bad += 1
+        print(f"DRIFTED  tests/README.md states {len(problems)} thing(s) that are not:")
+        for problem in problems:
+            print(f"         - {problem}")
+    else:
+        print(f"OK       tests/README.md's {len(readme_claims()) + 2} stated figures")
+
+    # The README check's own guards. A checker whose patterns quietly stopped
+    # matching would report a clean README forever, so each break is applied to
+    # a copy and has to be noticed — and the break itself has to land, or the
+    # "it was caught" would be about nothing.
+    for what, pattern, replacement in (
+        (
+            "a README that undercounts the entries",
+            r"^(\d+) entries, (\d+) arms,",
+            r"16 entries, 5 arms,",
+        ),
+        (
+            "a README whose per-arm table lost a row",
+            r"^\| `--web-only` \| \d+ \|.*\n",
+            "",
+        ),
+        (
+            "a README that has dropped the coverage claim",
+            r"\*\*\d+ of `tests/smoke`'s \d+ check functions have no entry\*\*",
+            "**most check functions have no entry**",
+        ),
+        (
+            "a README naming a covered check function as a gap",
+            r"check functions have no entry\*\*",
+            "check functions have no entry**\n  `check_overlay_pair` has none.",
+        ),
+    ):
+        broken, hits = re.subn(
+            pattern, replacement, readme, count=1, flags=re.MULTILINE
+        )
+        if not hits:
+            bad += 1
+            print(f"NO-OP    {what}: the break did not land, so it proved nothing")
+        elif readme_problems(broken):
+            print(f"CAUGHT   {what}")
+        else:
+            bad += 1
+            print(f"MISSED   {what} — the README check is not checking")
+
     if bad:
         print(f"\n{bad} guard(s) did not hold. This harness cannot be trusted.")
         return 1
     print("\nEvery guard refused what it exists to refuse.")
     return 0
+
+
+# --------------------------------------------------------------------------
+# What tests/README.md says about this manifest, checked against it
+# --------------------------------------------------------------------------
+#
+# Every figure in the README's "What the injection manifest covers" was
+# maintained by hand, and by issue #184 every one of them was wrong: sixteen
+# entries claimed against 25, five arms against 7, "23 of 32 check functions
+# have no entry" against 22 of 35 — a coverage claim that read *better* than
+# the truth, in the document whose job is to say what this manifest does not
+# cover. Correcting them by hand is how they got that way.
+#
+# So they are read back out of the file as text and compared against what the
+# manifest computes. Nothing here consults the README for a number it then
+# checks the README against; the left-hand side is prose and the right-hand
+# side is `INJECTIONS`, `ARM_SECONDS` and the AST of `tests/smoke`.
+
+
+README = REPO / "tests" / "README.md"
+
+
+def arm_cost(entries: list[Injection]) -> int:
+    """Seconds of takes: every entry's arm, plus one clean baseline per arm."""
+    arms = dict.fromkeys(entry.arm for entry in entries)
+    return sum(ARM_SECONDS[entry.arm] for entry in entries) + sum(
+        ARM_SECONDS[arm] for arm in arms
+    )
+
+
+def readme_claims() -> list[tuple[str, str, tuple[str, ...]]]:
+    """(what the README states, the pattern that finds it, what is true).
+
+    A pattern that stops matching is a failure, not a pass: a README reworded
+    past the check would otherwise take its numbers out of the check's reach
+    silently, which is the same drift one level up.
+    """
+    arms = list(dict.fromkeys(entry.arm for entry in INJECTIONS))
+    cost = arm_cost(INJECTIONS)
+    coverage = arm_cost([e for e in INJECTIONS if e.arm == "--coverage-only"])
+    return [
+        (
+            "the tree diagram's cost for smoke-inject",
+            r"smoke-inject[ ]+# proves smoke's assertions can still fail "
+            r"\(~(\d+) min, nightly\)",
+            (f"{cost / 60:.0f}",),
+        ),
+        (
+            "the `--arm coverage` example's cost",
+            r"tests/smoke-inject --arm coverage # one arm's entries \(~(\d+) s\)",
+            (str(coverage),),
+        ),
+        (
+            "the whole-manifest example",
+            r"tests/smoke-inject[ ]+# all (\d+) entries, ~(\d+) min",
+            (str(len(INJECTIONS)), f"{cost / 60:.0f}"),
+        ),
+        (
+            "the quoted `--list` summary",
+            r"^(\d+) entries, (\d+) arms, ~(\d+\.\d) min of takes$",
+            (str(len(INJECTIONS)), str(len(arms)), f"{cost / 60:.1f}"),
+        ),
+        (
+            "the ungraded-coverage claim",
+            r"\*\*(\d+) of `tests/smoke`'s (\d+) check functions have no entry\*\*",
+            (str(len(ungraded())), str(len(check_functions(smoke_tree())))),
+        ),
+    ]
+
+
+def readme_tables(text: str) -> list[str]:
+    """The two per-arm tables, whose rows are a mapping and not a number.
+
+    A count alone would be satisfied by a table with the right number of wrong
+    rows, so both are compared as dictionaries: an arm that gained entries, an
+    arm nobody added a row for, and a row for an arm that no longer exists are
+    three different complaints.
+    """
+    problems = []
+    entries_by_arm = {
+        arm: sum(1 for entry in INJECTIONS if entry.arm == arm)
+        for arm in dict.fromkeys(entry.arm for entry in INJECTIONS)
+    }
+    for what, pattern, truth in (
+        (
+            "the arm cost table",
+            r"^\| `(--[a-z-]+-only)` \| (\d+) s \|",
+            {arm: str(sec) for arm, sec in ARM_SECONDS.items()},
+        ),
+        (
+            "the entries-per-arm table",
+            r"^\| `(--[a-z-]+-only)` \| (\d+) \|",
+            {arm: str(count) for arm, count in entries_by_arm.items()},
+        ),
+    ):
+        stated = dict(re.findall(pattern, text, re.MULTILINE))
+        if not stated:
+            problems.append(f"{what}: no row matched {pattern!r} — where did it go?")
+            continue
+        for arm in sorted(set(stated) | set(truth)):
+            if arm not in stated:
+                problems.append(f"{what}: no row for {arm}")
+            elif arm not in truth:
+                problems.append(f"{what}: a row for {arm}, which is not one")
+            elif stated[arm] != truth[arm]:
+                problems.append(
+                    f"{what}: says {arm} is {stated[arm]}, it is {truth[arm]}"
+                )
+    return problems
+
+
+def readme_named_gaps(text: str) -> list[str]:
+    """The check functions the README names as uncovered must be uncovered.
+
+    The count is the cheap half. `check_evidence` was listed here as having no
+    entry for as long as it had six; a number would never have said so.
+    """
+    section = re.search(
+        r"check functions have no entry\*\*(.*?)(?=\n- \*\*)", text, re.DOTALL
+    )
+    if section is None:
+        return ["the ungraded bullet: could not find it to read the names out of"]
+    blind = set(ungraded())
+    named = re.findall(r"`(_?check_[a-z_]+)`", section.group(1))
+    if not named:
+        return ["the ungraded bullet: names no check function, so it names no gap"]
+    return [
+        f"the ungraded bullet: names {name} as having no entry, and it has one"
+        for name in named
+        if name not in blind
+    ]
+
+
+def readme_problems(text: str) -> list[str]:
+    """Everything `tests/README.md` states about this manifest that is untrue."""
+    problems = []
+    for what, pattern, truth in readme_claims():
+        found = [m.groups() for m in re.finditer(pattern, text, re.MULTILINE)]
+        if len(found) != 1:
+            problems.append(
+                f"{what}: its pattern matched {len(found)} times, expected 1 — "
+                f"either the claim is gone or it was reworded past the check, "
+                f"and an unreadable number is not a checked one.\n"
+                f"         looked for: {pattern}"
+            )
+        elif found[0] != truth:
+            problems.append(
+                f"{what}: the README says {'/'.join(found[0])}, "
+                f"`--list` says {'/'.join(truth)}"
+            )
+    return problems + readme_tables(text) + readme_named_gaps(text)
 
 
 def listing(entries: list[Injection]) -> int:
@@ -954,9 +1157,7 @@ def listing(entries: list[Injection]) -> int:
     except Refused as exc:
         note = f"STALE: {exc}"
     arms = list(dict.fromkeys(entry.arm for entry in entries))
-    cost = sum(ARM_SECONDS[entry.arm] for entry in entries) + sum(
-        ARM_SECONDS[arm] for arm in arms
-    )
+    cost = arm_cost(entries)
     for arm in arms:
         print(f"{arm}  ({ARM_SECONDS[arm]}s an entry, plus one clean baseline)")
         for entry in entries:
@@ -966,7 +1167,10 @@ def listing(entries: list[Injection]) -> int:
     print(f"\n{len(entries)} entries, {len(arms)} arms, ~{cost / 60:.1f} min of takes")
     print(f"{note}")
     blind = ungraded()
-    print(f"\n{len(blind)} ungraded check function(s): {', '.join(blind)}")
+    print(
+        f"\n{len(blind)} of tests/smoke's {len(check_functions(smoke_tree()))} "
+        f"check function(s) are ungraded: {', '.join(blind)}"
+    )
     return 0
 
 


### PR DESCRIPTION
Closes #184 and #189. One slice: **a number a human maintains by hand is a
measurement that grades nothing.**

## What changed

**#184 — `tests/README.md`'s figures are now read back and compared.**
`tests/smoke-inject --self-test` (already run on every push, in ci.yml's `unit`
job) now reads the README **as text** and compares seven stated figures against
what `INJECTIONS`, `ARM_SECONDS` and the AST of `tests/smoke` compute: the tree
diagram's runtime, the `--arm coverage` cost, the whole-manifest example, the
quoted `--list` summary, the ungraded-coverage claim, and the two per-arm
tables. Then the README was corrected to what the manifest actually reports.

Three things this deliberately is not:

- **Not a number compared to itself.** The left-hand side is prose parsed out
  of the file; the right-hand side is computed. Nothing reads a count out of
  the README and then checks the README against it.
- **Not a count standing in for content.** The two per-arm tables are compared
  as *mappings* — a missing row, a row for an arm that no longer exists and a
  wrong number are three different complaints — and the check functions the
  ungraded bullet names in backticks must actually be ungraded. That last one
  caught a live lie: `check_evidence` was listed as having no entry while six
  entries name it.
- **Not silent when reworded.** A pattern that matches 0 times is a failure,
  not a pass; otherwise a README rewrite would take its numbers out of the
  check's reach quietly, which is the same drift one level up.

**#189 — one command, one pin.** `tests/lint` parses the `RUFF_VERSION:` line
out of `.github/workflows/ci.yml` and runs that ruff (`ruff check` +
`ruff format --check` from the repo root). ci.yml's lint job now runs
`tests/lint --github`, so CI and a contributor run the same command at the same
version. `tests/lint --self-test` refuses a workflow with no pin, two pins, an
unpinned version, or any step that reaches ruff without going through this
script — the pin cannot quietly become decorative again.

## The measurement #189 asked for: changing `RUFF_VERSION` changes what runs

Same local command, only the pin edited.

```
$ ./tests/lint
lint: ruff 0.14.2, pinned by .github/workflows/ci.yml
All checks passed!
13 files already formatted

$ python3 -c "…"          # RUFF_VERSION: "0.14.2" -> "0.16.1", 1 substitution
injection landed: RUFF_VERSION 0.14.2 -> 0.16.1

$ ./tests/lint
lint: ruff 0.16.1, pinned by .github/workflows/ci.yml
All checks passed!
unformatted: File would be reformatted
   --> skills/demo-video/SKILL.md:179:1
…
3 files would be reformatted, 31 files already formatted
lint: ruff format --check failed
```

Different binary, different file set (34 vs 13), different verdict. Pin
restored afterwards.

## Assertions, each seen to fail

Every injection asserted its own substitution count and refused to proceed on
anything but exactly one.

**1. A stale count in the README (#184's shape, injected into the real file).**

```
$ python3 …   # "25 entries, 7 arms, ~31.9 min" -> "16 entries, 5 arms, ~16.3 min"
injection landed: 1 substitution
$ ./tests/smoke-inject --self-test
DRIFTED  tests/README.md states 1 thing(s) that are not:
         - the quoted `--list` summary: the README says 16/5/16.3, `--list` says 25/7/31.9
1 guard(s) did not hold. This harness cannot be trusted.
```

**2. The exact claim #184 was filed about, restored verbatim.**

```
$ python3 …   # "22 of ... 35 check functions" -> "23 of ... 32 check functions"
injection landed: 1 substitution
$ ./tests/smoke-inject --self-test
DRIFTED  tests/README.md states 1 thing(s) that are not:
         - the ungraded-coverage claim: the README says 23/32, `--list` says 22/35
1 guard(s) did not hold. This harness cannot be trusted.
```

**3. The realistic direction — the *manifest* changes and nobody edits the
README.** One entry moved from `--web-only` to `--terminal-only`:

```
injection landed: line 366 now arm="--terminal-only",
$ ./tests/smoke-inject --self-test
DRIFTED  tests/README.md states 3 thing(s) that are not:
         - the quoted `--list` summary: the README says 25/7/31.9, `--list` says 25/8/36.1
         - the entries-per-arm table: no row for --terminal-only
         - the entries-per-arm table: says --web-only is 6, it is 5
```

**4. Before the README was corrected at all** — the check's first run against
`main`'s text, which is the evidence that it grades the thing #184 reported:

```
DRIFTED  tests/README.md states 7 thing(s) that are not:
         - the tree diagram's cost for smoke-inject: the README says 14, `--list` says 32
         - the whole-manifest example: its pattern matched 0 times, expected 1 …
         - the quoted `--list` summary: its pattern matched 0 times, expected 1 …
         - the ungraded-coverage claim: the README says 23/32, `--list` says 22/35
         - the entries-per-arm table: no row for --determinism-only
         - the entries-per-arm table: no row for --web-only
         - the ungraded bullet: names check_evidence as having no entry, and it has one
```

**5. The README checker's own patterns**, exercised on every run against
mutated copies — a break that fails to land is itself reported (`NO-OP`), so
"it was caught" is never about nothing:

```
CAUGHT   a README that undercounts the entries
CAUGHT   a README whose per-arm table lost a row
CAUGHT   a README that has dropped the coverage claim
CAUGHT   a README naming a covered check function as a gap
```

**6. `tests/lint`: a second pin reintroduced into ci.yml.**

```
$ python3 …   # `run: tests/lint --github` -> an inline `uv run --with "ruff==0.14.2" ruff check …`
injection landed: ci.yml runs ruff by hand again
$ ./tests/lint --self-test
TWO PINS ci.yml runs ruff without going through tests/lint:run: uv run --with "ruff==0.14.2" ruff check --output-format github .
1 guard(s) did not hold: the pin cannot be trusted.
```

**7. `tests/lint`: the pin deleted.**

```
$ python3 …   # remove the RUFF_VERSION line
injection landed: the RUFF_VERSION line is gone
$ ./tests/lint --self-test
BROKEN   0 `RUFF_VERSION:` lines in the workflow, expected exactly 1 — with none there is no pin …
DEAD PIN a ci.yml pinning 9.9.9 still resolved to 'refused: 0 `RUFF_VERSION:` lines …'
$ ./tests/lint
lint: 0 `RUFF_VERSION:` lines in the workflow, expected exactly 1 …   (exit 3)
```

All injections reverted; `git status` clean before the commit.

## Verified

`./tests/unit` (110 OK) · `./tests/ci-unit` (49 OK) ·
`./tests/smoke-inject --self-test` · `actionlint .github/workflows/ci.yml` ·
`uv run --with "ruff==0.14.2" ruff check .` and `ruff format --check .`
(clean; `tests/lint` is that pair). `tests/smoke` was not run — nothing here
records, and it takes a lock another agent needs.

## Stated limits

- **The runtime figure is `--list`'s estimate, not a stopwatch.** The old
  "measured end to end, twice: 16.3 and 16.4 minutes" was a real measurement of
  a 16-entry manifest and is not comparable to the 25-entry one; nobody has sat
  through the current manifest end to end. The README now says so explicitly
  rather than quoting a wall clock nobody took. What is checked is that the
  README states the same estimate the tool prints.
- **Only `tests/README.md` is machine-checked.** ci.yml's prose comment about
  the manifest's cost was corrected by hand here; `.github/workflows/
  smoke-inject.yml`'s two `~14 min` comments and its `timeout-minutes: 45` were
  left alone — see the issue filed below, since that one needs a decision and a
  real nightly measurement, not a rewrite.
- **The 33-file (here 3-file) formatting difference is untouched, by design.**
  It is not style drift: ruff ≥ 0.16 formats Python inside Markdown fences,
  which 0.14.2 does not do at all — that is the entire disagreement, and it
  lands in `skills/demo-video/SKILL.md` and two `reference/*.md` files. Whether
  to accept those rewrites is a separate decision, filed below.
- **`tests/lint` runs ruff only.** shellcheck, actionlint and mypy still live
  as their own CI steps with their own (or no) pins.
