### PR TITLE
Make three unwatched numbers and one unrun suite honest (#182, #191, #192)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   # Pinned so a tool release never turns a green branch red on its own.
-  RUFF_VERSION: "0.14.2"
+  RUFF_VERSION: "0.16.1"
   MYPY_VERSION: "1.18.2"
 
 jobs:

--- a/.github/workflows/smoke-inject.yml
+++ b/.github/workflows/smoke-inject.yml
@@ -3,10 +3,11 @@ name: smoke-inject
 # The executed half of the fault-injection rule for `tests/smoke` (issue #136).
 #
 # **Why this is not a job in ci.yml.** Every entry in the manifest records a
-# real take, and the manifest measures ~14 minutes on a developer box against
+# real take, and the manifest measures **40.3 minutes on a CI runner** against
 # ~10 for `tests/smoke` itself — CI already pays that once per push, and paying
-# it twice more would make every pull request wait on a check that answers a
-# question nobody asked in that pull request: "can the smoke suite still fail?"
+# it four times more would make every pull request wait on a check that answers
+# a question nobody asked in that pull request: "can the smoke suite still
+# fail?"
 # That question needs an answer regularly, not per-commit, because what rots is
 # the *assertion*, and assertions rot on the timescale of weeks.
 #
@@ -42,10 +43,35 @@ jobs:
       github.event_name != 'pull_request' ||
       contains(github.event.pull_request.labels.*.name, 'fault-inject')
     runs-on: ubuntu-latest
-    # ~14 min measured on a 16-core developer box; CI's smoke job runs about
-    # twice as slow as the same box, so this is that doubled with room for the
-    # ffmpeg and Chromium installs.
-    timeout-minutes: 45
+    # **Measured here, not derived.** `workflow_dispatch` run 30705025900 on
+    # main, 2026-08-01, at the 30-entry manifest:
+    #
+    #   job wall clock          41m23s   (15:01:56 -> 15:43:19)
+    #   checkout + uv + ffmpeg + Chromium + --self-test    ~61 s
+    #   tests/smoke-inject      40.3 min  (the script's own figure)
+    #
+    # `tests/smoke-inject --list` estimates ~34.9 min of takes on a developer
+    # box, so **CI runs this manifest at about 1.16x a developer box** — not the
+    # 2x this file used to assume. The 25-entry run of 2026-08-01 06:42 gives
+    # the second point: 34m50s in the step against a ~31.9 min estimate, 1.09x.
+    # The old rule (estimate, doubled, plus install room) predicts ~71 minutes
+    # for the manifest that actually costs 41; it was wrong in the direction
+    # that looks safe, which is why the 45 it produced survived unnoticed while
+    # the manifest grew underneath it.
+    #
+    # It was also nearly breached. 41m23s against 45 is **8% of headroom** — one
+    # slow runner from a job that reports no verdict at all, which is the worst
+    # outcome for the one thing that says whether the smoke suite can still
+    # fail.
+    #
+    # 60 is the measured 41m23s with ~45% headroom. The headroom is for runner
+    # variance, not for growth: the two measured CI-vs-estimate factors differ
+    # by 6% between runs, and this covers many times that. It does leave room
+    # for the manifest to reach roughly 50 minutes of takes before the timeout
+    # is the binding constraint — and #190's `--self-test` fails a push when the
+    # *documented* figure drifts, which is the signal to come back and measure
+    # again rather than to nudge this number.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ticket-queue.yml
+++ b/.github/workflows/ticket-queue.yml
@@ -55,6 +55,13 @@ jobs:
   test:
     name: examples/ticket-queue/test
     runs-on: ubuntu-latest
+    # A bound on a hang, not a budget. Measured on this runner: 2m08s end to end
+    # for a green run (installs included), and the one failure mode this is for
+    # is a browser that never answers, where the suite's own 20 s server deadline
+    # and Playwright's 30 s default would already have fired. Seven times the
+    # observed cost, because being wrong in the tight direction here costs a
+    # verdict and being wrong in the loose direction costs runner minutes nobody
+    # notices.
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ticket-queue.yml
+++ b/.github/workflows/ticket-queue.yml
@@ -1,0 +1,78 @@
+name: ticket-queue
+
+# `examples/ticket-queue/test` — the queue's own suite, and the one thing in
+# this repository that reads a rendered page the way a viewer does.
+#
+# **Why it needed a workflow of its own (issue #182).** It landed with #132 as
+# the gate on the queue's search: 12 assertions off a real browser and an
+# `INJECTIONS` table of 11 breaks that must each make a *named* test fire.
+# Nothing ran it. `ticket-queue-demo.yml` fires on the same paths and *records*
+# — it never invokes `./test` — and `tests/unit`/`tests/ci-unit` do not know the
+# example exists. So those injections graded the change that introduced them,
+# and nothing since.
+#
+# **Why both halves run on every triggering push, and not just the suite.**
+# Measured on a 16-core developer box: the suite is 12 tests in 3.6 s and the
+# manifest is 11 injections in 87 s. That is inside the noise of the demo
+# recording that already fires on these same paths, and the manifest is the
+# half that answers "can these assertions still fail" — the question that goes
+# stale exactly when `web/app.js` changes, which is when this fires. Running it
+# nightly *as well* is what covers the weeks nobody touches the example.
+#
+# Chromium only. No ffmpeg, no lock, nothing shared: `serve` is stdlib-only and
+# the suite binds an ephemeral port, so this can run beside anything.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "examples/ticket-queue/**"
+      - ".github/workflows/ticket-queue.yml"
+  pull_request:
+    paths:
+      - "examples/ticket-queue/**"
+      - ".github/workflows/ticket-queue.yml"
+  # Same cadence as smoke-inject, half an hour later so the two do not contend
+  # for a runner. This is the leg that keeps the manifest honest in a week when
+  # the paths filter above never fires.
+  schedule:
+    - cron: "50 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ticket-queue-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: examples/ticket-queue/test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      # The suite's only prerequisite. `--with-deps` because a fresh runner has
+      # none of the shared libraries headless Chromium links against.
+      - name: Install Chromium for Playwright
+        run: uv run --with playwright playwright install --with-deps chromium
+
+      # The gate. A non-zero exit here fails the job: no pipe, no `|| true`,
+      # no `continue-on-error` — the suite's exit status is the step's.
+      - name: examples/ticket-queue/test
+        run: examples/ticket-queue/test
+
+      # An assertion nobody has watched fail is a claim, not a check. This
+      # breaks the app eleven named ways — the filter, the row markup, the case
+      # fold, the row's identity, the heading count, and the fixture control
+      # that stops a requester match being satisfied by a title — and requires
+      # the *named* test to be the one that fires. It aborts with exit 3 rather
+      # than passing if an injection's pattern does not match exactly once.
+      - name: examples/ticket-queue/test --fault-inject
+        run: examples/ticket-queue/test --fault-inject

--- a/.github/workflows/ticket-queue.yml
+++ b/.github/workflows/ticket-queue.yml
@@ -44,7 +44,12 @@ permissions:
 
 concurrency:
   group: ticket-queue-${{ github.ref }}
-  cancel-in-progress: true
+  # Ten pushes to a branch should cost one run — but **not** at the price of the
+  # nightly. A scheduled run and a push to main share `github.ref`, so a plain
+  # `true` here lets a 04:51 commit cancel the 04:50 leg, and a cancelled run
+  # reports nothing at all. The nightly is the leg that covers the weeks the
+  # paths filter never fires, so it is the one that must not be silently lost.
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
 
 jobs:
   test:

--- a/examples/ticket-queue/web/app.js
+++ b/examples/ticket-queue/web/app.js
@@ -23,12 +23,12 @@ function visibleTickets() {
     (t) =>
       (activeStatus === "all" || t.status === activeStatus) &&
       (term === "" ||
-        t.title.toLowerCase().includes(term) ||
-        t.id.toLowerCase().includes(term) ||
         // The requester is searchable *and* rendered on the row below. A match
         // on a field the queue does not show is indistinguishable from a bug:
         // the viewer sees a row survive a term that appears nowhere on it.
-        t.requester.toLowerCase().includes(term))
+        t.requester.toLowerCase().includes(term) ||
+        t.title.toLowerCase().includes(term) ||
+        t.id.toLowerCase().includes(term))
   );
 }
 

