### PR TITLE
Seal the base's guarantees so a medium cannot switch one off by picking a name (#147)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -547,6 +547,86 @@ class _DemoBase:
     storyboard author's to pin down. See the determinism section above.
     """
 
+    # -- the medium seam ----------------------------------------------------
+    #
+    # **Every base member not named here is sealed**, and `__init_subclass__`
+    # below refuses — at import — a medium that shadows one.
+    #
+    # This exists because the seam used to be prose. `_DemoBase`'s docstring
+    # named the hooks, nothing checked, and while #181 was landing a medium
+    # added a method called `_watch_page` — a name the base already used for
+    # the `console`/`pageerror`/`requestfailed`/`response` subscription. Python
+    # resolved the override, web takes recorded zero problems, `strict=True`
+    # refused nothing, and `timeline.json` stayed well-formed and empty. No
+    # error, no warning, no failing unit test: the whole error-detection
+    # surface was off because a subclass picked a name.
+    #
+    # The rule that follows is the one the accident argues for: a medium
+    # *extends* by implementing a hook it was offered, never by re-declaring
+    # something the base already promises to do. Two hooks here exist only to
+    # give the shape somewhere to go — `_watch_extra` (subscribe more) and
+    # `_before_shot` (do something before a still) — because sealing a member
+    # a medium legitimately needed to reach would just move the problem.
+    #
+    # Adding a name here is a deliberate act with a cost: it says a medium may
+    # replace that behaviour wholesale, and nothing downstream may rely on it
+    # any more.
+    MEDIUM_HOOKS = frozenset(
+        {
+            "__init__",
+            # lifecycle
+            "_init_context",
+            "_start",
+            "_stop",
+            "_postprocess",
+            # what only this medium can answer
+            "_content_rect",
+            "_evidence_payload",
+            "_failure_screen",
+            "_media_path",
+            # extension points, each beside the sealed member it extends
+            "_watch_extra",
+            "_before_shot",
+            "_idle",
+        }
+    )
+
+    def __init_subclass__(cls, **kwargs: object) -> None:
+        """Refuse a medium that shadows a sealed base member.
+
+        Import time, not call time: the failure this replaces was invisible
+        precisely because the shadowed method still *ran* — the wrong one.
+        A `TypeError` while the module loads is the loudest available moment
+        and the only one that cannot be reached by a take.
+
+        Identity, not `in vars(cls)`: a mixin listed ahead of the recorder in
+        the MRO shadows exactly as effectively as a method on the class
+        itself, and `tests/unit` uses one.
+        """
+        super().__init_subclass__(**kwargs)  # type: ignore[call-arg]
+        broken = []
+        for name in vars(_DemoBase):
+            # Read off `_DemoBase`, never off `cls`: a subclass that could
+            # widen its own permit would have the escape hatch this exists to
+            # remove, and it would read as configuration rather than as a
+            # mistake.
+            if name in _DemoBase.MEDIUM_HOOKS or name == "__init_subclass__":
+                continue
+            promised = getattr(_DemoBase, name, None)
+            if not callable(promised):
+                continue
+            if getattr(cls, name, None) is not promised:
+                broken.append(name)
+        if broken:
+            raise TypeError(
+                f"{cls.__module__}.{cls.__qualname__} overrides "
+                f"{', '.join(sorted(broken))} — sealed on _DemoBase, so this "
+                f"silently replaces a guarantee every take is owed rather "
+                f"than extending one. A medium may override only "
+                f"_DemoBase.MEDIUM_HOOKS: "
+                f"{', '.join(sorted(_DemoBase.MEDIUM_HOOKS))}."
+            )
+
     def __init__(
         self,
         out_dir: Path | str | None = None,
@@ -1125,11 +1205,31 @@ class _DemoBase:
         self._pumped_at = time.monotonic() - self._t0
 
     def _watch_page(self, page: Page) -> None:
-        """Subscribe to everything the page can say about being broken."""
+        """Subscribe to everything the page can say about being broken.
+
+        **Sealed** (see `MEDIUM_HOOKS`). These four listeners are what the
+        issue log is made of and what `strict=True` refuses a take over, and a
+        medium that replaced this method would take all four off itself
+        without changing anything a reader of `timeline.json` could see. A
+        medium adds to them through `_watch_extra`, which cannot subtract.
+        """
         page.on("console", self._on_console)
         page.on("pageerror", self._on_page_error)
         page.on("requestfailed", self._on_request_failed)
         page.on("response", self._on_response)
+        self._watch_extra(page)
+
+    def _watch_extra(self, page: Page) -> None:
+        """Subscriptions this medium wants on top of the four above.
+
+        Called once, from `_watch_page`, before `_start()` — so the first
+        navigation is watched too. Do not subscribe from `_start` as well:
+        two subscriptions record every event twice.
+
+        A handler here should only set an attribute. Playwright delivers page
+        events on the thread that is blocked inside a Playwright call, so
+        calling back into the API from one is a way to deadlock a take.
+        """
 
     def _on_console(self, message) -> None:
         try:
@@ -2032,13 +2132,27 @@ take with fewer beats than the last one would otherwise leave the
         self._idle(max(min_s, remaining))
 
 
+    def _before_shot(self) -> None:
+        """Bring the screen up to date before a still is taken.
+
+        The hook that keeps `shot` sealed. A medium sitting on buffered output
+        (the terminal reads its PTY here) flushes it, and everything a still
+        is *for* — the beat, the `ac` claim, the file the coverage report
+        points at — stays the base's to guarantee.
+        """
+
     def shot(self, name: str, ac: str | Sequence[str] | None = None) -> Path:
         """Still for the written guide -> images/<name>.png.
 
         `ac` names the acceptance criterion this still is here to demonstrate.
         A tagged `shot` is the strongest thing a coverage report can hand a
         reviewer — a committed picture of the moment, at a known timestamp.
