### PR TITLE
The cursor dot follows pointer motion, not Chromium's load-time hover event (#186)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -549,9 +549,9 @@ return.
 - **Scripting oversized asks to in-app agents.** If the app has chat or
   agent turns with a budget, one big scripted message can exhaust it and
   waste the take — script 1–2 steps per message.
-- **Layout shifts strand the cursor.** When the app inserts rows/cards
-  mid-recording, elements move but the cursor doesn't — re-`move_to` the
-  target after any wait that can reflow the page.
+- **Layout shifts strand the cursor.** Elements the app inserts mid-recording
+  move, the cursor does not — re-`move_to` after any wait that can reflow.
+  The dot stays undrawn until the pointer first moves, and after each `goto()`.
 - **Recording real data and planning to blur it later.** There is no later,
   and there is no blur: the frame is captured the moment it paints, nothing
   here hides anything, and a published video leaks forever. Decide what must

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -65,6 +65,47 @@ _FRAME_HTML = """<!doctype html><meta charset="utf-8">
 
 # A visible stand-in for the mouse: headless recordings have no OS cursor,
 # so inject a dot that follows pointer events (and squeezes on click).
+#
+# **The dot follows pointer *motion*, not every `mousemove` — issue #186.**
+#
+# Chromium dispatches one `mousemove` of its own per document, at the widget's
+# initial pointer position — `(0, 0)` on a fresh page — when it recomputes
+# hover state after the first layout. Nothing about it says "synthetic": it is
+# `isTrusted`, it carries a `pointerover`, a `mouseover` and a `pointermove`
+# beside it exactly as a real move does, and it belongs to no storyboard beat.
+# Measured on the fixture page here, it is *created* at `timeStamp` 9 ms and
+# *delivered* at ~89 ms, against a `DOMContentLoaded` at ~20 ms — and `attach`
+# below subscribes at `DOMContentLoaded`, because it needs `document.body`.
+# Which of the two wins is load-dependent, so whether an 18 px dot is burned
+# into the top-left corner of a take's opening stills is a coin flip: eleven of
+# twelve takes under 14-way CPU load had it, one did not. That is what makes a
+# `deterministic=True` take's stills fail to reproduce (#185, #188), and it is
+# the whole of it — two stills that disagree differ in 69 of 921 600 pixels,
+# all of them inside x 0-8, y 0-8.
+#
+# What tells that event apart from a real one is not its trust, its type or
+# its timing: it is that it reports **no movement**, because it is dispatched
+# at the position the pointer is already at. `movementX`/`movementY` are the
+# browser's own delta between this event and the last, so the test is
+# structural rather than a heuristic — a `mousemove` that reports no movement
+# cannot need the dot moved, since the pointer did not move. Ignoring it
+# leaves the dot where the stylesheet parks it, off screen, until the
+# storyboard moves the pointer for the first time; that position is the one
+# thing here that does not depend on when an event was delivered.
+#
+# Written `=== 0` rather than `!e.movementX`, and the difference is the
+# failure mode: on an engine that does not implement `movementX` the strict
+# test is false and the dot follows the event as it always did (a determinism
+# bug), while the falsy test would swallow *every* move and the take would
+# record no cursor at all (an invisible-cursor bug nobody watching can report).
+#
+# What this does not do: place the dot after a navigation. A document that
+# replaces the one the dot lived in gets a fresh, parked dot, and Chromium
+# sends its hover-recompute move only for the *first* document — measured, two
+# further navigations with the pointer inside the viewport produced no
+# `mousemove` at all, over four seconds. So the cursor is already absent
+# between a `goto()` and the next pointer verb today, and this changes nothing
+# about that.
 _CURSOR_JS = """
 (() => {
   const attach = () => {
@@ -83,6 +124,7 @@ _CURSOR_JS = """
     dot.id = '__demo_cursor';
     document.body.appendChild(dot);
     window.addEventListener('mousemove', (e) => {
+      if (e.movementX === 0 && e.movementY === 0) return;
       dot.style.left = e.clientX + 'px';
       dot.style.top = e.clientY + 'px';
     }, true);

--- a/skills/demo-video/reference/determinism.md
+++ b/skills/demo-video/reference/determinism.md
@@ -122,4 +122,8 @@ no matter what this section does:
 - **The bytes of `demo.mp4`.** H.264 is not byte-reproducible and the
   screencast's frame timing is not either. Two takes match in what they *show*,
   not in their checksums — compare the stills, which are lossless PNGs and do
-  reproduce exactly.
+  reproduce exactly. The recorder's own cursor dot used to be the exception
+  ([#186](https://github.com/rogvid/skills/issues/186)): it followed the
+  movement-free `mousemove` Chromium dispatches at load, so a storyboard that
+  never touched the pointer got an 18 px dot in the corner of about half its
+  takes. It is now drawn only once the pointer actually moves.

--- a/tests/unit
+++ b/tests/unit
@@ -142,7 +142,7 @@ sys.modules["playwright.sync_api"] = _pw_sync
 
 from demo_recording.core import _beat_verb, _DemoBase  # noqa: E402
 from demo_recording.terminal import TerminalRecorder  # noqa: E402
-from demo_recording.web import Recorder  # noqa: E402
+from demo_recording.web import _CURSOR_JS, Recorder  # noqa: E402
 
 # --------------------------------------------------------------------------
 # Helpers — deliberately hand-written
@@ -2383,6 +2383,229 @@ class VerbTarget(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# web.py — which mousemove moves the cursor dot (issue #186)
+# --------------------------------------------------------------------------
+#
+# `Recorder(deterministic=True)` announces "re-recording reproduces the take",
+# and for a storyboard that never moves the pointer that was false about the
+# opening stills. Chromium dispatches one `mousemove` of its own per document,
+# at the widget's initial pointer position — `(0, 0)` on a fresh page — when it
+# recomputes hover state after the first layout. The overlay's handler
+# subscribes at `DOMContentLoaded`, because it needs `document.body`, and which
+# of the two comes first is decided by machine load: eleven takes in twelve
+# under 14-way load had an 18 px dot in the corner of the still and one did
+# not, and two stills that disagree differ in 69 of 921 600 pixels, all of them
+# inside x 0-8, y 0-8 (#185, #186, #188).
+#
+# The overlay now refuses a `mousemove` that reports no movement — the one
+# property that separates Chromium's event from a real one, and a structural
+# one rather than a heuristic: an event dispatched at the position the pointer
+# already has cannot report a delta, and an event that reports no delta cannot
+# need the dot moved.
+#
+# What is graded here is that **predicate**, read out of the shipped script and
+# evaluated against event shapes measured off Chromium rather than imagined. A
+# check that restated the rule in Python would agree with itself while the take
+# shipped something else, so the rule is extracted; the JS-to-Python
+# translation is hand-written and deliberately narrow, so a guard written in a
+# form it does not model fails the extraction loudly instead of passing
+# silently. What this suite cannot grade — that Chromium's events still look
+# like this, and that two takes therefore produce the same bytes — is stated at
+# the bottom of the file.
+
+
+def event(**over: object) -> dict:
+    """One `mousemove` as Chromium delivered it, with every field a guard
+    might plausibly read.
+
+    Measured with a Playwright probe against `tests/fixture`, not imagined:
+    the settle event arrives at (0, 0) with `movementX`/`movementY` 0,
+    `isTrusted` true, and a `pointermove` and `mouseover` beside it exactly as
+    a real move has. Nothing but the movement tells the two apart.
+    """
+    doc = {
+        "type": "mousemove",
+        "isTrusted": True,
+        "clientX": 0,
+        "clientY": 0,
+        "screenX": 0,
+        "screenY": 0,
+        "pageX": 0,
+        "pageY": 0,
+        "movementX": 0,
+        "movementY": 0,
+        "buttons": 0,
+        "detail": 0,
+    }
+    doc.update(over)
+    return doc
+
+
+# The event the race is about, and the only one the storyboard did not ask for.
+SETTLE_EVENT = event()
+
+# What a real glide is made of. The diagonal is the first step of `move_to`'s
+# 30-step move; the axis-aligned two are what a glide along a row or a column
+# produces, and they are why the rule is "no movement on *either* axis" rather
+# than "on one of them" — a guard joined with `||` would freeze the dot for
+# every horizontal drag across a toolbar.
+REAL_MOVES = [
+    (
+        "a diagonal glide step",
+        event(clientX=150, clientY=150, movementX=150, movementY=150),
+    ),
+    (
+        "a horizontal glide step",
+        event(clientX=310, clientY=150, movementX=160, movementY=0),
+    ),
+    (
+        "a vertical glide step",
+        event(clientX=310, clientY=400, movementX=0, movementY=250),
+    ),
+]
+
+# An engine that does not report movement at all. The dot must follow this one:
+# a rule written `!e.movementX` would swallow every move on such an engine and
+# the take would record no cursor anywhere, which is worse than the bug it
+# fixes — a determinism failure is measurable in the pixels, and a cursor that
+# was never drawn is an absence nobody watching the video can report.
+NO_MOVEMENT_FIELD = event(clientX=150, clientY=150, movementX=None, movementY=None)
+
+# The JS the guard may be written in, translated one form at a time. `!==`
+# before `!`, or the `!=` it just produced would become `not =`.
+_JS_GUARD_RE = re.compile(r"if \((?P<cond>[^)]*(?:\([^)]*\))?[^)]*)\) return;")
+_JS_TOKEN = re.compile(r"e\.[A-Za-z]+|-?\d+(?:\.\d+)?|==|!=|and\b|or\b|not\b|[()\s]")
+
+
+class _JsEvent:
+    """An event object the translated guard can read fields off."""
+
+    def __init__(self, fields: dict) -> None:
+        self.__dict__.update(fields)
+
+
+def cursor_mousemove_body() -> str:
+    """The body of the overlay's `mousemove` listener, as shipped."""
+    opening = "window.addEventListener('mousemove'"
+    if opening not in _CURSOR_JS:
+        raise AssertionError(
+            "the cursor overlay no longer subscribes to mousemove under the "
+            "name this suite looks for, so nothing below graded the rule that "
+            "decides where the dot is drawn"
+        )
+
+    start = _CURSOR_JS.index(opening)
+    return _CURSOR_JS[start : _CURSOR_JS.index("}, true);", start)]
+
+
+def cursor_guard_py() -> str:
+    """The condition the overlay refuses a `mousemove` under, in Python."""
+    found = _JS_GUARD_RE.findall(cursor_mousemove_body())
+    if len(found) != 1:
+        raise AssertionError(
+            f"the mousemove handler holds {len(found)} early-return guards, "
+            f"expected exactly 1 — with none, every event Chromium dispatches "
+            f"moves the dot, including the one it sends at load (#186)"
+        )
+    expr = found[0].replace("!==", "!=").replace("===", "==")
+    expr = re.sub(r"!(?!=)", "not ", expr)
+    expr = expr.replace("&&", " and ").replace("||", " or ")
+    residue = _JS_TOKEN.sub("", expr).strip()
+    if residue:
+        raise AssertionError(
+            f"the guard {found[0]!r} is written in a form this suite cannot "
+            f"evaluate (left over: {residue!r}). Extend the translation, or "
+            f"grade the new form in a browser — do not delete the check"
+        )
+    return expr
+
+
+class CursorMotion(unittest.TestCase):
+    """Which `mousemove` moves the recorder's cursor dot (issue #186)."""
+
+    def refuses(self, fields: dict) -> bool:
+        """Does the shipped guard drop this event?"""
+        expr = cursor_guard_py()
+        try:
+            return bool(eval(expr, {"__builtins__": {}}, {"e": _JsEvent(fields)}))
+        except AttributeError as exc:
+            self.fail(
+                f"the guard {expr!r} reads an event field this suite does not "
+                f"model ({exc}) — add it to `event()` with the value Chromium "
+                f"measured, rather than dropping the assertion"
+            )
+
+    def test_the_rule_is_one_condition_that_reads_the_event(self):
+        # The control. Every assertion below is "the guard says X about this
+        # event", and all of them are satisfied by a guard that says nothing —
+        # so what the guard is, and that it reads the event at all, is graded
+        # first and separately.
+        expr = cursor_guard_py()
+        self.assertIn(
+            "e.",
+            expr,
+            f"the guard {expr!r} never reads the event, so which mousemove "
+            f"moves the dot is not decided by the mousemove",
+        )
+
+    def test_chromiums_load_time_hover_event_does_not_move_the_dot(self):
+        self.assertTrue(
+            self.refuses(SETTLE_EVENT),
+            "the overlay accepts the movement-free mousemove Chromium "
+            "dispatches at load, so whether an 18 px dot is burned into the "
+            "corner of a take's opening stills is decided by machine load "
+            "and not by the storyboard (#186)",
+        )
+
+    def test_every_real_move_moves_the_dot(self):
+        for what, fields in REAL_MOVES:
+            with self.subTest(what):
+                self.assertFalse(
+                    self.refuses(fields),
+                    f"the overlay drops {what} ({fields['movementX']}, "
+                    f"{fields['movementY']}), so the cursor stops following "
+                    f"the pointer it exists to stand in for",
+                )
+
+    def test_a_move_that_reports_no_movement_field_still_moves_the_dot(self):
+        self.assertFalse(
+            self.refuses(NO_MOVEMENT_FIELD),
+            "an engine that does not implement movementX makes the overlay "
+            "drop every move, and a take recorded there has no cursor in it "
+            "at all — the guard is written `=== 0` rather than falsy for "
+            "exactly this reason",
+        )
+
+    def test_nothing_moves_the_dot_except_through_the_rule(self):
+        # A second positioning path — a `pointermove` listener added beside
+        # this one, a `mouseover` that snaps the dot into place — would restore
+        # the race while every assertion above stayed green.
+        body = cursor_mousemove_body()
+        for property_ in ("dot.style.left", "dot.style.top"):
+            self.assertEqual(
+                _CURSOR_JS.count(property_),
+                1,
+                f"{property_} is written in {_CURSOR_JS.count(property_)} "
+                f"places in the cursor overlay; only the guarded mousemove "
+                f"handler may position the dot (#186)",
+            )
+            self.assertIn(property_, body)
+            self.assertIn(
+                "return;",
+                body,
+                "the mousemove handler positions the dot with no early return "
+                "in front of it, so every event Chromium dispatches moves it — "
+                "including the one it sends at load (#186)",
+            )
+            self.assertLess(
+                body.index("return;"),
+                body.index(property_),
+                "the dot is positioned before the rule that decides whether "
+                "this event should move it, so the rule changes nothing",
+            )
+
+
+# --------------------------------------------------------------------------
 # Fault injection
 # --------------------------------------------------------------------------
 
@@ -3002,6 +3225,41 @@ INJECTIONS = [
         '        self._navigated = True\n        self._caption = ""',
         ["CaptionTruth.test_an_spa_route_change_keeps_the_caption"],
     ),
+    (
+        # Issue #186 exactly as it shipped: every mousemove moves the dot,
+        # including the movement-free one Chromium dispatches at load, so a
+        # deterministic take's opening stills are a coin flip.
+        "the cursor dot follows every mousemove again",
+        "web.py",
+        "      if (e.movementX === 0 && e.movementY === 0) return;\n",
+        "",
+        [
+            "CursorMotion.test_the_rule_is_one_condition_that_reads_the_event",
+            "CursorMotion.test_chromiums_load_time_hover_event_does_not_move_the_dot",
+            "CursorMotion.test_nothing_moves_the_dot_except_through_the_rule",
+        ],
+    ),
+    (
+        # The rule pointing the other way, and the reason it is `&&`: a guard
+        # that drops a move with a zero on *either* axis freezes the dot for
+        # every horizontal glide, which no still comparison would ever notice
+        # because it makes takes agree.
+        "the cursor rule drops a move that is along one axis",
+        "web.py",
+        "if (e.movementX === 0 && e.movementY === 0) return;",
+        "if (e.movementX === 0 || e.movementY === 0) return;",
+        ["CursorMotion.test_every_real_move_moves_the_dot"],
+    ),
+    (
+        # The falsy spelling, which reads better and is wrong where it matters:
+        # on an engine that does not implement movementX it swallows every move
+        # and the take records no cursor at all.
+        "the cursor rule tests movement for falsiness instead of zero",
+        "web.py",
+        "if (e.movementX === 0 && e.movementY === 0) return;",
+        "if (!e.movementX && !e.movementY) return;",
+        ["CursorMotion.test_a_move_that_reports_no_movement_field_still_moves_the_dot"],
+    ),
 ]
 
 
@@ -3116,6 +3374,14 @@ def fault_inject() -> int:
 #   rather than off the screen. What a real Chromium does with the same events
 #   is still smoke's: that `domcontentloaded` fires when this claims it does is
 #   Playwright's contract, not an assertion made here.
+# - **That Chromium's events still look the way `event()` says they do.** The
+#   cursor rule (#186) is graded here as a predicate over measured event
+#   shapes: the guard is read out of the shipped overlay and evaluated, so a
+#   rule that changed meaning fails, but a *browser* that changed — a settle
+#   event that started reporting movement — would not. That claim, and the
+#   take-level one it serves ("two takes of a storyboard that never moves the
+#   pointer produce byte-identical stills"), need Chromium and belong to
+#   `tests/smoke`. A re-measurement lands in `event()`.
 # - **Anything measured off real frames.** `content_report`'s ffmpeg sampling,
 #   `opening_gap`, `_luma_stddev` and `_moved_pixels` need a video to be true
 #   about. What is graded here is the logic *around* them: the warning


### PR DESCRIPTION
Fixes #186.

## Diagnosis

`Recorder(deterministic=True)` announces "Re-recording reproduces the take", and
`reference/determinism.md` tells an author to diff a still against the one
committed last month. For a storyboard that never moves the pointer that was
false about the opening stills, and the difference is the recorder's own cursor.

Chromium dispatches **one `mousemove` of its own per document**, at the widget's
initial pointer position — `(0, 0)` on a fresh page — when it recomputes hover
state after the first layout. Probed against `tests/fixture` (full dumps below),
nothing about the event says "synthetic":

| | Chromium's settle event | first step of a real `move_to` |
|---|---|---|
| `type` | `mousemove` | `mousemove` |
| `isTrusted` | `true` | `true` |
| neighbours | `pointerover`, `mouseover`, `pointermove` | `pointerover`, `mouseover`, `pointermove` |
| `clientX/Y` | `0, 0` | `150, 150` |
| **`movementX/Y`** | **`0, 0`** | **`150, 150`** |

Its `timeStamp` is 9 ms and it is *delivered* at ~89 ms; `DOMContentLoaded` is at
~20 ms, and `DOMContentLoaded` is when the overlay's `attach` subscribes, because
it needs `document.body`. Which of the two comes first is decided by machine
load — that is the race, and it is not "the event is late", it is "the listener
is early or late against a fixed-time event".

**Measured on this box under 14-way CPU load, 24 takes of a storyboard that
never touches the pointer, `deterministic=True`** — dot rect read off the live
page with `getBoundingClientRect`, stills hashed as bytes, corner pixel decoded
with ffmpeg:

| dot | takes | still sha256 | pixel at (2, 2) |
|---|---|---|---|
| centred on the viewport origin | **12** | `e3d8a91b4beaa6e6` | `(240, 185, 146)` — the dot |
| off screen, where the stylesheet parks it | **12** | `6f95a864aa645e46` | `(245, 246, 249)` — page background |

That is the same hash pair and the same two corner pixels #188 recorded, so this
is the same defect, still in the product. A coin flip, not one in twelve: this
storyboard shoots earlier than smoke's does, so it sits nearer the middle of the
race.

## The fix, and why not the other three

**The overlay ignores a `mousemove` that reports no movement.** One line in
`_CURSOR_JS`, and the reasoning is in the comment above it.

```js
window.addEventListener('mousemove', (e) => {
  if (e.movementX === 0 && e.movementY === 0) return;
  ...
```

This is structural rather than a heuristic in both directions: an event
dispatched at the position the pointer already has *cannot* report a delta, and
an event that reports no delta *cannot* need the dot moved, because the pointer
did not move. The dot's position becomes a pure function of the storyboard's
pointer motions, with no dependence on when anything was delivered. Written
`=== 0` rather than `!e.movementX` on purpose: on an engine that does not
implement `movementX` the strict test is false and the cursor behaves as it
always did, while the falsy test would swallow every move and record a take with
no cursor in it — an absence nobody watching can report.

**Why not park the pointer off-frame at recorder start-up, as #188 did for the
suite.** It does not work, and the measurement is the reason rather than taste.
Probed three ways:

- `page.mouse.move(60, 640)` **before the first `goto`** is lost entirely — the
  new document still gets its settle event at `(0, 0)`, so the race is untouched.
  #188's 12-of-12 comes from parking *after* `goto`, i.e. from arriving after the
  settle event, which is the same race won rather than removed.
- Parking **off-frame** cannot move the dot at all: `mouse.move(-40, -40)`
  dispatches `mouseout`, not `mousemove`, and `(1400, 800)` and `(-1, -1)`
  dispatch nothing. The dot stays wherever the last in-viewport event left it.
- Parking **on-frame** would leave an 18 px dot somewhere in every take from
  frame zero, over whatever the app draws there, hovering whatever has a
  `:hover` rule — a coordinate only the storyboard could choose safely, which is
  precisely what the recorder cannot know.

**Why not suppress the dot until the first pointer verb.** It needs arming from
Python, and the recorder documents `self.page` as the escape hatch "for anything
the verbs don't cover" — a storyboard driving `page.mouse` directly (which is
exactly what `tests/smoke`'s determinism arm does) would arm nothing and record
no cursor at all. That trades a race in the pixels for an invisible cursor,
which is the worse failure: `check_parked_pointer` would go red on a change that
looks like a fix.

**Why not ignore untrusted events, or the first event, or an event at `(0, 0)`.**
The settle event *is* trusted (measured above), so trust separates nothing.
"The first" and "at the origin" are the shapes that make the race *less likely*
rather than absent — a storyboard whose first pointer verb legitimately lands at
the origin gets silently dropped, and neither says anything true about why the
event should be ignored.

## After

Same box, same 14-way load, same storyboard, same harness:

| | takes | dot rect (live page) | distinct still hashes |
|---|---|---|---|
| before | 24 | `(0,0)` ×12, off-screen ×12 | **2** |
| after | 24 | off-screen ×24 | **1** (`6f95a864aa645e46`) |

24 identical takes against a 12/12 base rate is p ≈ 1.2e-7 under "still a coin
flip", which is the distinction between a fix and a narrowing.

**Not regressed**, same harness:

| storyboard | takes | dot rect | still hashes |
|---|---|---|---|
| parks the pointer at (60, 640), as `tests/smoke`'s does | 6 | `60,640` ×6 | 1 |
| `move_to("#entropy-panel")` — a real pointer verb | 4 | `640,108` ×4 | 1 |

So `check_parked_pointer` still reads the dot where the storyboard put it (and
now reads it there deterministically: whichever side of the park the settle
event falls on, it is movement-free and ignored), and the cursor still glides
onto elements and is still photographed doing it.

## What the assertion grades, and what it cannot

`tests/unit` gains `CursorMotion` (5 tests, no browser, 0.01 s). It **reads the
guard out of the shipped overlay and evaluates it** against event shapes measured
off Chromium — it does not restate the rule in Python, where it would agree with
itself while the take shipped something else. The JS→Python translation is
hand-written and narrow: a guard in a form it cannot model fails the extraction
loudly rather than passing silently.

Stated limits, both written into the suite's "what this does not cover":

- It cannot grade that **Chromium's events still look like this**. A browser that
  started reporting movement on its settle event would reopen the bug with the
  unit suite green. That claim, and the take-level one it serves, need Chromium.
- The take-level claim — *two takes of a pointer-free storyboard produce
  byte-identical stills* — is graded here only by the 24-take run above, because
  `tests/smoke` is being edited by another agent and is out of this change's
  scope. Filed as #193 with the storyboard and the check to add.

## Fault injection

Three entries added to `tests/unit`'s manifest, all watched to fail, all
matching exactly once (the harness aborts otherwise).

**1. `the cursor dot follows every mousemove again`** — the guard deleted, which
is the code exactly as it shipped before this change:

```
FAIL: test_chromiums_load_time_hover_event_does_not_move_the_dot
AssertionError: the mousemove handler holds 0 early-return guards, expected
exactly 1 — with none, every event Chromium dispatches moves the dot, including
the one it sends at load (#186)

FAIL: test_nothing_moves_the_dot_except_through_the_rule
AssertionError: the mousemove handler positions the dot with no early return in
front of it, so every event Chromium dispatches moves it — including the one it
sends at load (#186)
```

**2. `the cursor rule drops a move that is along one axis`** — `&&` weakened to
`||`, which would freeze the dot for every horizontal drag while making takes
agree with each other, so no still comparison would ever notice:

```
FAIL: test_every_real_move_moves_the_dot [a horizontal glide step]
AssertionError: True is not false : the overlay drops a horizontal glide step
(160, 0), so the cursor stops following the pointer it exists to stand in for

FAIL: test_every_real_move_moves_the_dot [a vertical glide step]
AssertionError: True is not false : the overlay drops a vertical glide step
(0, 250), so the cursor stops following the pointer it exists to stand in for
```

**3. `the cursor rule tests movement for falsiness instead of zero`** —
`!e.movementX && !e.movementY`, the spelling that reads better and is wrong
where it matters:

```
FAIL: test_a_move_that_reports_no_movement_field_still_moves_the_dot
AssertionError: True is not false : an engine that does not implement movementX
makes the overlay drop every move, and a take recorded there has no cursor in it
at all — the guard is written `=== 0` rather than falsy for exactly this reason
```

Whole manifest: `All 69 injections were caught.`

## Verification

```
./tests/unit                  115 tests OK
./tests/unit --fault-inject   All 69 injections were caught.
./tests/unit --budget         SKILL.md: 599 lines, budget 600
./tests/ci-unit               49 tests OK
./tests/smoke-inject --self-test   Every guard refused what it exists to refuse.
ruff==0.14.2 check .          All checks passed!
ruff==0.14.2 format --check . 12 files already formatted
mypy==1.13.0 helpers/         Success: no issues found in 12 source files
```

`tests/smoke` was **not** run: it takes the machine-wide lock and another agent
needs it, and a timing measurement taken under contention with another suite is
worth nothing. The 34 browser takes above were recorded outside the lock against
`tests/fixture`, under deliberate 14-way load.

## Demo judgment

No demo video. The visible change is the *disappearance* of an artifact that was
in roughly half of all opening stills, and it is graded in the pixels — two
hashes becoming one, and the corner pixel `(240, 185, 146)` becoming the page
background in 24 of 24 takes. A video would be a picture of an absence, which is
the row CLAUDE.md's table calls not demoable.

## Probe output, verbatim

The settle event and a real move, from a Playwright probe against
`tests/fixture` with a listener attached at `document_start`:

```
SETTLE
   {'type': 'pointerover', 'x': 0, 'y': 0, 'trusted': True, 'mx': 0, 'my': 0, 'ts': 9}
   {'type': 'mouseover',   'x': 0, 'y': 0, 'trusted': True, 'mx': 0, 'my': 0, 'ts': 9}
   {'type': 'pointermove', 'x': 0, 'y': 0, 'trusted': True, 'mx': 0, 'my': 0, 'ts': 9}
   {'type': 'mousemove',   'x': 0, 'y': 0, 'trusted': True, 'mx': 0, 'my': 0, 'ts': 9}
REAL MOVE (page.mouse.move(300, 300, steps=2))
   {'type': 'pointermove', 'x': 150, 'y': 150, 'trusted': True, 'mx': 150, 'my': 150}
   {'type': 'mousemove',   'x': 150, 'y': 150, 'trusted': True, 'mx': 150, 'my': 150}
   {'type': 'pointermove', 'x': 300, 'y': 300, 'trusted': True, 'mx': 150, 'my': 150}
   {'type': 'mousemove',   'x': 300, 'y': 300, 'trusted': True, 'mx': 150, 'my': 150}
```

Off-frame parks, and why none of them place the dot:

```
settle          : [[0, 0]]
park (-40, -40) : [['out', -40, -40]]     mouseout, no mousemove
park (-1, -1)   : []                      nothing at all
park (1400, 800): []                      nothing at all
park (1279, 719): [[1279, 719]]           back inside: a move
```

Documents after the first get no settle event at all — two further navigations
with the pointer inside the viewport produced no `mousemove` over four seconds —
so the cursor was already absent between a `goto()` and the next pointer verb
before this change, and nothing about that moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
