### PR TITLE
The cursor dot follows the pointer's position, not the browser's movement delta (#202)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -84,20 +84,38 @@ _FRAME_HTML = """<!doctype html><meta charset="utf-8">
 # all of them inside x 0-8, y 0-8.
 #
 # What tells that event apart from a real one is not its trust, its type or
-# its timing: it is that it reports **no movement**, because it is dispatched
-# at the position the pointer is already at. `movementX`/`movementY` are the
-# browser's own delta between this event and the last, so the test is
-# structural rather than a heuristic — a `mousemove` that reports no movement
-# cannot need the dot moved, since the pointer did not move. Ignoring it
-# leaves the dot where the stylesheet parks it, off screen, until the
-# storyboard moves the pointer for the first time; that position is the one
-# thing here that does not depend on when an event was delivered.
+# its timing: it is that it reports **a position the pointer was already at**.
+# So the overlay remembers the position it has been told about — seeded with
+# `(0, 0)`, where a fresh page's pointer sits and where that event lands — and
+# drops a `mousemove` that repeats it. Nothing is drawn until the pointer is
+# somewhere it has not been, so the dot stays where the stylesheet parks it,
+# off screen, until the storyboard moves the pointer for the first time. That
+# is the one thing here that does not depend on when an event was delivered:
+# both orderings of the load-time event and a storyboard's first move end with
+# the dot at the position the storyboard asked for.
 #
-# Written `=== 0` rather than `!e.movementX`, and the difference is the
-# failure mode: on an engine that does not implement `movementX` the strict
-# test is false and the dot follows the event as it always did (a determinism
-# bug), while the falsy test would swallow *every* move and the take would
-# record no cursor at all (an invisible-cursor bug nobody watching can report).
+# **Positions rather than `movementX`/`movementY`, and this is issue #202.**
+# The delta the browser reports for the *first* mouse event in a page is a
+# build detail, because there is no previous event to measure it against:
+#
+#   | Chromium | park at (60, 640) as the page's first mouse event |
+#   |---|---|
+#   | 136 (playwright 1.52) | `movementX/Y` 60, 640 — measured from the origin |
+#   | 147 (playwright 1.59) | `movementX/Y` **0, 0** — measured from itself |
+#   | 151 (playwright 1.61) | 60, 640 — and a settle event precedes it |
+#
+# A guard reading `movementX === 0 && movementY === 0` therefore threw the
+# storyboard's own park away on 147 — indistinguishable there from the
+# load-time event — while staying green on 151, which is how it passed CI and
+# `tests/smoke` on one machine and failed on another. Reading positions costs
+# nothing on any of the three and does not ask the engine for a delta at all,
+# so an engine that implements no `movementX` behaves like every other.
+#
+# What it cannot do, and cannot be made to do: draw the dot for a pointer verb
+# that lands on exactly `(0, 0)`. The pointer *starts* there, so "the pointer
+# was moved to the origin" and "the pointer has not moved" are the same state
+# and no rule reading events can separate them. A storyboard that wants the
+# cursor at the very corner of the viewport has to pass through somewhere else.
 #
 # What this does not do: place the dot after a navigation. A document that
 # replaces the one the dot lived in gets a fresh, parked dot, and Chromium
@@ -123,8 +141,11 @@ _CURSOR_JS = """
     const dot = document.createElement('div');
     dot.id = '__demo_cursor';
     document.body.appendChild(dot);
+    let atX = 0, atY = 0;
     window.addEventListener('mousemove', (e) => {
-      if (e.movementX === 0 && e.movementY === 0) return;
+      if (e.clientX === atX && e.clientY === atY) return;
+      atX = e.clientX;
+      atY = e.clientY;
       dot.style.left = e.clientX + 'px';
       dot.style.top = e.clientY + 'px';
     }, true);

--- a/skills/demo-video/reference/determinism.md
+++ b/skills/demo-video/reference/determinism.md
@@ -126,4 +126,9 @@ no matter what this section does:
   ([#186](https://github.com/rogvid/skills/issues/186)): it followed the
   movement-free `mousemove` Chromium dispatches at load, so a storyboard that
   never touched the pointer got an 18 px dot in the corner of about half its
-  takes. It is now drawn only once the pointer actually moves.
+  takes. It is now drawn only once the pointer is somewhere it has not been:
+  the overlay remembers the position it was last told about, starting from
+  `(0, 0)` where a fresh page's pointer sits, and ignores an event that repeats
+  it. One consequence worth knowing: a pointer verb that lands on exactly
+  `(0, 0)` draws no cursor, because "moved to the origin" and "never moved" are
+  the same state as far as the page can tell — move somewhere else first.

--- a/tests/unit
+++ b/tests/unit
@@ -2771,21 +2771,38 @@ class VerbTarget(unittest.TestCase):
 # not, and two stills that disagree differ in 69 of 921 600 pixels, all of them
 # inside x 0-8, y 0-8 (#185, #186, #188).
 #
-# The overlay now refuses a `mousemove` that reports no movement — the one
-# property that separates Chromium's event from a real one, and a structural
-# one rather than a heuristic: an event dispatched at the position the pointer
-# already has cannot report a delta, and an event that reports no delta cannot
-# need the dot moved.
+# The overlay refuses a `mousemove` that reports the pointer at the position
+# it was already known to be at. It remembers that position — seeded at
+# `(0, 0)`, where a fresh page's pointer sits and where Chromium's load-time
+# event lands — so the settle event says nothing new and is dropped, while any
+# move the storyboard makes is somewhere the pointer has not been and is drawn.
 #
-# What is graded here is that **predicate**, read out of the shipped script and
-# evaluated against event shapes measured off Chromium rather than imagined. A
-# check that restated the rule in Python would agree with itself while the take
-# shipped something else, so the rule is extracted; the JS-to-Python
-# translation is hand-written and deliberately narrow, so a guard written in a
-# form it does not model fails the extraction loudly instead of passing
-# silently. What this suite cannot grade — that Chromium's events still look
-# like this, and that two takes therefore produce the same bytes — is stated at
-# the bottom of the file.
+# **It reads positions rather than `movementX`/`movementY`, and that is issue
+# #202.** The rule shipped for #186 read the browser's movement delta, which
+# for the *first* mouse event in a page has no previous event to be measured
+# against, and what Chromium substitutes there is a build detail: Chromium 136
+# and 151 measure it from the origin, so a park at (60, 640) reports (60, 640),
+# and Chromium 147 measures it from the event's own position, so the same park
+# reports (0, 0) — identical to the load-time event. On 147 the movement rule
+# therefore threw away the storyboard's own park: `tests/smoke`'s determinism
+# arm went red three ways while CI, which installs whatever Chromium the newest
+# Playwright ships (151 the day this was written), stayed green.
+#
+# What is graded here is the **rule**, read out of the shipped script and run
+# over event *sequences* measured off Chromium rather than imagined. Sequences
+# rather than single events because the rule is now stateful, and because the
+# claim that matters is about a sequence: the two orders in which the load-time
+# event and a storyboard's first move can arrive have to leave the dot in the
+# same place, which is what "the dot's position does not depend on delivery
+# timing" means. A check that restated the rule in Python would agree with
+# itself while the take shipped something else, so the guard is extracted; the
+# JS-to-Python translation is hand-written and deliberately narrow, so a guard
+# written in a form it does not model fails the extraction loudly instead of
+# passing silently, and the two statements the harness *does* model (the seed
+# and the update) are pinned to the shipped text by
+# `test_nothing_moves_the_dot_except_through_the_rule`. What this suite cannot
+# grade — that Chromium's events still look like this, and that two takes
+# therefore produce the same bytes — is stated at the bottom of the file.
 
 
 def event(**over: object) -> dict:
@@ -2795,7 +2812,7 @@ def event(**over: object) -> dict:
     Measured with a Playwright probe against `tests/fixture`, not imagined:
     the settle event arrives at (0, 0) with `movementX`/`movementY` 0,
     `isTrusted` true, and a `pointermove` and `mouseover` beside it exactly as
-    a real move has. Nothing but the movement tells the two apart.
+    a real move has. Nothing but the position it reports tells the two apart.
     """
     doc = {
         "type": "mousemove",
@@ -2818,11 +2835,35 @@ def event(**over: object) -> dict:
 # The event the race is about, and the only one the storyboard did not ask for.
 SETTLE_EVENT = event()
 
+# Where `tests/smoke`'s determinism storyboard parks the pointer with a raw
+# `page.mouse.move`, and the position the same event reports when Chromium's
+# hover recompute arrives *after* the park instead of before it.
+PARKED = (60, 640)
+
+# The same park, as the three browsers this was measured on report it when it
+# is the first mouse event in the page. The dot has to end up at PARKED in all
+# three: what the movement fields say about a move the storyboard actually made
+# is the browser's business, and #202 is what reading them cost.
+FIRST_MOVE_SHAPES = [
+    (
+        "Chromium 136 and 151, which measure the first delta from the origin",
+        event(clientX=60, clientY=640, movementX=60, movementY=640),
+    ),
+    (
+        "Chromium 147, which measures it from the event's own position",
+        event(clientX=60, clientY=640, movementX=0, movementY=0),
+    ),
+    (
+        "an engine that implements no movementX at all",
+        event(clientX=60, clientY=640, movementX=None, movementY=None),
+    ),
+]
+
 # What a real glide is made of. The diagonal is the first step of `move_to`'s
 # 30-step move; the axis-aligned two are what a glide along a row or a column
-# produces, and they are why the rule is "no movement on *either* axis" rather
-# than "on one of them" — a guard joined with `||` would freeze the dot for
-# every horizontal drag across a toolbar.
+# produces, and they are why the rule is "the same position on *both* axes"
+# rather than "on one of them" — a guard joined with `||` would freeze the dot
+# for every horizontal drag across a toolbar.
 REAL_MOVES = [
     (
         "a diagonal glide step",
@@ -2838,17 +2879,16 @@ REAL_MOVES = [
     ),
 ]
 
-# An engine that does not report movement at all. The dot must follow this one:
-# a rule written `!e.movementX` would swallow every move on such an engine and
-# the take would record no cursor anywhere, which is worse than the bug it
-# fixes — a determinism failure is measurable in the pixels, and a cursor that
-# was never drawn is an absence nobody watching the video can report.
-NO_MOVEMENT_FIELD = event(clientX=150, clientY=150, movementX=None, movementY=None)
-
 # The JS the guard may be written in, translated one form at a time. `!==`
 # before `!`, or the `!=` it just produced would become `not =`.
 _JS_GUARD_RE = re.compile(r"if \((?P<cond>[^)]*(?:\([^)]*\))?[^)]*)\) return;")
-_JS_TOKEN = re.compile(r"e\.[A-Za-z]+|-?\d+(?:\.\d+)?|==|!=|and\b|or\b|not\b|[()\s]")
+_JS_TOKEN = re.compile(
+    r"e\.[A-Za-z]+|at[XY]\b|-?\d+(?:\.\d+)?|==|!=|and\b|or\b|not\b|[()\s]"
+)
+# The remembered position, as the overlay declares it. Read rather than
+# assumed: a seed anywhere other than where the pointer starts would either
+# let the load-time event through (#186) or swallow a real move.
+_JS_SEED_RE = re.compile(r"let atX = (-?\d+), atY = (-?\d+);")
 
 
 class _JsEvent:
@@ -2894,25 +2934,62 @@ def cursor_guard_py() -> str:
     return expr
 
 
-class CursorMotion(unittest.TestCase):
-    """Which `mousemove` moves the recorder's cursor dot (issue #186)."""
+def cursor_seed() -> tuple[int, int]:
+    """The pointer position the overlay starts a document believing in."""
+    found = _JS_SEED_RE.findall(_CURSOR_JS)
+    if len(found) != 1:
+        raise AssertionError(
+            f"the cursor overlay declares its remembered pointer position "
+            f"{len(found)} times, expected exactly 1 — this suite reads the "
+            f"seed out of the script rather than assuming it, because a seed "
+            f"anywhere but where the pointer starts either lets Chromium's "
+            f"load-time event through (#186) or swallows a real move (#202)"
+        )
+    return int(found[0][0]), int(found[0][1])
 
-    def refuses(self, fields: dict) -> bool:
-        """Does the shipped guard drop this event?"""
+
+class CursorMotion(unittest.TestCase):
+    """Which `mousemove` moves the recorder's cursor dot (#186, #202)."""
+
+    def dot_trail(self, events: list[dict]) -> list[tuple[int, int] | None]:
+        """Run a document's `mousemove` stream through the shipped rule.
+
+        Returns where the dot stands after *each* event — `None` while the
+        overlay has never moved it, which is the stylesheet's off-screen park
+        and what a take that never moves the pointer has to show. Per event
+        rather than at the end: a rule that drops a glide's middle steps and
+        catches up on the last one lands the dot in the right place having
+        shown the wrong motion, and the cursor exists to be watched moving.
+        """
         expr = cursor_guard_py()
-        try:
-            return bool(eval(expr, {"__builtins__": {}}, {"e": _JsEvent(fields)}))
-        except AttributeError as exc:
-            self.fail(
-                f"the guard {expr!r} reads an event field this suite does not "
-                f"model ({exc}) — add it to `event()` with the value Chromium "
-                f"measured, rather than dropping the assertion"
-            )
+        at_x, at_y = cursor_seed()
+        drawn: tuple[int, int] | None = None
+        trail: list[tuple[int, int] | None] = []
+        for fields in events:
+            scope = {"e": _JsEvent(fields), "atX": at_x, "atY": at_y}
+            try:
+                refused = bool(eval(expr, {"__builtins__": {}}, scope))
+            except AttributeError as exc:
+                self.fail(
+                    f"the guard {expr!r} reads an event field this suite does "
+                    f"not model ({exc}) — add it to `event()` with the value "
+                    f"Chromium measured, rather than dropping the assertion"
+                )
+            if not refused:
+                # The two statements the shipped handler runs next, and the
+                # only part of it this harness restates. `test_nothing_moves_
+                # the_dot_except_through_the_rule` pins them to the script's
+                # own text.
+                at_x, at_y = fields["clientX"], fields["clientY"]
+                drawn = (at_x, at_y)
+            trail.append(drawn)
+        return trail
 
     def test_the_rule_is_one_condition_that_reads_the_event(self):
-        # The control. Every assertion below is "the guard says X about this
-        # event", and all of them are satisfied by a guard that says nothing —
-        # so what the guard is, and that it reads the event at all, is graded
+        # The control. Every assertion below is "the dot ended up at X after
+        # this stream", and all of them are satisfied by a guard that says
+        # nothing about the event — so what the guard is, and that it reads
+        # both the event and the position the overlay remembers, is graded
         # first and separately.
         expr = cursor_guard_py()
         self.assertIn(
@@ -2921,40 +2998,120 @@ class CursorMotion(unittest.TestCase):
             f"the guard {expr!r} never reads the event, so which mousemove "
             f"moves the dot is not decided by the mousemove",
         )
-
-    def test_chromiums_load_time_hover_event_does_not_move_the_dot(self):
         self.assertTrue(
-            self.refuses(SETTLE_EVENT),
-            "the overlay accepts the movement-free mousemove Chromium "
-            "dispatches at load, so whether an 18 px dot is burned into the "
-            "corner of a take's opening stills is decided by machine load "
-            "and not by the storyboard (#186)",
+            "atX" in expr or "atY" in expr,
+            f"the guard {expr!r} never reads the position the overlay "
+            f"remembers, so it cannot be telling an event that reports a new "
+            f"position from one that repeats the old one (#186, #202)",
         )
 
-    def test_every_real_move_moves_the_dot(self):
-        for what, fields in REAL_MOVES:
-            with self.subTest(what):
-                self.assertFalse(
-                    self.refuses(fields),
-                    f"the overlay drops {what} ({fields['movementX']}, "
-                    f"{fields['movementY']}), so the cursor stops following "
-                    f"the pointer it exists to stand in for",
+    def test_chromiums_load_time_hover_event_does_not_move_the_dot(self):
+        self.assertEqual(
+            self.dot_trail([SETTLE_EVENT]),
+            [None],
+            "the overlay draws the dot for the mousemove Chromium dispatches "
+            "at load, at the position the pointer already had, so whether an "
+            "18 px dot is burned into the corner of a take's opening stills is "
+            "decided by machine load and not by the storyboard (#186)",
+        )
+
+    def test_the_storyboards_own_park_moves_the_dot_on_every_engine(self):
+        # #202. A raw `page.mouse.move` — the documented escape hatch, and what
+        # smoke's determinism arm uses — is often the first mouse event in the
+        # page, and what the browser reports for its movement is a build
+        # detail. Whether the cursor appears in the recording at all must not
+        # be.
+        #
+        # The second shape is the same event a park *after a navigation*
+        # produces on every build: the pointer is already where the storyboard
+        # is putting it, so nothing moves, but the new document's dot is a new
+        # element parked off screen that nothing else will ever place. There is
+        # no separate test for it because the overlay sees the same event, and
+        # an assertion that cannot fail independently is decoration; it was
+        # measured in a browser instead — Chromium 151, movement rule, dot off
+        # screen in 4 takes of 4.
+        for engine, park in FIRST_MOVE_SHAPES:
+            with self.subTest(engine):
+                self.assertEqual(
+                    self.dot_trail([park]),
+                    [PARKED],
+                    f"on {engine}, the overlay drops the storyboard's own park "
+                    f"at {PARKED} because of what that engine reports about "
+                    f"it — so every take driving page.mouse directly records "
+                    f"no cursor at all (#202)",
                 )
 
-    def test_a_move_that_reports_no_movement_field_still_moves_the_dot(self):
-        self.assertFalse(
-            self.refuses(NO_MOVEMENT_FIELD),
-            "an engine that does not implement movementX makes the overlay "
-            "drop every move, and a take recorded there has no cursor in it "
-            "at all — the guard is written `=== 0` rather than falsy for "
-            "exactly this reason",
+    def test_both_orders_of_the_load_event_leave_the_dot_in_one_place(self):
+        # The determinism claim in the rule's own terms, and the reason the
+        # race is *removed* rather than made less likely: Chromium's hover
+        # recompute can land before the park (at the origin) or after it (at
+        # the position the park moved the pointer to), and the storyboard
+        # cannot control which. Both have to end at the parked position.
+        _, park = FIRST_MOVE_SHAPES[1]
+        settled_after = event(clientX=60, clientY=640, movementX=0, movementY=0)
+        for order, stream in (
+            ("the settle event first", [SETTLE_EVENT, park]),
+            ("the park first", [park, settled_after]),
+        ):
+            with self.subTest(order):
+                self.assertEqual(
+                    self.dot_trail(stream)[-1],
+                    PARKED,
+                    f"with {order}, the dot ends up somewhere other than the "
+                    f"{PARKED} the storyboard parked the pointer at — so which "
+                    f"of the two arrives first decides what the take shows, "
+                    f"which is the race itself (#186, #202)",
+                )
+
+    def test_every_real_move_moves_the_dot(self):
+        # A glide as one stream, graded step by step: a rule that dropped the
+        # steps along a row would leave the dot in the right final place having
+        # skipped half the motion, and the cursor exists to be watched moving.
+        self.assertEqual(
+            self.dot_trail([fields for _, fields in REAL_MOVES]),
+            [(f["clientX"], f["clientY"]) for _, f in REAL_MOVES],
+            "the overlay drops steps of a glide "
+            f"({', '.join(what for what, _ in REAL_MOVES)}), so the cursor "
+            f"stops following the pointer it exists to stand in for",
+        )
+
+    def test_the_remembered_position_is_where_the_pointer_starts(self):
+        # The seed is the whole of why the load-time event is ignorable. At
+        # anything else, either that event reports a "new" position and the
+        # dot lands in the corner (#186), or a real move to the seed is
+        # swallowed.
+        self.assertEqual(
+            cursor_seed(),
+            (0, 0),
+            f"the overlay starts a document believing the pointer is at "
+            f"{cursor_seed()}, but a fresh page's pointer is at (0, 0) and "
+            f"that is where Chromium's load-time mousemove reports it (#186)",
         )
 
     def test_nothing_moves_the_dot_except_through_the_rule(self):
         # A second positioning path — a `pointermove` listener added beside
         # this one, a `mouseover` that snaps the dot into place — would restore
-        # the race while every assertion above stayed green.
+        # the race while every assertion above stayed green. The update of the
+        # remembered position is pinned here too, because `dot_trail` models
+        # it: if the script stopped doing it, the harness would keep simulating
+        # a rule the take no longer ships.
         body = cursor_mousemove_body()
+        for statement in ("atX = e.clientX;", "atY = e.clientY;"):
+            self.assertIn(
+                statement,
+                body,
+                f"the mousemove handler never runs `{statement}`, so the "
+                f"position it compares the next event against is not the "
+                f"position this event reported — the rule this suite "
+                f"evaluates is not the rule the take ships (#202)",
+            )
+            self.assertLess(
+                body.index("return;"),
+                body.index(statement),
+                f"`{statement}` runs before the rule decides whether this "
+                f"event should move the dot, so an ignored event still "
+                f"rewrites the position every later event is compared to",
+            )
         for property_ in ("dot.style.left", "dot.style.top"):
             self.assertEqual(
                 _CURSOR_JS.count(property_),
@@ -4070,12 +4227,12 @@ INJECTIONS = [
         ["CaptionTruth.test_an_spa_route_change_keeps_the_caption"],
     ),
     (
-        # Issue #186 exactly as it shipped: every mousemove moves the dot,
-        # including the movement-free one Chromium dispatches at load, so a
+        # Issue #186 exactly as it shipped before it was fixed: every mousemove
+        # moves the dot, including the one Chromium dispatches at load, so a
         # deterministic take's opening stills are a coin flip.
         "the cursor dot follows every mousemove again",
         "web.py",
-        "      if (e.movementX === 0 && e.movementY === 0) return;\n",
+        "      if (e.clientX === atX && e.clientY === atY) return;\n",
         "",
         [
             "CursorMotion.test_the_rule_is_one_condition_that_reads_the_event",
@@ -4084,25 +4241,55 @@ INJECTIONS = [
         ],
     ),
     (
+        # Issue #202: the rule as #194 wrote it, reading the browser's movement
+        # delta. Green on the Chromium CI installs, and on Chromium 147 it
+        # throws away the storyboard's own park — so a take recorded there has
+        # no cursor in it at all, which no still comparison notices because it
+        # makes every take agree.
+        "the cursor rule reads the browser's movement delta again",
+        "web.py",
+        "if (e.clientX === atX && e.clientY === atY) return;",
+        "if (e.movementX === 0 && e.movementY === 0) return;",
+        [
+            "CursorMotion.test_the_rule_is_one_condition_that_reads_the_event",
+            "CursorMotion.test_the_storyboards_own_park_moves_the_dot_on_every_engine",
+            "CursorMotion.test_both_orders_of_the_load_event_leave_the_dot_in_one_place",
+        ],
+    ),
+    (
         # The rule pointing the other way, and the reason it is `&&`: a guard
-        # that drops a move with a zero on *either* axis freezes the dot for
+        # that drops a move repeating *either* coordinate freezes the dot for
         # every horizontal glide, which no still comparison would ever notice
         # because it makes takes agree.
         "the cursor rule drops a move that is along one axis",
         "web.py",
-        "if (e.movementX === 0 && e.movementY === 0) return;",
-        "if (e.movementX === 0 || e.movementY === 0) return;",
+        "if (e.clientX === atX && e.clientY === atY) return;",
+        "if (e.clientX === atX || e.clientY === atY) return;",
         ["CursorMotion.test_every_real_move_moves_the_dot"],
     ),
     (
-        # The falsy spelling, which reads better and is wrong where it matters:
-        # on an engine that does not implement movementX it swallows every move
-        # and the take records no cursor at all.
-        "the cursor rule tests movement for falsiness instead of zero",
+        # The seed, which is the whole of why the load-time event can be
+        # ignored: at any position other than where the pointer starts, that
+        # event reports a "new" position and #186 is back.
+        "the overlay starts out believing the pointer is somewhere else",
         "web.py",
-        "if (e.movementX === 0 && e.movementY === 0) return;",
-        "if (!e.movementX && !e.movementY) return;",
-        ["CursorMotion.test_a_move_that_reports_no_movement_field_still_moves_the_dot"],
+        "    let atX = 0, atY = 0;",
+        "    let atX = -1, atY = -1;",
+        [
+            "CursorMotion.test_chromiums_load_time_hover_event_does_not_move_the_dot",
+            "CursorMotion.test_the_remembered_position_is_where_the_pointer_starts",
+        ],
+    ),
+    (
+        # The state update, which the harness models rather than extracts: if
+        # the script stopped running it, `dot_trail` would go on simulating a
+        # rule the take no longer ships, and every assertion above would grade
+        # a fiction.
+        "the overlay never records where it last saw the pointer",
+        "web.py",
+        "      atX = e.clientX;\n      atY = e.clientY;\n",
+        "",
+        ["CursorMotion.test_nothing_moves_the_dot_except_through_the_rule"],
     ),
     # -- the scored region (issue #135) ------------------------------------
     #
@@ -4356,13 +4543,20 @@ def fault_inject() -> int:
 #   is still smoke's: that `domcontentloaded` fires when this claims it does is
 #   Playwright's contract, not an assertion made here.
 # - **That Chromium's events still look the way `event()` says they do.** The
-#   cursor rule (#186) is graded here as a predicate over measured event
-#   shapes: the guard is read out of the shipped overlay and evaluated, so a
-#   rule that changed meaning fails, but a *browser* that changed — a settle
-#   event that started reporting movement — would not. That claim, and the
-#   take-level one it serves ("two takes of a storyboard that never moves the
-#   pointer produce byte-identical stills"), need Chromium and belong to
-#   `tests/smoke`. A re-measurement lands in `event()`.
+#   cursor rule (#186, #202) is graded here as a rule read out of the shipped
+#   overlay and run over measured event streams, so a rule that changed meaning
+#   fails — but a *browser* that changed would not. #202 is exactly that hole
+#   being fallen into: three Chromium builds report three different things
+#   about the same park, and no assertion in this file could have known. What
+#   protects against it now is that the rule no longer asks the browser for a
+#   delta at all — the positions in `FIRST_MOVE_SHAPES` are identical across
+#   the three builds, and only the movement fields differ. A browser that
+#   started reporting a *different position* for the load-time event would
+#   still reopen #186 with this suite green. That claim, and the take-level one
+#   it serves ("two takes of a storyboard that never moves the pointer produce
+#   byte-identical stills"), need Chromium and belong to `tests/smoke` — where
+#   the storyboard that never moves the pointer is still missing (#193). A
+#   re-measurement lands in `event()`.
 # - **Anything measured off real frames.** `content_report`'s ffmpeg sampling,
 #   `opening_gap`, `_luma_stddev` and `_moved_pixels` need a video to be true
 #   about. What is graded here is the logic *around* them: the warning


### PR DESCRIPTION
Fixes #202.

## Diagnosis

#194 fixed #186 by making the overlay ignore a `mousemove` that reports no
movement. `movementX`/`movementY` is the browser's delta from the *previous*
mouse event's position — and the first mouse event in a page has no previous
event, so what Chromium substitutes there decides everything. It is a build
detail. Measured against `tests/fixture`, park at (60, 640) with a raw
`page.mouse.move` right after `goto`, `main` as it stands:

| Chromium (playwright) | park's `movementX/Y` | settle event seen | dot, 3 takes |
|---|---|---|---|
| 136 (1.52) | 60, 640 — from the origin | no | (60, 640) ×3 |
| 147 (1.59) | **0, 0** — from the event's own position | no | **(-40, -40) ×3** |
| 151 (1.61) | 60, 640 — from the origin | yes, at (0, 0) | (60, 640) ×3 |

On 147 the storyboard's own park is identical in every field to the load-time
event #186 is about, so the guard threw it away and the dot never left the
off-screen position the stylesheet parks it at. Reproduced verbatim on `main`:

```
$ uv run --with 'playwright==1.59.0' --script tests/smoke --determinism-only
smoke: FAILED
  - determinism: in the determinism take, the cursor dot is centred at (-40, -40), not at the (60, 640) this storyboard parked the pointer at — ...
  - determinism: (same, second take)
  - default: (same, third take)
```

**Why CI stayed green, and why #194's own "6/6 not regressed" was also true.**
CI installs Chromium through `uv run --with playwright playwright install`,
i.e. whatever the newest Playwright ships. From the smoke job's log on `main`:

```
Chrome Headless Shell 151.0.7922.34 (playwright chromium-headless-shell v1234)
```

151 measures the first delta from the origin, so the park reports movement and
`check_parked_pointer` passes there — as it does on the build #194 measured on.
Both measurements were honest; they were taken on different browsers, and
nothing in the suite could see the difference. This is the *environment-agreeing
assertion* from `wip/verified-review`, in the form that is hardest to notice:
the assertion passed on CI for a reason unrelated to the claim it makes.

**A second symptom, on every build including CI's**: park, navigate, park again
at the same coordinates. The repeat move genuinely moves nothing, so the browser
reports no movement — but the new document's dot is a fresh element that nothing
else will ever place. Chromium 151, `main`: off screen in 4 takes of 4.

## The fix

The overlay remembers the position it has been told about, seeded at `(0, 0)`
where a fresh page's pointer sits, and drops a `mousemove` that repeats it.

```js
let atX = 0, atY = 0;
window.addEventListener('mousemove', (e) => {
  if (e.clientX === atX && e.clientY === atY) return;
  atX = e.clientX;
  atY = e.clientY;
  ...
```

The mechanism, rather than a lowered probability: Chromium's hover recompute
reports *the position the pointer already has*, which is the seed if it lands
first and the parked position if it lands second — in both orders it is
information the overlay already had, and in both orders the dot ends at the
position the storyboard asked for. Nothing is asked of the engine's delta, so
the three builds above agree, and an engine with no `movementX` at all behaves
like the rest (which is what #194's `=== 0`-not-falsy reasoning was protecting;
it is now protected structurally instead).

**Why not the alternatives.** Keeping `movementX` and adding a position test
("ignore only if both say nothing happened") still reopens #186 on any build
whose settle event reports a delta, and keeps a browser detail in the rule for
no gain — the only events it separates are pointer-lock ones, where `clientX`
does not move anyway. Parking the pointer from Python at recorder start-up was
measured and rejected in #194 and that measurement still holds (an off-frame
park dispatches `mouseout`, not `mousemove`). Arming the dot from Python breaks
exactly the escape hatch this bug is about.

## Stated limit

**A pointer verb that lands on exactly `(0, 0)` draws no dot.** The pointer
*starts* at the origin, so "moved to the origin" and "never moved" are the same
state, and no rule reading events can separate them — this is inherent, not an
artifact of the spelling. It costs a storyboard that wants the cursor in the
very corner of the viewport one intermediate position. Doc text for
`reference/determinism.md` is at the bottom, since this branch does not touch
`reference/`.

Also measured and **not** fixed here, filed as #203: a pointer move dispatched
before `DOMContentLoaded` is lost, because that is when the overlay subscribes.
`Recorder.goto()` waits for `load`, so the verbs cannot reach it; a storyboard
using `rec.page.goto(..., wait_until="commit")` can. On 147, 2 of 4 takes place
the dot — better than `main`'s 0 of 4, still a race, and #202's rule cannot
close it because the handler does not exist yet when the event arrives.

## Measurements

All against `tests/fixture`, dot rect read off the live page with
`getBoundingClientRect`, plus the sha256 of a 40×40 screenshot of the viewport
corner where #186's dot lands — a picture, not the overlay's own bookkeeping.
The 12-take runs were taken under deliberate 14-way CPU load on a 16-core box,
which is the condition #186 was measured under.

| storyboard | Chromium | takes | dot | distinct corner hashes |
|---|---|---|---|---|
| never moves the pointer (#186) | 151 | 12 (under load) | off screen ×12 | 1 |
| never moves the pointer (#186) | 147 | 12 (under load) | off screen ×12 | 1 |
| parks at (60, 640) with `page.mouse.move` (#202) | 147 | 12 (under load) | (60, 640) ×12 | 1 |
| parks at (60, 640) with `page.mouse.move` (#202) | 151 | 12 (under load) | (60, 640) ×12 | 1 |
| `move_to("#entropy-panel")` — a real verb | 147 | 4 | (640, 108) ×4 | 1 |
| `move_to("#entropy-panel")` — a real verb | 151 | 4 | (640, 108) ×4 | 1 |
| park, navigate, park again | 147 | 4 | (60, 640) ×4 | 1 |
| park, navigate, park again | 151 | 4 | (60, 640) ×4 (`main`: off screen ×4) | 1 |

`tests/smoke --determinism-only`, the arm that went red:

| Chromium | runs | takes | result |
|---|---|---|---|
| 147 (the build that reproduces #202) | 3 | 9 | PASSED — stills reproduce byte for byte, no cursor complaint |
| 151 (CI's build) | 1 | 3 | PASSED |

`tests/smoke --web-only` (the `move_to`/`click` behaviour checks) PASSED on 151.

## Fault injection

`tests/unit`'s `CursorMotion` is rewritten: it still reads the rule out of the
shipped overlay rather than restating it, but runs it over event *streams* and
grades where the dot stands **after each event**, because a rule that drops a
glide's middle steps lands the dot in the right final place having shown the
wrong motion. The event shapes are the three builds' measured reports of the
same park. Five manifest entries, all watched to fail, all matching exactly
once (the harness aborts otherwise); three are new or retargeted.

**`the cursor rule reads the browser's movement delta again`** — the rule
exactly as #194 shipped it, which is this bug:

```
FAIL: test_the_storyboards_own_park_moves_the_dot_on_every_engine [Chromium 147, which measures it from the event's own position]
AssertionError: Lists differ: [None] != [(60, 640)]
- [None]
+ [(60, 640)] : on Chromium 147, which measures it from the event's own
position, the overlay drops the storyboard's own park at (60, 640) because of
what that engine reports about it — so every take driving page.mouse directly
records no cursor at all (#202)

FAIL: test_the_rule_is_one_condition_that_reads_the_event
AssertionError: False is not true : the guard 'e.movementX == 0  and
e.movementY == 0' never reads the position the overlay remembers, so it cannot
be telling an event that reports a new position from one that repeats the old
one (#186, #202)

FAIL: test_both_orders_of_the_load_event_leave_the_dot_in_one_place [the park first]
AssertionError: None != (60, 640) : with the park first, the dot ends up
somewhere other than the (60, 640) the storyboard parked the pointer at — so
which of the two arrives first decides what the take shows, which is the race
itself (#186, #202)
```

**`the overlay starts out believing the pointer is somewhere else`** — the seed
moved to (-1, -1), which is #186 back:

```
FAIL: test_chromiums_load_time_hover_event_does_not_move_the_dot
AssertionError: Lists differ: [(0, 0)] != [None]

FAIL: test_the_remembered_position_is_where_the_pointer_starts
AssertionError: Tuples differ: (-1, -1) != (0, 0)
- (-1, -1)
+ (0, 0) : the overlay starts a document believing the pointer is at (-1, -1),
but a fresh page's pointer is at (0, 0) and that is where Chromium's load-time
mousemove reports it (#186)
```

**`the overlay never records where it last saw the pointer`** — the two state
statements deleted. This entry exists because the harness *models* those two
lines rather than extracting them, so without it a script that stopped running
them would leave every assertion above grading a fiction:

```
FAIL: test_nothing_moves_the_dot_except_through_the_rule
AssertionError: 'atX = e.clientX;' not found in the mousemove handler : the
handler never runs `atX = e.clientX;`, so the position it compares the next
event against is not the position this event reported — the rule this suite
evaluates is not the rule the take ships (#202)
```

The two entries kept from #194 (`the cursor dot follows every mousemove again`,
`the cursor rule drops a move that is along one axis`) are retargeted at the new
rule and still caught. The `||` spelling now freezes the dot for a glide along
a row, which the step-by-step trail catches and a final-position check would
not — that is why `dot_trail` returns a trail. Whole manifest:
`All 93 injections were caught.`

`tests/smoke-inject --only pointer` was run too — the entry that deletes smoke's
`page.mouse.move(*PARKED_POINTER)` and requires `check_parked_pointer` to fire:
`All 1 injections were caught. [0.7 min]`. So the browser-level assertion still
grades what it claims with this rule in place.

## Verification

```
./tests/unit                         153 tests OK
./tests/unit --fault-inject          All 93 injections were caught.
./tests/unit --budget                SKILL.md: 599 lines, budget 600
./tests/ci-unit                      49 tests OK
./tests/lint                         All checks passed! · 13 files already formatted
./tests/smoke-inject --self-test     Every guard refused what it exists to refuse.
./tests/smoke-inject --only pointer  All 1 injections were caught.
mypy==1.13.0 helpers/                Success: no issues found in 12 source files
./tests/smoke --determinism-only     PASSED ×1 on Chromium 151, ×3 on Chromium 147
./tests/smoke --web-only             PASSED
```

## Demo judgment

No demo video. What changes is where an 18 px dot is, in cases separated by a
browser build — graded in the pixels above (corner hashes) and in the live dot
rect. The user-visible half is a cursor that was *missing* from takes on some
builds, and a video of an absence is the row `CLAUDE.md`'s table calls not
demoable.

## Notes for `tests/smoke` (PR #201) and for `reference/`

Neither is touched by this branch. `tests/smoke` needs **no change** for this
fix: `check_parked_pointer` passes as written on both builds, and its injection
still fires. The gap that remains is #193's (no arm records a pointer-free
take), unchanged by this.

`reference/determinism.md` currently ends its cursor paragraph with "It is now
drawn only once the pointer actually moves." Suggested replacement, with the
limit stated where a storyboard author reads it:

> It is now drawn only once the pointer is somewhere it has not been: the
> overlay remembers the position it was last told about, starting from `(0, 0)`
> where a fresh page's pointer sits, and ignores an event that repeats it. One
> consequence worth knowing: a pointer verb that lands on exactly `(0, 0)`
> draws no cursor, because "moved to the origin" and "never moved" are the same
> state as far as the page can tell — move somewhere else first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