+
+        **Sealed** (see `MEDIUM_HOOKS`): a medium that replaced this would take
+        the beat and its `ac` claim with it, and the coverage report reads
+        nothing else. Medium-specific work goes in `_before_shot`.
         """
+        self._before_shot()
         claims = self._checked_ac(ac, "shot()")
         path = self.images_dir / f"{name}.png"
         rel = path.relative_to(self.out_dir).as_posix()

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -33,7 +33,6 @@ import sys
 import termios
 import time
 from collections import deque
-from collections.abc import Sequence
 from pathlib import Path
 
 from .content import content_rect
@@ -788,16 +787,15 @@ class TerminalRecorder(_DemoBase):
 
     # -- capture ------------------------------------------------------------
 
-    def shot(self, name: str, ac: str | Sequence[str] | None = None) -> Path:
-        """Still for the written guide -> images/<name>.png (pumps pending
-        output first so the latest screen state is captured).
+    def _before_shot(self) -> None:
+        """Pump pending output so the still is of the latest screen state.
 
-        `ac` is passed straight through — a terminal take records against a
-        ticket exactly like a web one, and a criterion demonstrated on the
-        command line is the ordinary reason a demo has a terminal half.
+        A hook rather than a `shot` override (#147): `shot` writes the beat
+        and the `ac` claim the coverage report is built from, and a medium
+        that owned the whole method could drop either without anything
+        noticing. All this medium needs is the flush.
         """
         self._pump()
-        return super().shot(name, ac=ac)
 
     # -- evidence (issue #9) ------------------------------------------------
 

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -494,28 +494,22 @@ class Recorder(_DemoBase):
             .replace("__SLACK_MS__", str(SPOTLIGHT_EXIT_SLACK_MS))
         )
 
-    def _watch_page(self, page) -> None:
-        """Everything `_DemoBase` watches, plus what a *document* being
-        replaced means to a web take.
+    def _watch_extra(self, page) -> None:
+        """What a *document* being replaced means to a web take.
 
