### PR TITLE
Make tests/smoke tell the truth about its own runs (#105, #168, #209)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -96,6 +96,8 @@ tests/smoke --strict-only         # just the two takes strict=True must refuse
 tests/smoke --issues-only         # just the broken page and the failing
                                   #   commands, which is what check_issues
                                   #   grades (issue #197)
+tests/smoke --lock-only           # records nothing: what a run the machine
+                                  #   lock refuses leaves behind (issue #105)
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -107,7 +109,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~48 s)
-tests/smoke-inject                # all 30 entries, ~35 min
+tests/smoke-inject                # all 34 entries, ~35 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -1308,6 +1310,35 @@ Three things about how these are built are worth knowing before trusting them:
   deviation against the same 6.0 floor the web stills use — which transitively
   says `demo.mp4` has a picture where it stopped.
 
+### What a run that never started leaves behind (issue #105)
+
+`tests/smoke --lock-only` records nothing and takes under a second. It spawns
+two child runs of `tests/smoke` and grades what they say about their own output
+directory — the suite's account of itself, on the one path where the suite used
+to lie.
+
+`main()` built its output directory and announced it *before* taking the
+machine lock, so a run the lock refused created an empty
+`/tmp/demo-video-smoke-*`, never removed it, and printed `recordings left in`
+naming it, directly under `smoke: FAILED`. 85 such directories, 80 MB, over
+three days of ordinary work — and a reader who followed that last line went
+looking for a failure's evidence and found an empty directory.
+
+It is **a pair**, and it has to be:
+
+| child | how it ends | what it must show |
+|---|---|---|
+| refused | the arm itself holds the machine lock, so the child is refused by construction | it added nothing to `$TMPDIR`, and printed no `recordings left in` |
+| started, then failed | `--allow-concurrent`, into an `--out-dir` whose take directory carries a planted file `fresh_take_dir` refuses | it *did* print `recordings left in`, naming that directory |
+
+Without the second, "never print that line" is a passing answer to #105 and it
+is the wrong one: the line is how somebody reading `smoke: FAILED` finds the
+recordings, on every failure of a run that actually started. What the two pin
+between them is the only rule true on both paths — **the line follows whether
+this run started**, not whether the directory happens to hold anything. All
+three of the manifest's entries for this arm are there to keep both halves
+gradeable.
+
 ## The injection manifest — proving `smoke` can still fail
 
 Everything above is an assertion. `tests/smoke-inject` is what says those
@@ -1325,6 +1356,7 @@ are what changed that, and they are now load-bearing rather than a convenience.
 
 | arm | clean, measured on one box |
 |---|---|
+| `--lock-only` | 1 s |
 | `--evidence-only` | 7 s |
 | `--coverage-only` | 8 s |
 | `--narration-only` | 8 s |
@@ -1401,7 +1433,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-30 entries, 10 arms, ~34.9 min of takes
+34 entries, 12 arms, ~35.2 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -1420,6 +1452,8 @@ paragraph whose job is to say what this manifest does not cover.
 
 | arm | entries | what a miss would mean |
 |---|---|---|
