### PR TITLE
Stop every repo-root tool walking 21 copies of the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ tests/out/
 
 # ffmpeg concat listing, written and removed by stitch()
 .concat.txt
+
+# Agent worktrees, each a full checkout of this repo. Ruff respects
+# .gitignore, so leaving these tracked makes every repo-root tool walk all of
+# them: tests/lint read 657 files here against CI's 13, and a red run pointed
+# at files on other branches (#219).
+.claude/


### PR DESCRIPTION
Adds `.claude/` to `.gitignore`. Partially addresses #219 — the fix, not the guard.

## What it costs today

```
$ ./tests/lint     # before
657 files already formatted
$ ./tests/lint     # after
13 files already formatted
```

CI checks 13. A developer with agent worktrees under `.claude/worktrees/` checked 657, the extra 644 being copies of this repo at other commits. Ruff respects `.gitignore`, so an un-ignored `.claude/` puts all of them in scope.

## How it was found

Rebasing #216 onto #213's ruff bump produced `lint: ruff format --check failed`. That reads as "this branch's Python needs reformatting under 0.16.1" — and it was false. The unformatted files were in other agents' worktrees, at other commits.

Running `ruff format .` to clear it reformatted **57 files across 19 worktrees**, left `git status` clean, and did not fix the red. The only signal that anything was wrong was the file count being 657 when the repo has 13.

## Stated limits

- **This is the fix, not the measurement.** #219 stays open for the guard, and its criterion is deliberately not "assert `.gitignore` contains `.claude/`" — that grades a string, not the behaviour. What would grade it is creating a throwaway checkout under the repo root and asserting the file count does not move.
- #189/#190 made one command give CI's ruff **version**, guarded by `tests/lint --self-test`. That guard is real and still holds. It says nothing about the **file set**, which is how this got through.
- No assertion is added here, so nothing was broken to watch it fail. The before/after counts above are the evidence, and they are a measurement rather than a test.