-        **`super()` first, and it is load-bearing.** The base subscribes
-        `console`, `pageerror`, `requestfailed` and `response` — every problem
-        this recorder exists to write down, and what `strict=True` refuses a
-        take over. An override that forgot the call would silently unsubscribe
-        all four for web takes only, which is the one shape of bug that leaves
-        `timeline.json` looking healthy because the problems never reach it.
-        `tests/unit` holds that shut behaviourally, and it is registered as an
-        injection because it is a mistake this file has already made once.
-
-        `__enter__` calls this before `_start()`, so the first navigation is
-        watched too. Do not call it again from `_start`: two subscriptions
-        record every console error twice.
+        **This used to be a `_watch_page` override, and that is the bug #147
+        is about.** `_DemoBase._watch_page` already existed under that name —
+        the subscription for `console`, `pageerror`, `requestfailed` and
+        `response`, every problem this recorder exists to write down and what
+        `strict=True` refuses a take over. Declaring it here shadowed all four
+        for web takes only: no error, no warning, `timeline.json` well-formed
+        and empty of issues. The base now seals `_watch_page` and calls this,
+        so the same mistake is a `TypeError` while the module imports.
 
         Both callbacks below only set an attribute. Playwright delivers page
         events on the same thread that is blocked in a Playwright call, so
         calling back into the API from one of them is a way to deadlock a take.
         """
-        super()._watch_page(page)
         # **Kept deliberately when the masking went** — #142's carve-out.
         # Written for the paint gate, which is gone; nothing reads the flag.
         #

--- a/tests/unit
+++ b/tests/unit
@@ -2498,6 +2498,192 @@ class WatchedEvents(unittest.TestCase):
         self.assertEqual(doubled, {})
 
 
+# --------------------------------------------------------------------------
+# The medium seam (#147)
+# --------------------------------------------------------------------------
+#
+# `WatchedEvents` above grades the *outcome* — that a web take really is
+# subscribed to the base's four problem listeners. It caught the regression
+# once it had been fixed; it could not have stopped it being written, and it
+# says nothing about the next member somebody shadows by picking its name.
+#
+# What follows grades the seal instead: `_DemoBase.MEDIUM_HOOKS` names what a
+# medium may replace, and `__init_subclass__` refuses everything else while
+# the module imports.
+
+# The guarantees a take is owed, spelled out rather than derived from
+# `MEDIUM_HOOKS`. A list read out of the code under test agrees with that code
+# by construction — including with a change that moved one of these names into
+# the permit, which is the one edit these assertions exist to notice.
+GUARANTEED = frozenset(
+    {
+        # the take's own lifecycle
+        "__enter__",
+        "__exit__",
+        # #147's regression: the four problem listeners, and their handlers
+        "_watch_page",
+        "_on_console",
+        "_on_page_error",
+        "_on_request_failed",
+        "_on_response",
+        "_pump_events",
+        # what a take says about its problems
+        "_note_issue",
+        "_print_issue_summary",
+        "_strict_message",
+        # the artifacts a reviewer reads
+        "_beat",
+        "shot",
+        "caption",
+        "interlude",
+        "_capture_evidence",
+        "_write_evidence",
+        "_write_failure",
+        "_write_failure_marker",
+        "_timeline_doc",
+        "_convert",
+    }
+)
+
+
+class SealedSeam(unittest.TestCase):
+    """What a medium may override, and what it may not.
+
+    Written from the outage: while #181 was landing, `Recorder` gained a
+    method called `_watch_page` — a name `_DemoBase` already used for the
+    `console`/`pageerror`/`requestfailed`/`response` subscription. Python
+    resolved the override, web takes recorded zero problems, `strict=True`
+    refused nothing, and `timeline.json` stayed well-formed and empty. Nothing
+    raised, nothing warned, and `tests/unit` could not see it because no test
+    here enters the context manager that calls the shadowed method.
+
+    The fix is not another assertion about `_watch_page`; it is that a medium
+    which shadows a sealed member does not import.
+    """
+
+    def refusal(self, bases=(_DemoBase,), **members):
+        """Define a medium with `members`; return the TypeError, or None."""
+        try:
+            type("Medium", bases, dict(members))
+        except TypeError as refused:
+            return refused
+        return None
+
+    def test_a_medium_that_shadows_the_page_subscription_is_refused(self):
+        # The regression, written exactly as web.py once wrote it.
+        refused = self.refusal(_watch_page=lambda self, page: None)
+        self.assertIsNotNone(
+            refused,
+            "a medium redeclaring _watch_page silently unsubscribes the "
+            "base's four problem listeners, and that is what shipped",
+        )
+        self.assertIn("_watch_page", str(refused))
+
+    def test_the_refusal_names_the_seam_a_medium_should_have_used(self):
+        # An import-time TypeError that only says "no" sends the next author
+        # looking for the mechanism instead of the hook.
+        refused = self.refusal(_watch_page=lambda self, page: None)
+        self.assertIn("_watch_extra", str(refused))
+
+    def test_a_mixin_shadows_just_as_well_and_is_refused_too(self):
+        # `in vars(cls)` is the obvious way to write this check and it is
+        # wrong: a class listed ahead of the base in the MRO takes the call
+        # without appearing on the medium at all. `tests/unit` ships such a
+        # mixin (`_NoWait`), so this is not hypothetical here.
+        mixin = type("Mixin", (), {"_watch_page": lambda self, page: None})
+        refused = self.refusal(bases=(mixin, _DemoBase))
+        self.assertIsNotNone(
+            refused, "a mixin ahead of _DemoBase in the MRO shadows it"
+        )
+        self.assertIn("_watch_page", str(refused))
+
+    def test_a_medium_cannot_widen_its_own_permit(self):
+        # An escape hatch that reads as configuration is the accident this
+        # exists to remove, wearing a different hat.
+        refused = self.refusal(
+            MEDIUM_HOOKS=_DemoBase.MEDIUM_HOOKS | {"_watch_page"},
+            _watch_page=lambda self, page: None,
+        )
+        self.assertIsNotNone(
+            refused, "a medium granted itself permission to shadow a seal"
+        )
+
+    def test_every_declared_hook_can_still_be_implemented(self):
+        # The control. A seal that refused *everything* would satisfy all four
+        # assertions above and make the package undefinable — and this is the
+        # test that fires, rather than an unreadable import error, when a hook
+        # is dropped from the permit by mistake.
+        hooks = {
+            name: (lambda self, *args, **kwargs: None)
+            for name in _DemoBase.MEDIUM_HOOKS
+        }
+        self.assertIsNone(self.refusal(**hooks))
+
+    def test_the_guarantees_a_take_is_owed_are_not_in_the_permit(self):
+        self.assertEqual(GUARANTEED & _DemoBase.MEDIUM_HOOKS, frozenset())
+
+    def test_every_guaranteed_name_is_something_the_base_actually_defines(self):
+        # Without this the assertion above is the catalogue's vacuous sweep:
+        # a renamed member leaves a stale name in GUARANTEED that intersects
+        # nothing, forever, whatever the permit says.
+        self.assertEqual(GUARANTEED - set(vars(_DemoBase)), set())
+
+    def test_every_declared_hook_is_something_the_base_actually_defines(self):
+        # The mirror. A hook named for a member that does not exist permits
+        # nothing and hides that the real member is still sealed.
+        self.assertEqual(_DemoBase.MEDIUM_HOOKS - set(vars(_DemoBase)), frozenset())
+
+
+class TerminalStill(unittest.TestCase):
+    """A terminal still is taken of the flushed screen, not the stale one.
+
+    This behaviour predates the seam work — it was a `shot` override that
+    pumped and then called `super()`. It is asserted here because the seal
+    moved it to `_before_shot`, and a refactor's only honest evidence is that
+    what it moved still happens.
+    """
+
+    class Page(FakePage):
+        def __init__(self, log: list) -> None:
+            super().__init__()
+            self.log = log
+
+        def screenshot(self, path: str) -> None:
+            self.log.append("screenshot")
+
+    class Rec(TermRec):
+        """A terminal recorder that writes down when its screen was flushed.
+
+        `_pump` reads the PTY and returns immediately when there is none, so
+        the real one is silent in this suite — which is exactly the shape of
+        a still taken of a screen nobody refreshed.
+        """
+
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.log: list[str] = []
+
+        def _pump(self) -> None:
+            self.log.append("pump")
+
+    def test_the_screen_is_flushed_before_the_still_is_taken(self):
+        rec = recorder(self, cls=self.Rec)
+        rec.page = self.Page(rec.log)
+        rec.shot("01-done")
+        self.assertEqual(rec.log, ["pump", "screenshot"])
+
+    def test_the_still_is_still_a_beat_that_carries_its_criterion(self):
+        # The half a `shot` override could have dropped, and the reason `shot`
+        # is sealed: the coverage report reads nothing but this beat.
+        rec = recorder(self, cls=self.Rec, criteria={"AC-2": "The queue empties."})
+        rec.page = self.Page(rec.log)
+        rec.shot("01-done", ac="AC-2")
+        self.assertEqual(
+            [(b["verb"], b["selector"], b.get("ac")) for b in rec._beats],
+            [("shot", "01-done", ["AC-2"])],
+        )
+
+
 class VerbTarget(unittest.TestCase):
     """Which target a verb's beat names, by position and by keyword (#177).
 