--- a/examples/ticket-queue/web/app.js
+++ b/examples/ticket-queue/web/app.js
@@ -23,12 +23,12 @@ function visibleTickets() {
     (t) =>
       (activeStatus === "all" || t.status === activeStatus) &&
       (term === "" ||
+        t.title.toLowerCase().includes(term) ||
+        t.id.toLowerCase().includes(term) ||
         // The requester is searchable *and* rendered on the row below. A match
         // on a field the queue does not show is indistinguishable from a bug:
         // the viewer sees a row survive a term that appears nowhere on it.
-        t.requester.toLowerCase().includes(term) ||
-        t.title.toLowerCase().includes(term) ||
-        t.id.toLowerCase().includes(term))
+        t.requester.toLowerCase().includes(term))
   );
 }
 

--- a/examples/ticket-queue/web/app.js
+++ b/examples/ticket-queue/web/app.js
@@ -28,7 +28,7 @@ function visibleTickets() {
         // The requester is searchable *and* rendered on the row below. A match
         // on a field the queue does not show is indistinguishable from a bug:
         // the viewer sees a row survive a term that appears nowhere on it.
-        t.requester.toLowerCase().includes(term))
+        false)
   );
 }
 

--- a/examples/ticket-queue/web/app.js
+++ b/examples/ticket-queue/web/app.js
@@ -28,7 +28,7 @@ function visibleTickets() {
         // The requester is searchable *and* rendered on the row below. A match
         // on a field the queue does not show is indistinguishable from a bug:
         // the viewer sees a row survive a term that appears nowhere on it.
-        false)
+        t.requester.toLowerCase().includes(term))
   );
 }
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -47,4 +47,34 @@ select = ["E4", "E7", "E9", "F", "W", "I", "UP", "B"]
 # rewrite all three files and collide with every queued PR, so they are
 # excluded rather than reformatted. This is a starting point: delete the
 # exclusion (and land the reformat as its own commit) once #3–#12 are merged.