+| `--lock-only` | 3 | a run the machine lock refuses goes back to building an output directory it will never write to and printing `recordings left in` under `smoke: FAILED`, naming it ([#105](https://github.com/rogvid/skills/issues/105)) — or the fix overshoots and no failing run is told where its recordings are, which the third entry is the control for |
+| `--narration-only` | 1 | the narration fixture goes back to leaving its interlude card up for the whole take, so every frame after the third beat — both captions the arm measures included — is the card and not the app, and nothing fails ([#168](https://github.com/rogvid/skills/issues/168)) |
 | `--coverage-only` | 5 | the report flatters the storyboard: nothing reported unclaimed, a claim pointing at the wrong beat or forgetting its segment, an undeclared tag accepted, the finding dropped from `timeline.md` |
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
@@ -1433,7 +1467,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **19 of `tests/smoke`'s 35 check functions have no entry**, and the harness
+- **19 of `tests/smoke`'s 37 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -1601,6 +1635,55 @@ knows is missing is worse than one that is openly absent.
   the wall clock while pixels ride the screencast. Tracked in
   [#18](https://github.com/rogvid/skills/issues/18), which matters most to
   [#8](https://github.com/rogvid/skills/issues/8).
+
+- **`--web-only` still goes red when the capture loses more than 0.75 s, and
+  the bars were not widened to stop it.**
+  [#209](https://github.com/rogvid/skills/issues/209) asked whether the
+  caption-timing bars measure something real that load breaks, or an artefact
+  of the harness's own timing. Measured, four `--web-only` runs on this box,
+  one at a time behind the machine lock, reading how far the video sits ahead
+  of the beat log at each of the two probes:
+
+  | run | loadavg | result | first probe | closing probe |
+  |---|---|---|---|---|
+  | 1 | 1.25 | FAILED | -880 ms | -800 ms |
+  | 2 | 2.05 | PASSED | -80 ms | 0 ms |
+  | 3 | 2.85 | FAILED | -120 ms | -800 ms |
+  | 4 | 19.8, 16 busy workers | FAILED | -880 ms | -840 ms |
+
+  **Real, and not load.** The reading is bimodal — either under 120 ms or
+  800-880 ms, never in between — and it is taken off a file that was already
+  written, so nothing the analysis does can produce it. Two of the three runs
+  with no load generator failed, at the loads the issue's own
+  counter-measurement called idle; the run at loadavg 19.8 failed the same way
+  and took 383 s against 137 s, with extra failures in
+  [#78](https://github.com/rogvid/skills/issues/78)'s shape (a blank opening,
+  both spotlight windows). Load makes it worse and much slower. It does not
+  cause it.
+
+  **Why the bars are unchanged.** Run 3 is the reason. Its first probe read
+  -120 ms and its closing probe -800 ms: 680 ms of screencast stall landing
+  *between* the probes, with `TICKER_JS` injected and asserted alive. A
+  `MAX_CAPTURE_LOSS_S` wide enough to absorb runs 1 and 4 turns run 3 into a
+  `MAX_SKEW_DRIFT_S` failure instead — and that bar's message attributed drift
+  to the beat log's clock, so the arm would have gone from red to *confidently
+  wrong* about a third of the time. A bar tuned to this box, buying a worse
+  artifact, is not a trade worth making, so it was not made.
+
+  What did change is the one thing here that was the harness's own.
+  `ALIGN_PRE_S` was a hand-written 1.2 s against a requirement of
+  `MAX_CAPTURE_LOSS_S + 0.48 s` = 1.23 s, so a slide *inside* the tolerance
+  this file states was reported as "the caption could not be timed" instead of
+  passing; its comment claimed 0.45 s of margin and the real figure was
+  -0.03 s. It is derived from the bar now, and reaches `ALIGN_OVERSHOOT_S`
+  past it so a slide the bar rejects is reported as a number rather than as a
+  measurement that could not be made. The drift message no longer names a
+  cause it cannot tell apart from the other one.
+
+  So `--web-only` on a box where the capture loses that window is still red,
+  and now it is red about something it can state. What nothing here grades is
+  *why* the capture loses it with the ticker running —
+  [#215](https://github.com/rogvid/skills/issues/215).
 - **Nothing reads the caption text off the video.** The timing check proves the
   caption *band* changed when `timeline.json` says it did; that the words are
   the right words is a DOM assertion (`check_caption`) taken at record time.

--- a/tests/smoke
+++ b/tests/smoke
@@ -426,8 +426,10 @@ CAPTION_PROBE = ("90-caption-off", "91-caption-on")
 # is how long the clearing caption's fade-out keeps moving the band after
 # `caption("")` returns. Reach back further than that and the measurement takes
 # the tail of the *previous* caption as its baseline and reports a busy run-up.
-# At 2.0 against ALIGN_PRE_S of 1.2 there is 0.54 s of margin. A capture loss
-# does not enter into it: it slides the window and the fade together.
+# At 2.0 against ALIGN_PRE_S of 1.50 there is 0.24 s of margin — six frames,
+# and down from the 0.54 s it was before issue #209 widened the window to reach
+# the bar it feeds. A capture loss does not enter into it: it slides the window
+# and the fade together.
 PROBE_CAPTION = "Recorded end to end."
 PROBE_QUIET_S = 2.0
 
@@ -786,31 +788,40 @@ DURATION_TOLERANCE_S = 0.2
 #     wall time and everything after it lands early. TICKER_JS removes that
 #     for the whole storyboard, but not for the ~0.7 s between the page being
 #     created and the first line of storyboard running — the recorder's own
-#     setup, which no test code can reach. Roughly 1 web take in 12 loses that
-#     window whole: -600 ms, uniformly, from the very first caption. Tolerated
-#     and reported, not asserted away; issue #18.
+#     setup, which no test code can reach. A web take that loses that window
+#     loses it whole, uniformly, from the very first caption. Tolerated and
+#     reported, not asserted away; issue #18.
+#
+#     The number is stale and knowingly so. It was written as "roughly 1 take
+#     in 12, -600 ms", which is what 0.75 was set from; four `--web-only` runs
+#     measured while grading issue #209 read -880/-800, -80/-0, -120/-800 and
+#     -880/-840 ms. That is over the bar, at idle as well as under load, and
+#     the bar was **not** widened to absorb it — `tests/README.md`, Known gaps,
+#     says why, and issue #215 is where the cause is being looked for.
 #
 #   * MAX_SKEW_DRIFT_S — how far the two probes' skews may differ. This is the
-#     sharp one, and it is symmetric. Anything the capture does to a take, it
-#     does to every frame after it equally, so a stall moves both probes
-#     together and cancels here. Anything wrong with the *clock* does not: a
-#     backwards step lands between the probes and shows up as drift, as does a
+#     sharp one, and it is symmetric. A capture stall *before* the first probe
+#     moves both of them equally and cancels here; anything wrong with the
+#     *clock* does not, since a backwards step lands between them, as does a
 #     beat stamped somewhere other than where its verb ran. Observed across
 #     twelve takes with the ticker: 0 to 120 ms, all of it the 40 ms sampling
-#     grid and the caption's own 0.3 s fade. A mid-take screencast stall (520
-#     ms) and the measured clock step (573 ms) are both well over the bar.
+#     grid and the caption's own 0.3 s fade.
+#
+#     What this bar does **not** do is say which of the two it caught, and the
+#     comment here used to: a stall landing *between* the probes does not
+#     cancel either. Measured on this box while grading issue #209, one
+#     `--web-only` take read -120 ms at the first probe and -800 ms at the
+#     closing one — 680 ms of screencast stall, mid-take, with TICKER_JS
+#     running and asserted alive. The measured clock step (573 ms) is over the
+#     same bar, and from inside this measurement the two are the same number.
 MAX_LOG_EARLY_S = 0.25
 MAX_CAPTURE_LOSS_S = 0.75
 MAX_SKEW_DRIFT_S = 0.25
 
-# Window sampled around the probe beat, and the rate it is sampled at (the
-# recorders encode at 25 fps, so this is every frame and the measurement
-# quantises to 40 ms). The run-up has to clear MAX_CAPTURE_LOSS_S — a take that
-# lost that much wall time puts the caption that far into the window, and a
-# window starting after it has no baseline at all — while staying inside the
-# caption-band quiet PROBE_QUIET_S buys. Both, at 1.2: 0.45 s of margin on the
-# first, 0.54 s on the second.
-ALIGN_PRE_S, ALIGN_POST_S, ALIGN_FPS = 1.2, 0.8, 25
+# The rate the window is sampled at (the recorders encode at 25 fps, so this is
+# every frame and the measurement quantises to 40 ms), and how far past the
+# beat it runs.
+ALIGN_POST_S, ALIGN_FPS = 0.8, 25
 
 # How far the band may wander before the caption arrives, as a fraction of how
 # far it travels once it does. Measured on quiet run-ups: under 1%. Judged over
@@ -820,6 +831,37 @@ ALIGN_PRE_S, ALIGN_POST_S, ALIGN_FPS = 1.2, 0.8, 25
 MAX_BASELINE_NOISE_FRACTION = 0.15
 CAPTION_FADE_FRAMES = int(ALIGN_FPS * 0.35)
 MIN_BASELINE_FRAMES = 4
+
+# How far back the window reaches from the beat — **derived**, because a
+# hand-written number here was narrower than the bar it feeds and nothing said
+# so (issue #209). The old comment read "the run-up has to clear
+# MAX_CAPTURE_LOSS_S ... 0.45 s of margin", and 1.2 - 0.75 is indeed 0.45; but
+# clearing the loss is not enough. `caption_appearance_s` also needs
+# CAPTION_FADE_FRAMES + MIN_BASELINE_FRAMES (0.48 s) of quiet *in front of* the
+# arrival, so a window of 1.2 s could not measure a slide past 0.72 s — inside
+# the 0.75 s this file says it tolerates. The real margin was -0.03 s, and what
+# a reader got instead of a passing take was "the caption could not be timed".
+#
+# So: reach back far enough to measure a slide at the tolerance, plus
+# ALIGN_OVERSHOOT_S past it, so that a slide the bar *rejects* is reported as a
+# number rather than as a measurement that could not be made. Measured slides
+# on this box are 0.80-0.88 s when the capture loses anything at all, which is
+# inside the overshoot and therefore now says so in the failure.
+#
+# Bounded above by the caption-band quiet PROBE_QUIET_S buys:
+#
+#     ALIGN_PRE_S < PROBE_QUIET_S + 0.04 - 0.30 = 1.74
+#
+# At 1.50 that leaves 0.24 s — six frames — between the start of the window and
+# the previous caption's fade-out. Thinner than the 0.54 s the old number had,
+# and the trade is deliberate: the fade is at a known place and a capture slide
+# is not.
+ALIGN_OVERSHOOT_S = 0.27
+ALIGN_PRE_S = (
+    MAX_CAPTURE_LOSS_S
+    + ALIGN_OVERSHOOT_S
+    + (CAPTION_FADE_FRAMES + MIN_BASELINE_FRAMES) / ALIGN_FPS
+)
 
 # When the narrow window comes up empty, re-sample this far either side before
 # concluding the caption was never drawn. The two answers — "the video slid out
@@ -4714,6 +4756,51 @@ def check_overlay_pair(takes: dict[str, dict]) -> list[str]:
     return failures
 
 
+def check_overlay_cleared(label: str, out_dir: Path) -> list[str]:
+    """This take did not end with one of the recorder's own overlays up.
+
+    The clean-path half of #163, on an arm that is not about overlays at all.
+    `check_overlay_pair` and `check_content_pair` grade the *reporting* — a
+    take that leaves a card up must name it by element id — and both leave one
+    up deliberately, so neither can notice a fixture that leaves one up by
+    accident. Issue #168 is what that costs: the narration take raised an
+    interlude in its third beat and never took it down, so every frame from
+    there to the end was the card rather than the app, including both captions
+    the arm exists to measure. Nothing failed. A warning was printed on an arm
+    the suite then called healthy, which is how a reader learns to skim
+    (`reference/limits.md`, "A demo of an error path always records a
+    problem").
+
+    Read off `content.warnings` in timeline.json — what a reader is handed —
+    rather than off the stderr line that carries the same finding, and by
+    element-id prefix rather than by the sentence the recorder happens to
+    phrase it in.
+    """
+    content = content_of(out_dir)
+    if content is None or not content.get("measured"):
+        return [
+            f"{label}: timeline.json carries no measured `content` report, so "
+            f"whether this take ended with one of the recorder's own overlays "
+            f"on screen was not graded at all "
+            f"({None if content is None else content.get('note')})"
+        ]
+    still_up = [
+        str(w)
+        for w in content.get("warnings") or []
+        if "__demo_" in str(w) or "__term_" in str(w)
+    ]
+    if still_up:
+        return [
+            f"{label}: the take ended with one of the recorder's own overlays "
+            f"still on screen — {still_up[0]!r}. It is opaque and at the top of "
+            f"the z-order, so every frame from the moment it went up is that "
+            f"overlay and not the app, whatever else this arm measures off the "
+            f'beat log. Take it down with `interlude("")` before the storyboard '
+            f"ends, or say in a comment why it has to stay (issue #168)"
+        ]
+    return []
+
+
 def crop_png(src: Path, rect: Rect, out: Path) -> bytes | None:
     """`rect` of a PNG, losslessly, as bytes."""
     x, y, w, h = rect
@@ -5014,9 +5101,15 @@ def caption_appearance_s(
     if usable < MIN_BASELINE_FRAMES:
         return None, (
             f"the caption arrives {arrived / ALIGN_FPS:.2f}s into a "
-            f"{ALIGN_PRE_S:.1f}s run-up, leaving no frames before its fade to "
-            f"use as a baseline — the video has slid further under the beat log "
-            f"than the search window allows for (see issue #18)"
+            f"{ALIGN_PRE_S:.2f}s run-up, so the video is "
+            f"{(ALIGN_PRE_S - arrived / ALIGN_FPS) * 1000:.0f} ms ahead of the "
+            f"beat log — further than this window can measure and still leave "
+            f"{MIN_BASELINE_FRAMES} frames of baseline in front of the "
+            f"caption's own fade. The window already reaches "
+            f"{ALIGN_OVERSHOOT_S * 1000:.0f} ms past the "
+            f"{MAX_CAPTURE_LOSS_S * 1000:.0f} ms of capture loss this file "
+            f"tolerates, so a slide this size is the capture and not the "
+            f"measurement (issue #18)"
         )
     noise = max(travel[1:usable], default=0.0)
     if noise > settled * MAX_BASELINE_NOISE_FRACTION:
@@ -5461,9 +5554,14 @@ def check_timeline(
         same_capture = probes[0][1].get("segment") == probes[1][1].get("segment")
         bound = MAX_SKEW_DRIFT_S if same_capture else MAX_CROSS_SEGMENT_DRIFT_S
         why = (
-            "A capture that dropped time would have moved both equally, so "
-            "this is the beat log's clock: time between beats is not being "
-            "measured monotonically."
+            "Two causes reach this bar and it cannot tell them apart: a clock "
+            "that is not being read monotonically between beats, and a "
+            "screencast stall landing *between* the probes rather than before "
+            "them. A stall before the first probe does move both equally and "
+            "does cancel here — that is what this bar is for — but one in the "
+            "middle does not, and on this box a stall of 680 ms was measured "
+            "doing exactly that with TICKER_JS running (issue #209). Read the "
+            "two skews above before blaming the beat log."
             if same_capture
             else "These two probes are in different segments, so they rode "
             "different captures and this bar is only a flake guard — the "
@@ -8621,6 +8719,15 @@ def record_narration(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
             rec.goto("/")
             rec.wait_for("#kpi-rev")
             rec.interlude(NARRATION_LONG_LINE, hold=NARRATION_HOLD_S)
+            # Take the card down before the captions this arm measures are on
+            # screen (issue #168). It is opaque at the top of the z-order, so
+            # without this every frame from here to the end of the take is the
+            # card and not the app — including both captions — and the arm
+            # still passed, because pacing is read out of timeline.json and
+            # the mix out of the audio track. The take now demonstrates what
+            # SKILL.md tells an author to do rather than the thing #162/#163
+            # exist to report.
+            rec.interlude("")
             rec.caption(NARRATION_SHORT_LINE)
             rec.pause(NARRATION_HOLD_S)
             rec.caption("")
@@ -8801,6 +8908,7 @@ def run_narration(out_root: Path) -> list[str]:
         + check_narration_pacing(out_dir)
         + check_narration_audio(out_dir, info["lines"])
         + check_healthy("narration", out_dir)
+        + check_overlay_cleared("narration", out_dir)
     )
     if not failures:
         offsets = ", ".join(f"{off:.2f}s" for off, _ in info["lines"])
@@ -9634,6 +9742,144 @@ def only_one_suite(allow_concurrent: bool) -> Iterator[None]:
         handle.close()
 
 
+# How long a child run of this file gets before the arm below gives up on it.
+# Both children fail within a second or two — one is refused by the lock, the
+# other by `fresh_take_dir` — so this is only a bound on a hang.
+LOCK_CHILD_TIMEOUT_S = 120.0
+
+
+def check_lock_refusal(out_root: Path) -> list[str]:
+    """What a run that never started leaves behind, against one that did.
+
+    Issue #105. `main()` used to build its output directory and announce it
+    *before* taking the machine lock, so a run the lock refused created an
+    empty `/tmp/demo-video-smoke-*`, never removed it, and printed
+    `recordings left in` naming it — directly under `smoke: FAILED`. That is
+    the artifact-lying shape this whole suite exists to catch, produced by the
+    suite: a reader goes looking for the failure's evidence, finds an empty
+    directory, and reads it as "the recorder wrote nothing" rather than "this
+    run never happened".
+
+    **Graded as a pair, and it has to be a pair.** The refusal on its own would
+    be satisfied by a `main()` that never printed the line at all, and that
+    line is right and wanted on every failure of a run that *did* start — a
+    failed take is debugged out of its directory. So the second child gets past
+    the lock and fails, and must name its directory. What the two pin between
+    them is the rule "the line follows whether this run started", which is the
+    only rule that is true on both paths.
+
+    This process holds the machine lock — every arm runs inside
+    `only_one_suite()` — so the first child is refused by construction rather
+    than by a fixture that has to be believed. The second is handed
+    `--allow-concurrent` for the same reason: this arm records nothing, which
+    is the one circumstance the flag documents.
+
+    `--coverage-only` on both, deliberately: if the lock were somehow *not*
+    held, the first child would run an 8 s arm rather than the whole suite.
+    """
+    smoke = Path(__file__).resolve()
+    failures: list[str] = []
+
+    def child(*extra: str) -> subprocess.CompletedProcess[str] | None:
+        try:
+            return subprocess.run(
+                [str(smoke), "--coverage-only", *extra],
+                capture_output=True,
+                text=True,
+                timeout=LOCK_CHILD_TIMEOUT_S,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            failures.append(
+                f"lock: a child smoke run did not finish in "
+                f"{LOCK_CHILD_TIMEOUT_S:.0f}s ({' '.join(extra) or 'no flags'})"
+            )
+            return None
+
+    # -- the refused run ------------------------------------------------------
+    #
+    # Written from the reader's side: the reproduction in #105 is
+    # `ls -d /tmp/demo-video-smoke-*`, and the claim is that a refused run adds
+    # nothing to the temp directory. Matched more broadly than the prefix
+    # `open_output()` uses, so a renamed prefix surfaces as a failure here
+    # rather than as a check quietly looking for the wrong name.
+    tmp = Path(tempfile.gettempdir())
+
+    def litter() -> set[str]:
+        return {
+            p.name for p in tmp.iterdir() if "smoke" in p.name or "demo-video" in p.name
+        }
+
+    before = litter()
+    refused = child()
+    left = sorted(litter() - before)
+    if refused is not None:
+        output = refused.stdout + refused.stderr
+        if "refusing to run a second smoke suite" not in output:
+            failures.append(
+                f"lock: a second suite started while this one holds "
+                f"{SMOKE_LOCK} — the premise of everything below is that the "
+                f"child is refused, and it was not. Exit {refused.returncode}, "
+                f"tail: {output[-400:]!r}"
+            )
+        else:
+            if left:
+                failures.append(
+                    f"lock: a run the lock refused created {left!r} in {tmp} "
+                    f"and left it there. The run never recorded anything, so "
+                    f"each refusal adds an empty directory nothing will ever "
+                    f"reap — 85 of them, 80 MB, is what issue #105 measured"
+                )
+            said = [ln for ln in output.splitlines() if "recordings left in" in ln]
+            if said:
+                failures.append(
+                    f"lock: a run the lock refused printed `recordings left "
+                    f"in` under `smoke: FAILED`, naming a directory it never "
+                    f"wrote to. Nothing was recorded, so there is nothing to "
+                    f"read there and the line sends its reader looking: "
+                    f"{said[0].strip()!r}"
+                )
+
+    # -- the run that started, and failed -------------------------------------
+    #
+    # The control. `fresh_take_dir` refuses a take directory this harness did
+    # not create, which fails the child in about a second, past the lock and
+    # with an output directory of its own — so the line the refused run must
+    # not print is one this run must.
+    started_root = (out_root / "lock-started").resolve()
+    (started_root / "coverage").mkdir(parents=True, exist_ok=True)
+    (started_root / "coverage" / "somebody-elses-file.txt").write_text(
+        "Planted by check_lock_refusal so the child fails after it starts.\n"
+    )
+    started = child("--allow-concurrent", "--out-dir", str(started_root))
+    if started is not None:
+        output = started.stdout + started.stderr
+        if "refusing to touch" not in output:
+            failures.append(
+                f"lock: the control run was supposed to get past the lock and "
+                f"fail on a take directory it does not own, and did not — so "
+                f"nothing here grades the failure path the `recordings left "
+                f"in` line is *for*. Exit {started.returncode}, tail: "
+                f"{output[-400:]!r}"
+            )
+        elif f"recordings left in {started_root}" not in output:
+            failures.append(
+                f"lock: a run that started and then failed did not say "
+                f"`recordings left in {started_root}`. That line is how "
+                f"somebody reading `smoke: FAILED` finds the evidence, and "
+                f"suppressing it everywhere is not the fix to issue #105 — the "
+                f"refusal path is. tail: {output[-400:]!r}"
+            )
+
+    if not failures:
+        print(
+            "smoke: lock — a refused run left nothing in "
+            f"{tmp} and claimed no recordings; a run that started and failed "
+            "named its directory"
+        )
+    return failures
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Smoke-test the demo-video recorders against tests/fixture.",
@@ -9707,6 +9953,12 @@ def main() -> int:
         "what check_issues grades (issue #197)",
     )
     parser.add_argument(
+        "--lock-only",
+        action="store_true",
+        help="record nothing: grade what a run the machine lock refuses "
+        "leaves behind, against one that started and failed (issue #105)",
+    )
+    parser.add_argument(
         "--allow-concurrent",
         action="store_true",
         help="run even when another suite holds the machine lock. The timing "
@@ -9743,6 +9995,7 @@ def main() -> int:
             ("--coverage-only", args.coverage_only),
             ("--strict-only", args.strict_only),
             ("--issues-only", args.issues_only),
+            ("--lock-only", args.lock_only),
         )
         if on
     ]
@@ -9765,18 +10018,13 @@ def main() -> int:
 
     scrub_env()
 
-    if args.out_dir:
-        out_root = args.out_dir.resolve()
-        out_root.mkdir(parents=True, exist_ok=True)
-        ephemeral = False
-    else:
-        out_root = Path(tempfile.mkdtemp(prefix="demo-video-smoke-"))
-        ephemeral = True
-    print(f"smoke: output -> {out_root}")
-
     failures: list[str] = []
+    out_root: Path | None = None
+    ephemeral = False
     try:
         with only_one_suite(args.allow_concurrent):
+            out_root, ephemeral = open_output(args)
+            print(f"smoke: output -> {out_root}")
             failures += run_phases(only, out_root)
     except SmokeFailure as exc:
         failures.append(str(exc))
@@ -9785,20 +10033,57 @@ def main() -> int:
         print("\nsmoke: FAILED", file=sys.stderr)
         for line in failures:
             print(f"  - {line}", file=sys.stderr)
-        print(f"\nsmoke: recordings left in {out_root}", file=sys.stderr)
+        # `out_root is None` is exactly "this run never got past the lock", and
+        # that — rather than whether the directory happens to hold anything —
+        # is what decides the line. On every other failure the directory is the
+        # evidence and saying where it is is the useful thing; on a refusal
+        # there is no directory, and telling somebody who has just been told
+        # their run did not happen where to find its recordings sends them
+        # looking for files that were never written (issue #105).
+        if out_root is None:
+            print(
+                "\nsmoke: nothing was recorded — this run never started, so "
+                "there is no output directory to look in.",
+                file=sys.stderr,
+            )
+        else:
+            print(f"\nsmoke: recordings left in {out_root}", file=sys.stderr)
         return 1
 
     print("\nsmoke: PASSED")
-    if ephemeral and not args.keep:
+    if out_root is not None and ephemeral and not args.keep:
         shutil.rmtree(out_root, ignore_errors=True)
-    else:
+    elif out_root is not None:
         print(f"smoke: recordings kept in {out_root}")
     return 0
+
+
+def open_output(args: argparse.Namespace) -> tuple[Path, bool]:
+    """This run's output directory, and whether the run owns it.
+
+    Called from **inside** `only_one_suite()`, which is the whole of issue
+    #105: a run the lock refuses has not started, and a directory it will
+    never write to is not evidence of anything. Creating it first left an
+    empty `/tmp/demo-video-smoke-*` behind for every refused run — 85 of them,
+    80 MB, over three days of ordinary work — and named it in a
+    `recordings left in` line printed directly under `smoke: FAILED`.
+    """
+    if args.out_dir:
+        out_root = args.out_dir.resolve()
+        out_root.mkdir(parents=True, exist_ok=True)
+        return out_root, False
+    return Path(tempfile.mkdtemp(prefix="demo-video-smoke-")), True
 
 
 def run_phases(only: str | None, out_root: Path) -> list[str]:
     """Every phase the chosen flag selects, in order."""
     failures: list[str] = []
+    # First, and it records nothing: it spawns two child runs of this file and
+    # reads what they say about their own output directory (issue #105). Two
+    # seconds, before ten minutes of takes, so a full run's own report about
+    # where its recordings are is graded before there are any.
+    if only in (None, "--lock-only"):
+        failures += check_lock_refusal(out_root)
     if only in (None, "--web-only"):
         failures += run_web(out_root)
     if only in (None, "--terminal-only"):

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -86,6 +86,10 @@ ARM_TIMEOUT_S = 1_200
 
 # Measured on this box, clean, one arm at a time (see tests/README.md).
 ARM_SECONDS = {
+    # Records nothing at all: two child runs of tests/smoke that both fail
+    # before a browser starts. Measured at 0.31 s, rounded to the 1 s this
+    # table's other rows are in.
+    "--lock-only": 1,
     "--evidence-only": 7,
     "--coverage-only": 8,
     "--issues-only": 26,
@@ -117,6 +121,67 @@ class Injection(NamedTuple):
 # The order is the order they run in: cheapest arm first, so a manifest that is
 # going to abort on a stale search string does it in eight seconds.
 INJECTIONS = [
+    # -- what a run that never started leaves behind (issue #105), 1 s an entry
+    #
+    # Three entries against one check function, because it is a *pair* of
+    # claims and either half alone is satisfied by the wrong fix. The first two
+    # break the refusal path — the directory, then the line — and the third
+    # breaks the control, a run that started and failed and must still be told
+    # where its recordings are. Without the third, "do not print that line" is
+    # a passing answer to issue #105 and it is the wrong one.
+    Injection(
+        name="a refused run builds its output directory before taking the lock",
+        module="tests/smoke",
+        old=(
+            "        with only_one_suite(args.allow_concurrent):\n"
+            "            out_root, ephemeral = open_output(args)\n"
+        ),
+        new=(
+            "        out_root, ephemeral = open_output(args)\n"
+            "        with only_one_suite(args.allow_concurrent):\n"
+        ),
+        arm="--lock-only",
+        sites=("check_lock_refusal",),
+        must_contain=(
+            "a run the lock refused created ",
+            "a run the lock refused printed `recordings left in`",
+        ),
+    ),
+    Injection(
+        name="a run that never started is told where its recordings are",
+        module="tests/smoke",
+        old="        if out_root is None:\n",
+        new="        if False:\n",
+        arm="--lock-only",
+        sites=("check_lock_refusal",),
+        must_contain=("a run the lock refused printed `recordings left in`",),
+    ),
+    Injection(
+        # The control. A `main()` that never says where the recordings are
+        # passes both entries above and fails this one.
+        name="no failing run is told where its recordings are",
+        module="tests/smoke",
+        old='            print(f"\\nsmoke: recordings left in {out_root}", file=sys.stderr)',
+        new="            pass",
+        arm="--lock-only",
+        sites=("check_lock_refusal",),
+        must_contain=("a run that started and then failed did not say",),
+    ),
+    # -- an overlay left up by accident (issue #168), 8 s an entry -------------
+    Injection(
+        # The narration fixture put an interlude card up in its third beat and
+        # never took it down, so every frame after it — including both captions
+        # the arm measures — was the card. Nothing failed: pacing is read out
+        # of timeline.json and the mix out of the audio track, and a warning
+        # was printed on an arm the suite called healthy.
+        name="the narration fixture leaves its interlude card up",
+        module="tests/smoke",
+        old='            rec.interlude("")\n            rec.caption(NARRATION_SHORT_LINE)',
+        new="            rec.caption(NARRATION_SHORT_LINE)",
+        arm="--narration-only",
+        sites=("check_overlay_cleared",),
+        must_contain=("the take ended with one of the recorder's own overlays",),
+    ),
     # -- the coverage report (issue #12), 8 s an entry ------------------------
     Injection(
         name="nothing is ever reported unclaimed",
@@ -699,7 +764,18 @@ class Refused(Exception):
 # A contended arm records nothing, so its failure list is that refusal and not
 # a verdict — reporting it as "the assertion did not fire" would be a lie in
 # the one direction this file exists to prevent.
+#
+# Matched against the *start of a failure line* rather than anywhere in the
+# failure list, and that is not tidiness: `--lock-only` grades the refusal path
+# by running a child of tests/smoke that the lock refuses, and quotes what the
+# child said. Searching the whole blob read that quotation as this run being
+# contended and aborted the manifest — a guard against a lie, telling one.
 CONTENDED = "refusing to run a second smoke suite"
+
+
+def contended(lines: list[str]) -> bool:
+    """Was this arm refused by the machine lock? `lines` is the failure list."""
+    return any(line.startswith(CONTENDED) for line in lines)
 
 
 def verify_manifest(entries: list[Injection]) -> None:
@@ -848,7 +924,7 @@ def baseline(arm: str) -> float:
     spent = time.monotonic() - started
     if code != 0:
         blob, lines = failure_report(err)
-        if CONTENDED in blob:
+        if contended(lines):
             raise Refused(
                 f"another smoke run holds the machine lock, so {arm} recorded "
                 f"nothing. Wait for it — a contended arm is not a verdict."
@@ -922,7 +998,7 @@ def inject(entries: list[Injection]) -> int:
             path.write_text(text.replace(entry.old, entry.new), encoding="utf-8")
             code, _, err = run_arm(root, entry.arm, Path(tmp) / "out")
         blob, lines = failure_report(err)
-        if CONTENDED in blob:
+        if contended(lines):
             print(
                 f"ABORT: another smoke run took the machine lock partway "
                 f"through, so {entry.arm} recorded nothing for "
@@ -1055,6 +1131,32 @@ def self_test() -> int:
         else:
             bad += 1
             print(f"WRONG    {what}: verdict said {'caught' if got else 'missed'}")
+
+    # And "was this arm refused by the lock", both ways. The false direction is
+    # the one that bit: `--lock-only` grades the refusal path by quoting what a
+    # refused child said, and a substring search over the whole failure list
+    # read that quotation as this run being contended.
+    for what, lines, want in (
+        (
+            "an arm the machine lock refused",
+            ["refusing to run a second smoke suite on this machine"],
+            True,
+        ),
+        (
+            "an assertion quoting a refused child (--lock-only)",
+            [
+                "lock: a run the lock refused printed `recordings left in`, "
+                "naming a directory it never wrote to: 'smoke: ANOTHER RUN "
+                "HOLDS ... refusing to run a second smoke suite'"
+            ],
+            False,
+        ),
+    ):
+        if contended(lines) == want:
+            print(f"{'REFUSED ' if want else 'CAUGHT  '} {what}")
+        else:
+            bad += 1
+            print(f"WRONG    {what}: contended() said {contended(lines)}")
 
     # The real manifest, against the real tree.
     try:


### PR DESCRIPTION
One slice: **`tests/smoke` tells the truth about its own runs.** Three issues,
two fixed and one measured and recorded as a gap.

Fixes #105. Fixes #168. **Does not close #209** — see below.

## #105 — a refused run built a directory and claimed recordings in it

`main()` created `out_root` and printed `smoke: output -> …` before entering
`only_one_suite()`, so a run the lock refused made an empty
`/tmp/demo-video-smoke-*`, never removed it, and printed `recordings left in`
naming it, directly under `smoke: FAILED`.

Both halves are fixed: `open_output()` is called from inside the lock, and the
line is printed only when the run got past it — `out_root is None` is exactly
"never started". A refused run now ends with

```
smoke: nothing was recorded — this run never started, so there is no output
directory to look in.
```

**Graded by a new `--lock-only` arm** (0.31 s, records nothing), and graded as a
pair, because the issue's own note is right: an absence check would pass for the
wrong reason. The arm holds the machine lock — every arm does — and spawns two
children of `tests/smoke`. One is refused by construction: it must add nothing
to `$TMPDIR` and print no `recordings left in`. The other gets past the lock and
fails on a take directory it does not own: it *must* print that line, naming its
directory. What the two pin between them is "the line follows whether this run
started", the only rule true on both paths — and it makes "never print the line"
a failing answer rather than a passing one.

## #168 — the narration fixture recorded a take under its own interlude card

`record_narration` raised an interlude in its third beat and never took it down,
so every frame after it — including both captions the arm measures — was the
card. Nothing failed, because pacing is read out of `timeline.json` and the mix
out of the audio track; a warning was printed on an arm the suite then called
healthy.

The card comes down with `interlude("")` right after the interlude beat rather
than at the end of the take, so the captions are recorded over the app and not
only the last few frames. `check_narration_pacing` still finds its
interlude/caption pair — the beat after the interlude is now the clear, and the
recorder still waits out the long clip before starting it — and
`--narration-only` passes clean.

New `check_overlay_cleared()` grades it off `content.warnings`, the artifact a
reader is handed, rather than off the stderr line carrying the same finding.

## #209 — measured, and deliberately not closed

**Verdict: real, and not load.** Four `--web-only` runs, one at a time behind
the machine lock, reading how far `demo.mp4` sits ahead of the beat log at each
of the two caption probes:

| run | loadavg | result | first probe | closing probe |
|---|---|---|---|---|
| 1 | 1.25 | FAILED | -880 ms | -800 ms |
| 2 | 2.05 | PASSED | -80 ms | 0 ms |
| 3 | 2.85 | FAILED | -120 ms | -800 ms |
| 4 | 19.8, 16 busy workers | FAILED | -880 ms | -840 ms |

Bimodal — under 120 ms or 800-880 ms, never in between — and read off a file
that was already written, so nothing the analysis does can produce it. Two of
the three runs with no load generator failed, at the loads the issue's own
counter-measurement called idle. The run at loadavg 19.8 failed the same way and
took 383 s against 137 s, with extra failures in #78's shape (a blank opening,
both spotlight windows). **Load makes it worse and much slower. It does not
cause it.**

**The bars were not widened.** Run 3 is why: its probes read -120 and -800 ms,
so 680 ms of screencast stall landed *between* them, with `TICKER_JS` injected
and asserted alive. A `MAX_CAPTURE_LOSS_S` wide enough to absorb runs 1 and 4
turns run 3 into a `MAX_SKEW_DRIFT_S` failure instead — and that bar's message
attributed drift to the beat log's clock, so the arm would have gone from red to
*confidently wrong* about a third of the time. That is a bar tuned to this box
buying a worse artifact.

**What did change** is the one thing here that was the harness's own timing
rather than the recording's. `ALIGN_PRE_S` was a hand-written 1.2 s against a
requirement of `MAX_CAPTURE_LOSS_S + 0.48 s` = 1.23 s: the search window could
not measure a slide *inside* the tolerance this file states, and reported it as
"the caption could not be timed" instead of passing. Its comment claimed 0.45 s
of margin; the real figure was -0.03 s. It is derived from the bar now and
reaches `ALIGN_OVERSHOOT_S` past it, so a slide the bar rejects is reported as a
number rather than as a measurement that could not be made. The drift message no
longer names a cause it cannot distinguish, and the stale "1 take in 12,
-600 ms" calibration is replaced by the readings above.

The dead pointers are fixed by reopening what they point at. **#18 and #78 are
reopened**, each with the measurement, because live text in `tests/smoke` cites
them — `only_one_suite`'s comment says in as many words that #78 "stays open".
**#215** is new: the screencast still loses 0.8 s with the ticker running, and
sometimes mid-take. That is #209's root cause and it is outside this scope.

`tests/README.md` **Known gaps** carries the table, the verdict and the reason
the bars are unchanged. A `--web-only` run on a box that loses that window is
still red, and it is now red about something it can state.

## Fault injection

Every assertion added here was watched failing. `tests/smoke-inject` refuses an
injection whose search string does not match exactly once.

```
$ ./tests/smoke-inject --arm lock
smoke-inject: 3 injection(s) over 1 arm(s), plus 1 clean baseline(s)

BASE  --lock-only passes clean (0s)

PASS  break: a refused run builds its output directory before taking the lock  [0s]
      --lock-only, in tests/smoke: with only_one_suite(args.allow_concurrent):
            out_root…
      caught: lock: a run the lock refused created ['demo-video-smoke-lgq8nxd6'] in /tmp and left it there. The run never recorded anything, so each refusal adds an
      caught: lock: a run the lock refused printed `recordings left in` under `smoke: FAILED`, naming a directory it never wrote to. Nothing was recorded, so there

PASS  break: a run that never started is told where its recordings are  [0s]
      --lock-only, in tests/smoke: if out_root is None:…
      caught: lock: a run the lock refused printed `recordings left in` under `smoke: FAILED`, naming a directory it never wrote to. Nothing was recorded, so there

PASS  break: no failing run is told where its recordings are  [0s]
      --lock-only, in tests/smoke: print(f"\nsmoke: recordings left in {out_root}", file=sys.stderr…
      caught: lock: a run that started and then failed did not say `recordings left in /tmp/smoke-inject-w431ey2_/out/lock-started`. That line is how somebody readi

All 3 injections were caught. [0.0 min]
```

```
$ ./tests/smoke-inject --arm narration
smoke-inject: 1 injection(s) over 1 arm(s), plus 1 clean baseline(s)

BASE  --narration-only passes clean (9s)

PASS  break: the narration fixture leaves its interlude card up  [8s]
      --narration-only, in tests/smoke: rec.interlude("")
            rec.caption(NARRATION_SHORT_LINE)…
      caught: narration: the take ended with one of the recorder's own overlays still on screen — 'the recorder\'s own overlay (#__demo_interlude) was still on scre

All 1 injections were caught. [0.1 min]
```

The third lock entry is the control the issue's note asks for: it deletes the
`recordings left in` line entirely, which satisfies both of the other two and
fails only this one.

`tests/smoke-inject`'s own contention guard needed narrowing for this arm to be
possible, and that is in the diff with a self-test case in both directions. The
guard searched the whole failure list for "refusing to run a second smoke
suite"; `--lock-only` *quotes* a refused child, so the manifest read that
quotation as its own run being contended and aborted — a guard against a lie,
telling one. It matches the start of a failure line now.

## What was run

| command | result |
|---|---|
| `./tests/unit` | 153 tests, OK |
| `./tests/unit --fault-inject` | all 93 injections caught |
| `./tests/ci-unit` | 49 tests, OK |
| `./tests/lint` | clean |
| `./tests/smoke-inject --self-test` | every guard held |
| `./tests/smoke-inject --arm lock` | 3/3 caught |
| `./tests/smoke-inject --arm narration` | 1/1 caught |
| `./tests/smoke --lock-only` | PASSED, 0.31 s |
| `./tests/smoke --narration-only` | PASSED |
| `./tests/smoke --segments-only` | PASSED |
| `./tests/smoke --web-only` | PASSED |
| `./tests/smoke --terminal-only` | PASSED |

**The whole suite was not run.** `tests/smoke` with no flag is ~10 minutes under
a machine-wide lock other agents are using, and every arm this diff can reach
was run on its own. `--segments-only`, `--web-only` and `--terminal-only` are
the three that exercise the widened `ALIGN_PRE_S` through `check_timeline`;
nothing else in the suite reads `caption_appearance_s`.

## Stated limits

- **`ALIGN_PRE_S` is graded by nothing.** Its effect shows only on a take that
  slid, and no injection can make a capture stall, so it joins the ungraded
  constants rather than getting an entry. What the diff pins is that it is
  *derived* from `MAX_CAPTURE_LOSS_S` rather than hand-written, which is the
  half that went wrong.
- **The `--lock-only` control run fails before a browser starts,** not after
  recording frames. It fails in `fresh_take_dir` on a planted file, so its
  directory holds that file rather than a partial take. It pins the rule — the
  line follows whether the run started — and not the stronger claim that the
  named directory contains video.
- The arm's temp-directory check watches for new entries whose name contains
  `smoke` or `demo-video`, deliberately broader than the prefix `open_output()`
  uses, so a renamed prefix surfaces as a failure here rather than as a check
  looking for the wrong name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