@@ -3741,28 +3927,136 @@ INJECTIONS = [
         ["CaptionTruth.test_a_take_watches_its_page_before_the_medium_starts"],
     ),
     (
-        # The regression the first version of this change shipped, and the one
-        # `tests/smoke` caught after `tests/unit` went green: `Recorder`
-        # declaring `_watch_page` without delegating shadows the base's four
-        # problem listeners, so a web take records no console error, no
-        # pageerror, no failed request — and `strict=True` refuses nothing.
-        "the web recorder's page subscription shadows the base's",
-        "web.py",
-        "        super()._watch_page(page)",
-        "        pass  # the base's problem listeners are on their own",
+        # The other half of #147's regression. The seal below stops a medium
+        # *shadowing* `_watch_page`; nothing stops the base forgetting to call
+        # what a medium was told to implement instead, and then the two web
+        # subscriptions are dead code nobody notices.
+        "the base stops calling what a medium subscribes on top",
+        "core.py",
+        "        self._watch_extra(page)",
+        "        pass  # the medium's own subscriptions never happen",
         [
-            "WatchedEvents.test_a_web_take_watches_the_problems_every_take_watches",
             "WatchedEvents.test_the_web_recorder_only_adds_to_what_the_base_watches",
+            "CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption",
         ],
     ),
     (
         # And the mirror: subscribing twice logs every problem the page emits
         # twice, which is the shape the fix for the above invites.
         "a medium subscribes its page a second time",
-        "web.py",
-        "        super()._watch_page(page)",
-        "        super()._watch_page(page)\n        super()._watch_page(page)",
+        "core.py",
+        "        self._watch_extra(page)",
+        "        self._watch_extra(page)\n        self._watch_extra(page)",
         ["WatchedEvents.test_no_page_event_is_subscribed_twice"],
+    ),
+    (
+        # #147's regression itself, and the reason there is a seal rather than
+        # one more assertion about `_watch_page`: with nothing sealed, a medium
+        # that picks a name the base already uses takes the base's four problem
+        # listeners off itself, and every artifact still looks healthy.
+        #
+        # This breaks the seal rather than re-creating the shadowing in web.py,
+        # and the difference is the point: re-declaring `_watch_extra` as
+        # `_watch_page` no longer *runs*. It raises while `demo_recording.web`
+        # imports, so there is no suite left to report a failing test — a
+        # stronger outcome than this manifest can express, and one the pull
+        # request pastes rather than automates.
+        "nothing is sealed, so a medium may shadow whatever it likes",
+        "core.py",
+        "                broken.append(name)",
+        "                continue  # every base member is a medium's to replace",
+        [
+            "SealedSeam.test_a_medium_that_shadows_the_page_subscription_is_refused",
+            "SealedSeam.test_a_mixin_shadows_just_as_well_and_is_refused_too",
+            "SealedSeam.test_a_medium_cannot_widen_its_own_permit",
+        ],
+    ),
+    (
+        # The permit read off the subclass instead of off the base: an escape
+        # hatch that reads as configuration, so the next medium turns a
+        # guarantee off in a diff nobody questions.
+        "a medium may widen its own permit",
+        "core.py",
+        '            if name in _DemoBase.MEDIUM_HOOKS or name == "__init_subclass__":',
+        '            if name in cls.MEDIUM_HOOKS or name == "__init_subclass__":',
+        ["SealedSeam.test_a_medium_cannot_widen_its_own_permit"],
+    ),
+    (
+        # The obvious way to write the check, and the wrong one: a class ahead
+        # of the base in the MRO shadows without appearing on the medium at
+        # all. `tests/unit`'s own `_NoWait` is exactly that shape.
+        "the seal only looks at the medium's own methods",
+        "core.py",
+        "            if getattr(cls, name, None) is not promised:",
+        "            if name in vars(cls):",
+        ["SealedSeam.test_a_mixin_shadows_just_as_well_and_is_refused_too"],
+    ),
+    (
+        # The seal defeated without touching the seal: move the sealed name
+        # into the permit. This is the edit a future author reaches for when
+        # the import refuses them, and it is why the guarantees are listed by
+        # hand in `tests/unit` rather than derived from `MEDIUM_HOOKS`.
+        "the page subscription is moved into the permit",
+        "core.py",
+        '            "_watch_extra",\n',
+        '            "_watch_extra",\n            "_watch_page",\n',
+        [
+            "SealedSeam.test_a_medium_that_shadows_the_page_subscription_is_refused",
+            "SealedSeam.test_the_guarantees_a_take_is_owed_are_not_in_the_permit",
+        ],
+    ),
+    (
+        # The seal pointing the other way. A permit that does not actually
+        # permit is only visible on the hook nobody has implemented yet —
+        # `_media_path` here — because every other one takes the package down
+        # at import with a traceback instead of a named failure.
+        "a declared hook is refused anyway",
+        "core.py",
+        "            if name in _DemoBase.MEDIUM_HOOKS or ",
+        '            if name in _DemoBase.MEDIUM_HOOKS - {"_media_path"} or ',
+        ["SealedSeam.test_every_declared_hook_can_still_be_implemented"],
+    ),
+    (
+        # What the seal moved, and the only thing about it that a viewer would
+        # ever have noticed: a terminal still taken before the PTY was drained
+        # is a picture of the screen one command ago.
+        "a terminal still is taken of a screen nobody refreshed",
+        "core.py",
+        "        self._before_shot()",
+        "        pass  # whatever the medium last painted will do",
+        ["TerminalStill.test_the_screen_is_flushed_before_the_still_is_taken"],
+    ),
+    (
+        # The other half of why `shot` is sealed: the still is on disk either
+        # way, and the criterion it was taken to demonstrate is what a medium
+        # owning this method could have dropped without anyone seeing it.
+        "a still stops recording the criterion it demonstrates",
+        "core.py",
+        '        with self._beat("shot", selector=name, still=rel, **_ac_field(claims)):',
+        '        with self._beat("shot", selector=name, still=rel):',
+        ["TerminalStill.test_the_still_is_still_a_beat_that_carries_its_criterion"],
+    ),
+    (
+        # The permit's own vacuity check: a name in GUARANTEED that the base
+        # does not define intersects nothing, so the assertion above it would
+        # go green on a member that had quietly moved into MEDIUM_HOOKS.
+        "a guaranteed name outlives the member it names",
+        "tests/unit",
+        '        "_strict_message",\n',
+        '        "_strict_verdict",\n',
+        [
+            "SealedSeam.test_every_guaranteed_name_is_something_the_base_actually_defines"
+        ],
+    ),
+    (
+        # And the same trap on the permit's side: a hook named for a member
+        # that does not exist permits nothing, while the real member stays
+        # sealed and the author believes they opened it.
+        "the permit names a hook the base does not have",
+        "core.py",
+        '            "_before_shot",\n',
+        '            "_before_shot",\n            "_verify_redaction_final",\n',
+        ["SealedSeam.test_every_declared_hook_is_something_the_base_actually_defines"],
     ),
     (
         # The naive fix, and the reason the clear is not on `framenavigated`:


### PR DESCRIPTION
Closes #135 and #173. They are one slice: #135 is a worked example of the
problem #173 describes — a check nobody could afford to re-run is a check
nobody has watched fail.

## Acceptance criteria

**#135** — "With `CONTENT_CAPTION_TRIM` set to `0.0`, `--content-only` fails
**and** the failure list contains an item naming the scored region — not only
the `content-toured` premise guard." Met; output below.

**#173** — "these five are certified by nothing." The gradeable core of
`check_issues`, `check_timeline` and `check_take`'s picture half now has
browser-free assertions in `tests/unit`, each broken and watched fail.
110 → 136 tests, 66 → 79 injections, 0.29 s for the suite.

## What moved, and what could not

| smoke check | cheapest arm | moved to `tests/unit` | what stays smoke's |
|---|---|---|---|
| `check_issues` | 123 s | `TakeIssues` — 9 tests, 6 injections | that Chromium fires `console` for `console.error`, that a refused connection arrives as `requestfailed` |
| `check_timeline` | 123 s | `BeatLog` — 8 tests, 4 injections | that the document reaches disk, that beat times line up with frames, that ffprobe agrees about the duration |
| `check_take` (picture half, via `check_content_healthy`) | 123 s | `ContentRect` — 5 tests, 2 injections | that the rect is where the app really ended up on a live page |
| `check_issues` (the `timeline.md` half) | 123 s | `TimelineMd` — 5 tests, 2 injections | — |
| `check_caption` | 123 s | **nothing** | it reads the caption bar off the live DOM and off the caption band's pixels; the beat-record half was already `CaptionTruth`'s |
| `check_beat_frames` | 123 s | **nothing** | it matches review frames cut from `demo.mp4` against the caption each beat put up |
| `check_evidence` | 123 s | **nothing needed** | it already has three registered `smoke-inject` entries; it was never one of the ungraded ones |

## #135, demonstrated

Staged copy of the repo, `CONTENT_CAPTION_TRIM = 0.2 -> 0.0`, confirmed to
match exactly once before anything ran:

```
injection landed exactly once: CONTENT_CAPTION_TRIM = 0.2 -> CONTENT_CAPTION_TRIM = 0.0
```

```
smoke: FAILED
  - content-shown: the recorder scored the region (74, 110, 1132, 540), this run expected (74, 110, 1132, 432) (off by (0, 0, 0, 108) px). The app box is (74, 110, 1132, 540) and the bottom 20% of it is the recorder's own caption bar, burned into the recording. Scoring that as if it were the app lets a caption supply the contrast for a blank take on the score arm, and lets a caption *change* count as the picture changing on the static arm — either one turns a broken take green (issues #17 and #135).
  - content-covered: the recorder scored the region (74, 110, 1132, 540), this run expected (74, 110, 1132, 432) (off by (0, 0, 0, 108) px). […same message…]
  - content-toured: the recorder scored the region (74, 110, 1132, 540), this run expected (74, 110, 1132, 432) (off by (0, 0, 0, 108) px). […same message…]
  - content-toured: this take was written to hold one picture past the recorder's 15.0s limit and only held it for 8.0s, so it does not reach the false-positive path at all — as written, it would keep passing after the thing it grades regressed. The scored region is wrong (see the failure above), which is the likely cause: a rect that includes the caption bar turns every caption swap into motion and chops the stretch. Fix that first and do not touch this storyboard.
```

Hole 3 is closed by the last line: the premise guard's remedy is now chosen by
whether the region checked out, so it no longer sends a maintainer to lengthen
the fixture's captions for a fault in the recorder.

Clean baseline, same arm, working tree: `smoke: PASSED` in 147 s.

## The 13 new injections

Each confirmed to match exactly once — the harness aborts on any other count.

```
PASS  break: the caption bar is left inside the region the picture check scores
      in content.py: CONTENT_CAPTION_TRIM = 0.2…
      FAIL: test_the_caption_band_is_cut_off_the_bottom (__main__.ContentRect.test_the_caption_band_is_cut_off_the_bottom)
      FAIL: test_the_scored_rect_is_the_one_issue_135_expected_to_see (__main__.ContentRect.test_the_scored_rect_is_the_one_issue_135_expected_to_see)
      FAIL: test_the_trim_reaches_the_caption_bar_on_both_media (__main__.ContentRect.test_the_trim_reaches_the_caption_bar_on_both_media)

PASS  break: the trim eats most of the app instead of the caption bar
      in content.py: CONTENT_CAPTION_TRIM = 0.2…
      FAIL: test_the_caption_band_is_cut_off_the_bottom (__main__.ContentRect.test_the_caption_band_is_cut_off_the_bottom)
      FAIL: test_the_scored_rect_is_the_one_issue_135_expected_to_see (__main__.ContentRect.test_the_scored_rect_is_the_one_issue_135_expected_to_see)
      FAIL: test_the_trim_does_not_eat_the_app_it_exists_to_score (__main__.ContentRect.test_the_trim_does_not_eat_the_app_it_exists_to_score)

PASS  break: an event between beats is blamed on the last beat that ran
      in core.py: if not self._in_beat or not self._beats:…
      FAIL: test_a_problem_with_no_beat_open_is_attributed_to_nobody (__main__.TakeIssues.test_a_problem_with_no_beat_open_is_attributed_to_nobody)

PASS  break: an app writing to the console at all is recorded as an app failing
      in core.py: if kind is None:…
      FAIL: test_an_app_talking_is_not_an_app_failing (__main__.TakeIssues.test_an_app_talking_is_not_an_app_failing)

PASS  break: a redirect the browser followed is recorded as an HTTP error
      in core.py: if response.status < 400:…
      FAIL: test_the_http_error_bar_is_graded_at_400_and_not_inside_it (__main__.TakeIssues.test_the_http_error_bar_is_graded_at_400_and_not_inside_it)

PASS  break: a 404 is not an error until the server says 500
      in core.py: if response.status < 400:…
      FAIL: test_the_http_error_bar_is_graded_at_400_and_not_inside_it (__main__.TakeIssues.test_the_http_error_bar_is_graded_at_400_and_not_inside_it)

PASS  break: the strict verdict depends on how much noise preceded the exception
      in core.py: if kind in STRICT_KINDS:…
      FAIL: test_a_fatal_problem_past_the_cap_still_fails_a_strict_take (__main__.TakeIssues.test_a_fatal_problem_past_the_cap_still_fails_a_strict_take)

PASS  break: the envelope drops the problems the take recorded
      in core.py: "issues": issues,…
      FAIL: test_the_envelope_carries_every_problem_and_the_count_that_saw_them_all (__main__.BeatLog.test_the_envelope_carries_every_problem_and_the_count_that_saw_them_all)

PASS  break: a beat is numbered one past the position it sits at
      in core.py: "index": len(self._beats),…
      FAIL: test_every_beat_carries_its_own_position_as_its_index (__main__.BeatLog.test_every_beat_carries_its_own_position_as_its_index)
      FAIL: test_the_envelope_a_take_recorded_in_one_piece_writes (__main__.BeatLog.test_the_envelope_a_take_recorded_in_one_piece_writes)
      FAIL: test_a_problem_during_a_beat_names_that_beat_its_verb_and_its_line (__main__.TakeIssues.test_a_problem_during_a_beat_names_that_beat_its_verb_and_its_line)

PASS  break: a beat that did not set the caption reports no caption at all
      in core.py: self._caption = text…
      FAIL: test_every_beat_says_which_caption_was_on_screen_while_it_ran (__main__.BeatLog.test_every_beat_says_which_caption_was_on_screen_while_it_ran)
      FAIL: test_a_beat_after_a_document_load_reports_no_caption (__main__.CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption)
      FAIL: test_a_caption_set_after_the_load_is_reported_again (__main__.CaptionTruth.test_a_caption_set_after_the_load_is_reported_again)
      FAIL: test_an_spa_route_change_keeps_the_caption (__main__.CaptionTruth.test_an_spa_route_change_keeps_the_caption)

PASS  break: a take that encoded no mp4 reports a duration of zero rather than none
      in core.py: mp4 = self._media_path()…
      FAIL: test_a_take_that_encoded_nothing_reports_no_duration (__main__.BeatLog.test_a_take_that_encoded_nothing_reports_no_duration)

PASS  break: a run() beat's exit status never reaches timeline.md
      in timeline.py: shows_exit = any("exit_code" in b for b in beats)…
      FAIL: test_a_run_beats_exit_status_gets_a_column_and_a_web_take_does_not (__main__.TimelineMd.test_a_run_beats_exit_status_gets_a_column_and_a_web_take_does_not)
      FAIL: test_a_run_whose_status_could_not_be_read_says_so_rather_than_nothing (__main__.TimelineMd.test_a_run_whose_status_could_not_be_read_says_so_rather_than_nothing)

PASS  break: timeline.md files the take's problems under a heading nobody greps for
      in timeline.py: "## Issues",…
      FAIL: test_every_recorded_problem_is_listed_with_the_beat_it_fired_during (__main__.TimelineMd.test_every_recorded_problem_is_listed_with_the_beat_it_fired_during)

All 79 injections were caught.
```

One of the thirteen found a defect in my own manifest on its first run: the
`< 400 -> < 500` entry named
`test_every_kind_a_web_take_can_record_is_one_the_package_declares` as a test
that must then fail, and it did not — that test uses a 500, which is still an
error under the broken bar. The entry was corrected rather than the test
weakened.

## Audited against the catalogue of measurements that grade nothing

- **A control computed by the same code path as the thing it controls.**
  `ContentRect` used to assert `int(720 * (1.0 - CONTENT_CAPTION_TRIM))`, which
  agrees with whatever that constant is set to. It now uses a hand-written
  `UNIT_CONTENT_KEEP = 0.8`; the smoke side uses its own `CONTENT_KEEP`.
  Neither side imports the trim to build an expectation.
- **An assertion satisfied by the warning text.** The `"caption bar" not in
  still` check is kept — a reader still has to be told what was measured — but
  it is no longer the only thing in the suite that mentions the trim, and the
  comment above it says exactly that.
- **A tautological round-trip.** `segment_index` is compared against
  `range(len(beats))`, not against `index`. Comparing the two is a tautology on
  a single take, and it is the merge that makes them differ.
- **An ungraded constant.** `CONTENT_CAPTION_TRIM` is pinned from both sides
  (it must reach the web caption's top edge at 84.2 %, and must leave at least
  half the app scored), and the HTTP error bar is graded at 302/400/404 rather
  than comfortably inside one side.
- **The count that stands in for the content.** The `| exit |` test asserts the
  value in the cell, not only the header — `check_issues` looks for the header
  alone and would pass on an empty column on every row.
- **The vacuous sweep.**
  `test_every_kind_a_web_take_can_record_is_one_the_package_declares` asserts
  five kinds were recorded before claiming anything about them, and
  `test_a_problem_with_no_beat_open_is_attributed_to_nobody` asserts a beat
  existed before claiming none was named.

## Stated limits

- **`tests/smoke` is not made cheaper by this, and no arm was split.** #173's
  own checklist (`--issues-only`, `--timeline-only`, an entry aimed at
  `check_evidence`) touches `run_phases` outside the content arm and
  `tests/smoke-inject`, both outside this change's scope. Filed as a follow-up.
- **`tests/smoke-inject` still prints the same 22 `ungraded` check functions.**
  Nothing here registers a smoke injection; what changed is that three of those
  functions' load-bearing claims are now certified somewhere affordable. The
  line that run prints — "see tests/README.md for which of them are covered by
  tests/unit at sub-second cost" — is now out of date, and `tests/README.md` is
  outside this change's scope. Filed as a follow-up.
- **`_check_scored_region` still scores the rect the recorder reported**, and
  that is deliberate rather than #135's hole left open: the blanked control is
  only a comparison if it blanks the region actually scored. What closes the
  hole is that its premise is now asserted immediately before it runs, by
  `scored_region_failures`, against a rect this file computed for itself.
  Moving the two apart re-opens it, and both docstrings say so. Scoring the
  independent rect there instead — which I tried first — silently regresses the
  registered `smoke-inject` entry "the recorder scores the whole frame instead
  of the app rect", because that injection is caught through the *blanked copy*
  the reported rect builds. Re-verified: `tests/smoke-inject --only "whole
  frame"` → `All 1 injections were caught. [4.9 min]`.
- **The unit-level geometry checks use a hand-written app rect** — the one #135
  measured. That the recorder's `_content_rect` is handed the *live* app's box
  is still graded only by smoke.
- **`CONTENT_RECT_SLACK_PX = 1`.** Both rects are read off `#__term_host` with
  the same `int()` and nothing resizes it, so the honest tolerance is zero; the
  slack is two orders of magnitude under the 108 px the trim removes.
- **`BeatLog` reads `_beats` and `_timeline_doc()`, never a written file.**
  That `write_timeline` puts them on disk, and that the timestamps point at the
  frames they claim to, remains `check_timeline`'s.
- The beat log is exercised through the **web** recorder; a terminal `run()`
  beat needs a PTY, so the `| exit |` assertions are made against a hand-built
  document rather than a recorded one.

## Verification

```
./tests/unit                                136 tests, 0.29 s, OK
./tests/unit --fault-inject                 All 79 injections were caught.
./tests/unit --budget                       SKILL.md: 599 lines (~14,036 tokens), budget 600
./tests/ci-unit                             49 tests, OK
./tests/smoke --content-only                PASSED (147 s)
./tests/smoke-inject --self-test            Every guard refused what it exists to refuse.
./tests/smoke-inject --only "whole frame"   All 1 injections were caught. [4.9 min]
ruff==0.14.2 check / format --check         clean (pinned — see #189)
mypy==1.13.0 skills/demo-video/helpers/     no issues found in 12 source files
```

No demo video: everything here is an assertion or a document, and a video of a
green suite is ceremony.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
