### PR TITLE
Make tests/lint measure what it claims: the file set, the include list, the docs (#219, #212, #211)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,16 @@ jobs:
         with:
           enable-cache: true
 
-      # The guards on the pin itself: that RUFF_VERSION above is the only one,
-      # that tests/lint reads it rather than remembering a version, and that no
-      # workflow reaches ruff any other way. Runs no ruff and costs nothing.
+      # The guards on the pin: that RUFF_VERSION above is the only one, that
+      # tests/lint reads it rather than remembering a version, and that no
+      # workflow reaches ruff any other way.
+      #
+      # And the guards on the *file set*, which the pin says nothing about
+      # (#219): this plants a throwaway checkout where agent worktrees land,
+      # plus a control file where nothing is ignored, and requires the first to
+      # move nothing and the second to move exactly one file. It also requires
+      # every PEP 723 executable in the tree to be inside what ruff reads, which
+      # is what `examples/*/test` was not (#212). Four cached ruff runs, ~0.3 s.
       - name: tests/lint --self-test
         run: tests/lint --self-test
 
@@ -39,7 +46,12 @@ jobs:
       # so `tests/lint` locally is this step, at this version. Running ruff
       # here by hand instead would be a second pin; issue #189 is what that
       # cost, and tests/lint --self-test above refuses it.
-      - name: ruff check + ruff format --check
+      #
+      # This step also compiles every ```python fence in the tracked Markdown.
+      # ruff cannot: its checker does not read `.md` at any version, and its
+      # formatter reads a fence without validating it — `def f(:` comes back
+      # "1 file already formatted", exit 0 (#211).
+      - name: ruff check + ruff format --check + doc fences
         run: tests/lint --github
 
       # shellcheck comes from PyPI rather than apt so this is the same binary

--- a/examples/ticket-queue/test
+++ b/examples/ticket-queue/test
@@ -78,9 +78,9 @@ def setUpModule() -> None:  # noqa: N802  (unittest naming)
         try:
             with urllib.request.urlopen(f"{BASE_URL}/api/tickets", timeout=1):
                 break
-        except (urllib.error.URLError, ConnectionError, OSError):
+        except (urllib.error.URLError, ConnectionError, OSError) as exc:
             if time.monotonic() > deadline:
-                raise RuntimeError(f"serve never answered on {BASE_URL}")
+                raise RuntimeError(f"serve never answered on {BASE_URL}") from exc
             time.sleep(0.05)
     _playwright = sync_playwright().start()
     _browser = _playwright.chromium.launch()
@@ -122,7 +122,9 @@ class QueuePage(unittest.TestCase):
 
     def row_text(self, ticket_id: str) -> str:
         """Everything a person can read on one row (hidden text excluded)."""
-        return self.page.locator(f'#ticket-list .ticket[data-id="{ticket_id}"]').inner_text()
+        return self.page.locator(
+            f'#ticket-list .ticket[data-id="{ticket_id}"]'
+        ).inner_text()
 
     def search(self, term: str) -> None:
         box = self.page.locator("#queue-search")
@@ -317,9 +319,7 @@ INJECTIONS = [
         "web/app.js",
         "headingEl.textContent = `Support queue (${shown.length})`;",
         "headingEl.textContent = `Support queue (${tickets.length})`;",
-        [
-            "QueuePage.test_search_and_the_status_filter_combine_and_the_heading_agrees"
-        ],
+        ["QueuePage.test_search_and_the_status_filter_combine_and_the_heading_agrees"],
     ),
     (
         "the placeholder goes back to naming only the title and the id",

--- a/ruff.toml
+++ b/ruff.toml
@@ -24,6 +24,7 @@ extend-include = [
     "skills/*/scripts/*",  # every skill's PEP 723 executables
     "examples/*/serve",    # the example app's PEP 723 executables
     "examples/*/tickets",
+    "examples/*/test",     # …and the suite that grades it (#212)
 ]
 
 [lint]

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,8 @@ tests/
 ├── smoke-inject       # proves smoke's assertions can still fail (~35 min, nightly)
 ├── unit               # the browser-free half (~0.07 s, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
-├── lint               # ruff, at exactly the version ci.yml pins (~0.3 s)
+├── lint               # ruff at the version ci.yml pins, over the files CI
+│                      #   sees, plus the docs' python fences (~0.3 s)
 └── fixture/
     └── index.html     # the app smoke records: static, dependency-free, deterministic
 ```
@@ -76,7 +77,8 @@ tests/unit                        # the browser-free half of the recorder
 tests/unit --fault-inject         # break each thing an assertion watches
 tests/ci-unit                     # the CI workflow's three helper scripts
 tests/ci-unit --fault-inject
-tests/lint                        # ruff check + ruff format --check, as CI runs them
+tests/lint                        # ruff check + ruff format --check + doc fences
+tests/lint --self-test            # prove all three grade something
 ```
 
 **Lint with `tests/lint`, not with `uvx ruff`.** They are not the same command.
@@ -90,6 +92,26 @@ and one pin. Change the pin and the local command changes with it;
 reaches ruff any other way.
 [#189](https://github.com/rogvid/skills/issues/189) is what this cost before.
 
+**One pin is not one question, though — the file set is the other half.** With
+agent worktrees un-ignored under the repo root, `tests/lint` read **657** files
+where CI read 13, and the 644 extra were copies of this repo at other commits;
+a red run then named files on other branches, and the diagnosis came only from
+noticing that 657 is not 13
+([#219](https://github.com/rogvid/skills/issues/219)). `--self-test` grades
+that by **planting**, not by reading config: a throwaway checkout goes in at
+`.claude/worktrees/`, carrying this repo's own `ruff.toml` the way a real
+worktree does, and the file set must not move — while a control `.py` at the
+repo root, where nothing is ignored, must move it by exactly one. The control
+is what stops "nothing appeared" from meaning "nothing was measured". Asserting
+`.gitignore` contains `.claude/` would have graded a string, and said nothing
+about the next tool with its own ignore semantics.
+
+The same guard asks the question in the other direction: **every PEP 723
+executable in the tree must be inside that file set**, read off the shebangs
+rather than off `ruff.toml`. `examples/ticket-queue/test` — 416 lines, the gate
+on the queue's search — was outside `extend-include` and therefore unlinted
+until [#212](https://github.com/rogvid/skills/issues/212).
+
 **The pin is 0.16.1, and `ruff.toml` excludes `*.md` from the formatter**
 ([#192](https://github.com/rogvid/skills/issues/192)). From 0.16 ruff's
 formatter reads Python out of Markdown code fences — its checker still does
@@ -100,11 +122,32 @@ and the reformat measured at 0.16.1 ragged out two columns of deliberately
 aligned trailing comments and spent the last line of `SKILL.md`'s 600-line
 budget on a blank one. What the exclusion gives up is **only layout**: the
 formatter does not validate a fence either way — hand it ```` ```python ````
-followed by `def f(:` and it prints "1 file already formatted" and exits 0. That
-nothing checks a documentation example parses is
-[#211](https://github.com/rogvid/skills/issues/211), and predates this. The
+followed by `def f(:` and it prints "1 file already formatted" and exits 0. The
 reasoning is written at the exclusion in `ruff.toml`, which is the file a reader
 lands in.
+
+**So `tests/lint` compiles the fences itself**
+([#211](https://github.com/rogvid/skills/issues/211)). A parse check, not a
+lint: the fences legitimately name things that do not exist here (`rec`, `OUT`,
+`mytool`), so `ruff check` semantics would be wrong even if ruff read Markdown.
+It walks the tracked `*.md` — 21 files, 39 fences — and `compile()`s the 10
+whose info string says `python`/`py`/`python3`. The other 29 are skipped **by
+language and counted out loud** (`sh` 11, none 8, `json` 5, `yaml` 2, `bash` 2,
+`html` 1), because a checker that silently skipped everything reports the same
+clean line a healthy tree does; `MIN_PY_FENCES` is the floor that fires if the
+walker stops finding fences at all.
+
+A fence's own indent is stripped before it is compiled, so a block inside a
+list item is graded as the Python it renders as. Two things that look like
+fences and are not — a run of backticks written inline in a sentence, and a
+four-backtick block quoting a three-backtick one — open nothing, and each has a
+case in `--self-test` that fails if it starts to.
+
+`KNOWN_FRAGMENTS` in `tests/lint` waives the figures that are deliberately not
+whole Python — today exactly one, a `with` header with no body in
+`reference/determinism.md`. It is a waiver list graded like one: an entry whose
+fence has vanished, or whose fence now compiles, **fails**, so it can only
+shrink.
 
 Then the recorder itself:
 

--- a/tests/lint
+++ b/tests/lint
@@ -3,11 +3,12 @@
 # requires-python = ">=3.10"
 # dependencies = []
 # ///
-"""Ruff, at exactly the version CI pins (issue #189).
+"""Ruff at exactly the version CI pins, over exactly the files CI sees (#189).
 
-    tests/lint                # ruff check + ruff format --check, from the root
+    tests/lint                # ruff check + ruff format --check + doc fences
     tests/lint --github       # ...with GitHub annotations; what ci.yml runs
-    tests/lint --self-test    # prove the pin is live and single-sourced (0 s)
+    tests/lint --self-test    # prove the pin, the file set and the fence
+                              #   checker are live rather than decorative
 
 **Why this file exists rather than a line in a README.** `.github/workflows/
 ci.yml` pins ruff and runs it as `uv run --with "ruff==$RUFF_VERSION" ruff …`.
@@ -22,12 +23,31 @@ this script reads it out of that file as text. CI runs this script too, so
 there is one command and one version. Changing `RUFF_VERSION` changes what a
 local `tests/lint` runs — that is the measurement issue #189 asked for, and
 `--self-test` is what keeps it true.
+
+**A version is only half of "the same question".** The other half is the file
+set, and it drifted the same way: with agent worktrees un-ignored under the
+repo root, this command read **657** files where CI read 13, and the 644 extra
+were copies of this repo at other commits (#219). A red run then pointed at
+files on other branches. `--self-test` grades that behaviourally — it plants a
+throwaway checkout where agent worktrees actually land and requires the file
+set not to move — rather than asserting a string is in `.gitignore`, because
+the next tool with its own ignore semantics is not covered by a string in a
+file. It also requires every PEP 723 executable in the tree to be *in* that
+set, which is the check `examples/*/test` went four months without (#212).
+
+**And ruff reads no documentation.** Its formatter parses Python out of
+Markdown fences from 0.16 but never validates one — hand it ```python followed
+by `def f(:` and it prints "1 file already formatted" and exits 0 — and its
+checker does not look at `.md` at any version. So the examples an agent copies
+out of a SKILL.md were the one Python in this repo nothing parsed (#211).
+`check_fences()` compiles them.
 """
 
 from __future__ import annotations
 
 import argparse
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -43,6 +63,73 @@ PIN = re.compile(r'^\s*RUFF_VERSION:\s*"([^"]+)"\s*$', re.MULTILINE)
 # A workflow running ruff by hand instead of through this script: the exact
 # drift #189 is about, since such a step carries its own version.
 INLINE_RUFF = re.compile(r"^\s*run:.*\bruff\b.*$", re.MULTILINE)
+
+# An opening code fence: up to three spaces of indent (CommonMark), three or
+# more backticks or tildes, then the info string. The info string may not
+# contain a backtick, which is what keeps inline ``` ```python ``` in prose
+# from opening a block.
+FENCE_OPEN = re.compile(r"^(?P<indent> {0,3})(?P<ticks>`{3,}|~{3,})(?P<info>[^`\n]*)$")
+
+# Info strings whose contents this file claims to be Python. Everything else —
+# sh, json, yaml, html, and a fence with no language at all — is skipped by
+# language and *counted*, so "nothing was checked" cannot look like a pass.
+PY_LANGS = frozenset({"python", "py", "python3"})
+
+# The tree measured 9 compiling fences across 21 markdown files when this was
+# written. The floor is a control, not a target: a fence walker that stopped
+# matching (a renamed directory, a `git ls-files` that returned nothing, a
+# regex that stopped opening blocks) reports zero failures just as happily as a
+# healthy tree does, and this is what tells the two apart.
+MIN_PY_FENCES = 5
+
+# Fences that are deliberately not whole Python, each with the reason. A
+# figure showing a call's shape — a `with` header with nothing under it — is
+# legitimate documentation and no parser accepts it.
+#
+# This is a waiver list and it is graded like one: an entry whose fence has
+# vanished, or whose fence now compiles, **fails** rather than being ignored,
+# so the list can only shrink. Keys are (repo-relative path, the fence body
+# exactly as it appears after the fence's own indent is stripped), so editing
+# the fence at all takes it back out of the waiver and into the check.
+KNOWN_FRAGMENTS: dict[tuple[str, str], str] = {
+    (
+        "skills/demo-video/reference/determinism.md",
+        "with Recorder(out_dir, deterministic=True) as rec:"
+        "   # or DEMO_VIDEO_DETERMINISTIC=1",
+    ): (
+        "a one-line signature figure: a `with` header with no body, which no "
+        "Python parses. Adding `    ...` under it would close this (#211)"
+    ),
+}
+
+# Where an agent worktree lands, and what --self-test plants there. The name is
+# this script's own so cleanup can never reach a real one.
+PROBE_CHECKOUT = REPO / ".claude" / "worktrees" / "_tests-lint-file-set-probe"
+
+# The control: a file at a path nothing ignores. If planting it does not move
+# the measurement, the measurement is dead and the guard below grades nothing.
+PROBE_CONTROL = REPO / "_tests-lint-file-set-probe.py"
+
+# Badly formatted on purpose: a copy that got walked would fail `ruff format
+# --check` as well as showing up in the file set, which is the shape #219 took.
+PROBE_PY = "import os,sys\nx = [\n    1\n]\n"
+PROBE_SCRIPT = "#!/usr/bin/env -S uv run --script\n" + PROBE_PY
+
+# What the stray checkout contains: a plain `.py`, which any Python tool finds
+# without being told, and one extension-less executable per `extend-include`
+# pattern — which are found only because the checkout carries a copy of
+# `ruff.toml` too, exactly as a real agent worktree does. That copy is why #219
+# measured 657 files rather than 21 stray `.py` files: each worktree teaches
+# ruff its own include list, relative to itself.
+PROBE_FILES = {
+    "stray.py": PROBE_PY,
+    "tests/lint": PROBE_SCRIPT,
+    "tests/unit": PROBE_SCRIPT,
+    ".github/scripts/probe": PROBE_SCRIPT,
+    "skills/demo-video/scripts/probe": PROBE_SCRIPT,
+    "examples/ticket-queue/serve": PROBE_SCRIPT,
+    "examples/ticket-queue/test": PROBE_SCRIPT,
+}
 
 
 class Refused(Exception):
@@ -74,6 +161,230 @@ def ruff(version: str, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+# --- the file set -----------------------------------------------------------
+
+
+def relative(path: str) -> str:
+    """A path ruff printed, as this repository names it."""
+    try:
+        return str(Path(path).resolve().relative_to(REPO))
+    except ValueError:
+        return path
+
+
+def ruff_file_set(version: str) -> set[str]:
+    """Every file `ruff check .` would read, by name — not merely how many.
+
+    `--show-files` is what makes this a claim about the *set*: a stray checkout
+    that added a file while a real one disappeared would leave any count alone.
+    """
+    done = ruff(version, "check", "--show-files", ".")
+    if done.returncode != 0:
+        raise Refused(f"ruff check --show-files failed: {done.stderr.strip()[:200]}")
+    return {relative(line) for line in done.stdout.splitlines() if line.strip()}
+
+
+def format_file_count(version: str) -> int:
+    """How many files `ruff format --check .` read.
+
+    The formatter has its own exclusions (`ruff.toml`'s `[format] exclude`), so
+    it is a second file set rather than a view of the first, and it is the one
+    #219 was measured on: 657 files where CI read 13.
+    """
+    done = ruff(version, "format", "--check", ".")
+    text = done.stdout + done.stderr
+    # Both halves of "1 file would be reformatted, 13 files already formatted",
+    # which ruff prints on one line — anchoring to the start of a line reads
+    # the first number and silently drops the rest of the tree.
+    counts = re.findall(
+        r"(\d+) files? (?:would be reformatted|already formatted)", text
+    )
+    if not counts:
+        raise Refused(
+            "ruff format --check printed no file count, so there is nothing to "
+            f"compare: {text.strip()[:200]!r}"
+        )
+    return sum(int(n) for n in counts)
+
+
+def tracked(*patterns: str) -> list[str]:
+    """Files git is tracking here. Untracked scratch is nobody's lint budget."""
+    done = subprocess.run(
+        ["git", "ls-files", "-z", "--", *patterns],
+        cwd=REPO,
+        text=True,
+        capture_output=True,
+    )
+    if done.returncode != 0:
+        raise Refused(f"git ls-files failed: {done.stderr.strip()[:200]}")
+    return sorted(p for p in done.stdout.split("\0") if p)
+
+
+def pep723_scripts() -> list[str]:
+    """Every executable this repo ships as a PEP 723 uv script.
+
+    Read off the shebang rather than off `ruff.toml`, deliberately: a list
+    derived from the config could not disagree with the config, and disagreeing
+    with it is the entire job. `examples/*/test` was invisible for exactly as
+    long as nothing asked this question (#212).
+    """
+    found = []
+    for rel in tracked():
+        path = REPO / rel
+        if path.is_symlink() or not path.is_file():
+            continue
+        with path.open("rb") as handle:
+            first = handle.readline(200).decode("utf-8", "replace").strip()
+        if first.startswith("#!") and "uv run" in first and "--script" in first:
+            found.append(rel)
+    return found
+
+
+def clear_probes() -> None:
+    """Remove anything a previous --self-test left behind. Named paths only."""
+    if PROBE_CHECKOUT.name != "_tests-lint-file-set-probe":  # pragma: no cover
+        raise Refused("the probe path is not this script's own; refusing to delete")
+    shutil.rmtree(PROBE_CHECKOUT, ignore_errors=True)
+    PROBE_CONTROL.unlink(missing_ok=True)
+    for parent in (PROBE_CHECKOUT.parent, PROBE_CHECKOUT.parent.parent):
+        if parent.is_dir() and not any(parent.iterdir()):
+            parent.rmdir()
+
+
+def plant_probes() -> None:
+    """A throwaway checkout where agent worktrees land, and a control beside it."""
+    files = dict(PROBE_FILES)
+    # The real config, copied in rather than re-stated: a checkout of this repo
+    # has this repo's ruff.toml, and a probe carrying a stale copy would stop
+    # being representative the moment `extend-include` changed.
+    files["ruff.toml"] = (REPO / "ruff.toml").read_text(encoding="utf-8")
+    for rel, body in files.items():
+        target = PROBE_CHECKOUT / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+    PROBE_CONTROL.write_text(PROBE_PY, encoding="utf-8")
+
+
+# --- Python in the documentation --------------------------------------------
+
+
+def fences(text: str) -> list[tuple[int, str, str]]:
+    """Every fenced code block: (1-based opening line, language, body).
+
+    The fence's own indent is stripped from its body, so a block inside a list
+    item is the Python it renders as rather than an "unexpected indent".
+    """
+    found: list[tuple[int, str, str]] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        opened = FENCE_OPEN.match(lines[i])
+        if not opened:
+            i += 1
+            continue
+        indent, ticks = opened.group("indent"), opened.group("ticks")
+        # Only a run of the same character, at least as long, closes it — which
+        # is what lets a ````-fenced block quote a ```-fenced one.
+        closes = re.compile(rf"^ {{0,3}}{re.escape(ticks[0])}{{{len(ticks)},}}[ \t]*$")
+        body: list[str] = []
+        j = i + 1
+        while j < len(lines) and not closes.match(lines[j]):
+            line = lines[j]
+            cut = 0
+            while cut < len(indent) and line[cut : cut + 1] == " ":
+                cut += 1
+            body.append(line[cut:])
+            j += 1
+        info = opened.group("info").strip()
+        found.append((i + 1, info.split()[0].lower() if info else "", "\n".join(body)))
+        i = j + 1
+    return found
+
+
+def check_fences(github: bool = False) -> int:
+    """Compile every Python fence in the tracked Markdown. Returns failures.
+
+    Not a lint: the fences legitimately name things that do not exist here
+    (`rec`, `OUT`, `mytool`), so `ruff check` semantics would be wrong even if
+    ruff read Markdown. The claim is only that a reader who copies the figure
+    gets something Python can parse.
+    """
+    counted: dict[str, int] = {}
+    compiled = 0
+    waived: set[tuple[str, str]] = set()
+    problems: list[tuple[str, int, str]] = []
+
+    for rel in tracked("*.md"):
+        path = REPO / rel
+        if path.is_symlink():  # CLAUDE.md -> AGENTS.md; one document, once
+            continue
+        for line, lang, body in fences(path.read_text(encoding="utf-8")):
+            if lang not in PY_LANGS:
+                counted[lang or "(none)"] = counted.get(lang or "(none)", 0) + 1
+                continue
+            key = (rel, body.strip())
+            reason = KNOWN_FRAGMENTS.get(key)
+            try:
+                compile(body, rel, "exec")
+            except SyntaxError as exc:
+                if reason is None:
+                    at = line + (exc.lineno or 1)
+                    problems.append((rel, at, f"{exc.msg} (```python at line {line})"))
+                else:
+                    waived.add(key)
+                continue
+            if reason is not None:
+                waived.add(key)
+                problems.append(
+                    (
+                        rel,
+                        line,
+                        "this fence compiles now — delete its KNOWN_FRAGMENTS entry",
+                    )
+                )
+                continue
+            compiled += 1
+
+    for path_and_body in KNOWN_FRAGMENTS:
+        if path_and_body not in waived:
+            problems.append(
+                (
+                    path_and_body[0],
+                    1,
+                    "KNOWN_FRAGMENTS waives a fence this file no longer contains "
+                    "— delete the entry",
+                )
+            )
+
+    # The control. Every line above reports an absence, and an absence holds
+    # perfectly over an empty haystack: a walker that found no fences at all
+    # prints the same "0 problems" a healthy tree does.
+    if compiled < MIN_PY_FENCES:
+        problems.append(
+            (
+                "tests/lint",
+                1,
+                f"only {compiled} python fence(s) compiled, under the {MIN_PY_FENCES} "
+                f"floor — this reads as a fence walker that stopped finding fences, "
+                f"not as documentation that has none",
+            )
+        )
+
+    skipped = ", ".join(f"{lang} {n}" for lang, n in sorted(counted.items()))
+    print(
+        f"docs: {compiled} python fence(s) parse"
+        + (f", {len(waived)} waived" if waived else "")
+        + f"; {sum(counted.values())} fence(s) skipped by language ({skipped})"
+    )
+    for rel, line, message in problems:
+        if github:
+            print(f"::error file={rel},line={line}::{message}")
+        print(f"docs: {rel}:{line}: {message}", file=sys.stderr)
+    if problems:
+        print(f"lint: {len(problems)} documentation fence problem(s)")
+    return len(problems)
+
+
 def run(github: bool) -> int:
     version = pinned_version(CI.read_text(encoding="utf-8"))
     print(f"lint: ruff {version}, pinned by .github/workflows/ci.yml")
@@ -103,11 +414,175 @@ def run(github: bool) -> int:
         if done.returncode != 0:
             failed += 1
             print(f"lint: {label} failed")
+
+    # The half ruff cannot answer: a Markdown fence is invisible to `ruff
+    # check` at every version, and the formatter reads one without validating
+    # it (#211). Run last so its one summary line is not lost above ruff's.
+    failed += 1 if check_fences(github) else 0
     return 1 if failed else 0
 
 
+def file_set_guard(version: str) -> int:
+    """Does this command read CI's files? Graded by planting, not by reading.
+
+    The version pin and the file set are two different ways for `tests/lint`
+    to answer a question CI is not asking, and only the first had a guard: on
+    the box where #219 was found this read 657 files against CI's 13, because
+    agent worktrees under the repo root were not ignored.
+
+    Asserting `.gitignore` contains `.claude/` would grade a string. This
+    plants a checkout where those worktrees actually land, and a control file
+    where nothing ignores anything, and reads the file set back out of ruff —
+    so whatever mechanism does the ignoring, and whichever tool grows its own,
+    the claim under test stays "the stray copy is not in what CI lints".
+    """
+    bad = 0
+    clear_probes()
+    before_files = ruff_file_set(version)
+    before_format = format_file_count(version)
+    try:
+        plant_probes()
+        after_files = ruff_file_set(version)
+        after_format = format_file_count(version)
+    finally:
+        clear_probes()
+
+    control = relative(str(PROBE_CONTROL))
+    appeared = after_files - before_files
+    vanished = before_files - after_files
+
+    # The control first: everything below is "nothing appeared", which is what
+    # a measurement that cannot see anything also reports.
+    if control in appeared:
+        print(f"OK       planting {control} moves the file set — the probe is live")
+    else:
+        bad += 1
+        print(
+            f"DEAD     planting {control} did not change what ruff reads "
+            f"({len(before_files)} files before, {len(after_files)} after), so "
+            f"nothing below is being measured"
+        )
+
+    strays = sorted(appeared - {control}) + sorted(vanished)
+    if strays:
+        bad += 1
+        print(
+            f"WORKTREE a throwaway checkout at "
+            f"{relative(str(PROBE_CHECKOUT))} changed the file set by "
+            f"{len(strays)} file(s) — `tests/lint` is not reading CI's tree "
+            f"(#219): {', '.join(strays[:4])}"
+        )
+    else:
+        print(
+            f"OK       ruff reads {len(before_files)} file(s) here, and the "
+            f"{len(PROBE_FILES) + 1} file(s) of a checkout planted under the "
+            f"repo root (its own ruff.toml included) add none of them"
+        )
+
+    if after_format == before_format + 1:
+        print(
+            f"OK       ruff format reads {before_format} file(s), and the same "
+            f"checkout adds none of them either"
+        )
+    else:
+        bad += 1
+        print(
+            f"WORKTREE ruff format read {before_format} file(s) before the "
+            f"probe and {after_format} after, expected {before_format + 1} — "
+            f"the formatter has its own excludes, so either it is walking the "
+            f"checkout or the control above never landed"
+        )
+
+    # The other direction, and #212's whole story: a file set that is stable is
+    # not yet a file set that is *complete*. `examples/*/test` was outside
+    # `extend-include` for as long as nothing asked.
+    scripts = pep723_scripts()
+    missing = [s for s in scripts if s not in before_files]
+    if missing:
+        bad += 1
+        print(
+            f"UNLINTED {len(missing)} of {len(scripts)} PEP 723 executable(s) are "
+            f"outside what ruff reads — add them to ruff.toml's extend-include "
+            f"(#212): {', '.join(missing)}"
+        )
+    else:
+        print(
+            f"OK       every one of the {len(scripts)} PEP 723 executable(s) in "
+            f"the tree is inside that set"
+        )
+    return bad
+
+
+def fence_guard() -> int:
+    """Prove the fence checker can fail, and on what.
+
+    ruff's formatter reads a `def f(:` fence and prints "1 file already
+    formatted"; a checker that inherited that blindness would pass this tree
+    just as quietly. So the checker is run against documents whose answers are
+    known, including several that are deliberately *not* Python.
+
+    Each case fixes **two** numbers, how many Python fences the document has
+    and how many of them fail, because the first is what stops the second from
+    being satisfied by finding nothing. The last two cases exist only for that
+    reason: each hides a broken fence inside something that must not open a
+    block, and then puts a real, healthy Python fence after it — a walker that
+    swallowed the document reports "0 problems" on the first number alone.
+    """
+    bad = 0
+    good = "```python\nx = 1\n```\n"
+    cases = (
+        ("a fence that does not parse", "```python\ndef f(:\n    pass\n```\n", 1, 1),
+        ("a fence that does", "```python\ndef f():\n    pass\n```\n", 1, 0),
+        (
+            "a fence indented inside a list item",
+            '- like so:\n\n  ```python\n  rec.caption("hi")\n  rec.hold()\n  ```\n',
+            1,
+            0,
+        ),
+        (
+            "shell that would not parse as Python",
+            "```sh\nfor f in *; do echo $f; done\n```\n",
+            0,
+            0,
+        ),
+        ("a fence with no language at all", "```\ndef f(:\n```\n", 0, 0),
+        (
+            "a broken fence quoted inside a ````-fenced block",
+            "````\n```python\ndef f(:\n```\n````\n\n" + good,
+            1,
+            0,
+        ),
+        (
+            "a ```python written inline in a sentence",
+            "hand it ```` ```python ```` followed by `def f(:` and see\n\n" + good,
+            1,
+            0,
+        ),
+    )
+    for what, document, expect_py, expect_bad in cases:
+        python = [body for _line, lang, body in fences(document) if lang in PY_LANGS]
+        found = sum(1 for body in python if not _compiles(body))
+        if (len(python), found) == (expect_py, expect_bad):
+            print(f"{'CATCHES ' if expect_bad else 'SKIPS   '} {what}")
+        else:
+            bad += 1
+            print(
+                f"BLIND    {what}: {len(python)} python fence(s) and {found} "
+                f"problem(s), expected {expect_py} and {expect_bad}"
+            )
+    return bad
+
+
+def _compiles(body: str) -> bool:
+    try:
+        compile(body, "<fence>", "exec")
+    except SyntaxError:
+        return False
+    return True
+
+
 def self_test() -> int:
-    """The guards that keep the pin from becoming decorative. Runs no ruff."""
+    """The guards that keep the pin from becoming decorative."""
     bad = 0
 
     # 1. The pin is readable from the file CI reads it from.
@@ -169,10 +644,24 @@ def self_test() -> int:
     if not bad:
         print("OK       every workflow reaches ruff through tests/lint")
 
+    # 5. The file set is CI's too, not this working copy's — the half of "the
+    #    same command" that #189's guards do not reach (#219, #212). This is
+    #    the only part of --self-test that runs ruff: four invocations of a
+    #    resolved-and-cached ruff, measured at 0.05 s each.
+    if version:
+        try:
+            bad += file_set_guard(version)
+        except Refused as exc:
+            bad += 1
+            print(f"BROKEN   the file set could not be measured: {exc}")
+
+    # 6. The documentation checker can fail, and only for the right reason.
+    bad += fence_guard()
+
     if bad:
-        print(f"\n{bad} guard(s) did not hold: the pin cannot be trusted.")
+        print(f"\n{bad} guard(s) did not hold: this command cannot be trusted.")
         return 1
-    print("\nOne pin, one command: tests/lint runs exactly what CI runs.")
+    print("\nOne pin, one file set, one command: tests/lint runs exactly what CI runs.")
     return 0
 
 
@@ -182,7 +671,9 @@ def main() -> int:
         "--github", action="store_true", help="GitHub annotations (what ci.yml runs)"
     )
     parser.add_argument(
-        "--self-test", action="store_true", help="prove the pin is live and singular"
+        "--self-test",
+        action="store_true",
+        help="prove the pin, the file set and the fence checker are live",
     )
     args = parser.parse_args()
     if args.self_test:


### PR DESCRIPTION
One slice, three issues: **the tooling checks a different thing than it claims to.**
#189/#190 settled the ruff *version* and guarded it. #219 is the *file set*, #212
is the *include list*, #211 is a whole file type nothing parsed.

Fixes #219, fixes #212, fixes #211.

## What changed

| Commit | |
|---|---|
| `ba58dc5` | `examples/ticket-queue/test`: the B904 and the two-hunk reformat. Lint only, no behaviour. |
| `c45878f` | `ruff.toml`: `examples/*/test` in `extend-include`. One line. |
| `b6c9812` | `tests/lint`: the file-set guard, the PEP 723 coverage guard, and the doc-fence checker. |

Fix-then-config, so no commit in the history is a red `tests/lint`.

### #219 — the file set, graded behaviourally

The `.gitignore` line landed in #220; this is the guard, and it deliberately does
**not** assert that line exists. Asserting `.gitignore` contains `.claude/` grades
a string and says nothing about the next tool with its own ignore semantics. So
`--self-test` plants:

- **a throwaway checkout** at `.claude/worktrees/_tests-lint-file-set-probe/`,
  carrying this repo's own `ruff.toml` the way a real worktree does — that copy is
  why #219 measured 657 files and not 21 stray `.py` files, since each worktree
  teaches ruff its own include list relative to itself. Measured while writing
  this: without the `ruff.toml` copy only 1 of the 8 planted files was
  discoverable, with it all 8. The file set must not move.
- **a control `.py` at the repo root**, where nothing is ignored, which must move
  it by exactly one. Every other line in this guard reports an absence, and an
  absence holds perfectly over a measurement that has died.

Read back through `ruff check --show-files` (the *set*, not a count) and through
`ruff format --check`'s count as well, since the formatter has its own excludes
and is the sub-command #219 was measured on.

### #212 — the include list, and the guard that makes it stick

`examples/*/test` added; the B904 raises `from exc` and the formatter's two hunks
are applied. The permanent half is in `--self-test`: **every PEP 723 executable in
the tree must be inside what ruff reads**, read off the shebangs rather than off
`ruff.toml` — a list derived from the config could not disagree with the config,
and disagreeing with it is the entire job.

### #211 — the fences

21 tracked markdown files, **39 fences**. 10 are labelled `python`; 9 compile, 1 is
waived (below). The other **29 are skipped by language and counted out loud**:
`sh` 11, no language 8, `json` 5, `yaml` 2, `bash` 2, `html` 1. A checker that
silently skipped everything prints the same clean line a healthy tree does, so
`MIN_PY_FENCES` fires if the walker stops walking.

A parse check, not a lint: the fences legitimately name `rec`, `OUT`, `mytool`.

```
$ ./tests/lint
lint: ruff 0.16.1, pinned by .github/workflows/ci.yml
All checks passed!
14 files already formatted
docs: 9 python fence(s) parse, 1 waived; 29 fence(s) skipped by language ((none) 8, bash 2, html 1, json 5, sh 11, yaml 2)
```

## Stated limits

- **One broken fence in the tree, not fixed here.**
  `skills/demo-video/reference/determinism.md:31` is a one-line signature figure —
  a `with` header with no body — and no Python parses it. `reference/` is outside
  this PR's scope, so it is in `KNOWN_FRAGMENTS` with its reason. Adding a `...`
  line under it closes it; the waiver then **fails** and must be deleted, which is
  the point. Waiver entries that vanish or start compiling are errors, so the list
  can only shrink. What the checker reports with the waiver removed:

  ```
  docs: skills/demo-video/reference/determinism.md:32: expected an indented block after 'with' statement on line 1
  ```

  `skills/demo-video/SKILL.md:284` was the other candidate and is **not** broken —
  it is a fence indented two spaces inside a list item, and the checker strips a
  fence's own indent before compiling. Without that it reports
  `SKILL.md:285: unexpected indent`, which would be a checker bug, not a doc bug.
- The fence checker grades `python`/`py`/`python3` only. A Python example in an
  unlabelled fence is not checked, and would need a label to be.
- `--self-test` now runs ruff — four cached invocations, measured 0.05 s each — and
  writes into the working tree while it runs. Cleanup is in a `finally` and names
  only its own paths.
- What the probe plants is what a stray checkout of *this* repo carries. A tool
  with entirely different discovery could still be fooled by something else; what
  is asserted is that ruff's two sub-commands are not.

## Fault injection

Every guard below was broken, run, and restored. The driver refuses to proceed
unless its pattern matched **exactly once**.

<details><summary><b>#219 — remove <code>.claude/</code> from .gitignore</b></summary>

```
-.claude/
$ ./tests/lint --self-test
OK       planting _tests-lint-file-set-probe.py moves the file set — the probe is live
WORKTREE a throwaway checkout at .claude/worktrees/_tests-lint-file-set-probe changed the file set by 8 file(s) — `tests/lint` is not reading CI's tree (#219): .claude/worktrees/_tests-lint-file-set-probe/.github/scripts/probe, .claude/worktrees/_tests-lint-file-set-probe/examples/ticket-queue/serve, .claude/worktrees/_tests-lint-file-set-probe/examples/ticket-queue/test, .claude/worktrees/_tests-lint-file-set-probe/ruff.toml
WORKTREE ruff format read 14 file(s) before the probe and 22 after, expected 15 — the formatter has its own excludes, so either it is walking the checkout or the control above never landed
OK       every one of the 11 PEP 723 executable(s) in the tree is inside that set

2 guard(s) did not hold: this command cannot be trusted.
[exit 1]
```
</details>

<details><summary><b>#219's control — stop planting the control file</b></summary>

```
-    PROBE_CONTROL.write_text(PROBE_PY, encoding="utf-8")
+    pass  # injected: the control is not planted
$ ./tests/lint --self-test
DEAD     planting _tests-lint-file-set-probe.py did not change what ruff reads (27 files before, 27 after), so nothing below is being measured
OK       ruff reads 27 file(s) here, and the 8 file(s) of a checkout planted under the repo root (its own ruff.toml included) add none of them
WORKTREE ruff format read 14 file(s) before the probe and 14 after, expected 15 — ...
[exit 1]
```

This is the one that matters: without it, "the checkout added nothing" is satisfied
by a measurement that can see nothing.
</details>

<details><summary><b>#212 — the same file, before and after the config line</b></summary>

With the B904 present and `examples/*/test` **not** in `extend-include`:

```
$ ./tests/lint
lint: ruff 0.16.1, pinned by .github/workflows/ci.yml
All checks passed!
13 files already formatted
```

With the line in:

```
$ ./tests/lint
F841 [*] Local variable `exc` is assigned to but never used
  --> examples/ticket-queue/test:81:69
B904 Within an `except` clause, raise exceptions with `raise ... from err` or `raise ... from None` ...
  --> examples/ticket-queue/test:83:17
Found 2 errors.
lint: ruff check failed
14 files already formatted
```
</details>

<details><summary><b>#212's guard — drop <code>examples/*/test</code> from extend-include</b></summary>

```
-    "examples/*/test",     # …and the suite that grades it (#212)
$ ./tests/lint --self-test
OK       ruff reads 26 file(s) here, and the 8 file(s) of a checkout planted under the repo root (its own ruff.toml included) add none of them
OK       ruff format reads 13 file(s), and the same checkout adds none of them either
UNLINTED 1 of 11 PEP 723 executable(s) are outside what ruff reads — add them to ruff.toml's extend-include (#212): examples/ticket-queue/test

1 guard(s) did not hold: this command cannot be trusted.
[exit 1]
```
</details>

<details><summary><b>#211 — a broken fence in a document</b></summary>

A `python`-labelled fence containing `def f(:` planted in `tests/README.md`:

```
$ ./tests/lint --github
docs: 9 python fence(s) parse, 1 waived; 29 fence(s) skipped by language (...)
::error file=tests/README.md,line=72::invalid syntax (```python at line 71)
lint: 1 documentation fence problem(s)
docs: tests/README.md:72: invalid syntax (```python at line 71)
[exit 1]
```

For contrast, ruff on the same tree: `1 file already formatted`, exit 0.
</details>

<details><summary><b>#211 — the waiver list, both directions</b></summary>

A waiver naming a fence that is not there (one character changed in the key):

```
$ ./tests/lint
docs: 9 python fence(s) parse; 29 fence(s) skipped by language (...)
lint: 2 documentation fence problem(s)
docs: skills/demo-video/reference/determinism.md:32: expected an indented block after 'with' statement on line 1 (```python at line 31)
docs: skills/demo-video/reference/determinism.md:1: KNOWN_FRAGMENTS waives a fence this file no longer contains — delete the entry
[exit 1]
```

A waiver on a fence that compiles (a planted `rec.hold()` fence plus an entry
claiming it is a fragment):

```
$ ./tests/lint
docs: 9 python fence(s) parse, 2 waived; 29 fence(s) skipped by language (...)
lint: 1 documentation fence problem(s)
docs: tests/README.md:71: this fence compiles now — delete its KNOWN_FRAGMENTS entry
[exit 1]
```
</details>

<details><summary><b>#211's vacuity floor — make the walker find nothing</b></summary>

```
-FENCE_OPEN = re.compile(r"^(?P<indent> {0,3})...
+FENCE_OPEN = re.compile(r"^ZZZ(?P<indent> {0,3})...
$ ./tests/lint
docs: 0 python fence(s) parse; 0 fence(s) skipped by language ()
lint: 2 documentation fence problem(s)
docs: tests/lint:1: only 0 python fence(s) compiled, under the 5 floor — this reads as a fence walker that stopped finding fences, not as documentation that has none
[exit 1]
```
</details>

<details><summary><b>The fence checker's own cases — each seen to fail for its own reason</b></summary>

Every case fixes **two** numbers, how many Python fences the document has and how
many of them fail, because the first is what stops the second from being satisfied
by finding nothing. The first draft fixed only the second, and the ````-nesting
case then passed for the wrong reason — caught by injecting into it.

`PY_LANGS` drops `"python"`:

```
BLIND    a fence that does not parse: reported 0 problem(s), expected 1
```

`PY_LANGS` gains `"sh"` and `""`:

```
BLIND    shell that would not parse as Python: 1 python fence(s) and 1 problem(s), expected 0 and 0
BLIND    a fence with no language at all: 1 python fence(s) and 1 problem(s), expected 0 and 0
BLIND    a broken fence quoted inside a ````-fenced block: 2 python fence(s) and 1 problem(s), expected 1 and 0
```

The fence body keeps its own indent (`body.append(line)`):

```
BLIND    a fence indented inside a list item: 1 python fence(s) and 1 problem(s), expected 1 and 0
docs: skills/demo-video/SKILL.md:285: unexpected indent (```python at line 284)   # on the real tree
```

A three-backtick line closes a four-backtick block:

```
BLIND    a broken fence quoted inside a ````-fenced block: 0 python fence(s) and 0 problem(s), expected 1 and 0
```

A fence opener may have prose before it:

```
BLIND    a ```python written inline in a sentence: 0 python fence(s) and 0 problem(s), expected 1 and 0
```
</details>

## Verification

```
./tests/lint                     All checks passed! 14 files already formatted; 9 fences parse
./tests/lint --self-test         One pin, one file set, one command
actionlint .github/workflows/*   clean
./tests/unit                     Ran 164 tests — OK
./tests/ci-unit                  Ran 49 tests — OK
./tests/unit --budget            SKILL.md: 599 lines, budget 600
./tests/smoke-inject --self-test Every guard refused what it exists to refuse
examples/ticket-queue/test       Ran 12 tests in 3.055s — OK
```

`tests/smoke` was not run: it holds a machine-wide lock another agent needs, and
nothing here touches the recorder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
