### PR TITLE
Make the one broken example in the docs parse, and retire its waiver

### DIFF
--- a/skills/demo-video/reference/determinism.md
+++ b/skills/demo-video/reference/determinism.md
@@ -30,6 +30,7 @@ switched on together.
 
 ```python
 with Recorder(out_dir, deterministic=True) as rec:   # or DEMO_VIDEO_DETERMINISTIC=1
+    ...
 ```
 
 ### Why the clock is opt-in — read this before turning it on

--- a/tests/lint
+++ b/tests/lint
@@ -91,16 +91,11 @@ MIN_PY_FENCES = 5
 # so the list can only shrink. Keys are (repo-relative path, the fence body
 # exactly as it appears after the fence's own indent is stripped), so editing
 # the fence at all takes it back out of the waiver and into the check.
-KNOWN_FRAGMENTS: dict[tuple[str, str], str] = {
-    (
-        "skills/demo-video/reference/determinism.md",
-        "with Recorder(out_dir, deterministic=True) as rec:"
-        "   # or DEMO_VIDEO_DETERMINISTIC=1",
-    ): (
-        "a one-line signature figure: a `with` header with no body, which no "
-        "Python parses. Adding `    ...` under it would close this (#211)"
-    ),
-}
+# Empty, and that is the intended state. A waiver here says "this fence is not
+# Python and never will be"; the only entry it ever held was a `with` header
+# missing its body, which was a defect rather than a figure (#222). A waiver on
+# a fence that compiles is itself refused, so an entry cannot outlive its cause.
+KNOWN_FRAGMENTS: dict[tuple[str, str], str] = {}
 
 # Where an agent worktree lands, and what --self-test plants there. The name is
 # this script's own so cleanup can never reach a real one.


### PR DESCRIPTION
Closes #222.

`reference/determinism.md`'s `with Recorder(out_dir, deterministic=True) as rec:` had no body, so no Python parses it. It is the only broken fence in 39 across 21 tracked `.md` files — found by #221's checker on its first run.

## Why nothing caught it before

Ruff's **checker** never reads Markdown fences, at any version. Its **formatter** does from 0.16, and #192 excluded `.md` from the formatter for good reasons (aligned trailing comments, and SKILL.md's 600-line budget). So the tooling's verdict on this file was:

```
1 file already formatted
```

on a fence containing a syntax error. That is the vacuous sweep, in the one file type where the docs *are* the product.

## Seen to fail

Body removed again:

```
docs: skills/demo-video/reference/determinism.md:32: expected an indented block
      after 'with' statement on line 1 (```python at line 31)
lint: 1 documentation fence problem(s)                                  exit 1
```

## The waiver is deleted, not updated

`KNOWN_FRAGMENTS` goes back to empty, with a comment saying that is the intended state. A waiver means "this fence is not Python and never will be" — which was never true here; it was a defect wearing a waiver.

The ordering was forced by the checker rather than by care: adding the body made `tests/lint` **red**, because a waiver on a fence that compiles is itself refused. The entry could not outlive its cause even if somebody wanted it to. That guard is #221's, and this is the first time it fired for real.

## Stated limits

- **29 of 39 fences are still unparsed**, by language: `sh` 11, unlabelled 8, `json` 5, `yaml` 2, `bash` 2, `html` 1. The checker counts them out loud rather than implying coverage. Whether an unlabelled fence should be forced to declare a language is a separate question and not asked here.
- This fixes the example; it does not check that the example is *correct*, only that it parses. `with Recorder(...) as rec: ...` would parse just as well with a wrong argument name.