-exclude = ["skills/demo-video/helpers/demo_recording/*.py"]
+#
+# `*.md` is the decision issue #192 asked for, and it is a scope statement, not
+# a lint waiver. From 0.16 ruff's *formatter* reads Python out of Markdown code
+# fences; its *checker* still does not (`ruff check` on a `.md` says "No Python
+# files found"), so this one line is the entire difference between 0.14.2 and a
+# current ruff on this tree — 3 files rewritten, all of them prose.
+#
+# A fence in a document is a figure, not source. Nothing imports it, runs it or
+# tests it; its only consumer is a person reading the page, and its layout was
+# chosen for that person. The three rewrites measured at 0.16.1 each cost the
+# reader: two ragged out columns of trailing comments that were lined up on
+# purpose (`rec.run(...)  # types visibly` under `rec.wait_for_prompt()  # …`),
+# one exploded a single-line call into a five-line vertical list, and one added
+# a blank line to skills/demo-video/SKILL.md — the always-loaded file, which
+# sits at 599 of the 600-line budget `tests/unit --budget` reports, so accepting
+# it would spend the last line of that budget on whitespace.
+#
+# What this gives up is *only* layout, and that is measured rather than assumed.
+# The formatter does not validate a fence: given ```python\ndef f(:\n it prints
+# "1 file already formatted" and exits 0. So including `.md` buys no error
+# detection at any version — it buys the formatter's opinion about columns, on
+# text whose columns were chosen by hand. Nothing in this repo checks that a
+# documentation example parses; that gap is issue #211 and this line does not
+# widen it.
+#
+# The counterpart, so this stays a decision and not a hiding place: RUFF_VERSION
+# in ci.yml names a current ruff, and `tests/lint` is clean at it.
+exclude = [
+    "skills/demo-video/helpers/demo_recording/*.py",
+    "*.md",
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -56,13 +56,14 @@ select = ["E4", "E7", "E9", "F", "W", "I", "UP", "B"]
 #
 # A fence in a document is a figure, not source. Nothing imports it, runs it or
 # tests it; its only consumer is a person reading the page, and its layout was
-# chosen for that person. The three rewrites measured at 0.16.1 each cost the
-# reader: two ragged out columns of trailing comments that were lined up on
-# purpose (`rec.run(...)  # types visibly` under `rec.wait_for_prompt()  # …`),
-# one exploded a single-line call into a five-line vertical list, and one added
-# a blank line to skills/demo-video/SKILL.md — the always-loaded file, which
-# sits at 599 of the 600-line budget `tests/unit --budget` reports, so accepting
-# it would spend the last line of that budget on whitespace.
+# chosen for that person. Measured at 0.16.1, the three rewrites cost that
+# reader in three ways: six trailing comments deliberately lined up in a column
+# get ragged out (`rec.run(…)       # types visibly` over `rec.wait_for_prompt()
+#            # waits …`); two calls written on one line explode into vertical
+# lists, one of them five lines longer; and skills/demo-video/SKILL.md gains a
+# blank line after a docstring, taking the always-loaded file from 599 to 600 of
+# the 600-line budget `tests/unit --budget` reports — the last line of a metered
+# file, spent on whitespace.
 #
 # What this gives up is *only* layout, and that is measured rather than assumed.
 # The formatter does not validate a fence: given ```python\ndef f(:\n it prints

--- a/tests/README.md
+++ b/tests/README.md
@@ -77,6 +77,22 @@ and one pin. Change the pin and the local command changes with it;
 reaches ruff any other way.
 [#189](https://github.com/rogvid/skills/issues/189) is what this cost before.
 
+**The pin is 0.16.1, and `ruff.toml` excludes `*.md` from the formatter**
+([#192](https://github.com/rogvid/skills/issues/192)). From 0.16 ruff's
+formatter reads Python out of Markdown code fences — its checker still does
+not — and that one behaviour was the entire disagreement between 0.14.2 and a
+current ruff on this tree: 3 files, all documentation. A fence in a document is
+a figure rather than source; nothing imports or runs it, its reader is a person,
+and the reformat measured at 0.16.1 ragged out two columns of deliberately
+aligned trailing comments and spent the last line of `SKILL.md`'s 600-line
+budget on a blank one. What the exclusion gives up is **only layout**: the
+formatter does not validate a fence either way — hand it ```` ```python ````
+followed by `def f(:` and it prints "1 file already formatted" and exits 0. That
+nothing checks a documentation example parses is
+[#211](https://github.com/rogvid/skills/issues/211), and predates this. The
+reasoning is written at the exclusion in `ruff.toml`, which is the file a reader
+lands in.
+
 Then the recorder itself:
 
 ```sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -48,6 +48,17 @@ tests/
 
 [#136]: https://github.com/rogvid/skills/issues/136
 
+**A fourth suite lives outside this directory**, and it is here so nobody has
+to find that out by accident: `examples/ticket-queue/test` grades the example
+app the demo-video reference PR records — 12 assertions read off a real browser
+(3.6 s) and 11 injections against `web/app.js` and the seeded data (87 s). It
+belongs beside the app rather than here because it grades *that application*,
+not the recorder. `.github/workflows/ticket-queue.yml` runs both halves on any
+push touching `examples/ticket-queue/**` and nightly
+([#182](https://github.com/rogvid/skills/issues/182)); before that workflow
+existed nothing ran either half, so its injections graded the change that
+introduced them and nothing after it.
+
 Takes: `web/` and `terminal/` (the two media), the determinism pair, the
 problem takes, `segments/` — one demo recorded in two parts and joined with
 `stitch()` — and `evidence/`, a few seconds against what a beat's page text

--- a/tests/README.md
+++ b/tests/README.md
@@ -1434,10 +1434,18 @@ rather than remembered:
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
-plus one clean baseline per arm — not a stopwatch reading. The last measured
-end-to-end pair, 16.3 and 16.4 minutes, was taken when the manifest held
-sixteen entries and is not comparable; nobody has sat through the current one,
-and the nightly job's budget is set from the estimate.
+plus one clean baseline per arm — not a stopwatch reading. It has now been
+measured against a real run:
+[30705025900](https://github.com/rogvid/skills/actions/runs/30705025900), a
+`workflow_dispatch` of the nightly on main, took **41m23s** end to end, of which
+**40.3 minutes** was `tests/smoke-inject` itself and about a minute was the
+checkout and the ffmpeg and Chromium installs. So a CI runner costs about
+**1.16x** the estimate above; the 25-entry manifest, measured the same way on
+2026-08-01, gives 1.09x. `.github/workflows/smoke-inject.yml` sets its
+`timeout-minutes` from that measurement and says so
+([#191](https://github.com/rogvid/skills/issues/191)) — the 45 it replaced came
+from a rule that assumed 2x and would have predicted ~71 minutes for a manifest
+that costs 41.
 
 Every number in this section is read back out of this file and compared against
 the manifest by `tests/smoke-inject --self-test`, which runs on every push. It

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,10 +51,12 @@ tests/
 **A fourth suite lives outside this directory**, and it is here so nobody has
 to find that out by accident: `examples/ticket-queue/test` grades the example
 app the demo-video reference PR records — 12 assertions read off a real browser
-(3.6 s) and 11 injections against `web/app.js` and the seeded data (87 s). It
-belongs beside the app rather than here because it grades *that application*,
-not the recorder. `.github/workflows/ticket-queue.yml` runs both halves on any
-push touching `examples/ticket-queue/**` and nightly
+and 11 injections against `web/app.js`, its stylesheet and the seeded data. On a
+16-core developer box that is 3.6 s and 87 s; on a CI runner the whole job,
+Chromium install included, measured **2m08s**. It belongs beside the app rather
+than here because it grades *that application*, not the recorder.
+`.github/workflows/ticket-queue.yml` runs both halves on any push touching
+`examples/ticket-queue/**` and nightly
 ([#182](https://github.com/rogvid/skills/issues/182)); before that workflow
 existed nothing ran either half, so its injections graded the change that
 introduced them and nothing after it.


### PR DESCRIPTION
Three numbers and one suite that nothing kept honest. Each is settled by a
measurement taken for this pull request, not by a rule applied to an estimate.

Closes #182, #191, #192. Files opened along the way: #211, #212.

---

## #182 — the queue's suite now runs, and fails the job

`examples/ticket-queue/test` landed with #132 as the gate on the queue's search
— 12 assertions off a real browser, 11 injections that must each make a *named*
test fire — and nothing invoked it. `ticket-queue-demo.yml` fires on the same
paths and only *records*.

`.github/workflows/ticket-queue.yml` runs **both halves** on any push or pull
request touching `examples/ticket-queue/**`, nightly at 04:50 UTC (half an hour
after smoke-inject, so they do not contend for a runner), and on dispatch.
Chromium only; no ffmpeg, no lock.

Both halves per push rather than the suite alone: measured, the suite is 12
tests in 3.6 s locally and the manifest 11 injections in 87 s — inside the noise
of the demo recording that already fires on these paths, and the manifest is the
half that answers *can these assertions still fail*, which goes stale exactly
when `web/app.js` changes.

### Seen to fail — a workflow asserted to gate is not gating

A CI job that would pass on broken code is the catalogue's *measurement that
grades nothing*, and reading the YAML does not settle it. So the #132 bug was
pushed back into `web/app.js` on this branch and the job watched:

**Both** steps were broken, separately, because they fail for different reasons
and the first one failing hides the second.

| commit | what was done to `web/app.js` | run | result |
|---|---|---|---|
| `0ff84b2` | nothing (control) | [30705386844](https://github.com/rogvid/skills/actions/runs/30705386844) | **success**, 2m08s |
| `cc12064` | `t.requester…includes(term))` → `false)` — the #132 bug | [30705493848](https://github.com/rogvid/skills/actions/runs/30705493848) | **failure**, at the suite |
| `95cd852` | reverted | [30705564062](https://github.com/rogvid/skills/actions/runs/30705564062) | **success** |
| `3809d56` | filter clauses reordered — same semantics, suite green | [30706167037](https://github.com/rogvid/skills/actions/runs/30706167037) | **failure**, at the manifest |
| `457a3b4` | reverted | see checks | **success** |

The red run, from its log:

```
ERROR: test_the_requester_is_legible_on_the_matching_row
FAIL: test_a_requester_name_finds_the_ticket_whose_title_lacks_it
  File ".../examples/ticket-queue/test", line 174, in test_a_requester_name_finds_the_ticket_whose_title_lacks_it
    self.assertEqual(self.rows(), ["TQ-103"])
AssertionError: Lists differ: [] != ['TQ-103']
FAIL: test_a_shared_address_domain_finds_everyone_on_it
FAIL: test_part_of_an_address_finds_that_persons_tickets
FAIL: test_search_folds_case_in_both_directions (term='MIRA')
FAIL: test_search_folds_case_in_both_directions (term='Mira')
Ran 12 tests in 34.560s
FAILED (failures=5, errors=1)
##[error]Process completed with exit code 1.
```

Steps as GitHub recorded them on that run — the failure stops the job rather
than being swallowed:

```
success  Install Chromium for Playwright
failure  examples/ticket-queue/test
skipped  examples/ticket-queue/test --fault-inject
```

The second break is the one that matters more, because it is the shape a real
refactor takes: reordering the `||` clauses in `visibleTickets()` changes no
behaviour, all 12 tests still pass — and the exact string one `INJECTIONS` entry
searches for is gone, so the harness must refuse to certify rather than report
eleven caught injections out of ten.

```
success  examples/ticket-queue/test
failure  examples/ticket-queue/test --fault-inject
```

```
Ran 12 tests in 3.252s
OK
ABORT: injection 'the search stops comparing the requester (the bug in #132)'
       matched 0 times in web/app.js, expected exactly 1. The injection did not
       land, so nothing it would have proven is proven.
       looked for: '        t.requester.toLowerCase().includes(term))'
##[error]Process completed with exit code 3.
```

Without that second break the manifest step would be an unwatched claim — the
catalogue's *dominated assertion*, since the run I had proved red never reached
it.

`examples/` is **net-unchanged** by this branch: `git diff origin/main --
examples/` is empty. The break and its revert are two commits whose sum is zero.

The trap the task named was checked directly: neither step is piped, `|| true`'d
or `continue-on-error`'d, so the suite's exit status is the step's and the
step's is the job's — which is what the table above measures rather than claims.

---

## #191 — the nightly's budget, measured

`timeout-minutes: 45` came from *"~14 min on a developer box, doubled for CI,
plus install room"* — written at 16 entries, and no scheduled or dispatched run
had ever completed, so the 2× in that sentence was itself unmeasured. #191 was
right to refuse to fix it blind.

So it was measured: `workflow_dispatch`
[run 30705025900](https://github.com/rogvid/skills/actions/runs/30705025900) on
main, at the current 30-entry manifest, **success**.

| | |
|---|---|
| job wall clock | **41m23s** (15:01:56 → 15:43:19 UTC) |
| checkout + uv + ffmpeg + Chromium + `--self-test` | ~61 s |
| `tests/smoke-inject` | **40.3 min** — `All 30 injections were caught. [40.3 min]` |

Two findings, both worth more than the number:

**CI is 1.16× a developer box, not 2×.** `--list` estimates ~34.9 min of takes;
the runner spent 40.3. The 25-entry scheduled run of the same morning gives a
second point at 1.09× (34m50s in the step against a ~31.9 min estimate). The
rule the file stated would have predicted **~71 minutes for a manifest that
costs 41** — wrong in the direction that looks safe, which is exactly how the 45
survived unnoticed while the manifest grew underneath it.

**The 45 was nearly breached regardless.** 41m23s against 45 is **8 % of
headroom** — one slow runner away from a job that produces no verdict at all,
which is the worst outcome for the one thing that says whether the smoke suite
can still fail.

**`timeout-minutes: 60`** — the measured 41m23s with ~45 % headroom. The headroom
is for runner variance, not growth: the two measured factors differ by 6 %
between runs. It leaves room to reach roughly 50 min of takes before the timeout
binds, and #190's `--self-test` already fails a push when the *documented* figure
drifts, which is the signal to come back and measure rather than to nudge this.

Both `~14 min` comments are gone, and `tests/README.md`'s "nobody has sat through
the current one" paragraph now carries the measured pair. The `~35 min` figures
in that file are `--list`'s **estimate** and are machine-checked against
`arm_cost` by `tests/smoke-inject --self-test`, so they stay as they are on
purpose.

### Not fault-injected, and why

A `timeout-minutes` is not an assertion; there is nothing to break and watch.
Its evidence is the run above, whose id and wall clock are now in the file so
the next person can check the derivation instead of the conclusion.

### Also, while in this file

`ticket-queue.yml`'s `cancel-in-progress` is `${{ github.event_name !=
'schedule' }}` rather than `true`: a scheduled run and a push to main share
`github.ref`, so a plain `true` lets a 04:51 commit cancel the 04:50 leg, and a
cancelled run reports nothing. `smoke-inject.yml` has the same expression and is
**not** affected — it has no `push:` trigger, so only a manual dispatch on main
shares its group.

---

## #192 — a current ruff, and a doc fence is a figure

`RUFF_VERSION` 0.14.2 → **0.16.1**, with `*.md` added to `ruff.toml`'s
`[format] exclude` and the reasoning written there.

**What the disagreement was.** From 0.16 ruff's *formatter* reads Python out of
Markdown fences; its *checker* does not, at any version — `ruff check` on a
`.md` answers `warning: No Python files found under the given path(s)`. That one
behaviour is the whole gap: 34 files in scope against 13, 3 that would be
rewritten, all documentation.

**The decision** is #192's third option, and it is a scope statement rather than
a lint waiver. A fence in a document is a figure — nothing imports, runs or
tests it; its only consumer is a person, and its layout was chosen for that
person. The cost of accepting the rewrite, measured:

- six trailing comments deliberately aligned in a column get ragged out
- two calls written on one line explode into vertical lists, one five lines longer
- `skills/demo-video/SKILL.md` gains a blank line after a docstring — **599 → 600
  of a 600-line budget**. Not *over* (the check is `lines > 600`), but the last
  line of a metered, always-loaded file spent on whitespace.

**What it gives up is only layout, and that is measured.** The formatter does
not validate a fence either:

```
$ cat broken.md            # ```python / def f(: / pass / ```
$ ruff format --isolated --check broken.md
1 file already formatted
format exit=0
```

So keeping `.md` in scope buys no error detection at all. That nothing here
checks a documentation example parses is #211, filed with that measurement, and
this line does not widen it.

**No reformat lands**, so there is nothing to separate from the bump.

### Seen to fail

Each injection matched **exactly once** or the injector aborted.

**A — remove `"*.md"` from `[format] exclude`.** The exclusion has to be
load-bearing, or the pin could not have been moved at all.

```
$ ./tests/lint
lint: ruff 0.16.1, pinned by .github/workflows/ci.yml
All checks passed!
unformatted: File would be reformatted
   --> skills/demo-video/SKILL.md:179:1
178 | """<one line: the demo story>"""
179 +
180 | import os, sys
...
    -     rec.run("mytool init my-app")       # types visibly, presses Enter
325 +     rec.run("mytool init my-app")  # types visibly, presses Enter
unformatted: File would be reformatted
   --> skills/demo-video/reference/review.md:238:15
unformatted: File would be reformatted
  --> skills/demo-video/reference/terminal.md:27:13
3 files would be reformatted, 31 files already formatted
lint: ruff format --check failed
tests/lint exit=1
```

**B — `x = {  'a' :1,'b':2 }` into `.github/scripts/demo-comment`.** The
exclusion must not have widened past `.md`; if it had, the formatter check would
have stopped grading Python and would say nothing here.

```
$ ./tests/lint
lint: ruff 0.16.1, pinned by .github/workflows/ci.yml
I001 [*] Import block is un-sorted or un-formatted --> .github/scripts/demo-comment:29:1
E402 Module level import not at top of file --> .github/scripts/demo-comment:33:1
E402 ... :34:1
E402 ... :35:1
Found 4 errors.
lint: ruff check failed
unformatted: File would be reformatted --> .github/scripts/demo-comment:32:1
   - x = {  'a' :1,'b':2 }
33 + x = {"a": 1, "b": 2}
1 file would be reformatted, 12 files already formatted
lint: ruff format --check failed
tests/lint exit=1
```

**C — `RUFF_VERSION` back to `"0.14.2"`.** The property #189 bought, and the one
the task requires this change to keep: changing the pin changes what the local
command runs.

```
$ ./tests/lint
lint: ruff 0.14.2, pinned by .github/workflows/ci.yml     # was 0.16.1
```

`./tests/lint --self-test` guard 2 is what refuses to let that rot, and it
passes.

---

## Verification

Local, on this branch, all green:

| command | result |
|---|---|
| `actionlint .github/workflows/*.yml` | exit 0 |
| `./tests/lint` | ruff 0.16.1 · All checks passed · 13 files already formatted |
| `./tests/lint --self-test` | "One pin, one command" |
| `./tests/unit` | 153 tests, OK |
| `./tests/ci-unit` | 49 tests, OK |
| `./tests/unit --budget` | 599 lines, budget 600 — **unchanged** |
| `./tests/smoke-inject --self-test` | "Every guard refused what it exists to refuse", 7 README figures OK |
| `examples/ticket-queue/test` | 12 tests, OK |

`tests/smoke` was not run: it holds a machine-wide lock other work needed, and
nothing here touches the recorder. CI's `smoke` job ran it on this branch and
passed ([30705564063](https://github.com/rogvid/skills/actions/runs/30705564063)).

## Stated limits

- **The new nightly leg has never fired on a schedule.** Its per-push leg is
  proven above; the `cron:` line itself is only proven by the dispatch path
  they share.
- **`timeout-minutes: 60` rests on two runs**, both from the same morning and
  the same runner pool. Runner-to-runner variance beyond those two is covered by
  headroom rather than by measurement.
- **`examples/ticket-queue/test` is still unlinted** — `ruff.toml`'s
  `extend-include` names `examples/*/serve` and `examples/*/tickets`, not
  `examples/*/test`. Measured: one `B904` and a two-hunk reformat. Fixing it
  lands a diff inside `examples/` while other work is in flight there, so it is
  #212 rather than this branch.
- **Nothing checks that a Python example in the docs parses**, at any ruff
  version, before or after this change. #211, with the measurement.
- **The `*.md` exclusion is repo-wide**, not scoped to `skills/`. A future
  `.md` here whose fences would genuinely benefit from the formatter does not
  get it. The exclusion is one line to narrow.
