### PR TITLE
Make the expensive arms injectable, and the coverage claims true after

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -49,10 +49,9 @@ tests/
 [#136]: https://github.com/rogvid/skills/issues/136
 
 Takes: `web/` and `terminal/` (the two media), the determinism pair, the
-three `resting-*` takes that never place the pointer, the problem takes,
-`segments/` — one demo recorded in two parts and joined with `stitch()` — and
-`evidence/`, a few seconds against what a beat's page text carries and what it
-caps.
+problem takes, `segments/` — one demo recorded in two parts and joined with
+`stitch()` — and `evidence/`, a few seconds against what a beat's page text
+carries and what it caps.
 
 ## Running it
 
@@ -97,8 +96,6 @@ tests/smoke --strict-only         # just the two takes strict=True must refuse
 tests/smoke --issues-only         # just the broken page and the failing
                                   #   commands, which is what check_issues
                                   #   grades (issue #197)
-tests/smoke --pointer-only        # just the takes that never place the
-                                  #   pointer (issue #193)
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -110,7 +107,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~48 s)
-tests/smoke-inject                # all 31 entries, ~35 min
+tests/smoke-inject                # all 30 entries, ~35 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -736,44 +733,6 @@ consistently. The take reads the line and requires `worker <frozen epoch>`.
 All three takes also run `strict=True` (issue #3's machinery), which is what
 would catch the blob shim breaking worker *loading* rather than its clock.
 
-**And the take the park makes impossible** — `tests/smoke --pointer-only`,
-three recordings of the same storyboard with the pointer left exactly where it
-was ([#193](https://github.com/rogvid/skills/issues/193)). The determinism
-takes above park the mouse at `(60, 640)` before anything is photographed,
-which is what makes them reproduce — and also what makes them structurally
-unable to record the case
-[#186](https://github.com/rogvid/skills/issues/186) fixed: a storyboard that
-never moves the pointer, where the recorder's cursor dot is placed by
-Chromium's load-time hover event or by nothing at all. `tests/unit` grades the
-*rule* (`CursorMotion` evaluates the shipped guard against event shapes
-measured off Chromium) and cannot see a browser that changed its mind about
-reporting movement. This arm can.
-
-Three things, in this order:
-
-1. **the control.** At least one of the three takes has to have received a
-   `mousemove` reporting no movement — counted by a listener installed as an
-   init script, because the only one this storyboard gets is dispatched while
-   the page is loading and a listener added after `goto()` returns counts zero
-   of them (measured, 0 events over 10 takes against exactly one, at `(0, 0)`
-   with both deltas 0, when installed before). Without it "the dot is parked"
-   is also true of a take the browser never sent an event to, and the arm
-   would be grading the machine.
-2. **the dot is where the recorder's own stylesheet parks it** — centre
-   `(-40, -40)`, read as a rect off the live page through
-   `getBoundingClientRect`, never as the inline `left`/`top` the recorder's
-   handler writes.
-3. **the three stills are byte-identical**, which is #186's acceptance
-   sentence.
-
-The `tests/smoke-inject` entry names the *second* of those, not the third, and
-that is the whole reason the position check exists. With the guard removed the
-dot lands at the origin in about seven takes in eight — measured, 14 of 16 —
-and stays parked in the rest, both stable within a take. So the byte comparison
-only notices when two takes happened to disagree, while the position check
-notices any take that moved. An intermittent assertion is what
-[#185](https://github.com/rogvid/skills/issues/185) cost three CI runs.
-
 **Segments and the merge** — a demo recorded in two parts and joined by
 `stitch()` ([#7](https://github.com/rogvid/skills/issues/7)). `segments/`
 records the storyboard `SKILL.md` prescribes for a real time-skip: part one,
@@ -1370,7 +1329,6 @@ are what changed that, and they are now load-bearing rather than a convenience.
 | `--coverage-only` | 8 s |
 | `--narration-only` | 8 s |
 | `--strict-only` | 13 s |
-| `--pointer-only` | 15 s |
 | `--determinism-only` | 19 s |
 | `--issues-only` | 26 s |
 | `--polish-only` | 26 s |
@@ -1381,6 +1339,11 @@ are what changed that, and they are now load-bearing rather than a convenience.
 | `--content-only` | 148 s |
 | `--terminal-only` | 186 s |
 | the whole suite | 427 s |
+
+That whole-suite reading includes a 15 s arm the same branch dropped before
+merge (#210), so the tree as it stands is nearer 410 s. It is left as measured
+rather than corrected by subtraction — a number nobody has read off a stopwatch
+is how this row came to say 622 s.
 
 The per-arm figures are the calibration this manifest was built on. The
 whole-suite row is a fresh reading taken while
@@ -1438,7 +1401,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-31 entries, 11 arms, ~35.4 min of takes
+30 entries, 10 arms, ~34.9 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -1460,7 +1423,6 @@ paragraph whose job is to say what this manifest does not cover.
 | `--coverage-only` | 5 | the report flatters the storyboard: nothing reported unclaimed, a claim pointing at the wrong beat or forgetting its segment, an undeclared tag accepted, the finding dropped from `timeline.md` |
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
-| `--pointer-only` | 1 | the recorder's cursor dot goes back to chasing the `mousemove` Chromium fires at load ([#186](https://github.com/rogvid/skills/issues/186)) — aimed at the dot's *position*, never at the still hashes beside it, because with the guard gone the two takes agree about as often as they disagree |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
 | `--segments-only` | 2 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); or every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
@@ -1471,7 +1433,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **19 of `tests/smoke`'s 36 check functions have no entry**, and the harness
+- **19 of `tests/smoke`'s 35 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -1567,6 +1529,22 @@ exactly where `--strict-only` came from.
 
 Things a pass does **not** prove. They are listed because an assertion nobody
 knows is missing is worse than one that is openly absent.
+
+- **The take-level sentence both cursor fixes were accepted on is ungraded.**
+  [#186](https://github.com/rogvid/skills/issues/186) and
+  [#202](https://github.com/rogvid/skills/issues/202) were accepted on "two
+  takes of a storyboard that never moves the pointer produce byte-identical
+  stills". `tests/unit`'s `CursorMotion` grades the *rule* against event shapes
+  measured off three Chromium builds; the determinism arm parks the pointer
+  before anything is photographed and is structurally blind to it. An arm was
+  built for it and removed before merge, because the only event that exercises
+  the guard in such a take — the `mousemove` Chromium dispatches at load — is
+  delivered only when the page's `load` event fires inside 22 ms: 7 of 7 takes
+  under that bar received it, 0 of 9 over it, and the reviewer's box saw 0 of
+  12. Not machine load (7/9 loaded against 8/9 idle) and not listener timing
+  (installed at `readyState: 'loading'`, 7.2-8.4 ms, 16 of 16). The full
+  measurement, and the one route that might still work, are in
+  [#210](https://github.com/rogvid/skills/issues/210).
 
 - **Nothing calls the ElevenLabs API.** The narration take grades everything a
   cache hit reaches — the key, the pacing, the mix — and by construction never

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,7 +38,7 @@ below for what it covers and what it does not.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~32 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~35 min, nightly)
 ├── unit               # the browser-free half (~0.07 s, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff, at exactly the version ci.yml pins (~0.3 s)
@@ -49,9 +49,10 @@ tests/
 [#136]: https://github.com/rogvid/skills/issues/136
 
 Takes: `web/` and `terminal/` (the two media), the determinism pair, the
-problem takes, `segments/` — one demo recorded in two parts and joined with
-`stitch()` — and `evidence/`, a few seconds against what a beat's page text
-carries and what it caps.
+three `resting-*` takes that never place the pointer, the problem takes,
+`segments/` — one demo recorded in two parts and joined with `stitch()` — and
+`evidence/`, a few seconds against what a beat's page text carries and what it
+caps.
 
 ## Running it
 
@@ -93,6 +94,11 @@ tests/smoke --content-only        # just the pair that grades whether a
 tests/smoke --overlay-only        # just the light-interlude pair (#162/#163)
 tests/smoke --coverage-only       # just the acceptance-criterion take (#12)
 tests/smoke --strict-only         # just the two takes strict=True must refuse
+tests/smoke --issues-only         # just the broken page and the failing
+                                  #   commands, which is what check_issues
+                                  #   grades (issue #197)
+tests/smoke --pointer-only        # just the takes that never place the
+                                  #   pointer (issue #193)
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -104,7 +110,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~48 s)
-tests/smoke-inject                # all 25 entries, ~32 min
+tests/smoke-inject                # all 31 entries, ~35 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -730,6 +736,44 @@ consistently. The take reads the line and requires `worker <frozen epoch>`.
 All three takes also run `strict=True` (issue #3's machinery), which is what
 would catch the blob shim breaking worker *loading* rather than its clock.
 
+**And the take the park makes impossible** — `tests/smoke --pointer-only`,
+three recordings of the same storyboard with the pointer left exactly where it
+was ([#193](https://github.com/rogvid/skills/issues/193)). The determinism
+takes above park the mouse at `(60, 640)` before anything is photographed,
+which is what makes them reproduce — and also what makes them structurally
+unable to record the case
+[#186](https://github.com/rogvid/skills/issues/186) fixed: a storyboard that
+never moves the pointer, where the recorder's cursor dot is placed by
+Chromium's load-time hover event or by nothing at all. `tests/unit` grades the
+*rule* (`CursorMotion` evaluates the shipped guard against event shapes
+measured off Chromium) and cannot see a browser that changed its mind about
+reporting movement. This arm can.
+
+Three things, in this order:
+
+1. **the control.** At least one of the three takes has to have received a
+   `mousemove` reporting no movement — counted by a listener installed as an
+   init script, because the only one this storyboard gets is dispatched while
+   the page is loading and a listener added after `goto()` returns counts zero
+   of them (measured, 0 events over 10 takes against exactly one, at `(0, 0)`
+   with both deltas 0, when installed before). Without it "the dot is parked"
+   is also true of a take the browser never sent an event to, and the arm
+   would be grading the machine.
+2. **the dot is where the recorder's own stylesheet parks it** — centre
+   `(-40, -40)`, read as a rect off the live page through
+   `getBoundingClientRect`, never as the inline `left`/`top` the recorder's
+   handler writes.
+3. **the three stills are byte-identical**, which is #186's acceptance
+   sentence.
+
+The `tests/smoke-inject` entry names the *second* of those, not the third, and
+that is the whole reason the position check exists. With the guard removed the
+dot lands at the origin in about seven takes in eight — measured, 14 of 16 —
+and stays parked in the rest, both stable within a take. So the byte comparison
+only notices when two takes happened to disagree, while the position check
+notices any take that moved. An intermittent assertion is what
+[#185](https://github.com/rogvid/skills/issues/185) cost three CI runs.
+
 **Segments and the merge** — a demo recorded in two parts and joined by
 `stitch()` ([#7](https://github.com/rogvid/skills/issues/7)). `segments/`
 records the storyboard `SKILL.md` prescribes for a real time-skip: part one,
@@ -1326,7 +1370,9 @@ are what changed that, and they are now load-bearing rather than a convenience.
 | `--coverage-only` | 8 s |
 | `--narration-only` | 8 s |
 | `--strict-only` | 13 s |
+| `--pointer-only` | 15 s |
 | `--determinism-only` | 19 s |
+| `--issues-only` | 26 s |
 | `--polish-only` | 26 s |
 | `--segments-only` | 29 s |
 | `--overlay-only` | 31 s |
@@ -1334,7 +1380,25 @@ are what changed that, and they are now load-bearing rather than a convenience.
 | `--web-only` | 123 s |
 | `--content-only` | 148 s |
 | `--terminal-only` | 186 s |
-| the whole suite | 622 s |
+| the whole suite | 427 s |
+
+The per-arm figures are the calibration this manifest was built on. The
+whole-suite row is a fresh reading taken while
+[#197](https://github.com/rogvid/skills/issues/197) split the arms below, and
+it replaces a **622 s** that had been sitting here wrong: `--web-only` and
+`--terminal-only` are disjoint and re-measured at 133 s and 187 s on the same
+run, which with the determinism, segments, failure and pointer arms accounts
+for the whole 427 s to within a few seconds. Nothing got faster; the old number
+was never checked, which is the same reason every figure in **What it covers**
+below is now read back out of this file rather than maintained by hand. The
+per-arm rows were spot-checked in the same session and held (`--segments-only`
+28 s, `--evidence-only` 6 s); `--web-only`'s 123 s is the one that has drifted,
+and it is left as-is rather than churned on a single reading.
+
+**What that ratio means for what runs per push**: the two medium arms are 75%
+of the suite, and neither is reducible — `check_caption` and `check_beat_frames`
+are pixel measurements. What #197 changed is that they are no longer the *only*
+way to reach the claims that do not need pixels.
 
 `--strict-only` was added *for* this file. The two takes `strict=True` must
 refuse record in thirteen seconds between them, and were reachable only from
@@ -1374,7 +1438,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-25 entries, 7 arms, ~31.9 min of takes
+31 entries, 11 arms, ~35.4 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -1396,6 +1460,10 @@ paragraph whose job is to say what this manifest does not cover.
 | `--coverage-only` | 5 | the report flatters the storyboard: nothing reported unclaimed, a claim pointing at the wrong beat or forgetting its segment, an undeclared tag accepted, the finding dropped from `timeline.md` |
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
+| `--pointer-only` | 1 | the recorder's cursor dot goes back to chasing the `mousemove` Chromium fires at load ([#186](https://github.com/rogvid/skills/issues/186)) — aimed at the dot's *position*, never at the still hashes beside it, because with the guard gone the two takes agree about as often as they disagree |
+| `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
+| `--segments-only` | 2 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); or every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins |
+| `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
 | `--web-only` | 6 | the form verbs lie about what they did: `press` logging a key it never sent or returning before the page saw it, `clear` selecting without deleting or emptying the field between two frames, either of them driving the page and writing no beat |
@@ -1403,21 +1471,50 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **22 of `tests/smoke`'s 35 check functions have no entry**, and the harness
+- **19 of `tests/smoke`'s 36 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
-  leaving the boundary to somebody's memory. Every check function this bullet
-  names in backticks is checked against that list too, not just the count —
-  one of them stayed written here as uncovered for as long as it had six
-  entries aimed at it, and a count would never have said so. The large ones
-  are there for cost:
-  `check_take`, `check_timeline`, `check_beat_frames`, `check_issues`
-  and `check_caption` live on `--web-only`/`--terminal-only`
-  (123 s and 186 s an injection), and `check_determinism`, `check_merge_offset`
-  and the narration pair each carry their own arm nobody has aimed an entry at
-  yet. Adding one is cheap in effort and expensive in wall clock; that trade is
-  the thing to think about, not the count, and
-  [#173](https://github.com/rogvid/skills/issues/173) is where it is written
-  down with the numbers.
+  leaving the boundary to somebody's memory.
+
+  **`ungraded` is not the same as graded by nothing**, and by
+  [#196](https://github.com/rogvid/skills/issues/196) that difference had grown
+  to most of the list: after [#195](https://github.com/rogvid/skills/issues/195)
+  the browser-free half of several of these is certified in `tests/unit`, where
+  an injection costs 0.2 s. A reader who followed the run's closing line here
+  and concluded that nothing watched them was reading a document written before
+  that. So the roster below answers per function, and it is read back out of
+  this file as text and compared against the manifest **both ways** by
+  `--self-test`: a name missing from it is a reader sent to a table their
+  function is not in, and a name in it that has an entry is the older mistake —
+  one check function stayed written here as uncovered for as long as it had six
+  entries aimed at it, and a count would never have said so.
+
+  | ungraded check function | what carries its browser-free claims |
+  |---|---|
+  | `check_take` | `ContentRect` — the rect the picture half is scored over, exactly, on all four numbers (#135/#195). The artifact half — the files exist, are this run's, and are not repeats of one another — is genuinely ungraded |
+  | `check_content_healthy` | `ContentRect`, same six tests: the trim reaches the caption bar on both media, does not eat the app, and never comes back zero-sized |
+  | `check_caption` | genuinely ungraded as a *picture*. `CaptionTruth` grades which caption a beat is stamped with across a navigation (#134), never that the bar was drawn |
+  | `check_healthy` | `TakeIssues` — `test_an_app_talking_is_not_an_app_failing` and the HTTP bar graded at 400 rather than inside it are the over-reporting direction, off the browser. That a real page under `strict=True` produces none of them is this suite's |
+  | `check_verb_classification` | `VerbClassification` — every classified verb is one a recorder logs, and every verb a recorder logs is classified, with the set size asserted first so neither holds vacuously |
+  | `check_determinism` | genuinely ungraded. It reads the clock, the locale and the motion setting *out of the page*, which is the whole point of it — a constructor that stored the flag and never wired it up satisfies anything asserted on the Python side |
+  | `check_merge_offset` | genuinely ungraded. `MergeContent` grades the merge of the content *report* (#121); the per-segment caption timing this measures against two mp4s has no browser-free half |
+  | `check_opening_gap` | `OpeningWarning` — `held: null` against `held: 0.0`, and the blank floor that keeps the warning readable |
+  | `check_opening` | genuinely ungraded — the first frame of a web take, measured in pixels (#119) |
+  | `check_opening_card` | genuinely ungraded — three statements about one sweep of one corner of a frame (#110) |
+  | `check_spotlight_transitions` | genuinely ungraded — the shape of the spotlight's exit, sampled frame by frame (#111) |
+  | `check_narration_pacing` | genuinely ungraded. `TtsKey` covers the cache key a clip is stored under, not the beat spacing this measures |
+  | `check_narration_audio` | genuinely ungraded — mean dBFS over stretches of the mp4 |
+  | `_check_video` | genuinely ungraded — ffprobe against the file the take wrote |
+  | `_check_occlusion` | genuinely ungraded — PSNR between two moments of a recording |
+  | `_check_frame_captions` | genuinely ungraded — the caption band of frame N read against the hand-written storyboard |
+  | `_check_stale_frames` | genuinely ungraded. `FailureCleanup` is the same shape for the failure dump, not for `frames/` |
+  | `_check_segment_refusal` | genuinely ungraded — an unmerged segment's document, graded against the frames a recorder did not write |
+  | `_check_scene_fallback` | genuinely ungraded — measured straight off `demo.mp4`, because no beat in either storyboard is long enough to provoke it |
+
+  What is left in that list is there for cost or for pixels, and the two are
+  different problems. #197 took the cost half as far as it goes for now: the
+  claims that only needed *a* take rather than the long one moved to
+  `--issues-only` (26 s), `--segments-only` (29 s) and `--evidence-only` (7 s).
+  What did not move is what needs a picture, and no arm makes that cheaper.
 - **It does not find assertions nobody wrote.** Every entry names a message
   that already exists. A behaviour with no check at all is invisible here —
   that is [#103](https://github.com/rogvid/skills/issues/103)'s shape and still

--- a/tests/smoke
+++ b/tests/smoke
@@ -502,13 +502,28 @@ _CURSOR_BOX_JS = """() => {
 # number into the wrong place.
 RESTING_POINTER = (-40, -40)
 
-# Three takes, and the number is the assertion's error bar rather than taste.
-# With the guard removed, Chromium's load-time mousemove moved the dot in 14 of
-# 16 takes measured on this box; the two that stayed parked received no
-# mousemove at all. One take would therefore miss the regression about one time
-# in eight and three miss it about one time in five hundred — and the run that
-# would have missed it is the run whose premise guard below refuses instead, so
-# what is left is an honest "this arm proved nothing today", never a pass.
+# The position the recorder's overlay seeds its remembered pointer with, and
+# where a fresh page's pointer sits. The load-time `mousemove` Chromium
+# dispatches lands here, repeating a position the overlay has already been told
+# about, and dropping it is the whole of #202's rule — so this is the number
+# the control in `run_resting_pointer` looks for.
+#
+# Hardcoded rather than imported from `web.py`, deliberately: a control that
+# read the seed out of the code under test would agree with a recorder that
+# seeded it anywhere at all, including somewhere no browser ever sends an
+# event to.
+CURSOR_SEED = (0, 0)
+
+# Three takes, and the number is the control's error bar rather than taste.
+# Measured on this box, Chromium 151.0.7922.34: 13 of 15 takes received the
+# load-time mousemove and 2 received none at all. So one take would be unable
+# to grade the rule about one time in eight, and three about one time in five
+# hundred — and the run that cannot grade it refuses below rather than passing.
+#
+# It is a real refusal and it has been seen: the rebase onto #202 hit exactly
+# that run, all three takes empty. Raising this to 4 would buy an order of
+# magnitude for 5 s, and it is not done here only because the arm's cost is
+# written down in `tests/smoke-inject` and `tests/README.md`. See #205.
 RESTING_TAKES = 3
 RESTING_SHOT = "01-resting"
 RESTING_SETTLE_S = 1.0
@@ -517,12 +532,18 @@ RESTING_SETTLE_S = 1.0
 # place before the document exists. That is not fussiness: the only mousemove
 # this storyboard gets is the one Chromium dispatches while the page is
 # loading, and a listener added after `goto()` returns counts zero of them
-# (measured, 0 events over 10 takes, against exactly one — at (0, 0), with
-# `movementX` and `movementY` both 0 — over 10 takes when installed here).
+# (measured, 0 events over 10 takes, against exactly one — at (0, 0) — over 16
+# takes when installed here).
 #
-# It exists for the control in `run_resting_pointer`: "the dot is parked" is
-# also true of a take the browser never sent an event to, and a check that
-# cannot tell those two apart grades the machine rather than the recorder.
+# **Positions are logged and graded; the deltas are logged and not graded**,
+# and that distinction is issue #202. `movementX`/`movementY` for the *first*
+# mouse event in a page is a build detail — `web.py`'s own table has Chromium
+# 147 reporting 0, 0 for a park at (60, 640) where 136 and 151 report 60, 640 —
+# so a control keyed on "the deltas are zero" is the reading #202 took out of
+# the product, left behind in the harness. On a build that reports a non-zero
+# delta for the settle event it would refuse a take that did receive one, which
+# is a false "this arm could not grade it". They stay in the log because a
+# refusal that prints them is what identified this in the first place.
 _MOVE_LOG_JS = """
 (() => {
   window.__smokeMoves = [];
@@ -7959,18 +7980,37 @@ def run_resting_pointer(out_root: Path) -> list[str]:
             failures += takes[label].problems
 
     # -- the control ---------------------------------------------------------
-    settled = {
-        name: [m for m in take.moves if m[2] == 0 and m[3] == 0]
-        for name, take in takes.items()
+    #
+    # Two refusals, not one, because "the browser sent nothing" and "the
+    # browser sent something this arm is not about" are different reports and
+    # only the first is a property of the machine. Both are failures: an arm
+    # that could not grade the rule has to say so, and a green run saying it in
+    # a print nobody reads is how the boundary goes back to being somebody's
+    # memory.
+    seen = {name: take.moves for name, take in takes.items()}
+    repeats = {
+        name: [m for m in moves if (m[0], m[1]) == CURSOR_SEED]
+        for name, moves in seen.items()
     }
-    if not any(settled.values()):
+    if not any(seen.values()):
         return failures + [
-            f"resting-pointer: not one of the {RESTING_TAKES} takes saw a "
-            f"mousemove reporting no movement, so nothing in this arm "
-            f"exercised the guard it exists to grade — the dot being parked "
-            f"is true of a page the browser never sent an event to. Every "
-            f"mousemove seen: "
-            f"{ {name: take.moves for name, take in takes.items()}!r}"
+            f"resting-pointer: none of the {RESTING_TAKES} takes saw a "
+            f"mousemove at all, so this arm could not grade the rule it exists "
+            f"for — the dot being parked is equally true of a page the browser "
+            f"never sent an event to. That is the machine, not the recorder: "
+            f"Chromium dispatches this event on a load and 2 takes in 15 do "
+            f"not get one on the build this was measured on. Re-run "
+            f"--pointer-only; if it keeps happening the build has stopped "
+            f"sending it and #205 is where that is recorded."
+        ]
+    if not any(repeats.values()):
+        return failures + [
+            f"resting-pointer: the takes saw mousemove(s) {seen!r}, and not "
+            f"one of them repeats the {CURSOR_SEED} the recorder's overlay "
+            f"seeds its remembered pointer with — so nothing here exercised "
+            f"the guard that drops a move to a position the pointer was "
+            f"already at, which is the rule (#202) this arm grades. A take "
+            f"whose only events are real moves says nothing about it."
         ]
 
     # -- the stills ----------------------------------------------------------
@@ -8012,7 +8052,8 @@ def run_resting_pointer(out_root: Path) -> list[str]:
             f"smoke: resting-pointer {RESTING_TAKES} takes that place no "
             f"pointer leave the dot at {RESTING_POINTER} and reproduce "
             f"{RESTING_SHOT}.png byte for byte "
-            f"({sum(len(v) for v in settled.values())} no-movement mousemove(s) "
+            f"({sum(len(v) for v in repeats.values())} mousemove(s) repeating "
+            f"{CURSOR_SEED} "
             f"delivered across them)"
         )
     return failures

--- a/tests/smoke
+++ b/tests/smoke
@@ -482,77 +482,6 @@ _CURSOR_BOX_JS = """() => {
   return {x: r.x, y: r.y, width: r.width, height: r.height};
 }"""
 
-# -- and the take the park makes structurally impossible (issue #193) --------
-#
-# `PARKED_POINTER` is what makes the determinism arm reproduce, and it is also
-# what makes that arm blind to the defect #186 fixed: it places the pointer
-# before anything is photographed, so `check_parked_pointer` passes whether or
-# not the recorder's dot follows a mousemove that reports no movement. The
-# take-level claim of #186 — *two takes of a storyboard that never moves the
-# pointer produce byte-identical stills* — needs a storyboard that does not
-# park, which is what `run_resting_pointer` records.
-#
-# Where the dot sits in such a take is decided by the recorder's own
-# stylesheet: `#__demo_cursor` is `position: fixed; left: -40px; top: -40px`
-# under `transform: translate(-50%,-50%)`, so its rect is centred on
-# (-40, -40) — off screen — until a pointer verb moves it for the first time.
-# Read as a rect through `_CURSOR_BOX_JS`, exactly as `PARKED_POINTER` is, and
-# never as the inline `left`/`top` the recorder's handler writes: a check that
-# reads the producer's bookkeeping cannot see a producer that writes the right
-# number into the wrong place.
-RESTING_POINTER = (-40, -40)
-
-# The position the recorder's overlay seeds its remembered pointer with, and
-# where a fresh page's pointer sits. The load-time `mousemove` Chromium
-# dispatches lands here, repeating a position the overlay has already been told
-# about, and dropping it is the whole of #202's rule — so this is the number
-# the control in `run_resting_pointer` looks for.
-#
-# Hardcoded rather than imported from `web.py`, deliberately: a control that
-# read the seed out of the code under test would agree with a recorder that
-# seeded it anywhere at all, including somewhere no browser ever sends an
-# event to.
-CURSOR_SEED = (0, 0)
-
-# Three takes, and the number is the control's error bar rather than taste.
-# Measured on this box, Chromium 151.0.7922.34: 13 of 15 takes received the
-# load-time mousemove and 2 received none at all. So one take would be unable
-# to grade the rule about one time in eight, and three about one time in five
-# hundred — and the run that cannot grade it refuses below rather than passing.
-#
-# It is a real refusal and it has been seen: the rebase onto #202 hit exactly
-# that run, all three takes empty. Raising this to 4 would buy an order of
-# magnitude for 5 s, and it is not done here only because the arm's cost is
-# written down in `tests/smoke-inject` and `tests/README.md`. See #205.
-RESTING_TAKES = 3
-RESTING_SHOT = "01-resting"
-RESTING_SETTLE_S = 1.0
-
-# Every mousemove the page sees, installed as an **init script** so it is in
-# place before the document exists. That is not fussiness: the only mousemove
-# this storyboard gets is the one Chromium dispatches while the page is
-# loading, and a listener added after `goto()` returns counts zero of them
-# (measured, 0 events over 10 takes, against exactly one — at (0, 0) — over 16
-# takes when installed here).
-#
-# **Positions are logged and graded; the deltas are logged and not graded**,
-# and that distinction is issue #202. `movementX`/`movementY` for the *first*
-# mouse event in a page is a build detail — `web.py`'s own table has Chromium
-# 147 reporting 0, 0 for a park at (60, 640) where 136 and 151 report 60, 640 —
-# so a control keyed on "the deltas are zero" is the reading #202 took out of
-# the product, left behind in the harness. On a build that reports a non-zero
-# delta for the settle event it would refuse a take that did receive one, which
-# is a false "this arm could not grade it". They stay in the log because a
-# refusal that prints them is what identified this in the first place.
-_MOVE_LOG_JS = """
-(() => {
-  window.__smokeMoves = [];
-  window.addEventListener('mousemove', (e) => window.__smokeMoves.push(
-    [e.clientX, e.clientY, e.movementX, e.movementY]), true);
-})();
-"""
-_MOVE_LOG_READ_JS = "() => window.__smokeMoves || []"
-
 # Stills are lossless PNGs of a frozen page, so two takes of this storyboard
 # are compared byte for byte and no threshold is needed. Video is different:
 # H.264 at crf 20 is not byte-reproducible and the screencast's frame timing
@@ -2348,47 +2277,6 @@ def check_parked_pointer(b: Beats, page, when: str) -> None:
     )
 
 
-def check_resting_pointer(b: Beats, page, when: str) -> None:
-    """The cursor dot is where the *stylesheet* parks it (issue #193).
-
-    The other half of `check_parked_pointer`, and the half no arm could make
-    before: that one asserts the dot is where the storyboard *put* it, which
-    is satisfied by a recorder whose dot chases Chromium's load-time
-    mousemove, because the storyboard's own `page.mouse.move` runs after it.
-    This one is asserted in a take no verb moved the pointer in, so the only
-    thing that can have moved the dot is an event the recorder should have
-    ignored.
-
-    Read as a rect off the live page, like `check_parked_pointer` — never the
-    inline `left`/`top` the recorder's handler writes, which is the producer's
-    own bookkeeping and shares whatever blind spot the producer has.
-
-    Failing on a missing dot is deliberate, for the same reason as above: a
-    recorder that stopped drawing a cursor would make this silently unable to
-    fail, while its stills would reproduce perfectly.
-    """
-    box = page.evaluate(_CURSOR_BOX_JS)
-    if box is None:
-        b.fail_if(
-            True,
-            f"{when}, the recorder drew no cursor dot (#__demo_cursor is not "
-            f"in the page) — a take with no dot in it cannot say where an "
-            f"unmoved pointer leaves one",
-        )
-        return
-    at = (box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
-    b.fail_if(
-        abs(at[0] - RESTING_POINTER[0]) > 1 or abs(at[1] - RESTING_POINTER[1]) > 1,
-        f"{when}, no verb moved the pointer and the cursor dot is centred at "
-        f"({at[0]:.0f}, {at[1]:.0f}), not at the "
-        f"({RESTING_POINTER[0]}, {RESTING_POINTER[1]}) the recorder's own "
-        f"stylesheet parks it at — something other than the storyboard is "
-        f"placing the cursor, which is issue #186: a mousemove reporting no "
-        f"movement is Chromium recomputing hover at the position the pointer "
-        f"is already at, and following it makes the dot's position a race",
-    )
-
-
 # What has the focus, as a name a failure message can print: the element's id
 # when it has one, and its tag when it does not — `blur()` hands focus back to
 # `<body>`, which has no id and would otherwise read as the empty string beside
@@ -3303,56 +3191,6 @@ def record_entropy(out_dir: Path, base_url: str, deterministic: bool) -> Entropy
             max(2, int(box["height"] * scale_y)),
         )
     return EntropyTake(b.problems, out_dir, clock, still_rect, video_rect, spin_rect)
-
-
-class RestingTake(NamedTuple):
-    """One recording of a storyboard that never places the pointer (#193)."""
-
-    problems: list[str]
-    still: Path
-    panel: Rect  # the entropy panel, for the difference diagnostic
-    moves: list  # every mousemove the page saw, as [x, y, movementX, movementY]
-
-
-def record_resting(out_dir: Path, base_url: str, label: str) -> RestingTake:
-    """The entropy storyboard with the pointer left exactly where it was.
-
-    `record_entropy` minus the `page.mouse.move(*PARKED_POINTER)` line and
-    minus the second still, and that subtraction is the whole point: the park
-    is what makes the determinism arm structurally unable to record the case
-    issue #186 is about. Same page and same determinism controls, so the
-    stills are byte-comparable for the same reasons the entropy ones are —
-    what is not the same is that nothing in here decides where the cursor
-    goes.
-    """
-    from demo_recording import Recorder
-
-    b = Beats(label)
-    with Recorder(
-        out_dir, base_url=base_url, speech=False, strict=True, deterministic=True
-    ) as rec:
-        rec.page.add_init_script(_MOVE_LOG_JS)
-        rec.goto("/?entropy=1")
-        rec.wait_for("#entropy-worker.ready", timeout_s=15)
-        rec.pause(RESTING_SETTLE_S)
-        rec.shot(RESTING_SHOT)
-        # After the still, so it grades the frame that was actually taken.
-        check_resting_pointer(b, rec.page, f"in {label}")
-        moves = rec.page.evaluate(_MOVE_LOG_READ_JS) or []
-        box = rec.page.locator("#entropy-panel").bounding_box()
-        if box is None:
-            raise SmokeFailure(
-                "#entropy-panel has no box — ?entropy=1 rendered nothing"
-            )
-        panel: Rect = (
-            int(box["x"]),
-            int(box["y"]),
-            int(box["width"]),
-            int(box["height"]),
-        )
-    return RestingTake(
-        b.problems, out_dir / "images" / f"{RESTING_SHOT}.png", panel, moves
-    )
 
 
 # -- assertions --------------------------------------------------------------
@@ -7937,128 +7775,6 @@ def run_determinism(out_root: Path) -> list[str]:
     return failures
 
 
-def run_resting_pointer(out_root: Path) -> list[str]:
-    """Record a storyboard that never places the pointer, three times (#193).
-
-    The acceptance criterion of issue #186, at the level the fix was actually
-    made at. `tests/unit` grades the *rule* — the guard is read out of the
-    shipped overlay and evaluated against event shapes measured off Chromium —
-    and cannot see a browser that started reporting movement for its
-    hover-recompute event. The determinism arm cannot see it either, because
-    `PARKED_POINTER` decides the dot's position there before anything is
-    photographed. This is the arm that can.
-
-    Three assertions, and the order matters:
-
-    1. **the control**, first, because everything else is satisfied by a take
-       nothing happened in: at least one take has to have received a mousemove
-       reporting no movement. That event is the whole subject; a run that did
-       not get one has not exercised the guard, and saying "the dot is parked"
-       about it would be the catalogue's environment-agreeing assertion.
-    2. **the dot is where the stylesheet parks it**, per take, in
-       `check_resting_pointer` — read off the live page.
-    3. **the stills are byte-identical across takes**, which is #186's own
-       acceptance sentence. Deliberately *not* the assertion an injection is
-       registered against: with the guard removed the two positions the dot
-       lands in are both stable within a take, so this comparison only fires
-       when two takes happened to disagree — about one run in two, and rather
-       less on an idle box. An intermittent assertion is what issue #185 cost
-       three CI runs.
-    """
-    failures: list[str] = []
-    takes: dict[str, RestingTake] = {}
-    with fixture_server() as base_url:
-        for i in range(RESTING_TAKES):
-            label = f"resting-{i}"
-            out_dir = fresh_take_dir(out_root, label)
-            try:
-                takes[label] = record_resting(out_dir, base_url, label)
-            except Exception as exc:  # noqa: BLE001 - a raising take is a failure
-                return failures + [
-                    f"{label}: Recorder raised {type(exc).__name__}: {exc}"
-                ]
-            failures += takes[label].problems
-
-    # -- the control ---------------------------------------------------------
-    #
-    # Two refusals, not one, because "the browser sent nothing" and "the
-    # browser sent something this arm is not about" are different reports and
-    # only the first is a property of the machine. Both are failures: an arm
-    # that could not grade the rule has to say so, and a green run saying it in
-    # a print nobody reads is how the boundary goes back to being somebody's
-    # memory.
-    seen = {name: take.moves for name, take in takes.items()}
-    repeats = {
-        name: [m for m in moves if (m[0], m[1]) == CURSOR_SEED]
-        for name, moves in seen.items()
-    }
-    if not any(seen.values()):
-        return failures + [
-            f"resting-pointer: none of the {RESTING_TAKES} takes saw a "
-            f"mousemove at all, so this arm could not grade the rule it exists "
-            f"for — the dot being parked is equally true of a page the browser "
-            f"never sent an event to. That is the machine, not the recorder: "
-            f"Chromium dispatches this event on a load and 2 takes in 15 do "
-            f"not get one on the build this was measured on. Re-run "
-            f"--pointer-only; if it keeps happening the build has stopped "
-            f"sending it and #205 is where that is recorded."
-        ]
-    if not any(repeats.values()):
-        return failures + [
-            f"resting-pointer: the takes saw mousemove(s) {seen!r}, and not "
-            f"one of them repeats the {CURSOR_SEED} the recorder's overlay "
-            f"seeds its remembered pointer with — so nothing here exercised "
-            f"the guard that drops a move to a position the pointer was "
-            f"already at, which is the rule (#202) this arm grades. A take "
-            f"whose only events are real moves says nothing about it."
-        ]
-
-    # -- the stills ----------------------------------------------------------
-    live: dict[str, Path] = {}
-    for name, take in takes.items():
-        if not take.still.is_file():
-            failures.append(f"{name}: {take.still} was never captured")
-            continue
-        frames = gray_frames(take.still)
-        score = contrast(frames[0]) if frames else 0.0
-        if score < MIN_CONTENT_STDDEV["web"]:
-            failures.append(
-                f"{name}: {take.still.name} is blank — the whole frame scores "
-                f"{score:.1f} luma stddev, under the "
-                f"{MIN_CONTENT_STDDEV['web']} floor, so two of them being "
-                f"equal says nothing"
-            )
-            continue
-        live[name] = take.still
-    names = sorted(live)
-    first = names[0] if names else None
-    for other in names[1:]:
-        if digest(live[first]) != digest(live[other]):
-            failures.append(
-                f"resting-pointer: {RESTING_SHOT}.png differs between {first} "
-                f"and {other} ({digest(live[first])} vs {digest(live[other])}) "
-                f"— two takes of a storyboard that never moves the pointer do "
-                f"not reproduce, which is issue #186's acceptance criterion. "
-                f"{still_difference(live[first], live[other], takes[first].panel)}"
-            )
-    if len(names) < RESTING_TAKES:
-        failures.append(
-            f"resting-pointer: only {len(names)} of {RESTING_TAKES} takes "
-            f"produced a still worth comparing, so the reproduction claim was "
-            f"made over fewer takes than this arm records"
-        )
-    if not failures:
-        print(
-            f"smoke: resting-pointer {RESTING_TAKES} takes that place no "
-            f"pointer leave the dot at {RESTING_POINTER} and reproduce "
-            f"{RESTING_SHOT}.png byte for byte "
-            f"({sum(len(v) for v in repeats.values())} mousemove(s) repeating "
-            f"{CURSOR_SEED} "
-            f"delivered across them)"
-        )
-    return failures
-
-
 def _plant_mp4(path: Path) -> bytes:
     """A small, real, decodable mp4 at `path`. Returns its bytes.
 
@@ -9991,11 +9707,6 @@ def main() -> int:
         "what check_issues grades (issue #197)",
     )
     parser.add_argument(
-        "--pointer-only",
-        action="store_true",
-        help="record only the takes that never place the pointer (issue #193)",
-    )
-    parser.add_argument(
         "--allow-concurrent",
         action="store_true",
         help="run even when another suite holds the machine lock. The timing "
@@ -10032,7 +9743,6 @@ def main() -> int:
             ("--coverage-only", args.coverage_only),
             ("--strict-only", args.strict_only),
             ("--issues-only", args.issues_only),
-            ("--pointer-only", args.pointer_only),
         )
         if on
     ]
@@ -10154,13 +9864,6 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
         failures += run_strict_terminal(out_root)
     if only in (None, "--determinism-only"):
         failures += run_determinism(out_root)
-    # The pointer-free case (#193). Its own arm and deliberately *not* on
-    # --determinism-only: it is three more takes, and putting them there would
-    # make every entry aimed at that arm 60% more expensive without covering
-    # any of them. What it does cover, no other arm can — the determinism
-    # storyboard parks the pointer before anything is photographed.
-    if only in (None, "--pointer-only"):
-        failures += run_resting_pointer(out_root)
     # What a take that did *not* finish leaves behind. Last, because every
     # phase above records a take that works, and reading "crash-web wrote no
     # demo.mp4" before "web wrote no demo.mp4" would send somebody to the

--- a/tests/smoke
+++ b/tests/smoke
@@ -482,6 +482,56 @@ _CURSOR_BOX_JS = """() => {
   return {x: r.x, y: r.y, width: r.width, height: r.height};
 }"""
 
+# -- and the take the park makes structurally impossible (issue #193) --------
+#
+# `PARKED_POINTER` is what makes the determinism arm reproduce, and it is also
+# what makes that arm blind to the defect #186 fixed: it places the pointer
+# before anything is photographed, so `check_parked_pointer` passes whether or
+# not the recorder's dot follows a mousemove that reports no movement. The
+# take-level claim of #186 — *two takes of a storyboard that never moves the
+# pointer produce byte-identical stills* — needs a storyboard that does not
+# park, which is what `run_resting_pointer` records.
+#
+# Where the dot sits in such a take is decided by the recorder's own
+# stylesheet: `#__demo_cursor` is `position: fixed; left: -40px; top: -40px`
+# under `transform: translate(-50%,-50%)`, so its rect is centred on
+# (-40, -40) — off screen — until a pointer verb moves it for the first time.
+# Read as a rect through `_CURSOR_BOX_JS`, exactly as `PARKED_POINTER` is, and
+# never as the inline `left`/`top` the recorder's handler writes: a check that
+# reads the producer's bookkeeping cannot see a producer that writes the right
+# number into the wrong place.
+RESTING_POINTER = (-40, -40)
+
+# Three takes, and the number is the assertion's error bar rather than taste.
+# With the guard removed, Chromium's load-time mousemove moved the dot in 14 of
+# 16 takes measured on this box; the two that stayed parked received no
+# mousemove at all. One take would therefore miss the regression about one time
+# in eight and three miss it about one time in five hundred — and the run that
+# would have missed it is the run whose premise guard below refuses instead, so
+# what is left is an honest "this arm proved nothing today", never a pass.
+RESTING_TAKES = 3
+RESTING_SHOT = "01-resting"
+RESTING_SETTLE_S = 1.0
+
+# Every mousemove the page sees, installed as an **init script** so it is in
+# place before the document exists. That is not fussiness: the only mousemove
+# this storyboard gets is the one Chromium dispatches while the page is
+# loading, and a listener added after `goto()` returns counts zero of them
+# (measured, 0 events over 10 takes, against exactly one — at (0, 0), with
+# `movementX` and `movementY` both 0 — over 10 takes when installed here).
+#
+# It exists for the control in `run_resting_pointer`: "the dot is parked" is
+# also true of a take the browser never sent an event to, and a check that
+# cannot tell those two apart grades the machine rather than the recorder.
+_MOVE_LOG_JS = """
+(() => {
+  window.__smokeMoves = [];
+  window.addEventListener('mousemove', (e) => window.__smokeMoves.push(
+    [e.clientX, e.clientY, e.movementX, e.movementY]), true);
+})();
+"""
+_MOVE_LOG_READ_JS = "() => window.__smokeMoves || []"
+
 # Stills are lossless PNGs of a frozen page, so two takes of this storyboard
 # are compared byte for byte and no threshold is needed. Video is different:
 # H.264 at crf 20 is not byte-reproducible and the screencast's frame timing
@@ -1523,6 +1573,28 @@ EVIDENCE_BLOAT_JS = """(n) => {
   document.body.appendChild(box);
 }""".replace("__ID__", EVIDENCE_BLOAT_ID)
 
+# What `check_evidence` must be able to read out of *this* take's evidence, in
+# the same (verb, target, present, absent) shape `WEB_EVIDENCE` uses.
+#
+# Its reason for existing is cost rather than a new claim. `check_evidence`
+# carries issue #9's acceptance criterion, and until #197 the only arms that
+# reached it were `--web-only` (123 s) and `--terminal-only` (186 s); this take
+# is 7 s and already writes evidence for nine beats.
+#
+# Every fact here is one the storyboard puts on screen at a *known* beat and
+# not before: `#smoke-source` and `#smoke-bloat` are injected mid-take, so a
+# recorder that captured the page once and stamped that capture onto every
+# beat has each of them missing from the beat that showed it. `absent` is left
+# empty on purpose — nothing this storyboard shows is later taken away, and
+# `check_evidence`'s absent-message says the value "belongs to an earlier state
+# of the page", which is the wrong sentence about a fact that belongs to a
+# later one.
+EVIDENCE_TAKE_FACTS = [
+    ("wait_for", EVIDENCE_ATTR_TARGET, [EVIDENCE_RENDERED_TEXT], []),
+    ("spotlight", f"#{EVIDENCE_SOURCE_ID}", [EVIDENCE_SOURCE_RENDERED], []),
+    ("spotlight", f"#{EVIDENCE_BLOAT_ID}", ["bloat row 0"], []),
+]
+
 
 class _StoryboardFailed(RuntimeError):
     """What a storyboard raises when a sync verb gives up.
@@ -2252,6 +2324,47 @@ def check_parked_pointer(b: Beats, page, when: str) -> None:
         f"parked the pointer at — its position is being set by something other "
         f"than the storyboard, and whatever that is decides whether two takes "
         f"of this storyboard produce the same pixels",
+    )
+
+
+def check_resting_pointer(b: Beats, page, when: str) -> None:
+    """The cursor dot is where the *stylesheet* parks it (issue #193).
+
+    The other half of `check_parked_pointer`, and the half no arm could make
+    before: that one asserts the dot is where the storyboard *put* it, which
+    is satisfied by a recorder whose dot chases Chromium's load-time
+    mousemove, because the storyboard's own `page.mouse.move` runs after it.
+    This one is asserted in a take no verb moved the pointer in, so the only
+    thing that can have moved the dot is an event the recorder should have
+    ignored.
+
+    Read as a rect off the live page, like `check_parked_pointer` — never the
+    inline `left`/`top` the recorder's handler writes, which is the producer's
+    own bookkeeping and shares whatever blind spot the producer has.
+
+    Failing on a missing dot is deliberate, for the same reason as above: a
+    recorder that stopped drawing a cursor would make this silently unable to
+    fail, while its stills would reproduce perfectly.
+    """
+    box = page.evaluate(_CURSOR_BOX_JS)
+    if box is None:
+        b.fail_if(
+            True,
+            f"{when}, the recorder drew no cursor dot (#__demo_cursor is not "
+            f"in the page) — a take with no dot in it cannot say where an "
+            f"unmoved pointer leaves one",
+        )
+        return
+    at = (box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
+    b.fail_if(
+        abs(at[0] - RESTING_POINTER[0]) > 1 or abs(at[1] - RESTING_POINTER[1]) > 1,
+        f"{when}, no verb moved the pointer and the cursor dot is centred at "
+        f"({at[0]:.0f}, {at[1]:.0f}), not at the "
+        f"({RESTING_POINTER[0]}, {RESTING_POINTER[1]}) the recorder's own "
+        f"stylesheet parks it at — something other than the storyboard is "
+        f"placing the cursor, which is issue #186: a mousemove reporting no "
+        f"movement is Chromium recomputing hover at the position the pointer "
+        f"is already at, and following it makes the dot's position a race",
     )
 
 
@@ -3169,6 +3282,56 @@ def record_entropy(out_dir: Path, base_url: str, deterministic: bool) -> Entropy
             max(2, int(box["height"] * scale_y)),
         )
     return EntropyTake(b.problems, out_dir, clock, still_rect, video_rect, spin_rect)
+
+
+class RestingTake(NamedTuple):
+    """One recording of a storyboard that never places the pointer (#193)."""
+
+    problems: list[str]
+    still: Path
+    panel: Rect  # the entropy panel, for the difference diagnostic
+    moves: list  # every mousemove the page saw, as [x, y, movementX, movementY]
+
+
+def record_resting(out_dir: Path, base_url: str, label: str) -> RestingTake:
+    """The entropy storyboard with the pointer left exactly where it was.
+
+    `record_entropy` minus the `page.mouse.move(*PARKED_POINTER)` line and
+    minus the second still, and that subtraction is the whole point: the park
+    is what makes the determinism arm structurally unable to record the case
+    issue #186 is about. Same page and same determinism controls, so the
+    stills are byte-comparable for the same reasons the entropy ones are —
+    what is not the same is that nothing in here decides where the cursor
+    goes.
+    """
+    from demo_recording import Recorder
+
+    b = Beats(label)
+    with Recorder(
+        out_dir, base_url=base_url, speech=False, strict=True, deterministic=True
+    ) as rec:
+        rec.page.add_init_script(_MOVE_LOG_JS)
+        rec.goto("/?entropy=1")
+        rec.wait_for("#entropy-worker.ready", timeout_s=15)
+        rec.pause(RESTING_SETTLE_S)
+        rec.shot(RESTING_SHOT)
+        # After the still, so it grades the frame that was actually taken.
+        check_resting_pointer(b, rec.page, f"in {label}")
+        moves = rec.page.evaluate(_MOVE_LOG_READ_JS) or []
+        box = rec.page.locator("#entropy-panel").bounding_box()
+        if box is None:
+            raise SmokeFailure(
+                "#entropy-panel has no box — ?entropy=1 rendered nothing"
+            )
+        panel: Rect = (
+            int(box["x"]),
+            int(box["y"]),
+            int(box["width"]),
+            int(box["height"]),
+        )
+    return RestingTake(
+        b.problems, out_dir / "images" / f"{RESTING_SHOT}.png", panel, moves
+    )
 
 
 # -- assertions --------------------------------------------------------------
@@ -6703,6 +6866,7 @@ def check_evidence(
     out_dir: Path,
     expected: list[tuple[str, str, list[str], list[str]]],
     scope: tuple[str, str, str] | None = None,
+    segment: str | None = None,
 ) -> list[str]:
     """Issue #9's acceptance criterion, made concrete.
 
@@ -6712,22 +6876,36 @@ def check_evidence(
     values, labels, table rows, command output — have to be readable in the
     evidence for the beat that showed them, and the values the *previous*
     screen showed have to be gone.
+
+    `segment` names the segment the take recorded under, so this function can
+    grade a segmented take's evidence as well as a whole demo's. That is what
+    puts it on `--evidence-only`, 7 s, instead of only on the 123 s and 186 s
+    arms that record the two graded takes (issue #197).
     """
-    beats, docs, failures = evidence_docs(label, out_dir)
+    beats, docs, failures = evidence_docs(label, out_dir, segment=segment)
     if not docs:
         return failures
 
+    prefix = f"{segment}.seg." if segment else ""
     for position, (beat, doc) in enumerate(zip(beats, docs, strict=False)):
-        where = f"{label}: {EVIDENCE_DIR_NAME}/beat-{position:02d}.json"
+        where = f"{label}: {EVIDENCE_DIR_NAME}/{prefix}beat-{position:02d}.json"
         if doc.get("schema") != EVIDENCE_SCHEMA_EXPECTED:
             failures.append(
                 f"{where} says schema {doc.get('schema')!r}, expected "
                 f"{EVIDENCE_SCHEMA_EXPECTED!r}"
             )
-        if doc.get("segment") is not None:
-            failures.append(f"{where} claims segment {doc.get('segment')!r}")
-        if doc.get("media") != "demo.mp4":
-            failures.append(f"{where} describes media {doc.get('media')!r}")
+        if doc.get("segment") != segment:
+            failures.append(
+                f"{where} claims segment {doc.get('segment')!r}, expected {segment!r}"
+            )
+        # Computed here rather than read off the take, for the same reason the
+        # evidence filename is: a name taken from the file being graded agrees
+        # with whatever the file says.
+        media = f"{segment}.seg.mp4" if segment else "demo.mp4"
+        if doc.get("media") != media:
+            failures.append(
+                f"{where} describes media {doc.get('media')!r}, expected {media!r}"
+            )
         # The embedded beat has to be *this* beat. Without it every file could
         # hold the same screen and every fact below would still be found
         # somewhere.
@@ -7738,6 +7916,108 @@ def run_determinism(out_root: Path) -> list[str]:
     return failures
 
 
+def run_resting_pointer(out_root: Path) -> list[str]:
+    """Record a storyboard that never places the pointer, three times (#193).
+
+    The acceptance criterion of issue #186, at the level the fix was actually
+    made at. `tests/unit` grades the *rule* — the guard is read out of the
+    shipped overlay and evaluated against event shapes measured off Chromium —
+    and cannot see a browser that started reporting movement for its
+    hover-recompute event. The determinism arm cannot see it either, because
+    `PARKED_POINTER` decides the dot's position there before anything is
+    photographed. This is the arm that can.
+
+    Three assertions, and the order matters:
+
+    1. **the control**, first, because everything else is satisfied by a take
+       nothing happened in: at least one take has to have received a mousemove
+       reporting no movement. That event is the whole subject; a run that did
+       not get one has not exercised the guard, and saying "the dot is parked"
+       about it would be the catalogue's environment-agreeing assertion.
+    2. **the dot is where the stylesheet parks it**, per take, in
+       `check_resting_pointer` — read off the live page.
+    3. **the stills are byte-identical across takes**, which is #186's own
+       acceptance sentence. Deliberately *not* the assertion an injection is
+       registered against: with the guard removed the two positions the dot
+       lands in are both stable within a take, so this comparison only fires
+       when two takes happened to disagree — about one run in two, and rather
+       less on an idle box. An intermittent assertion is what issue #185 cost
+       three CI runs.
+    """
+    failures: list[str] = []
+    takes: dict[str, RestingTake] = {}
+    with fixture_server() as base_url:
+        for i in range(RESTING_TAKES):
+            label = f"resting-{i}"
+            out_dir = fresh_take_dir(out_root, label)
+            try:
+                takes[label] = record_resting(out_dir, base_url, label)
+            except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+                return failures + [
+                    f"{label}: Recorder raised {type(exc).__name__}: {exc}"
+                ]
+            failures += takes[label].problems
+
+    # -- the control ---------------------------------------------------------
+    settled = {
+        name: [m for m in take.moves if m[2] == 0 and m[3] == 0]
+        for name, take in takes.items()
+    }
+    if not any(settled.values()):
+        return failures + [
+            f"resting-pointer: not one of the {RESTING_TAKES} takes saw a "
+            f"mousemove reporting no movement, so nothing in this arm "
+            f"exercised the guard it exists to grade — the dot being parked "
+            f"is true of a page the browser never sent an event to. Every "
+            f"mousemove seen: "
+            f"{ {name: take.moves for name, take in takes.items()}!r}"
+        ]
+
+    # -- the stills ----------------------------------------------------------
+    live: dict[str, Path] = {}
+    for name, take in takes.items():
+        if not take.still.is_file():
+            failures.append(f"{name}: {take.still} was never captured")
+            continue
+        frames = gray_frames(take.still)
+        score = contrast(frames[0]) if frames else 0.0
+        if score < MIN_CONTENT_STDDEV["web"]:
+            failures.append(
+                f"{name}: {take.still.name} is blank — the whole frame scores "
+                f"{score:.1f} luma stddev, under the "
+                f"{MIN_CONTENT_STDDEV['web']} floor, so two of them being "
+                f"equal says nothing"
+            )
+            continue
+        live[name] = take.still
+    names = sorted(live)
+    first = names[0] if names else None
+    for other in names[1:]:
+        if digest(live[first]) != digest(live[other]):
+            failures.append(
+                f"resting-pointer: {RESTING_SHOT}.png differs between {first} "
+                f"and {other} ({digest(live[first])} vs {digest(live[other])}) "
+                f"— two takes of a storyboard that never moves the pointer do "
+                f"not reproduce, which is issue #186's acceptance criterion. "
+                f"{still_difference(live[first], live[other], takes[first].panel)}"
+            )
+    if len(names) < RESTING_TAKES:
+        failures.append(
+            f"resting-pointer: only {len(names)} of {RESTING_TAKES} takes "
+            f"produced a still worth comparing, so the reproduction claim was "
+            f"made over fewer takes than this arm records"
+        )
+    if not failures:
+        print(
+            f"smoke: resting-pointer {RESTING_TAKES} takes that place no "
+            f"pointer leave the dot at {RESTING_POINTER} and reproduce "
+            f"{RESTING_SHOT}.png byte for byte "
+            f"({sum(len(v) for v in settled.values())} no-movement mousemove(s) "
+            f"delivered across them)"
+        )
+    return failures
+
+
 def _plant_mp4(path: Path) -> bytes:
     """A small, real, decodable mp4 at `path`. Returns its bytes.
 
@@ -8310,9 +8590,20 @@ def run_evidence(out_root: Path) -> list[str]:
             f"evidence for all the others."
         )
 
+    # Issue #9's acceptance criterion, on the arm that can afford to grade it
+    # (#197). `check_evidence` owns the envelope, the per-beat stamping, the
+    # pointer/orphan pairing and "the facts that beat showed are readable in
+    # that beat's file"; everything below this call is about the *content* of
+    # four particular beats and is this take's own job.
+    failures += check_evidence(
+        label, out_dir, EVIDENCE_TAKE_FACTS, segment=EVIDENCE_SEGMENT
+    )
+
     beats, docs, problems = evidence_docs(label, out_dir, segment=EVIDENCE_SEGMENT)
-    failures += problems
-    if not docs:
+    # `problems` are already in `failures` — `check_evidence` above called the
+    # same helper — so they are not appended a second time. A broken pointer is
+    # one finding, not two.
+    if problems or not docs:
         return failures
     pauses = [
         (i, doc)
@@ -9653,6 +9944,17 @@ def main() -> int:
         help="record only the two short takes that strict=True must refuse (issue #3)",
     )
     parser.add_argument(
+        "--issues-only",
+        action="store_true",
+        help="record only the broken-page and failing-command takes, which is "
+        "what check_issues grades (issue #197)",
+    )
+    parser.add_argument(
+        "--pointer-only",
+        action="store_true",
+        help="record only the takes that never place the pointer (issue #193)",
+    )
+    parser.add_argument(
         "--allow-concurrent",
         action="store_true",
         help="run even when another suite holds the machine lock. The timing "
@@ -9688,6 +9990,8 @@ def main() -> int:
             ("--overlay-only", args.overlay_only),
             ("--coverage-only", args.coverage_only),
             ("--strict-only", args.strict_only),
+            ("--issues-only", args.issues_only),
+            ("--pointer-only", args.pointer_only),
         )
         if on
     ]
@@ -9775,7 +10079,13 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
     # recorder's beat record is running --web-only.
     if only in (None, "--web-only", "--coverage-only"):
         failures += run_coverage(out_root)
-    if only in (None, "--web-only"):
+    # What the recorder saw behind the pixels (`check_issues`). Reachable from
+    # --issues-only as well as from the medium flags, and that split is the
+    # point: these two takes record in well under a minute between them, and
+    # were reachable only from arms costing 123 s and 186 s. An assertion is
+    # only as gradeable as its cheapest arm — `--strict-only` is the worked
+    # example, and issue #197 is where this one is written down with numbers.
+    if only in (None, "--web-only", "--issues-only"):
         failures += run_web_problems(out_root)
     # The two takes strict=True must refuse. Reachable on their own as well as
     # from the medium flags, because they are the cheapest graded takes in this
@@ -9792,13 +10102,24 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
     # is running one of the two.
     if only in (None, "--web-only", "--narration-only"):
         failures += run_narration(out_root)
-    if only in (None, "--terminal-only"):
+    if only in (None, "--terminal-only", "--issues-only"):
         failures += run_terminal_problems(out_root)
+    # Not on --issues-only: `run_terminal_race` manufactures its condition with
+    # a shell that sleeps before exec'ing, and its assertions are its own —
+    # `check_issues` never sees this take.
+    if only in (None, "--terminal-only"):
         failures += run_terminal_race(out_root)
     if only in (None, "--terminal-only", "--strict-only"):
         failures += run_strict_terminal(out_root)
     if only in (None, "--determinism-only"):
         failures += run_determinism(out_root)
+    # The pointer-free case (#193). Its own arm and deliberately *not* on
+    # --determinism-only: it is three more takes, and putting them there would
+    # make every entry aimed at that arm 60% more expensive without covering
+    # any of them. What it does cover, no other arm can — the determinism
+    # storyboard parks the pointer before anything is photographed.
+    if only in (None, "--pointer-only"):
+        failures += run_resting_pointer(out_root)
     # What a take that did *not* finish leaves behind. Last, because every
     # phase above records a take that works, and reading "crash-web wrote no
     # demo.mp4" before "web wrote no demo.mp4" would send somebody to the

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -5,7 +5,7 @@
 # ///
 """An executed injection manifest for `tests/smoke` (issue #136).
 
-    tests/smoke-inject               # the whole manifest, ~31 minutes
+    tests/smoke-inject               # the whole manifest, ~35 minutes
     tests/smoke-inject --list        # what it covers, and what each entry costs
     tests/smoke-inject --self-test   # prove the harness refuses a bad entry (0s)
     tests/smoke-inject --arm coverage      # one arm's entries
@@ -22,9 +22,11 @@ this file is what notices.
 ~10 minutes behind a machine-wide lock, so an injection per assertion was never
 going to be maintained. But smoke has per-arm flags, and an injection aimed at
 one arm costs that arm: measured on this box, `--coverage-only` is 8 s,
-`--strict-only` 13 s, `--overlay-only` 31 s, `--failure-only` 48 s,
-`--web-only` 123 s, `--content-only` 148 s. Every entry below names the arm it
-needs, and nothing else runs.
+`--strict-only` 13 s, `--pointer-only` 15 s, `--issues-only` 26 s,
+`--overlay-only` 31 s, `--failure-only` 48 s, `--web-only` 123 s,
+`--content-only` 148 s. Every entry below names the arm it needs, and nothing
+else runs. Splitting a cheap take out of an expensive arm is what makes an
+assertion gradeable at all — see issue #197 and `--issues-only`.
 
 **The contract, per entry** — the same one `tests/unit`'s `INJECTIONS` uses,
 with the arm added:
@@ -51,10 +53,12 @@ an aborted run cannot leave a broken recorder behind.
 
 **What this does not do** is in `tests/README.md`, under "What the injection
 manifest covers". Read it before treating a green run here as coverage of
-`tests/smoke`: 25 entries against 13 of smoke's 35 check functions is a floor
+`tests/smoke`: 31 entries against 17 of smoke's 36 check functions is a floor
 under the assertions that would be worst to lose, not a statement about the
 rest. Every check function with no entry is printed as `ungraded` at the end of
-a run, so the gap is in the output rather than in somebody's memory.
+a run, so the gap is in the output rather than in somebody's memory — and the
+README's roster says, per name, whether `tests/unit` grades its browser-free
+half or whether nothing does (issue #196).
 """
 
 from __future__ import annotations
@@ -84,6 +88,8 @@ ARM_TIMEOUT_S = 1_200
 ARM_SECONDS = {
     "--evidence-only": 7,
     "--coverage-only": 8,
+    "--pointer-only": 15,
+    "--issues-only": 26,
     "--narration-only": 8,
     "--strict-only": 13,
     "--determinism-only": 19,
@@ -252,6 +258,147 @@ INJECTIONS = [
         must_contain=(
             "differ within one take, ",
             "largest channel delta ",
+        ),
+    ),
+    # -- a take that never places the pointer (issue #193), ~20 s an entry ----
+    #
+    # The arm-level half of #186. `tests/unit` grades the *rule* — the guard is
+    # read out of the shipped overlay and evaluated against event shapes
+    # measured off Chromium — and cannot see a browser that started reporting
+    # movement for its hover-recompute event; the determinism arm cannot see it
+    # either, because `PARKED_POINTER` decides where the dot is there before
+    # anything is photographed. `--pointer-only` records the case neither can.
+    Injection(
+        # Aimed at the *position* check and deliberately not at the byte
+        # comparison beside it. With the guard gone the dot lands at the origin
+        # in about seven takes in eight and stays parked in the rest, both
+        # stable within a take — so the still hashes only disagree when two
+        # takes of the three happened to differ, while the position check fires
+        # on any one of them that moved. An intermittent assertion is what #185
+        # cost three CI runs, and #193 asks for this entry by name.
+        name="the cursor dot follows a mousemove that reports no movement",
+        module="web.py",
+        old="      if (e.movementX === 0 && e.movementY === 0) return;\n",
+        new="",
+        arm="--pointer-only",
+        sites=("check_resting_pointer",),
+        must_contain=(
+            "stylesheet parks it at — something other than the storyboard is ",
+        ),
+    ),
+    # -- what the recorder saw behind the pixels (check_issues), ~30 s an entry
+    #
+    # Both were reachable only from `--web-only` (123 s) and `--terminal-only`
+    # (186 s) until #197 split `--issues-only` out of them, for two takes that
+    # record in well under a minute between them.
+    Injection(
+        # A beat claims an event that fired before it opened. The whole
+        # storyboard still records, every deliberate problem is still logged,
+        # and the only thing that changed is that one of them now carries a
+        # confident beat index and a quoted caption — the failure mode
+        # `_attributed_beat` exists for and the one a reviewer would believe.
+        #
+        # The whole body, replaced by the naive answer `self._beats[-1]` — the
+        # "most recently started beat" the function's own docstring says is a
+        # different question from "the beat that may honestly be blamed".
+        #
+        # Both of its guards, and not one of them, because taking either alone
+        # is a no-op and this file is how that was found out rather than
+        # reasoned about. Instrumented on the real take: the console error the
+        # storyboard fires between beats is delivered *inside the
+        # `page.evaluate` that raises it*, with `_in_beat` False, the last beat
+        # `wait_for` (t_start 0.934) and `_pumped_at` 0.383. So the open-beat
+        # guard refuses it — and with that guard deleted the 0.5 s slack guard
+        # refuses it too, on the same event, for a different reason. Two
+        # entries were written, each naming one line, and each passed against a
+        # broken recorder before this one replaced them.
+        name="an event is blamed on the most recently started beat",
+        module="core.py",
+        old=(
+            "        if not self._in_beat or not self._beats:\n"
+            "            return None\n"
+            "        beat = self._beats[-1]\n"
+            '        t_start = beat.get("t_start")\n'
+            "        if not isinstance(t_start, (int, float)):\n"
+            "            return None\n"
+            "        if t_start > self._pumped_at + ATTRIBUTION_SLACK_S:\n"
+            "            return None\n"
+            "        return beat\n"
+        ),
+        new="        return self._beats[-1] if self._beats else None\n",
+        arm="--issues-only",
+        sites=("check_issues",),
+        must_contain=(" — the attribution is invented",),
+    ),
+    Injection(
+        # The oldest run() still waiting becomes the newest. The storyboard
+        # types two commands without waiting between them — `run_terminal_
+        # problems`' "This pair is the regression, not decoration" — so their
+        # two statuses arrive in order and land on each other's beats. Every
+        # beat still carries an exit code and the take still succeeds; what is
+        # left is a command that exited 9 recorded as exiting 0.
+        name="a command's exit status lands on the newest run() rather than the oldest",
+        module="terminal.py",
+        old="        beat = self._pending_runs.popleft()",
+        new="        beat = self._pending_runs.pop()",
+        arm="--issues-only",
+        sites=("check_issues",),
+        must_contain=("failed is indistinguishable from one that worked",),
+    ),
+    # -- the beat log and the review sheet (issues #8/#22), 29 s an entry ------
+    #
+    # `check_timeline` and `check_beat_frames` grade *a* take, not specifically
+    # the 123 s web one, and `--segments-only` already records one and stitches
+    # it. #197's second bullet: reuse of an existing cheap take rather than a
+    # new arm.
+    Injection(
+        # Issue #22 exactly. `index` is the position in the merged file and is
+        # renumbered on purpose; `segment_index` is the beat's position in the
+        # segment that recorded it and must survive, or the pair (segment,
+        # segment_index) stops naming the same beat before and after a stitch —
+        # and per-beat evidence is keyed on it. Only a segmented take can see
+        # this at all, which is why it is registered against this arm.
+        name="the merge renumbers each beat's position within its own segment",
+        module="stitching.py",
+        old='            merged["segment_index"] = beat.get("segment_index", beat.get("index"))',
+        new='            merged["segment_index"] = len(beats)',
+        arm="--segments-only",
+        sites=("check_timeline",),
+        must_contain=("within its own segment, and unlike `index` a merge must not ",),
+    ),
+    Injection(
+        # Every review frame is cut at its beat's *start* instead of its
+        # midpoint. frames.json still lists one frame per beat, each frame is
+        # still faithfully the second it claims, and the sheet still embeds all
+        # of them — so the pairing and the byte comparison both pass. What is
+        # left is a sheet of caption fade-ins and pre-click screens: the
+        # instant `frames.py`'s own header says is the wrong one.
+        name="every review frame is cut at the start of its beat, not its midpoint",
+        module="frames.py",
+        old="        middle = min(max((float(t_start) + float(t_end)) / 2, 0.0), last)",
+        new="        middle = min(max(float(t_start), 0.0), last)",
+        arm="--segments-only",
+        sites=("check_beat_frames",),
+        must_contain=("moment the sheet numbers it for",),
+    ),
+    # -- what a beat's evidence says was on screen (issue #9), 7 s an entry ----
+    Injection(
+        # A capture reused across beats — the "stale dump" `check_evidence`'s
+        # per-beat claim exists to refuse. Every beat still points at its own
+        # file, every file still exists and is still stamped with its own beat
+        # record, so the pairing half of the check is untouched; what is gone
+        # is that the page each file describes is the page that beat showed.
+        # The storyboard injects `#smoke-source` and `#smoke-bloat` mid-take,
+        # so the facts they put on screen are missing from exactly the beats
+        # that showed them.
+        name="every beat's evidence describes the first beat's page",
+        module="core.py",
+        old="             self._evidence_doc(beat, payload))",
+        new="             self._evidence_doc(beat, self._evidence[0][1]))",
+        arm="--evidence-only",
+        sites=("check_evidence",),
+        must_contain=(
+            " was on screen. A reviewer holding only this file cannot state ",
         ),
     ),
     # -- the recorder's own overlay (issues #162/#163), 31 s an entry ---------
@@ -839,9 +986,12 @@ def inject(entries: list[Injection]) -> int:
     for name in blind:
         print(f"  {name}")
     print(
-        "\nThat list is the manifest's boundary, not a to-do list: see "
-        "tests/README.md for which of them are covered by tests/unit at "
-        "sub-second cost and which are genuinely ungraded.\n"
+        "\nThat list is the manifest's boundary, not a to-do list, and it is "
+        "not a list of what nothing grades: tests/README.md, under 'What it "
+        "does not cover', has a row for every name above naming either the "
+        "tests/unit class that carries its browser-free claims or 'genuinely "
+        "ungraded'. That roster is checked against this list, both ways, by "
+        "--self-test on every push.\n"
     )
     if missed:
         print(
@@ -978,6 +1128,16 @@ def self_test() -> int:
             "a README naming a covered check function as a gap",
             r"check functions have no entry\*\*",
             "check functions have no entry**\n  `check_overlay_pair` has none.",
+        ),
+        (
+            "a README whose ungraded roster lost a row",
+            r"^ *\| `_check_video` \| .*\n",
+            "",
+        ),
+        (
+            "a README whose roster answers a gap with nothing in particular",
+            r"^( *\| `check_determinism` \| )[^|]*\|",
+            r"\1still being thought about |",
         ),
     ):
         broken, hits = re.subn(
@@ -1130,6 +1290,67 @@ def readme_named_gaps(text: str) -> list[str]:
     ]
 
 
+def readme_ungraded_roster(text: str) -> list[str]:
+    """The per-function roster of issue #196, checked both ways.
+
+    `ungraded` means *this manifest aims nothing at it*. It does not mean
+    "graded by nothing", and after #195 that difference is most of the list:
+    the browser-free claims of several check functions are certified in
+    `tests/unit` at 0.2 s an injection. The closing line of a run points a
+    reader at `tests/README.md` to find out which — so that document has to
+    answer, per function, and the answer has to stay true.
+
+    Both directions, because each fails differently. A roster missing a row is
+    a reader sent to a table their function is not in; a roster with a row for
+    a function that has an entry is the older mistake — `check_evidence` was
+    written up as uncovered for as long as it had six.
+
+    Read as text. The left-hand side is prose in `tests/README.md`; the
+    right-hand side is `ungraded()`, which is `INJECTIONS` against the AST of
+    `tests/smoke`. Nothing here takes a name from the README and checks the
+    README against it.
+    """
+    # The roster sits inside the bullet that introduces it, so its rows carry
+    # the list's indentation. Anchored to the line start all the same: a row
+    # that has drifted out of the table into a paragraph is not a row.
+    rows = re.findall(r"^ *\| `(_?check_[a-z_]+)` \| (.*?) \|$", text, re.MULTILINE)
+    if not rows:
+        return [
+            "the ungraded roster: no row matched, so the per-function answer "
+            "issue #196 asks for is not in this file at all"
+        ]
+    problems = []
+    stated: dict[str, str] = {}
+    for name, answer in rows:
+        if name in stated:
+            problems.append(f"the ungraded roster: two rows for {name}")
+        stated[name] = answer.strip()
+    blind = set(ungraded())
+    for name in sorted(blind - set(stated)):
+        problems.append(
+            f"the ungraded roster: no row for {name}, which this manifest "
+            f"aims nothing at — the run's closing line sends its reader here"
+        )
+    for name in sorted(set(stated) - blind):
+        problems.append(
+            f"the ungraded roster: a row for {name}, which has an entry — it "
+            f"is graded by this manifest and does not belong in a list of what "
+            f"is not"
+        )
+    # And the answer itself. A row whose right-hand cell says nothing is a row
+    # that resolves to the same "somebody's memory" the roster replaced, so it
+    # has to name a `tests/unit` class or say plainly that there is none.
+    for name in sorted(set(stated) & blind):
+        answer = stated[name]
+        if "genuinely ungraded" in answer or re.search(r"`[A-Z]\w+`", answer):
+            continue
+        problems.append(
+            f"the ungraded roster: {name}'s row answers {answer!r}, which "
+            f"names no tests/unit class and does not say 'genuinely ungraded'"
+        )
+    return problems
+
+
 def readme_problems(text: str) -> list[str]:
     """Everything `tests/README.md` states about this manifest that is untrue."""
     problems = []
@@ -1147,7 +1368,12 @@ def readme_problems(text: str) -> list[str]:
                 f"{what}: the README says {'/'.join(found[0])}, "
                 f"`--list` says {'/'.join(truth)}"
             )
-    return problems + readme_tables(text) + readme_named_gaps(text)
+    return (
+        problems
+        + readme_tables(text)
+        + readme_named_gaps(text)
+        + readme_ungraded_roster(text)
+    )
 
 
 def listing(entries: list[Injection]) -> int:

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -278,7 +278,13 @@ INJECTIONS = [
         # cost three CI runs, and #193 asks for this entry by name.
         name="the cursor dot follows a mousemove that reports no movement",
         module="web.py",
-        old="      if (e.movementX === 0 && e.movementY === 0) return;\n",
+        # Retargeted from `movementX === 0 && movementY === 0` when #202 replaced
+        # that rule with a positional one: the engine's delta turned out to be a
+        # build detail (Chromium 147 reported 0,0 for the storyboard's own park),
+        # so the guard now reads the position the overlay remembers. Deleting
+        # this line is still the same defect — every mousemove moves the dot,
+        # including the one Chromium dispatches at load.
+        old="      if (e.clientX === atX && e.clientY === atY) return;\n",
         new="",
         arm="--pointer-only",
         sites=("check_resting_pointer",),

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -22,8 +22,8 @@ this file is what notices.
 ~10 minutes behind a machine-wide lock, so an injection per assertion was never
 going to be maintained. But smoke has per-arm flags, and an injection aimed at
 one arm costs that arm: measured on this box, `--coverage-only` is 8 s,
-`--strict-only` 13 s, `--pointer-only` 15 s, `--issues-only` 26 s,
-`--overlay-only` 31 s, `--failure-only` 48 s, `--web-only` 123 s,
+`--strict-only` 13 s, `--issues-only` 26 s, `--overlay-only` 31 s,
+`--failure-only` 48 s, `--web-only` 123 s,
 `--content-only` 148 s. Every entry below names the arm it needs, and nothing
 else runs. Splitting a cheap take out of an expensive arm is what makes an
 assertion gradeable at all — see issue #197 and `--issues-only`.
@@ -53,7 +53,7 @@ an aborted run cannot leave a broken recorder behind.
 
 **What this does not do** is in `tests/README.md`, under "What the injection
 manifest covers". Read it before treating a green run here as coverage of
-`tests/smoke`: 31 entries against 17 of smoke's 36 check functions is a floor
+`tests/smoke`: 30 entries against 16 of smoke's 35 check functions is a floor
 under the assertions that would be worst to lose, not a statement about the
 rest. Every check function with no entry is printed as `ungraded` at the end of
 a run, so the gap is in the output rather than in somebody's memory — and the
@@ -88,7 +88,6 @@ ARM_TIMEOUT_S = 1_200
 ARM_SECONDS = {
     "--evidence-only": 7,
     "--coverage-only": 8,
-    "--pointer-only": 15,
     "--issues-only": 26,
     "--narration-only": 8,
     "--strict-only": 13,
@@ -258,38 +257,6 @@ INJECTIONS = [
         must_contain=(
             "differ within one take, ",
             "largest channel delta ",
-        ),
-    ),
-    # -- a take that never places the pointer (issue #193), ~20 s an entry ----
-    #
-    # The arm-level half of #186. `tests/unit` grades the *rule* — the guard is
-    # read out of the shipped overlay and evaluated against event shapes
-    # measured off Chromium — and cannot see a browser that started reporting
-    # movement for its hover-recompute event; the determinism arm cannot see it
-    # either, because `PARKED_POINTER` decides where the dot is there before
-    # anything is photographed. `--pointer-only` records the case neither can.
-    Injection(
-        # Aimed at the *position* check and deliberately not at the byte
-        # comparison beside it. With the guard gone the dot lands at the origin
-        # in about seven takes in eight and stays parked in the rest, both
-        # stable within a take — so the still hashes only disagree when two
-        # takes of the three happened to differ, while the position check fires
-        # on any one of them that moved. An intermittent assertion is what #185
-        # cost three CI runs, and #193 asks for this entry by name.
-        name="the cursor dot follows a mousemove that reports no movement",
-        module="web.py",
-        # Retargeted from `movementX === 0 && movementY === 0` when #202 replaced
-        # that rule with a positional one: the engine's delta turned out to be a
-        # build detail (Chromium 147 reported 0,0 for the storyboard's own park),
-        # so the guard now reads the position the overlay remembers. Deleting
-        # this line is still the same defect — every mousemove moves the dot,
-        # including the one Chromium dispatches at load.
-        old="      if (e.clientX === atX && e.clientY === atY) return;\n",
-        new="",
-        arm="--pointer-only",
-        sites=("check_resting_pointer",),
-        must_contain=(
-            "stylesheet parks it at — something other than the storyboard is ",
         ),
     ),
     # -- what the recorder saw behind the pixels (check_issues), ~30 s an entry


### PR DESCRIPTION
Closes #197 and #196. One slice: make the expensive arms injectable, then make the coverage claims true afterwards.

> **#193 is no longer closed by this PR.** The `--pointer-only` arm it asked for was built, measured and removed before merge — Chromium dispatches the event it needs only when the page's `load` fires inside 22 ms (7 of 7 takes under that bar, 0 of 9 over it), which no storyboard controls. **#210** carries the measurement and the gap. The table below still describes the arm; the later comments describe its removal.
> 
> The commit `Make the expensive arms injectable...` still carries a `Fixes #193` trailer from before that decision. If this is merged as a merge commit rather than a squash, that trailer will close #193 — worth dropping or closing #193 as superseded by #210 by hand.

## The arms, measured on this box

| arm | before | after | what it now reaches |
|---|---|---|---|
| `--evidence-only` | 7 s | **6 s** | `check_evidence` (was `--web-only`/`--terminal-only` only) |
| `--pointer-only` | — | **15 s** | `check_resting_pointer` (new; no arm could record this) |
| `--issues-only` | — | **26 s** | `check_issues` (was 123 s / 186 s) |
| `--segments-only` | 29 s | **28 s** | `check_timeline`, `check_beat_frames` — it already did; nothing was aimed at it |
| `--web-only` | 123 s | **133 s** | unchanged; every split is additive |
| `--terminal-only` | 186 s | **187 s** | unchanged |
| the whole suite | 622 s *(documented)* | **427 s** | passes, `run_phases` ordering unchanged |

The 622 s was never checked and was wrong: `--web-only` and `--terminal-only` are disjoint and account for 320 of the 427 s, with the determinism, segments, failure and pointer arms making up the rest. `tests/README.md` now carries 427 s and says why.

Manifest: **25 entries over 7 arms (~31.9 min) → 31 over 11 (~35.4 min)**. Ungraded check functions: **22 of 35 → 19 of 36**.

## Every new entry, seen to fail

**#193 — `check_resting_pointer`, `--pointer-only`.** Removing `if (e.movementX === 0 && e.movementY === 0) return;` from `web.py`. The **whole failure list** of the injected arm, not only the matched lines:

```
smoke: FAILED
  - resting-0: in resting-0, no verb moved the pointer and the cursor dot is centred at (0, 0), not at the (-40, -40) the recorder's own stylesheet parks it at — something other than the storyboard is placing the cursor, which is issue #186: a mousemove reporting no movement is Chromium recomputing hover at the position the pointer is already at, and following it makes the dot's position a race
  - resting-1: in resting-1, ... (identical)
  - resting-2: in resting-2, ... (identical)
```

**That is the entire list — the still-hash comparison stayed silent.** All three takes moved to the origin, so the stills came out byte-identical and #193's byte claim passed against a recorder with the defect in it. That is the measurement the issue asked for, and it is why the entry names the position check.

**#197 — `check_issues`, `--issues-only`, two entries.**

```
PASS  break: an event is blamed on the most recently started beat  [26s]
      caught: web-problems: the console_error 'fixture: between beats' fired between beats, with none open, but is attributed to beat 1 ('wait_for') — the attributi

PASS  break: a command's exit status lands on the newest run() rather than the oldest  [26s]
      caught: terminal-problems: run() beats logged exit codes {'echo ok': 0, '(exit 3)': 3, 'sleep 1': 9, '(exit 9)': 0}, the storyboard's commands exit {'echo ok'
```

**#197 — `check_timeline` and `check_beat_frames`, `--segments-only`, two entries.**

```
PASS  break: the merge renumbers each beat's position within its own segment  [28s]
      caught: segments: beat 6 ('interlude') carries segment_index 6, expected 0 — it is the beat's position within its own segment, and unlike `index` a merge must
      caught: segments: beat 7 ('goto') carries segment_index 7, expected 1 — ...

PASS  break: every review frame is cut at the start of its beat, not its midpoint  [28s]
      caught: segments: beat-00.png was taken at 0.406s, but beat 0 runs 0.406-0.963s and its midpoint is 0.684s — the frame is not the moment the sheet numbers it
      caught: segments: beat-02.png was taken at 0.991s, but beat 2 runs 0.991-3.003s and its midpoint is 1.997s — ...
```

**#197 — `check_evidence`, `--evidence-only`, one entry.**

```
PASS  break: every beat's evidence describes the first beat's page  [6s]
      caught: evidence: the evidence for beat 5 (spotlight '#smoke-source') does not say ['this element renders one line'] was on screen. A reviewer holding only th
      caught: evidence: the evidence for beat 7 (spotlight '#smoke-bloat') does not say ['bloat row 0'] was on screen. A reviewer holding only this file cannot stat
```

**#196 — the README roster, two new `--self-test` guards.** Each is applied to a copy of the README, required to land (`re.subn` hits) before it is required to be caught:

```
CAUGHT   a README whose ungraded roster lost a row
CAUGHT   a README whose roster answers a gap with nothing in particular
```

## Two entries that graded nothing, and how that came out

The first entry aimed at `check_issues`' attribution named `if not self._in_beat or not self._beats:`. It passed against a broken recorder. The second named the other guard, `if t_start > self._pumped_at + ATTRIBUTION_SLACK_S:`. It passed too. Instrumenting `_attributed_beat` on the real take showed why: the between-beats console error is delivered **inside the `page.evaluate` that raises it** — `in_beat=False`, last beat `wait_for` at `t_start 0.934`, `_pumped_at 0.383` — so *both* guards refuse it independently and removing either alone is a behavioural no-op. The entry that landed replaces the whole body with the naive `self._beats[-1]`.

Neither miss would have been found by reading, and both would have shipped as "proof" that the assertion grades something.

## What #196 changed, and the property it preserves

`ungraded` is printed per run and has always meant "this manifest aims nothing at it" — never "nothing grades it". After #195 that difference was most of the list, and the closing line pointed at a `tests/README.md` written before it.

The README now carries a row per ungraded check function naming either the `tests/unit` class that carries its browser-free claims (`ContentRect`, `TakeIssues`, `VerbClassification`, `OpeningWarning`, `CaptionTruth`) or "genuinely ungraded", with what is given up stated in each case. `readme_ungraded_roster()` reads it **as text** and compares against `ungraded()` — `INJECTIONS` against the AST of `tests/smoke` — **both ways**: a name missing from the roster is a reader sent to a table their function is not in, and a name in it that has an entry is #184's mistake again. No number is taken from the README and then checked against the README.

`--self-test` now compares 7 figures, 2 tables and the roster.

## Stated limits

- **The pointer arm can refuse rather than fail.** With the guard removed the dot moves in ~14 of 16 takes; the rest receive no `mousemove` at all. Three takes make a miss ~1 in 500, and the run that would have missed it is the run whose control guard reports "not one of the 3 takes saw a mousemove reporting no movement" — an honest refusal, never a pass. The cost is a ~0.2% chance the arm goes red for its premise.
- **`--web-only`'s 123 s is stale** (re-measured 133 s). Left as written rather than churned on a single reading; the README says so.
- **`check_caption` and `check_content_healthy` are now reachable at 28 s** via `--segments-only` and still have no entry — filed as #200 with the measurement.
- The three pre-existing `check_evidence` entries were not all re-run. One was, as a regression check on the signature change: `clear selects the text and never deletes it`, PASS, 133 s.

## Verification

Run: `./tests/unit` (141 OK), `./tests/ci-unit` (49 OK), `./tests/lint`, `./tests/smoke-inject --self-test`, `./tests/smoke` **whole suite, PASSED, 427 s**, and clean + injected runs of `--pointer-only`, `--issues-only`, `--segments-only` and `--evidence-only`, plus clean `--web-only` (133 s) and `--terminal-only` (187 s).

Not run: the whole `tests/smoke-inject` manifest (~35 min), and the entries on `--content-only`, `--overlay-only`, `--failure-only`, `--coverage-only`, `--strict-only` and `--determinism-only` — none of those arms or their entries is touched here.

No demo video: nothing in this change is watchable. It is test harness and honesty surface, which is the right-hand column of CLAUDE.md's table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

