### PR TITLE
Put the beat log and demo.mp4 on the same clock, and say when they are not (#18, #215)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -92,11 +92,12 @@ behind every one, are in [reference/limits.md](reference/limits.md).
   it passes in silence — measured at 31.5 s of a 34 s take. Take cards down
   explicitly. A caption long enough to wrap can also silence the same warning
   on an app's own modal, so keep captions to one line.
-- **A frame is aimed at a beat, not stamped with one.** Chromium's screencast
-  loses wall time during idle stretches, so an event can land up to 0.75 s
-  earlier in `demo.mp4` than `timeline.json` puts it. Read a review frame as
-  *around* its beat, and do not build anything that needs a beat timestamp to
-  be exact to the frame.
+- **A frame is aimed at a beat, not stamped with one.** Chromium stamps frames
+  with the host's **wall** clock, the beat log uses a monotonic one, so on a
+  host whose clock steps an event lands earlier in `demo.mp4` — by the step,
+  once per step (0.75–0.81 s every 32.2 s on one WSL2 box). **No fixed bound
+  holds**; a longer demo accumulates more. `timeline.json`'s `capture_clock`
+  records each one: correct with it, or read a frame as *around* its beat.
 - **Sixty seconds buys about twenty screens.** At the pacing floors below, a
   demo shows roughly one new screen every 3 s — 69% of a real 61.2 s take was
   a picture already shown. A feature spanning two surfaces does not fit the

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -30,6 +30,7 @@ import os
 import re
 import subprocess
 import sys
+import threading
 import time
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
@@ -434,6 +435,130 @@ def _clock_epoch_ms(value: str) -> int:
     return int(parsed.timestamp() * 1000)
 
 
+# -- the clock the video is on (issues #18, #215) -----------------------------
+#
+# Everything this package times is `time.monotonic()`. **The video is not on
+# that clock**, and until this was measured nothing said so.
+#
+# Playwright records by acking Chromium's `Page.screencastFrame`, and the only
+# clock a frame carries is that event's `metadata.timestamp` — which the
+# protocol defines as `Network.TimeSinceEpoch`, i.e. the host's *wall* clock.
+# Playwright's `FfmpegVideoRecorder` turns it straight into the frame's
+# position in the webm (`frameNumber = (ts - firstFrameTs) * 25`). So the
+# video's clock is CLOCK_REALTIME and the beat log's is CLOCK_MONOTONIC, and
+# on a host whose wall clock *steps* the two part company by exactly the size
+# of the step, at exactly the instant of it.
+#
+# Measured on the WSL2 box this was found on (Chromium 151.0.7922.34,
+# Playwright 1.62.0), with the driver instrumented to log every frame:
+#
+#   ARRIVE 1146491075.755  ts=1785603308090.391   two consecutive screencast
+#   ARRIVE 1146491159.407  ts=1785603307379.542   frames, 84 ms apart on the
+#                                                 monotonic clock and 711 ms
+#                                                 *backwards* on Chromium's
+#
+# That host steps -0.75 to -0.81 s every 32.2 s, like a metronome, which in a
+# 19 s take is a coin flip — and is why the same storyboard loses ~0.8 s of
+# video on some runs and none on others with nothing else different. Seven
+# takes of one storyboard with this sampler beside them: the four whose window
+# contained a step encoded 0.78 s less video than the three that did not, to
+# within 12 ms, every time. An idle page does not do this — 30 s of a take
+# with nothing painting at all, seven screencast frames in total, lost nothing
+# but the one step.
+#
+# None of that is fixable here. The clock is the host's, the timestamp is the
+# protocol's, and the recorder cannot re-stamp a frame it never sees. What it
+# can do is **measure the same clock Chromium reads**, which needs no browser
+# at all, and write the result next to the beats — so a consumer holding a
+# beat at `t_start` can work out that the beat really sits at
+# `t_start + (sum of the steps before it)` in the video, instead of
+# discovering it as an unexplained 0.8 s.
+class _CaptureClock:
+    """CLOCK_REALTIME against CLOCK_MONOTONIC, for the life of one capture.
+
+    A daemon thread, because the storyboard is blocking in Playwright calls
+    for the whole take and a step has to be seen when it happens. It touches
+    nothing but `time` and its own list.
+    """
+
+    # A step is instantaneous, so this bounds only *where* it gets reported,
+    # and 20 ms is inside the 40 ms one frame of the 25 fps encode covers —
+    # under the resolution anything reading the answer has.
+    INTERVAL_S = 0.02
+    # Under this a reading is the scheduling gap between the two `time` calls,
+    # not a step. Measured idle: below 0.4 ms, four orders under a real one.
+    MIN_STEP_S = 0.005
+    # ...and how much has to have accumulated before the recorder says so out
+    # loud. One frame of the encode: below that the video and the log still
+    # agree about which frame a beat is on.
+    WARN_S = 0.04
+
+    def __init__(self) -> None:
+        self.steps: list[dict] = []
+        self._t0 = 0.0
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self, t0: float) -> None:
+        self._t0 = t0
+        self._thread = threading.Thread(
+            target=self._run, name="demo-video-clock", daemon=True
+        )
+        self._thread.start()
+
+    def _run(self) -> None:
+        previous = time.time() - time.monotonic()
+        while not self._stop.is_set():
+            offset = time.time() - time.monotonic()
+            delta = offset - previous
+            if abs(delta) >= self.MIN_STEP_S:
+                self.steps.append(
+                    {
+                        "t": round(time.monotonic() - self._t0, 3),
+                        "delta": round(delta, 4),
+                    }
+                )
+            previous = offset
+            self._stop.wait(self.INTERVAL_S)
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)
+            self._thread = None
+
+    @property
+    def total(self) -> float:
+        return sum(step["delta"] for step in self.steps)
+
+    def report(self) -> dict:
+        return {
+            "steps": list(self.steps),
+            "total": round(self.total, 4),
+            "sample_interval": self.INTERVAL_S,
+            "min_step": self.MIN_STEP_S,
+        }
+
+    def warning(self) -> str | None:
+        """What to tell the author, or None when the two clocks agreed."""
+        if abs(self.total) < self.WARN_S:
+            return None
+        when = ", ".join(
+            f"{step['delta'] * 1000:+.0f} ms at {step['t']:.1f}s"
+            for step in self.steps
+        )
+        return (
+            f"demo-video: WARNING — this host's wall clock stepped while the "
+            f"take was recording ({when}; {self.total * 1000:+.0f} ms in "
+            f"total). Chromium stamps every screencast frame with that clock, "
+            f"so demo.mp4 is {abs(self.total):.2f}s "
+            f"{'shorter' if self.total < 0 else 'longer'} than the take's own "
+            f"wall time and every beat after the step sits that far "
+            f"{'ahead of' if self.total < 0 else 'behind'} the frame it names. "
+            f"timeline.json records it as `capture_clock`; issues #18 and #215."
+        )
+
+
 def _env(name: str, default: str | None = None) -> str | None:
     """A DEMO_VIDEO_-prefixed environment variable, or the default."""
     value = os.environ.get(f"DEMO_VIDEO_{name}", "").strip()
@@ -731,6 +856,9 @@ class _DemoBase:
         # over- or under-run by the size of the step.
         self._line_end = 0.0  # when the current line stops speaking
         self._t0 = 0.0  # when video capture started
+        # ...and the one clock in here that is *not* monotonic, because the
+        # video is on it and nothing else can reach it. See _CaptureClock.
+        self._capture_clock = _CaptureClock()
         self.page: Page = None  # type: ignore[assignment]
         # The beat log (see "beat timeline" above) and the caption currently
         # on screen, which every beat is stamped with.
@@ -914,6 +1042,9 @@ class _DemoBase:
             # the medium's setup takes (~250 ms for the web recorder's
             # window-frame render, and it is not a constant).
             self._t0 = time.monotonic()
+            # Started with `_t0` and stopped with the capture, so its window is
+            # exactly the window the screencast was stamping frames in.
+            self._capture_clock.start(self._t0)
             # Before _start(), so the very first navigation is watched too —
             # a page that throws on load is the whole point of this.
             self._watch_page(self.page)
@@ -925,6 +1056,7 @@ class _DemoBase:
         except Exception:
             # __exit__ never runs when __enter__ raises — don't leak the
             # Playwright driver (typical cause: chromium not installed).
+            self._capture_clock.stop()
             try:
                 self._stop()
             except Exception:
@@ -1002,6 +1134,13 @@ class _DemoBase:
         convert_error: BaseException | None = None
         video = self.page.video
         self._context.close()
+        # The screencast has stopped stamping frames, so the window this
+        # sampler had to cover is closed. Stopping it any later would attribute
+        # a step taken during conversion to the recording (issue #215).
+        self._capture_clock.stop()
+        clock_warning = self._capture_clock.warning()
+        if clock_warning:
+            print(clock_warning, file=sys.stderr)
         webm = Path(video.path()) if video else None
         self._browser.close()
         self._pw.stop()
@@ -1961,6 +2100,14 @@ take with fewer beats than the last one would otherwise leave the
             # grows a quoted string
             # later must not be the one place the mask does not reach.
             "content": self._content,
+            # The clock demo.mp4 is actually on, and the only field here that
+            # is not a reading of `time.monotonic()` (issues #18, #215). See
+            # _CaptureClock: Chromium stamps every screencast frame with the
+            # host's wall clock, so a host that steps it moves the video out
+            # from under the beats by exactly that much. `steps` is empty on
+            # a host that did not step, which is the healthy answer and is
+            # *not* the same as the key being absent.
+            "capture_clock": self._capture_clock.report(),
             # Built from the *scrubbed* beats, not from `self._beats`, so a
             # still path or a caption that the mask reached is masked here too
             # rather than reappearing in the coverage table (issue #12).

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -72,27 +72,48 @@ attributes are stripped, in the same message that hands it the files
 
 ### A frame is aimed at a beat; it is not stamped with one
 
-Chromium's screencast emits a frame when the page paints and pads nothing when
-it does not, so an idle stretch costs the recording wall time that never
-reaches the webm — and every frame after it sits that much earlier in
-`demo.mp4` than `timeline.json` says. It is a discrete step, not a rate error:
-one 32-second take was measured flat at −30 ms for its first five probes and
-flat at −580 ms for its last five.
+Chromium stamps every screencast frame with
+`Page.screencastFrame.metadata.timestamp` — a `Network.TimeSinceEpoch`, which is
+the **host's wall clock** — and Playwright turns that straight into the frame's
+position in the webm. The beat log uses `time.monotonic()`. So when the host
+steps its clock, the video and the log disagree by the size of the step, and
+every frame after it sits that much earlier in `demo.mp4` than
+`timeline.json` says. It is a discrete step because a clock step is one.
+
+**The earlier explanation here was wrong, and it is worth saying why.** This
+section used to blame idle stretches: a screencast emits a frame when the page
+paints, so a still page was thought to cost wall time that never reached the
+webm. Measured directly, it does not — 30 s of a take with nothing painting
+produced seven frames and came back the full 30 s. The evidence that looked
+like idle loss was six samples of the clock step, and the ticker both
+storyboards inject was credited with preventing something it does not affect.
+
+Measured on one WSL2 host: **−0.75 to −0.81 s every 32.2 s**, confirmed by a
+sampler that opens no browser and by a patched Playwright driver that caught
+two consecutive frames 84 ms apart on the monotonic clock and 711 ms backwards
+on Chromium's. Seven takes of one storyboard: the four whose window contained a
+step encoded 0.78 s less video than the three that did not, to within 12 ms.
+A 19 s take against a 32.2 s interval is a coin flip, which is exactly the
+bimodality [#209](https://github.com/rogvid/skills/issues/209) measured.
 
 The suite's bars are asymmetric because the two directions have different
 causes: `MAX_LOG_EARLY_S = 0.25` for the log running ahead of the frame
 (nothing about capture can move an event later, so that direction is the log's
 own error) and `MAX_CAPTURE_LOSS_S = 0.75` for the video running ahead of the
-log (`tests/smoke:680-681`). Both storyboards inject a small animated element
-for their whole length to keep the compositor busy, which removes the confound
-and lets the bar grade the beat log. **A real demo has no such ticker.** What
-the ticker cannot cover is the ~0.7 s between the page being created and the
-first line of storyboard running — the recorder's own setup, which no test code
-can reach — and roughly **1 web take in 12** loses that window whole.
+log. Both storyboards inject a small animated element for their whole length,
+which gives the capture frames to measure with — **not**, as this file
+previously claimed, protection from idle loss, which does not exist. `MAX_CAPTURE_LOSS_S`
+now bounds only the gap before the first frame: 20–140 ms idle, 500–540 ms at
+load 3.1. The suite corrects for the clock step by measuring it independently
+rather than by widening a bar, which is why `MAX_SKEW_DRIFT_S` could be
+restored at 250 ms after being deleted in
+[#217](https://github.com/rogvid/skills/issues/217).
 
-What to do: read a review frame as *around* its beat. Do not build anything
-that needs a beat timestamp to be exact to the frame, and when a frame and its
-caption disagree by a fraction of a second, suspect the capture before the
+What to do: prefer `timeline.json`'s `capture_clock`, which records every step
+with its offset and size, and correct with it. Failing that, read a review
+frame as *around* its beat, do not build anything that needs a beat timestamp
+to be exact to the frame, and when a frame and its caption disagree by a
+fraction of a second, suspect the capture before the
 storyboard ([#18](https://github.com/rogvid/skills/issues/18)).
 
 ### Sixty seconds buys about twenty screens

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,7 +38,7 @@ below for what it covers and what it does not.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~35 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~37 min, nightly)
 ├── unit               # the browser-free half (~0.07 s, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
@@ -181,7 +181,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~48 s)
-tests/smoke-inject                # all 34 entries, ~35 min
+tests/smoke-inject                # all 38 entries, ~37 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -471,11 +471,24 @@ Both the take's first caption and its last are timed, and the skew is graded
 three ways, because the two directions have different causes and only one of
 them is the beat log's:
 
+Every reading is taken **after the host's wall clock is subtracted**, and
+that is the part to understand before trusting this axis
+([#215](https://github.com/rogvid/skills/issues/215)). Chromium stamps every
+screencast frame with `Page.screencastFrame`'s `metadata.timestamp` — wall
+clock by the protocol's own definition — and Playwright turns that straight
+into the frame's position in the webm, while the beat log is
+`time.monotonic()`. On a host that steps its wall clock the two part company
+by exactly the size of the step, at exactly the instant of it. So `HostClock`
+samples `time.time() - time.monotonic()` beside every recorded take, in this
+process, and each probe is measured against `t_start + steps_before(t_start)`.
+The raw figure is printed next to the corrected one, always, so a take that
+really did lose 0.8 s of video says so.
+
 | | bound | why |
 |---|---|---|
 | log **ahead** of the frame | 250 ms | nothing about the capture can move an event *later*, so a positive skew is the log's own error |
-| video **ahead** of the log | 750 ms | a screencast that drops frames only ever makes events land early; capped at one lost setup window |
-| the two probes **drifting apart** | 250 ms | whatever the capture loses, it loses for every later frame equally, so a stall cancels here and only a bad clock survives |
+| video **ahead** of the log, host clock subtracted | 750 ms | what is left once the host's steps are out: the gap before the screencast's *first* frame, which the video's zero is, plus the 40 ms sampling grid and the caption's fade. Measured at 20-140 ms over fifteen idle takes and **500-540 ms at load 3.1** — it is how long Chromium takes to paint, so it stays wide on purpose ([#78](https://github.com/rogvid/skills/issues/78) is what tightening it would become) |
+| the two probes **drifting apart** | 250 ms | whatever the capture loses at the head, it loses for every frame equally, so it cancels here — and a wall-clock step landing *between* the probes is now subtracted per probe rather than reaching this bar. **This is the sharp one, and the correction is what made it sharp:** before it, 680 ms of drift on a healthy recorder was indistinguishable from a beat log that was not being read monotonically |
 
 Observed across eight consecutive `--web-only` runs and six full runs, both
 media: first caption **-80 to -200 ms**, closing caption **-160 to 0 ms**,
@@ -483,19 +496,22 @@ drift **0 to 80 ms**. Nothing came near the 250 ms *ahead* bound — no run has
 ever produced a positive skew — which is the point of splitting by direction:
 the tight bound guards a failure mode with no natural variation near it.
 `_t0` set after `_start()` instead of at page creation measures **+320 ms** and
-fails it; a beat clock running 3% fast drifts **-360 ms** and fails the third.
+fails it; `_t0` set 0.9 s *early* measures **-900 ms** and fails the second
+(`tests/smoke-inject`, "every beat is stamped 0.9s after the frame it
+describes"); a beat clock running 3% fast drifts **-360 ms** and fails the
+third.
 
-That split, and the tightness, only work because of `TICKER_JS` — the part to
-understand before trusting this axis. Chromium's screencast emits a frame when
-the page paints and nothing pads the gap when it does not, so an idle stretch
-silently costs the recording ~0.6 s of wall time and everything after it sits
-that much early. Measured, three runs each: 3/3 idle takes stalled, 3/3 takes
-with a small animated element running did not. Both storyboards inject one for
-their whole length. It cannot cover the ~0.7 s between the page being created
-and the first line of storyboard running — the recorder's own setup, which no
-test code can reach — and roughly 1 web take in 12 loses that window whole,
-which is what the 750 ms bound is for. **A real demo has no ticker at all**;
-see Known gaps and [#18](https://github.com/rogvid/skills/issues/18).
+`TICKER_JS` is still injected for the length of both storyboards, and what it
+is for is now smaller than this file used to claim. Instrumenting Playwright's
+driver to log every screencast frame shows that an idle page loses **no** wall
+time on Playwright 1.62.0 / Chromium 151.0.7922.34: the recorder numbers each
+frame from its timestamp and writes the gaps into the webm's cluster
+timestamps, so 30 s of a take with nothing painting at all — seven frames in
+total — came back the full 30 s long. The 3/3-idle-stalled measurement that
+justified the ticker is the wall-clock step, sampled six times without the
+clock being watched. The ticker still buys frames to *measure* — a caption
+transition can only be timed to the nearest frame the screencast sent — so it
+stays, with its claim reduced to that.
 
 The recorder's determinism controls ([#10](https://github.com/rogvid/skills/issues/10))
 land an animation on its final frame — which is exactly what the ticker must
@@ -1505,7 +1521,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-34 entries, 12 arms, ~35.2 min of takes
+38 entries, 12 arms, ~37.2 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -1538,7 +1554,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
-| `--segments-only` | 2 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); or every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins |
+| `--segments-only` | 6 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; or the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)) |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
@@ -1547,7 +1563,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **19 of `tests/smoke`'s 37 check functions have no entry**, and the harness
+- **19 of `tests/smoke`'s 38 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -1712,21 +1728,78 @@ knows is missing is worse than one that is openly absent.
   the attribute while moving the app elsewhere would silently score the wrong
   pixels. Tracked in [#17](https://github.com/rogvid/skills/issues/17), which
   proposes the recorder expose its geometry as public API.
-- **This harness no longer sees the drift real demos have, on purpose.**
-  Chromium's screencast stalls during idle stretches and Playwright's webm does
-  not pad the gap, so a real take loses ~0.6 s of wall time per stall and every
-  frame after it sits that much early (a 32 s take was measured losing 1.44 s;
-  it is not confined to late in a take, it accumulates with idle time).
-  `TICKER_JS` removes the confound here so the timing bar grades the beat log —
-  which means **a pass says nothing about how well a real, tickerless demo's
-  timestamps line up.** Consequence: a frame extracted at a beat timestamp can
-  show the wrong beat, and narration inherits the same lag because audio rides
-  the wall clock while pixels ride the screencast. Tracked in
-  [#18](https://github.com/rogvid/skills/issues/18), which matters most to
-  [#8](https://github.com/rogvid/skills/issues/8).
+- **The video and the beat log are on different clocks, and this harness
+  corrects for that rather than fixing it.** Chromium stamps every screencast
+  frame with the host's *wall* clock and Playwright turns that into the frame's
+  position in the webm; the beat log is `time.monotonic()`. A host that steps
+  its wall clock therefore takes that much wall time out of `demo.mp4` and
+  leaves the log where it was. The box this was found on steps **-0.75 to
+  -0.81 s every 32.2 s**, which is a coin flip inside a 19 s take and is the
+  whole of the bimodality
+  [#215](https://github.com/rogvid/skills/issues/215) reported.
 
-- **`--web-only` still goes red when the capture loses more than 0.75 s, and
-  the bars were not widened to stop it.**
+  What is fixed: the recorder measures the same clock and writes it into
+  `timeline.json` as `capture_clock`, warns on the way out, and this harness
+  measures it independently and subtracts it before grading. What is **not**
+  fixed: a real demo's `timeline.json` still carries timestamps on a clock the
+  video is not on — a consumer has to apply `capture_clock` itself, and
+  nothing in the recorder does it for them. So a frame extracted at a beat
+  timestamp can still show the wrong moment, and narration still inherits the
+  lag because audio is mixed at wall-clock offsets while pixels ride the
+  screencast — measured at +0.70 s and now correctable from `capture_clock`,
+  which is [#226](https://github.com/rogvid/skills/issues/226). What is left of
+  [#18](https://github.com/rogvid/skills/issues/18) is that boundary, and it
+  matters most to [#8](https://github.com/rogvid/skills/issues/8).
+
+- **The terminal arm loses roughly a second more than its host clock explains,
+  and nothing here knows why.** The correction is exact on the web arm — six
+  consecutive `--web-only` runs after it, residual 20-140 ms, three of them
+  with a step inside the take — and on both segments of the stitched demo. The
+  terminal take is not. Four `--terminal-only` runs, each with the recorder's
+  own `capture_clock` read back out of the take:
+
+  | run | step | first probe | closing probe | result |
+  |---|---|---|---|---|
+  | 1 | none | -180 ms | -140 ms | PASSED |
+  | 2 | -800 ms at 1.8s | unmeasurable, ~-1.94 s raw | over the bar | FAILED |
+  | 3 | -839 ms at 8.9s | -100 ms | **-900 ms** after correction | FAILED |
+  | 4 | -830 ms at 15.5s, past the last beat | -100 ms | -60 ms | PASSED |
+
+  Both runs that failed are runs whose step landed *inside* the storyboard;
+  both that passed are runs where it did not. Run 3 is the shape: the step is subtracted, and what is left is another
+  0.9 s of wall time gone from the video between 8.9 s and 11.95 s — about one
+  more step, in a take where only one was measured and where this harness and
+  the recorder agree on that, inside the storyboard's own window. The take's
+  *length* only lost the one step (`duration` fell by 0.76 s against a
+  step-free run), so the video did not simply get shorter: something between
+  the jump and the closing caption is compressed. The most likely candidate is
+  what ffmpeg does with the non-monotonic cluster timestamps Playwright writes
+  after Chromium's clock goes backwards, which is not something this repo can
+  measure from outside. Tracked in
+  [#224](https://github.com/rogvid/skills/issues/224).
+
+  **The bars were not widened for it.** `MAX_SKEW_DRIFT_S` at 250 ms is the
+  sharp claim this whole correction exists to make usable, and a bar wide
+  enough for -800 ms of it grades nothing at all. So a `--terminal-only` run on
+  a box whose wall clock steps inside the take is still red about half the
+  time, and it is red about something true and now says which part of it is
+  the host and which is not.
+
+- **`stitch()` does not merge `capture_clock`.** Each part's own
+  `<segment>.seg.timeline.json` carries its own measurement and is graded
+  against this harness's, per part — but the merged envelope has no such field,
+  so a consumer of a stitched `demo.mp4` has nothing to correct with. The
+  harness works around it by keeping each part's clock and laying them on the
+  merged video itself; a reader of the artifact cannot. `stitching.py` is
+  outside the change that added the field. Tracked in
+  [#225](https://github.com/rogvid/skills/issues/225).
+
+- **~~`--web-only` still goes red when the capture loses more than 0.75 s, and
+  the bars were not widened to stop it.~~ Diagnosed and fixed** — the cause was
+  the host's wall clock and it is now measured and subtracted, per probe
+  ([#215](https://github.com/rogvid/skills/issues/215)). The measurement that
+  led there is kept below because it is what the fix was checked against, and
+  because "bimodal, and not load" is the reading that mattered.
   [#209](https://github.com/rogvid/skills/issues/209) asked whether the
   caption-timing bars measure something real that load breaks, or an artefact
   of the harness's own timing. Measured, four `--web-only` runs on this box,
@@ -1769,10 +1842,20 @@ knows is missing is worse than one that is openly absent.
   measurement that could not be made. The drift message no longer names a
   cause it cannot tell apart from the other one.
 
-  So `--web-only` on a box where the capture loses that window is still red,
-  and now it is red about something it can state. What nothing here grades is
-  *why* the capture loses it with the ticker running —
-  [#215](https://github.com/rogvid/skills/issues/215).
+  **What it turned out to be.** Playwright's driver, instrumented to log every
+  screencast frame, caught two consecutive frames 84 ms apart on the monotonic
+  clock and **711 ms backwards** on Chromium's. Chromium's frame timestamps are
+  the host's wall clock; a separate sampler that never opens a browser shows
+  that clock stepping -0.75 to -0.81 s every 32.2 s on this box, at the same
+  instants and the same sizes to the tenth of a millisecond. Seven takes of one
+  storyboard: the four whose window contained a step encoded 0.78 s less video
+  than the three that did not, to within 12 ms. The bars are now on the
+  residual after that is subtracted, and the residual is 20-140 ms on an idle
+  box. Six consecutive `--web-only` runs afterwards: **6/6 clean on the timing
+  bars**, three of them with a step inside the take and one of those between
+  the two probes — the shape that made the drift bar unusable. The two runs
+  that went red went red on the spotlight windows, at loads 1.7 and 3.1, which
+  is [#78](https://github.com/rogvid/skills/issues/78) and not this.
 - **Nothing reads the caption text off the video.** The timing check proves the
   caption *band* changed when `timeline.json` says it did; that the words are
   the right words is a DOM assertion (`check_caption`) taken at record time.
@@ -1800,12 +1883,20 @@ knows is missing is worse than one that is openly absent.
   frames only inside long beats — is vacuous today and says so where it is
   written. The mechanism is graded directly instead (see **Review frames**),
   which is what stops the vacuity from being total.
-- **The wall-clock regression cannot be fault-injected.** The recorders time
-  beats with `time.monotonic()`; using `time.time()` only misreports when the
-  system clock actually steps, which no assertion here can provoke. It is not
-  hypothetical — a WSL2 box was measured stepping 573 ms backwards inside 8 s,
-  which is how the bug was found — but a pass does not prove the fix is still
-  in place. Reading the diff does.
+- **Half the wall-clock class can now be fault-injected, and half still
+  cannot.** The half that can: everything the recorder *does* about a stepping
+  host — `_CaptureClock`'s sampler, its floor, the sign it records, the field
+  it writes and the warning it prints — is graded by `tests/unit`'s
+  `CaptureClock` over a **scripted** clock, and by four `tests/smoke-inject`
+  entries that break the recorder while `tests/smoke` watches a real one. None
+  of those depends on the box's clock actually stepping.
+
+  The half that cannot: that the recorders *pace* on `time.monotonic()` rather
+  than `time.time()`. Swapping them back only misreports when the system clock
+  steps during a take, which no assertion here can provoke — it can only wait
+  for it. On the box this was written on that wait is 32 s, which is why the
+  bug was found at all; on a machine with a well-behaved clock a pass proves
+  nothing about it. Reading the diff still does.
 - **Issue attribution is bounded, not exact.** Playwright's sync API delivers
   page events only while it is inside a call, so the recorder pumps every
   100 ms during a hold and refuses to attribute an event to a beat that has not

--- a/tests/smoke
+++ b/tests/smoke
@@ -102,6 +102,7 @@ import statistics
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import urllib.error
 import urllib.parse
@@ -783,40 +784,83 @@ DURATION_TOLERANCE_S = 0.2
 #     `_start()` instead of at page creation measures +280 to +320 ms here.
 #
 #   * MAX_CAPTURE_LOSS_S — the video shows it *before* the log says (negative
-#     skew). Chromium's screencast emits a frame when the page paints, and
-#     nothing pads the gap when it does not, so an idle stretch costs the webm
-#     wall time and everything after it lands early. TICKER_JS removes that
-#     for the whole storyboard, but not for the ~0.7 s between the page being
-#     created and the first line of storyboard running — the recorder's own
-#     setup, which no test code can reach. A web take that loses that window
-#     loses it whole, uniformly, from the very first caption. Tolerated and
-#     reported, not asserted away; issue #18.
+#     skew). Two separate things produce that, and the whole of issue #215 is
+#     that they were being read as one:
 #
-#     The number is stale and knowingly so. It was written as "roughly 1 take
-#     in 12, -600 ms", which is what 0.75 was set from; four `--web-only` runs
-#     measured while grading issue #209 read -880/-800, -80/-0, -120/-800 and
-#     -880/-840 ms. That is over the bar, at idle as well as under load, and
-#     the bar was **not** widened to absorb it — `tests/README.md`, Known gaps,
-#     says why, and issue #215 is where the cause is being looked for.
+#       - **the host's wall clock stepping.** Chromium stamps every screencast
+#         frame with `Page.screencastFrame`'s `metadata.timestamp`, which the
+#         protocol defines as wall-clock seconds since the epoch, and
+#         Playwright turns that straight into the frame's position in the webm.
+#         The beat log is `time.monotonic()`. So a host that steps its wall
+#         clock back by 0.8 s takes 0.8 s out of the video and leaves the log
+#         where it was. **This is not the recorder's, not the ticker's and not
+#         load** — it is measured directly, per take, by `HostClock` below and
+#         subtracted before anything is graded. See `_CaptureClock` in core.py
+#         for the frame-level evidence.
+#       - **the screencast's first frame**, which is what MAX_CAPTURE_LOSS_S
+#         is left bounding. The video's zero is that frame, not `_t0`, so
+#         everything between them is lost from the file uniformly, from the
+#         very first caption. No test code and no ticker can reach it, and
+#         **it is load-sensitive**: measured at 70-140 ms idle over fifteen
+#         takes and at 500-540 ms on one run at load 3.1. Plus the 40 ms
+#         sampling grid and the caption's fade.
 #
-#   * MAX_SKEW_DRIFT_S — how far the two probes' skews may differ. This is the
-#     sharp one, and it is symmetric. A capture stall *before* the first probe
-#     moves both of them equally and cancels here; anything wrong with the
-#     *clock* does not, since a backwards step lands between them, as does a
-#     beat stamped somewhere other than where its verb ran. Observed across
-#     twelve takes with the ticker: 0 to 120 ms, all of it the 40 ms sampling
-#     grid and the caption's own 0.3 s fade.
+#     The old comment attributed all of it to an idle screencast, and the old
+#     number — 0.75, from "roughly 1 take in 12, -600 ms" — was the size of
+#     this box's clock step. It is **unchanged** all the same, and that is the
+#     point rather than an omission: what the correction buys is not a tighter
+#     bar here, it is that MAX_SKEW_DRIFT_S below can now only be tripped by
+#     the beat log. Tightening this one would put a bar on how long Chromium
+#     takes to paint its first frame on the machine of the day, which is the
+#     shape issue #78 is about.
 #
-#     What this bar does **not** do is say which of the two it caught, and the
-#     comment here used to: a stall landing *between* the probes does not
-#     cancel either. Measured on this box while grading issue #209, one
-#     `--web-only` take read -120 ms at the first probe and -800 ms at the
-#     closing one — 680 ms of screencast stall, mid-take, with TICKER_JS
-#     running and asserted alive. The measured clock step (573 ms) is over the
-#     same bar, and from inside this measurement the two are the same number.
+#     Measured over seven takes of one storyboard with the sampler running:
+#     the four whose window contained a step encoded 0.78 s less video than
+#     the three that did not, to within 12 ms; the residual after subtracting
+#     the step is 20-140 ms on an idle box whether or not a step happened.
+#
+#   * MAX_SKEW_DRIFT_S — how far the two probes' skews may differ, **after**
+#     the same subtraction. This is the sharp one, and it is symmetric. A
+#     capture loss before the first probe moves both of them equally and
+#     cancels here; a beat stamped somewhere other than where its verb ran
+#     does not. Observed across twelve takes with the ticker: 0 to 120 ms, all
+#     of it the 40 ms sampling grid and the caption's own 0.3 s fade.
+#
+#     Before #215 this bar could not say which of two things it had caught,
+#     because a wall-clock step landing *between* the probes moved one and not
+#     the other — measured at 680 ms on this box while grading issue #209, and
+#     read at the time as a mid-take screencast stall. It is now the one thing
+#     the correction removes most cleanly: the step is timestamped, so it is
+#     subtracted from whichever probes it precedes and from no others.
 MAX_LOG_EARLY_S = 0.25
 MAX_CAPTURE_LOSS_S = 0.75
 MAX_SKEW_DRIFT_S = 0.25
+
+# How far the recorder's own `capture_clock` may sit from what this harness
+# measured over the same take. They are two samplers watching one clock from
+# two processes' threads, so this is the two sampling grids (20 ms each) plus
+# the wait for the recorder's thread to notice — not tolerance for a different
+# answer. Observed: 0.1 ms on the total, every take.
+#
+# It is what stops the correction from being self-fulfilling. This harness
+# corrects with *its own* numbers, so a recorder that stopped sampling, or
+# sampled the wrong clock, would otherwise change nothing here and the new
+# `capture_clock` field could quietly rot.
+MAX_CLOCK_RECORD_DISAGREEMENT_S = 0.06
+
+# ...and how far apart the two may put the *same* step in the take. Wider than
+# the size tolerance and for a different reason: the two samplers start on
+# their own 20 ms grids and neither is synchronised to the other, so a step
+# lands on one sample here and the next one there. What this rules out is a
+# step attributed to the wrong part of the take, which is what decides which
+# beats it applies to.
+MAX_CLOCK_STEP_TIME_DISAGREEMENT_S = 0.25
+
+# Steps smaller than this are not steps: two `time` calls are not atomic and
+# the gap between them is a reading. Deliberately the same figure the recorder
+# uses, and deliberately *not* imported from it — a threshold read out of the
+# code being graded agrees with that code no matter what it says.
+HOST_CLOCK_MIN_STEP_S = 0.005
 
 # The rate the window is sampled at (the recorders encode at 25 fps, so this is
 # every frame and the measurement quantises to 40 ms), and how far past the
@@ -835,18 +879,26 @@ MIN_BASELINE_FRAMES = 4
 # How far back the window reaches from the beat — **derived**, because a
 # hand-written number here was narrower than the bar it feeds and nothing said
 # so (issue #209). The old comment read "the run-up has to clear
-# MAX_CAPTURE_LOSS_S ... 0.45 s of margin", and 1.2 - 0.75 is indeed 0.45; but
+# MAX_CAPTURE_LOSS_S ... 0.45 s of margin", and 1.2 - 0.75 was indeed 0.45; but
 # clearing the loss is not enough. `caption_appearance_s` also needs
 # CAPTION_FADE_FRAMES + MIN_BASELINE_FRAMES (0.48 s) of quiet *in front of* the
 # arrival, so a window of 1.2 s could not measure a slide past 0.72 s — inside
-# the 0.75 s this file says it tolerates. The real margin was -0.03 s, and what
-# a reader got instead of a passing take was "the caption could not be timed".
+# the tolerance this file stated. The real margin was -0.03 s, and what a
+# reader got instead of a passing take was "the caption could not be timed".
 #
 # So: reach back far enough to measure a slide at the tolerance, plus
 # ALIGN_OVERSHOOT_S past it, so that a slide the bar *rejects* is reported as a
-# number rather than as a measurement that could not be made. Measured slides
-# on this box are 0.80-0.88 s when the capture loses anything at all, which is
-# inside the overshoot and therefore now says so in the failure.
+# number rather than as a measurement that could not be made.
+#
+# Derived from MAX_UNWATCHED_CAPTURE_LOSS_S rather than from the corrected bar,
+# and that is the point of the split: the window has to be able to *find* a
+# slide whether or not anything explains it. On a take whose host clock was
+# watched the window is additionally **centred on where the measured steps put
+# the beat in the video** rather than on `t_start` (issue #215), which costs
+# nothing here and buys back the whole overshoot — the probe's quiet run-up
+# slid by exactly the amount the probe did, so a window that follows the beat
+# sits in the same place relative to the picture on a stepped take as on a
+# clean one.
 #
 # Bounded above by the caption-band quiet PROBE_QUIET_S buys:
 #
@@ -950,13 +1002,17 @@ MAX_FRAME_PLACEMENT_S = 0.02
 # FRAME_CAPTION_GUARD_S is the honest part. The video slides under the beat log
 # (issue #18) and a frame cut at a beat's midpoint therefore shows a moment up
 # to that far *ahead* of the beat in story time — measured at 40-120 ms in
-# these ticker-protected takes, but a take that loses the recorder's own
-# ~0.7 s setup window loses it uniformly, which is what MAX_CAPTURE_LOSS_S
-# already tolerates elsewhere in this file. So a frame is graded for the
-# caption it shows only when its timestamp is at least that far from a caption
-# *change*; nearer than that, the beat log and the video genuinely disagree
-# about which side of the change the frame is on, and this harness is not the
-# place to pretend otherwise. Same number, same reason, one definition.
+# these ticker-protected takes. So a frame is graded for the caption it shows
+# only when its timestamp is at least that far from a caption *change*; nearer
+# than that, the beat log and the video genuinely disagree about which side of
+# the change the frame is on, and this harness is not the place to pretend
+# otherwise. Same number, same reason, one definition.
+#
+# It is `MAX_UNWATCHED_CAPTURE_LOSS_S` rather than the corrected bar, and it
+# stays that width: `_check_frame_captions()` corrects *where the frame is*
+# by the host's measured wall-clock steps (issue #215) rather than widening
+# the guard around it, so on a box whose clock never steps this excludes
+# exactly the frames it always did.
 #
 # Concretely, on the storyboards here that skips every `shot` beat that sits
 # against a caption change — and those frames really do show the next beat's
@@ -1097,21 +1153,27 @@ MAX_MERGE_OFFSET_ERROR_S = 0.1
 
 # Bound on how far the *two* timing probes may drift apart when they sit in
 # different segments. MAX_SKEW_DRIFT_S (250 ms) is sharp because whatever a
-# capture loses it loses for every later frame equally, so a stall moves both
+# capture loses it loses for every later frame equally, so a loss moves both
 # probes together and cancels. That argument holds inside one screencast and
 # stops at a segment boundary: each segment is its own capture, with its own
-# ~0.7 s of untickerable recorder setup, and a stall in the second shifts only
-# the second probe. Measured across four two-segment takes: -80, +80, +80, and
-# one at -520 — a real capture stall in segment two, not a merge error, which
-# a 250 ms bar here would fail on about one run in four.
+# first-frame gap, and a loss in the second shifts only the second probe.
+# Measured across four two-segment takes: -80, +80, +80, and one at -520 —
+# which a 250 ms bar here would have failed on about one run in four.
 #
-# **This is a flake guard, not a check.** It is loose because the mechanism it
-# would otherwise catch is measured properly elsewhere, per segment and per
-# capture, by check_merge_offset(): the merge's own error at 100 ms with
-# capture loss cancelled, and each segment's own skew against the same 250 /
-# 750 ms directional bars a single take gets. Neither of those is confounded
-# by the boundary, and neither is satisfied by a constant shift of any
-# segment's beats — which is what this bar, at any width, cannot say.
+# That -520 is now understood: it is the host's wall clock stepping (issue
+# #215), and `check_timeline()` subtracts it per probe before this bar sees
+# anything. What is left at a segment boundary is each capture's own
+# first-frame gap, ~80 ms, which is why this can now be the same 300 ms as
+# every other loss bar in this file rather than the 750 ms it took to absorb
+# a step nobody had measured.
+#
+# **This is still a flake guard, not a check.** The mechanism it would
+# otherwise catch is measured properly elsewhere, per segment and per capture,
+# by check_merge_offset(): the merge's own error at 100 ms with capture loss
+# cancelled, and each segment's own skew against the same directional bars a
+# single take gets. Neither of those is confounded by the boundary, and neither
+# is satisfied by a constant shift of any segment's beats — which is what this
+# bar, at any width, cannot say.
 MAX_CROSS_SEGMENT_DRIFT_S = MAX_CAPTURE_LOSS_S
 
 # -- how the recording looks (issues #110 and #111) ---------------------------
@@ -1861,6 +1923,235 @@ class Beats:
             self.problems.append(f"{self.label}: {message}")
 
 
+# -- the clock demo.mp4 is on (issues #18, #215) ------------------------------
+#
+# Chromium timestamps every screencast frame with the host's *wall* clock, and
+# Playwright turns that timestamp straight into the frame's position in the
+# webm. The beat log is `time.monotonic()`. On a host that steps its wall
+# clock — a WSL2 box was measured stepping -0.75 to -0.81 s **every 32.2 s**,
+# which in a 19 s take is a coin flip — the two clocks part company by exactly
+# the size of the step, at exactly the instant of it, and every reading of
+# "how far has the video slid under the beat log" inherits it.
+#
+# So this harness measures the same clock, itself, around every recorded take,
+# and subtracts it before grading. Three things about that are deliberate:
+#
+#   * **It is measured, not assumed.** Nothing here is tuned to 0.8 s or to
+#     32 s; a host that never steps produces an empty list and every bar below
+#     is exactly the bar it was.
+#   * **It is this harness's own reading**, not the recorder's. The recorder
+#     writes the same measurement into `timeline.json` as `capture_clock`, and
+#     that field is graded *against* this one — a correction taken from the
+#     code under test would agree with that code no matter what it said.
+#   * **It runs in this process**, not the recorder's, and watches a clock the
+#     recorder cannot influence. The two readings agreeing is therefore a
+#     claim about the recorder, not a tautology.
+class HostClock:
+    """CLOCK_REALTIME against CLOCK_MONOTONIC, sampled for a take's lifetime.
+
+    Steps are held in **absolute** `time.monotonic()` seconds and put on the
+    take's clock by `rebase()`, which is handed the recorder's own `_t0`. That
+    matters more than it looks: this watcher starts before the browser does,
+    so its zero is a second or so earlier than frame zero, and a step landing
+    inside that second would otherwise be attributed to the wrong side of a
+    beat. `_t0` is a `time.monotonic()` reading, not part of the measurement
+    being graded — the same kind of coupling as reading `Recorder._geom` for
+    the content rect.
+    """
+
+    INTERVAL_S = 0.02
+
+    def __init__(self) -> None:
+        self.raw: list[tuple[float, float]] = []  # (absolute monotonic, delta)
+        self._t0: float | None = None
+        # Where one capture ends and the next begins, on this clock. Empty for
+        # a take recorded in one piece; on a stitched demo it is where each
+        # part starts, and it is load-bearing rather than bookkeeping — see
+        # `before()`.
+        self.boundaries: list[float] = []
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def _run(self) -> None:
+        previous = time.time() - time.monotonic()
+        while not self._stop.is_set():
+            offset = time.time() - time.monotonic()
+            delta = offset - previous
+            if abs(delta) >= HOST_CLOCK_MIN_STEP_S:
+                self.raw.append((time.monotonic(), delta))
+            previous = offset
+            self._stop.wait(self.INTERVAL_S)
+
+    def rebase(self, t0: float) -> None:
+        """Put the steps on this take's own clock — `t0` is its frame zero."""
+        self._t0 = t0
+
+    @property
+    def steps(self) -> list[tuple[float, float]]:
+        """(seconds from the take's frame zero, delta), rebased."""
+        if self._t0 is None:
+            return []
+        return [(at - self._t0, delta) for at, delta in self.raw]
+
+    @property
+    def total(self) -> float:
+        return sum(delta for _, delta in self.steps)
+
+    def before(self, t: float) -> float:
+        """How much the wall clock had stepped by `t` seconds into the video.
+
+        Negative when the clock went backwards, which is the direction that
+        takes wall time out of the video. A beat the log puts at `t` is at
+        `t + before(t)` in demo.mp4.
+
+        **Only the steps inside `t`'s own capture count.** A capture's first
+        frame is where its clock starts, so a step during an earlier part
+        shortened that part and nothing else — and `stitch()` lays the parts
+        out by their real durations, so that shortening is already in the
+        offset. Adding it again to a later part's beats would over-correct by
+        a whole step. For a single take there are no boundaries and this is
+        the whole list.
+
+        Hand-written here rather than shared with the recorder: the two have
+        to be able to disagree, or `capture_clock` is not being graded.
+        """
+        start = max((b for b in self.boundaries if b <= t), default=0.0)
+        return sum(delta for at, delta in self.steps if start <= at <= t)
+
+    def describe(self) -> str:
+        if not self.steps:
+            return "the host's wall clock did not step during this take"
+        return "the host's wall clock stepped " + ", ".join(
+            f"{delta * 1000:+.0f} ms at {at:.1f}s" for at, delta in self.steps
+        )
+
+
+def joined_clock(parts: list[tuple[HostClock, float]]) -> HostClock:
+    """The clock of a video stitched from several captures.
+
+    `parts` is (that capture's clock, where its video starts in the joined
+    one). Nothing is mutated: each part keeps its own clock, because that is
+    what grades that part's own `capture_clock` and its own `.seg.mp4`.
+    """
+    joined = HostClock()
+    joined._t0 = 0.0
+    joined.raw = [
+        (at + offset, delta) for clock, offset in parts for at, delta in clock.steps
+    ]
+    joined.boundaries = [offset for _clock, offset in parts]
+    return joined
+
+
+@contextmanager
+def watch_wall_clock() -> Iterator[HostClock]:
+    """Sample the host's wall clock for as long as a take is recording."""
+    clock = HostClock()
+    clock._t0 = time.monotonic()
+    clock._thread = threading.Thread(
+        target=clock._run, name="smoke-host-clock", daemon=True
+    )
+    clock._thread.start()
+    try:
+        yield clock
+    finally:
+        clock._stop.set()
+        clock._thread.join(timeout=1.0)
+
+
+def check_capture_clock(
+    label: str, out_dir: Path, clock: HostClock, name: str = "timeline.json"
+) -> list[str]:
+    """`timeline.json`'s `capture_clock` against this harness's own reading.
+
+    The one assertion that grades the recorder's new field, and the reason the
+    corrections elsewhere are not circular: this harness corrects with its own
+    numbers, so without this a recorder that stopped sampling would change
+    nothing here and `capture_clock` could rot in silence.
+
+    **The window is the storyboard's**, `[0, last t_end]`, and both directions
+    are asserted inside it: a step this harness saw must be in the record, and
+    a step in the record must have been seen. Outside it the two watchers do
+    not cover the same seconds — this one keeps running through conversion,
+    which the capture is not part of — so a step out there is neither's error
+    and is reported rather than graded.
+    """
+    path = out_dir / name
+    try:
+        doc = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"{label}: {name} could not be read for capture_clock: {exc}"]
+    record = doc.get("capture_clock")
+    if not isinstance(record, dict):
+        return [
+            f"{label}: {name} has no `capture_clock` record. The video is on "
+            f"the host's wall clock and the beats are on the monotonic one "
+            f"(issues #18, #215); without this field nothing downstream can "
+            f"tell a stepped clock from a recorder that mis-stamped a beat"
+        ]
+    reported = record.get("total")
+    if not isinstance(reported, (int, float)):
+        return [
+            f"{label}: capture_clock.total is {reported!r}, not a number — "
+            f"a consumer correcting a beat timestamp with it would get nothing"
+        ]
+    listed = record.get("steps")
+    if not isinstance(listed, list):
+        return [
+            f"{label}: capture_clock.steps is {listed!r}, not a list — the "
+            f"total says how much was lost and only the steps say which beats "
+            f"lost it"
+        ]
+    if abs(sum(float(s.get("delta", 0.0)) for s in listed) - float(reported)) > 0.001:
+        return [
+            f"{label}: capture_clock.total is {reported!r} but its own steps "
+            f"sum to {sum(float(s.get('delta', 0.0)) for s in listed):+.4f} — "
+            f"the field disagrees with itself"
+        ]
+
+    beats = doc.get("beats") or []
+    horizon = max(
+        (float(b["t_end"]) for b in beats if isinstance(b.get("t_end"), (int, float))),
+        default=0.0,
+    )
+    mine = [(at, d) for at, d in clock.steps if 0.0 <= at <= horizon]
+    theirs = [
+        (float(s.get("t", -1.0)), float(s.get("delta", 0.0)))
+        for s in listed
+        if 0.0 <= float(s.get("t", -1.0)) <= horizon
+    ]
+    inside = (
+        f"inside the {horizon:.1f}s the storyboard ran, this harness saw "
+        f"{len(mine)} wall-clock step(s) [{clock.describe()}] and "
+        f"timeline.json records {len(theirs)}"
+    )
+    if len(mine) != len(theirs):
+        return [
+            f"{label}: {inside} — `capture_clock` is not measuring the clock "
+            f"the video is on, so every consumer correcting a beat timestamp "
+            f"with it is being told the wrong number (issues #18, #215)"
+        ]
+    for (at, delta), (their_at, their_delta) in zip(
+        sorted(mine), sorted(theirs), strict=True
+    ):
+        if abs(delta - their_delta) > MAX_CLOCK_RECORD_DISAGREEMENT_S:
+            return [
+                f"{label}: this harness measured a wall-clock step of "
+                f"{delta * 1000:+.0f} ms at {at:.1f}s and timeline.json "
+                f"records {their_delta * 1000:+.0f} ms at {their_at:.1f}s — "
+                f"the same step, two different sizes, and the smaller one is "
+                f"what a consumer would correct a beat timestamp by"
+            ]
+        if abs(at - their_at) > MAX_CLOCK_STEP_TIME_DISAGREEMENT_S:
+            return [
+                f"{label}: this harness put a {delta * 1000:+.0f} ms "
+                f"wall-clock step at {at:.1f}s into the take and "
+                f"timeline.json puts it at {their_at:.1f}s. Which beats a "
+                f"step applies to is the whole of what the timestamp is for"
+            ]
+    print(f"smoke: {label} capture_clock agrees with the harness ({clock.describe()})")
+    return []
+
+
 _CAPTION_JS = """() => {
   const el = document.getElementById('__demo_caption');
   if (!el) return null;
@@ -2340,7 +2631,7 @@ _TRAIL_JS = """() => {
 
 
 def record_web(
-    out_dir: Path, base_url: str
+    out_dir: Path, base_url: str, clock: HostClock | None = None
 ) -> tuple[list[str], Rect, Rect, tuple[int, int]]:
     """Land, read a KPI, filter the table, refresh it.
 
@@ -2371,6 +2662,11 @@ def record_web(
     with Recorder(
         out_dir, base_url=base_url, speech=False, strict=True, deterministic=True
     ) as rec:
+        # Frame zero, so the host-clock steps this run measured land on the
+        # same clock the beats do. `_t0` is a `time.monotonic()` reading and
+        # not part of what `capture_clock` claims — see HostClock.
+        if clock is not None:
+            clock.rebase(rec._t0)
         rec.goto("/")
         # #142's carve-out, graded. `framenavigated` was written for the paint
         # gate, and the gate went with the masking — but it is the recorder's
@@ -2627,7 +2923,7 @@ def record_web(
 
 
 def record_terminal(
-    out_dir: Path,
+    out_dir: Path, clock: HostClock | None = None
 ) -> tuple[list[str], Rect, Rect, tuple[int, int]]:
     """Two trivial commands — enough to exercise PTY, xterm.js, and prompt sync."""
     from demo_recording import TerminalRecorder
@@ -2660,6 +2956,8 @@ def record_terminal(
     with TerminalRecorder(
         out_dir, speech=False, strict=True, deterministic=True
     ) as rec:
+        if clock is not None:
+            clock.rebase(rec._t0)  # see HostClock
         start_ticker(b, rec.page)
         # The determinism controls live on the context, so the terminal
         # recorder inherits every one of them — and a page that renders a real
@@ -2716,7 +3014,7 @@ def record_terminal(
 
 def record_segments(
     out_dir: Path, base_url: str
-) -> tuple[list[str], Rect, Rect, tuple[int, int]]:
+) -> tuple[list[str], Rect, Rect, tuple[int, int], list[HostClock]]:
     """One demo, recorded as two segments — the shape a real time-skip takes.
 
     Deliberately the storyboard SKILL.md tells people to write: record part
@@ -2741,7 +3039,19 @@ def record_segments(
         "deterministic": True,
     }
 
-    with Recorder(out_dir, segment=SEGMENT_NAMES[0], **settings) as rec:
+    # One watcher per segment, because one watcher for the pair would be
+    # wrong: each segment is its own capture with its own first frame, so a
+    # wall-clock step between them moves nothing at all, and a step inside
+    # segment one does not move segment two's frames (issue #215). What is
+    # returned is therefore per-segment and `run_segments()` maps each onto the
+    # merged video's clock using the parts' own durations.
+    clocks: list[HostClock] = []
+
+    with (
+        watch_wall_clock() as clock_one,
+        Recorder(out_dir, segment=SEGMENT_NAMES[0], **settings) as rec,
+    ):
+        clock_one.rebase(rec._t0)
         rec.goto("/")
         rec.wait_for("#kpi-rev")
         start_ticker(b, rec.page)
@@ -2757,8 +3067,13 @@ def record_segments(
         video_rect: Rect = (g["appx"], g["appy"], g["appw"], g["apph"])
         size = (rec._size["width"], rec._size["height"])
         still_rect: Rect = (0, 0, size[0], size[1])
+    clocks.append(clock_one)
 
-    with Recorder(out_dir, segment=SEGMENT_NAMES[1], **settings) as rec:
+    with (
+        watch_wall_clock() as clock_two,
+        Recorder(out_dir, segment=SEGMENT_NAMES[1], **settings) as rec,
+    ):
+        clock_two.rebase(rec._t0)
         # On about:blank, before anything else: the second segment's opening
         # seconds are the ones most likely to go idle, and idle is what makes
         # the screencast lose wall time (TICKER_JS, issue #18). The interlude
@@ -2781,8 +3096,9 @@ def record_segments(
         check_caption(b, rec.page, PROBE_CAPTION)
         rec.shot(CAPTION_PROBE[1])
         rec.caption("")
+    clocks.append(clock_two)
 
-    return b.problems, video_rect, still_rect, size
+    return b.problems, video_rect, still_rect, size, clocks
 
 
 def record_spotlight(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
@@ -5043,12 +5359,20 @@ def _scored_region_failures(
 
 
 def caption_appearance_s(
-    label: str, mp4: Path, band: Rect, t_start: float
+    label: str, mp4: Path, band: Rect, expect_at: float
 ) -> tuple[float | None, str]:
     """When the probe caption really shows up in the video, in seconds.
 
     Returns (seconds, note) — seconds is None when the measurement could not
     be made, and `note` says why, or reports the numbers behind the answer.
+
+    `expect_at` is where the caller expects the caption **in the video's own
+    clock**, which is not the beat's `t_start` on a host whose wall clock
+    stepped: see HostClock. Centring the window there rather than on `t_start`
+    is what keeps the window in the same place relative to the *picture* — the
+    probe's quiet run-up slid by the same amount the probe did — instead of
+    reaching back past the previous caption's fade on stepped takes and
+    reporting a busy run-up (issue #215).
 
     The storyboard leaves PROBE_QUIET_S of caption-band quiet before the probe
     caption, so within this window the caption band changes for one reason
@@ -5059,6 +5383,7 @@ def caption_appearance_s(
     perturbed frame and the fully-drawn one are a third of a second apart and
     only one of them is a defensible answer.
     """
+    t_start = expect_at
     start = max(0.0, t_start - ALIGN_PRE_S)
     span = (t_start - start) + ALIGN_POST_S
     try:
@@ -5176,8 +5501,10 @@ def _explain_flat_window(
         f"{(nearest - t_start) * 1000:+.0f} ms away, outside the "
         f"{ALIGN_PRE_S:.1f}s search window. The video has slid out from under "
         f"the beat log by more than the window can see, so the skew cannot be "
-        f"measured (not that the caption is missing). Almost certainly a "
-        f"screencast stall — see issue #18."
+        f"measured (not that the caption is missing). The window is already "
+        f"centred on where the host's measured wall-clock steps put this beat "
+        f"in the video, so this slide is something else — see issues #18 "
+        f"and #215."
     )
 
 
@@ -5190,6 +5517,7 @@ def check_timeline(
     frame_size: tuple[int, int],
     expected_segments: list[str | None] | None = None,
     expected_interludes: list[str] | None = None,
+    clock: HostClock | None = None,
 ) -> list[str]:
     """The beat log the take left behind: timeline.json and timeline.md.
 
@@ -5204,6 +5532,13 @@ def check_timeline(
     segmented path is a second, softer standard. `expected_segments` names the
     segment each beat was recorded in (all None for a single take), and
     `expected_interludes` the lines any `interlude` beats show.
+
+    `clock` is this harness's own reading of the host's wall clock over the
+    take (see HostClock). The video is on that clock and the beat log is not,
+    so the timing probes below are measured against `t_start + clock.before
+    (t_start)` and the residual is what gets graded. Passing None is the same
+    as a host that never stepped, and is what every caller that does not
+    record a take of its own uses.
     """
     from demo_recording.content import media_duration
     from demo_recording.timeline import TIMELINE_SCHEMA
@@ -5401,6 +5736,12 @@ def check_timeline(
             )
 
     # -- the mp4 the timestamps are relative to ------------------------------
+    #
+    # How far the host's wall clock had stepped by a given point in the take.
+    # The video is on that clock and the beats are not (issue #215), so every
+    # comparison between the two below goes through this. Absent a reading the
+    # correction is zero and every bar is what it was.
+    stepped = clock.before if clock is not None else (lambda _t: 0.0)
     mp4 = out_dir / "demo.mp4"
     duration = doc.get("duration")
     if not mp4.is_file():
@@ -5420,11 +5761,18 @@ def check_timeline(
                 f"{label}: timeline.json says demo.mp4 is {duration}s, ffprobe "
                 f"says {probed:.3f}s"
             )
-        if previous_end > (probed or duration) + DURATION_TOLERANCE_S:
+        # On the *video's* clock: the beats are `time.monotonic()` and the
+        # file is the host's wall clock, so a take whose host stepped has a
+        # last beat past the end of a file that is exactly that much shorter
+        # (issue #215). Uncorrected, this fires on a healthy recorder.
+        last_end = previous_end + stepped(previous_end)
+        if last_end > (probed or duration) + DURATION_TOLERANCE_S:
             failures.append(
-                f"{label}: the last beat ends at {previous_end:.3f}s, past the "
-                f"end of a {duration}s demo.mp4 — the timestamps are not on "
-                f"the same clock as the video"
+                f"{label}: the last beat ends at {previous_end:.3f}s, which "
+                f"the host's measured wall-clock steps put at {last_end:.3f}s "
+                f"in the video — past the end of a {duration}s demo.mp4. The "
+                f"timestamps are not on the same clock as the video, and the "
+                f"clock this suite can see is not what put them there."
             )
 
     # -- every still a beat names is on disk ---------------------------------
@@ -5498,25 +5846,45 @@ def check_timeline(
     if not spoken:
         failures.append(f"{label}: no caption beats at all to time against")
 
+    # How far the host's wall clock had stepped by each probe. The video is on
+    # that clock, so this is where the beat really sits in demo.mp4 —
+    # subtracted here rather than absorbed by a wider bar, because a step is a
+    # *measured* quantity with a timestamp of its own and a bar is a guess
+    # about all of them at once. Absent a reading, the correction is zero and
+    # every bar below is what it was.
     measured: list[tuple[str, float]] = []
     for what, probe in probes:
         if not mp4.is_file() or not isinstance(probe.get("t_start"), (int, float)):
             continue
         text = probe["caption"]
         t_start = float(probe["t_start"])
+        shift = stepped(t_start)
+        expect_at = t_start + shift
         seen_at, note = caption_appearance_s(
-            label, mp4, caption_band(frame_size), t_start
+            label, mp4, caption_band(frame_size), expect_at
         )
         if seen_at is None:
             failures.append(
                 f"{label}: the {what} could not be timed against demo.mp4 — {note}"
             )
             continue
-        skew = seen_at - t_start
+        skew = seen_at - expect_at
         measured.append((what, skew))
+        # Both numbers, always. The raw one is what somebody scrubbing the file
+        # sees; the corrected one is what is graded. Printing only the graded
+        # one would say nothing about a take that really did lose 0.8 s.
+        raw = seen_at - t_start
+        because = (
+            f", raw {raw * 1000:+.0f} ms of which {shift * 1000:+.0f} ms is "
+            f"the host's wall clock stepping"
+            if abs(shift) >= HOST_CLOCK_MIN_STEP_S
+            else ""
+        )
         where = (
-            f"timeline.json puts the {what} {text!r} at {t_start:.2f}s, but "
-            f"demo.mp4 shows it at {seen_at:.2f}s ({skew * 1000:+.0f} ms)"
+            f"timeline.json puts the {what} {text!r} at {t_start:.2f}s, the "
+            f"host's measured wall-clock steps put that at {expect_at:.2f}s in "
+            f"the video, and demo.mp4 shows it at {seen_at:.2f}s "
+            f"({skew * 1000:+.0f} ms)"
         )
         if skew > MAX_LOG_EARLY_S:
             failures.append(
@@ -5528,24 +5896,33 @@ def check_timeline(
             )
         elif skew < -MAX_CAPTURE_LOSS_S:
             failures.append(
-                f"{label}: {where} — the video is {-skew * 1000:.0f} ms ahead of "
-                f"the log, past the {MAX_CAPTURE_LOSS_S * 1000:.0f} ms allowed "
-                f"for capture loss. That is more wall time than one stall of "
-                f"the recorder's un-tickerable setup window accounts for, so "
-                f"either TICKER_JS stopped working or issue #18 got worse. "
+                f"{label}: {where} — the video is {-skew * 1000:.0f} ms ahead "
+                f"of the log **with the host's wall-clock steps already taken "
+                f"out**, past the {MAX_CAPTURE_LOSS_S * 1000:.0f} ms this file "
+                f"allows for everything else (the screencast's first frame, "
+                f"the 40 ms sampling grid, the caption's fade). "
+                f"{clock.describe() if clock else 'This take ran without a host-clock reading'}"
+                f". So this is not issue #215's clock step: either TICKER_JS "
+                f"stopped working, or the capture lost time some other way. "
                 f"({note})"
             )
         else:
-            note = "" if abs(skew) <= MAX_LOG_EARLY_S else " — capture loss, see #18"
             print(
                 f"smoke: {label} {what} {text!r} logged at {t_start:.2f}s, on "
-                f"screen at {seen_at:.2f}s ({skew * 1000:+.0f} ms{note})"
+                f"screen at {seen_at:.2f}s ({skew * 1000:+.0f} ms{because})"
             )
 
     # The sharp one: whatever the capture loses, it loses for every frame after
-    # it, so both probes move together and the difference cancels. A clock that
-    # stepped, or a beat stamped somewhere other than where its verb ran, does
-    # not cancel.
+    # it, so both probes move together and the difference cancels. A beat
+    # stamped somewhere other than where its verb ran does not.
+    #
+    # A host wall-clock step landing *between* the probes used to reach this
+    # bar too, and used to be indistinguishable from the beat log's own error
+    # — 680 ms of it was measured on this box (issue #209) and read as a
+    # mid-take screencast stall. It no longer reaches here: the step is
+    # timestamped, so `stepped()` above subtracts it from the probes it
+    # precedes and from no others, which is exactly the distinction this bar
+    # could not make for itself.
     if len(measured) == 2:
         drift = measured[1][1] - measured[0][1]
         # ...as long as both probes rode the same capture. Across a segment
@@ -5554,14 +5931,13 @@ def check_timeline(
         same_capture = probes[0][1].get("segment") == probes[1][1].get("segment")
         bound = MAX_SKEW_DRIFT_S if same_capture else MAX_CROSS_SEGMENT_DRIFT_S
         why = (
-            "Two causes reach this bar and it cannot tell them apart: a clock "
-            "that is not being read monotonically between beats, and a "
-            "screencast stall landing *between* the probes rather than before "
-            "them. A stall before the first probe does move both equally and "
-            "does cancel here — that is what this bar is for — but one in the "
-            "middle does not, and on this box a stall of 680 ms was measured "
-            "doing exactly that with TICKER_JS running (issue #209). Read the "
-            "two skews above before blaming the beat log."
+            "Both skews above already have the host's measured wall-clock "
+            "steps taken out of them, per probe — which is the one cause that "
+            "used to land here and could not be told from the beat log's own "
+            "(issue #215). What is left is time between beats not being "
+            "measured monotonically, or a beat stamped somewhere other than "
+            "where its verb ran. "
+            f"{clock.describe() if clock else 'This take ran without a host-clock reading, so nothing was taken out'}."
             if same_capture
             else "These two probes are in different segments, so they rode "
             "different captures and this bar is only a flake guard — the "
@@ -5748,6 +6124,7 @@ def check_beat_frames(
     expected_captions: list[str],
     frame_size: tuple[int, int],
     expected_interludes: list[str] = [],  # noqa: B006 - read-only, never mutated
+    clock: HostClock | None = None,
 ) -> list[str]:
     """`frames/` — one frame per beat, at the beat's midpoint, showing it.
 
@@ -5908,6 +6285,7 @@ def check_beat_frames(
         listed,
         beats,
         _expected_context(expected_beats, expected_captions, expected_interludes),
+        clock,
     )
     failures += _check_stale_frames(label, out_dir, manifest)
     failures += _check_segment_refusal(label, out_dir, doc)
@@ -5928,6 +6306,7 @@ def _check_frame_captions(
     listed: list[dict],
     beats: dict[int, dict],
     context: list[str] | None,
+    clock: HostClock | None = None,
 ) -> list[str]:
     """Frame N shows beat N — measured on the pixels, one bit per frame.
 
@@ -5947,6 +6326,16 @@ def _check_frame_captions(
     close to a change the two disagree about which side a frame is on and
     neither is wrong. `MIN_GRADED_CAPTION_FRAMES` and the one-of-each rule keep
     that exclusion from turning the check off.
+
+    The guard is applied to **where the frame really sits in the story**, not
+    to the timestamp it was cut at. A frame cut at the log's idea of a beat's
+    midpoint shows a moment `|clock.before(t)|` later on a take whose host
+    stepped its wall clock (issue #215), so measuring its distance from a
+    caption change without that correction measures the wrong distance — and
+    grades a frame taken from well past a change as though it were nowhere
+    near one. That is #209's `beat-23.png` failure: a frame graded for a
+    caption the video had already dropped, reported as "the frames do not show
+    the beats they are named for". The guard's *width* is unchanged.
 
     The expectation comes from `_expected_context()` — the storyboard lists at
     the top of this file — and never from `timeline.json`, which is the
@@ -5969,13 +6358,28 @@ def _check_frame_captions(
     ]
 
     band = caption_band(frame_size)
+    stepped = clock.before if clock is not None else (lambda _t: 0.0)
     reference: bytes | None = None
     graded: list[tuple[int, str, bytes]] = []
     for i, frame in enumerate(listed):
         png = out_dir / "frames" / str(frame.get("file"))
         if not png.is_file():
             continue
-        near = min((abs(float(frame["t"]) - c) for c in changes), default=math.inf)
+        # Where the frame was cut, and where it actually sits in the story.
+        # The extractor seeks demo.mp4 at the beat's midpoint on the *log's*
+        # clock and the video is on the host's, so on a take whose host clock
+        # stepped those are two different moments (issue #215) — and a caption
+        # change *between* them is exactly the case where the sheet's label and
+        # the picture disagree and neither is wrong. Grade a frame only when
+        # the whole interval between the two accounts of where it is clears
+        # every caption change by the guard.
+        at = float(frame["t"])
+        shows = at - stepped(at)
+        lo, hi = min(at, shows), max(at, shows)
+        near = min(
+            (0.0 if lo <= c <= hi else min(abs(lo - c), abs(hi - c)) for c in changes),
+            default=math.inf,
+        )
         if near < FRAME_CAPTION_GUARD_S:
             continue
         try:
@@ -7109,7 +7513,13 @@ def run_web(out_root: Path) -> list[str]:
     started = time.time()
     with fixture_server() as base_url:
         try:
-            problems, video_rect, still_rect, size = record_web(out_dir, base_url)
+            # The host's wall clock, watched for exactly as long as the take is
+            # recording. demo.mp4 is on that clock and the beat log is not, so
+            # every timing reading below is corrected by this (issue #215).
+            with watch_wall_clock() as clock:
+                problems, video_rect, still_rect, size = record_web(
+                    out_dir, base_url, clock
+                )
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"web: Recorder raised {type(exc).__name__}: {exc}"]
     return (
@@ -7124,8 +7534,13 @@ def run_web(out_root: Path) -> list[str]:
             still_rect,
             size,
         )
-        + check_timeline("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
-        + check_beat_frames("web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size)
+        + check_capture_clock("web", out_dir, clock)
+        + check_timeline(
+            "web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size, clock=clock
+        )
+        + check_beat_frames(
+            "web", out_dir, started, WEB_BEATS, WEB_CAPTIONS, size, clock=clock
+        )
         + check_evidence("web", out_dir, WEB_EVIDENCE, WEB_EVIDENCE_SCOPE)
         # The form verbs' pacing (issue #130), read off the same beat log the
         # two checks above read for their contents.
@@ -7925,7 +8340,11 @@ def _probe_beat(doc: dict, text: str, segment: str | None = None) -> dict | None
     return None
 
 
-def check_merge_offset(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
+def check_merge_offset(
+    out_dir: Path,
+    frame_size: tuple[int, int],
+    clocks: list[HostClock] | None = None,
+) -> list[str]:
     """#7's acceptance criterion, per segment, with capture loss cancelled.
 
     Every segment carries a caption with a quiet run-up (`SEGMENT_PROBES`), and
@@ -7958,6 +8377,12 @@ def check_merge_offset(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
     demo = out_dir / "demo.mp4"
     merged_json = out_dir / "timeline.json"
     failures: list[str] = []
+    # One reading comes out of the part and one out of the stitched demo, but
+    # they are the same frames of the same capture, so the same wall-clock
+    # steps moved both (issue #215). Correcting them by the same amount leaves
+    # the differential below exactly where it was and makes each segment's own
+    # skew — the half the differential cancels on purpose — mean something.
+    per_segment = dict(zip(SEGMENT_NAMES, clocks or [], strict=False))
 
     for name, text in zip(SEGMENT_NAMES, SEGMENT_PROBES, strict=True):
         part = out_dir / f"{name}.seg.mp4"
@@ -7995,6 +8420,12 @@ def check_merge_offset(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
             continue
 
         readings: dict[str, float] = {}
+        segment_clock = per_segment.get(name)
+        shift = (
+            segment_clock.before(float(alone["t_start"]))
+            if segment_clock and isinstance(alone.get("t_start"), (int, float))
+            else 0.0
+        )
         for what, media, t_start in (
             ("in its own segment", part, alone.get("t_start")),
             ("in the stitched demo", demo, stitched.get("t_start")),
@@ -8003,8 +8434,12 @@ def check_merge_offset(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
                 readings.clear()
                 failures.append(f"segments: {name}'s probe has no t_start {what}")
                 break
+            # One shift for both readings, taken on this segment's own
+            # capture clock: `t_start` differs between the two files by the
+            # merge offset, but the frames are the same frames and the steps
+            # that moved them are this segment's either way.
             seen_at, note = caption_appearance_s(
-                "segments", media, band, float(t_start)
+                "segments", media, band, float(t_start) + shift
             )
             if seen_at is None:
                 readings.clear()
@@ -8013,7 +8448,7 @@ def check_merge_offset(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
                     f"({media.name}) — {note}"
                 )
                 break
-            readings[what] = seen_at - float(t_start)
+            readings[what] = seen_at - float(t_start) - shift
         if len(readings) != 2:
             continue
 
@@ -8039,9 +8474,11 @@ def check_merge_offset(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
                 f"segments: {name}'s probe caption is {own * 1000:+.0f} ms off "
                 f"its beat *within {part.name}*, outside the "
                 f"{-MAX_CAPTURE_LOSS_S * 1000:.0f}…{MAX_LOG_EARLY_S * 1000:+.0f} ms "
-                f"a single capture is allowed. The merge is not involved — this "
-                f"segment's own beat log and its own video disagree (a positive "
-                f"skew is the log's; a negative one is capture loss, issue #18)."
+                f"a single capture is allowed, with the host's measured "
+                f"wall-clock steps already taken out. The merge is not "
+                f"involved — this segment's own beat log and its own video "
+                f"disagree (a positive skew is the log's; a negative one is "
+                f"capture loss, issues #18 and #215)."
             )
             continue
         print(
@@ -8052,7 +8489,11 @@ def check_merge_offset(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
     return failures
 
 
-def stitch_segments(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
+def stitch_segments(
+    out_dir: Path,
+    frame_size: tuple[int, int],
+    clocks: list[HostClock] | None = None,
+) -> list[str]:
     """Stitch the recorded segments, twice, and grade what that produced.
 
     Twice because `keep_parts` has two directions and both are load-bearing:
@@ -8149,7 +8590,7 @@ def stitch_segments(out_dir: Path, frame_size: tuple[int, int]) -> list[str]:
 
     # While the parts are still here: the acceptance criterion, measured
     # against both videos so the screencast's own error cancels.
-    failures += check_merge_offset(out_dir, frame_size)
+    failures += check_merge_offset(out_dir, frame_size, clocks)
 
     # -- the default: parts and logs go together (issue #21) ------------------
     stitch(out_dir, SEGMENT_NAMES)
@@ -8260,15 +8701,45 @@ def run_segments(out_root: Path) -> list[str]:
     that is graded more softly than a single take is a segmented demo nobody
     can trust. What is extra here is `stitch_segments()`.
     """
+    from demo_recording.content import media_duration
+
     out_dir = fresh_take_dir(out_root, "segments")
     started = time.time()
     with fixture_server() as base_url:
         try:
-            problems, video_rect, still_rect, size = record_segments(out_dir, base_url)
+            problems, video_rect, still_rect, size, clocks = record_segments(
+                out_dir, base_url
+            )
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"segments: Recorder raised {type(exc).__name__}: {exc}"]
+        # Before `stitch()`, which removes the parts and their logs unless
+        # asked to keep them: each segment's own `capture_clock` is only on
+        # disk until then, and the merged envelope carries none (`stitch()`
+        # does not merge the field — see tests/README.md, Known gaps).
+        for name, part in zip(SEGMENT_NAMES, clocks, strict=True):
+            problems += check_capture_clock(
+                f"segments/{name}", out_dir, part, f"{name}.seg.timeline.json"
+            )
+        # Each segment watched its own capture; the stitched demo lays them end
+        # to end, so each part's steps sit that far along the merged clock
+        # (issue #215). The offsets are ffprobe's, taken off the parts *before*
+        # stitch() is allowed to remove them, rather than read out of the
+        # merged envelope this run is grading.
+        placed: list[tuple[HostClock, float]] = []
+        offset = 0.0
+        for name, part in zip(SEGMENT_NAMES, clocks, strict=True):
+            try:
+                placed.append((part, offset))
+                offset += media_duration(out_dir / f"{name}.seg.mp4")
+            except (subprocess.CalledProcessError, ValueError, OSError):
+                # No part durations, no merged clock. Correcting with the wrong
+                # offsets is worse than not correcting: the bar falls back to
+                # MAX_UNWATCHED_CAPTURE_LOSS_S and the failure says so.
+                placed = []
+                break
+        clock: HostClock | None = joined_clock(placed) if placed else None
         try:
-            problems += stitch_segments(out_dir, size)
+            problems += stitch_segments(out_dir, size, clocks)
         except Exception as exc:  # noqa: BLE001 - a raising stitch is a failure
             problems.append(f"segments: stitch() raised {type(exc).__name__}: {exc}")
     return (
@@ -8292,6 +8763,7 @@ def run_segments(out_root: Path) -> list[str]:
             size,
             expected_segments=SEGMENT_BEAT_SEGMENTS,
             expected_interludes=SEGMENT_INTERLUDES,
+            clock=clock,
         )
         + check_beat_frames(
             "segments",
@@ -8301,6 +8773,7 @@ def run_segments(out_root: Path) -> list[str]:
             SEGMENT_CAPTIONS,
             size,
             SEGMENT_INTERLUDES,
+            clock=clock,
         )
         + check_healthy("segments", out_dir)
     )
@@ -8935,7 +9408,10 @@ def run_terminal(out_root: Path) -> list[str]:
     previous = Path.cwd()
     os.chdir(REPO_ROOT)
     try:
-        problems, video_rect, still_rect, size = record_terminal(out_dir)
+        # The terminal records the same Chromium page through the same
+        # screencast, so it is on the same host wall clock (issue #215).
+        with watch_wall_clock() as clock:
+            problems, video_rect, still_rect, size = record_terminal(out_dir, clock)
     except Exception as exc:  # noqa: BLE001 - a raising take is a failure
         return [f"terminal: TerminalRecorder raised {type(exc).__name__}: {exc}"]
     finally:
@@ -8952,11 +9428,24 @@ def run_terminal(out_root: Path) -> list[str]:
             still_rect,
             size,
         )
+        + check_capture_clock("terminal", out_dir, clock)
         + check_timeline(
-            "terminal", out_dir, started, TERMINAL_BEATS, TERMINAL_CAPTIONS, size
+            "terminal",
+            out_dir,
+            started,
+            TERMINAL_BEATS,
+            TERMINAL_CAPTIONS,
+            size,
+            clock=clock,
         )
         + check_beat_frames(
-            "terminal", out_dir, started, TERMINAL_BEATS, TERMINAL_CAPTIONS, size
+            "terminal",
+            out_dir,
+            started,
+            TERMINAL_BEATS,
+            TERMINAL_CAPTIONS,
+            size,
+            clock=clock,
         )
         + check_evidence("terminal", out_dir, TERMINAL_EVIDENCE)
         + check_healthy("terminal", out_dir)

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -383,6 +383,71 @@ INJECTIONS = [
         sites=("check_issues",),
         must_contain=("failed is indistinguishable from one that worked",),
     ),
+    # -- the clock demo.mp4 is on (issues #18/#215), 29 s an entry ------------
+    #
+    # Chromium stamps every screencast frame with the host's *wall* clock and
+    # Playwright turns that into the frame's position in the webm, so a host
+    # that steps its wall clock takes that much wall time out of the video and
+    # leaves the beat log where it was. `tests/smoke` measures the same clock
+    # itself and corrects with its own reading; `capture_clock` is what makes
+    # the recorder's copy of that measurement gradeable rather than decorative.
+    #
+    # All four entries break the *recorder* and are watched by `tests/smoke`
+    # measuring a real clock, so none of them depends on the box's clock
+    # actually stepping — which is what the "environment-agreeing assertion"
+    # entry in wip/verified-review/SKILL.md is about, and what
+    # `tests/README.md` said could not be fault-injected before this existed.
+    Injection(
+        name="the timeline stops carrying the clock the video is on",
+        module="core.py",
+        old='            "capture_clock": self._capture_clock.report(),',
+        new='            "capture_clock_unwritten": self._capture_clock.report(),',
+        arm="--segments-only",
+        sites=("check_capture_clock",),
+        must_contain=("has no `capture_clock` record",),
+    ),
+    Injection(
+        # A step nobody else saw. The correction a consumer applies is then
+        # half a second of nothing, applied to every beat after 1.0s.
+        name="the recorder reports a wall-clock step that never happened",
+        module="core.py",
+        old="    def start(self, t0: float) -> None:\n        self._t0 = t0\n",
+        new=(
+            "    def start(self, t0: float) -> None:\n"
+            "        self._t0 = t0\n"
+            '        self.steps.append({"t": 1.0, "delta": -0.5})\n'
+        ),
+        arm="--segments-only",
+        sites=("check_capture_clock",),
+        must_contain=("is not measuring the clock",),
+    ),
+    Injection(
+        # The total and the steps it is a total of, disagreeing. A consumer
+        # reading only `total` and one reading only `steps` then correct a
+        # beat by different amounts, and neither can tell.
+        name="the recorded clock total stops being the total of its own steps",
+        module="core.py",
+        old='            "total": round(self.total, 4),',
+        new='            "total": round(self.total + 0.5, 4),',
+        arm="--segments-only",
+        sites=("check_capture_clock",),
+        must_contain=("the field disagrees with itself",),
+    ),
+    Injection(
+        # Frame zero taken 0.9 s before the screencast's, so every beat in the
+        # log is stamped that much later than the frame it describes. It is
+        # the loss bar that fires, and what makes the bar mean something is
+        # that the host's own wall-clock steps are already out of the reading:
+        # before #215 a run on this box arrived at -0.88 s of that bar's
+        # 0.75 s budget with nothing wrong at all.
+        name="every beat is stamped 0.9s after the frame it describes",
+        module="core.py",
+        old="            self._t0 = time.monotonic()",
+        new="            self._t0 = time.monotonic() - 0.9",
+        arm="--segments-only",
+        sites=("check_timeline",),
+        must_contain=("with the host's wall-clock steps already taken",),
+    ),
     # -- the beat log and the review sheet (issues #8/#22), 29 s an entry ------
     #
     # `check_timeline` and `check_beat_frames` grade *a* take, not specifically

--- a/tests/unit
+++ b/tests/unit
@@ -144,7 +144,8 @@ _pw.sync_api = _pw_sync  # type: ignore[attr-defined]
 sys.modules["playwright"] = _pw
 sys.modules["playwright.sync_api"] = _pw_sync
 
-from demo_recording.core import _beat_verb, _DemoBase  # noqa: E402
+import demo_recording.core as core_module  # noqa: E402
+from demo_recording.core import _beat_verb, _CaptureClock, _DemoBase  # noqa: E402
 from demo_recording.terminal import TerminalRecorder  # noqa: E402
 from demo_recording.web import _CURSOR_JS, Recorder  # noqa: E402
 
@@ -3914,12 +3915,253 @@ class BeatLog(unittest.TestCase):
         )
 
 
+class _ScriptedTime:
+    """A stand-in for the `time` module whose wall clock steps on cue.
+
+    `offsets[i]` is what CLOCK_REALTIME minus CLOCK_MONOTONIC reads at sample
+    `i`. Monotonic time advances by one sampling interval per sample and never
+    goes backwards, which is the whole point of the split being measured.
+    """
+
+    def __init__(self, offsets: list[float], interval: float = 0.02) -> None:
+        self.offsets = offsets
+        self.interval = interval
+        self.index = 0
+        # Zero, not a realistic uptime: `time() - monotonic()` at 1e3 seconds
+        # loses enough of a 5 ms offset that a step written as exactly
+        # MIN_STEP_S comes back a hair under it, and the boundary test below
+        # would then be grading float64 rather than the threshold.
+        self.mono = 0.0
+
+    def monotonic(self) -> float:
+        return self.mono
+
+    def time(self) -> float:
+        return self.mono + self.offsets[min(self.index, len(self.offsets) - 1)]
+
+
+class _ScriptedStop:
+    """Stands in for the sampler's stop Event, driving `_ScriptedTime`."""
+
+    def __init__(self, clock: _ScriptedTime, samples: int) -> None:
+        self.clock = clock
+        self.left = samples
+
+    def is_set(self) -> bool:
+        return self.left <= 0
+
+    def set(self) -> None:
+        self.left = 0
+
+    def wait(self, _timeout: float) -> None:
+        self.left -= 1
+        self.clock.index += 1
+        self.clock.mono += self.clock.interval
+
+
+def sampled(offsets: list[float]) -> _CaptureClock:
+    """Run the capture-clock sampler over a scripted wall clock."""
+    clock = _CaptureClock()
+    fake = _ScriptedTime(offsets)
+    clock._t0 = fake.mono
+    clock._stop = _ScriptedStop(fake, len(offsets))  # type: ignore[assignment]
+    real = core_module.time
+    core_module.time = fake  # type: ignore[assignment]
+    try:
+        clock._run()
+    finally:
+        core_module.time = real  # type: ignore[assignment]
+    return clock
+
+
+class CaptureClock(unittest.TestCase):
+    """The one clock in the recorder that is not `time.monotonic()`.
+
+    Chromium stamps every screencast frame with the host's wall clock and
+    Playwright turns that into the frame's position in the webm, so a host
+    that steps its wall clock takes that much wall time out of demo.mp4 and
+    leaves the beat log where it was (issues #18, #215). The recorder cannot
+    stop that; what it can do is measure it, and this grades the measuring.
+
+    Driven over a **scripted** clock rather than the real one, which is the
+    only way this is gradeable at all: the box a test runs on either steps or
+    it does not, and `tests/README.md` records that the wall-clock class of bug
+    could not be fault-injected before this existed.
+    """
+
+    def test_a_steady_wall_clock_records_no_steps(self):
+        clock = sampled([0.0] * 8)
+        self.assertEqual(clock.steps, [])
+        self.assertEqual(clock.total, 0.0)
+
+    def test_a_backwards_step_is_recorded_once_with_its_size_and_time(self):
+        # Four samples at the original offset, then four at 0.78 s less: one
+        # step, not four, and not one per sample after it.
+        clock = sampled([0.0] * 4 + [-0.78] * 4)
+        self.assertEqual(len(clock.steps), 1)
+        self.assertAlmostEqual(clock.steps[0]["delta"], -0.78, places=4)
+        # Sample 4, at 20 ms a sample, measured from `_t0`.
+        self.assertAlmostEqual(clock.steps[0]["t"], 0.08, places=3)
+        self.assertAlmostEqual(clock.total, -0.78, places=4)
+
+    def test_two_steps_in_one_take_accumulate(self):
+        clock = sampled([0.0, 0.0, -0.78, -0.78, -1.56, -1.56])
+        self.assertEqual(len(clock.steps), 2)
+        self.assertAlmostEqual(clock.total, -1.56, places=4)
+
+    def test_a_forward_step_is_recorded_with_its_sign(self):
+        # NTP correcting the other way lengthens the video instead. The sign
+        # has to survive: a consumer subtracting it does the opposite of the
+        # right thing if it does not.
+        clock = sampled([0.0, 0.0, 0.5, 0.5])
+        self.assertEqual(len(clock.steps), 1)
+        self.assertGreater(clock.steps[0]["delta"], 0.0)
+
+    # The floor, from both sides, and **hand-written**. Reading
+    # `_CaptureClock.MIN_STEP_S` here and scaling it agrees with the constant
+    # no matter what the constant says — widen the floor to five seconds and a
+    # test written that way still passes, which is exactly what fault
+    # injection found the first time these were written. 4 ms is jitter, 6 ms
+    # is a step, and between them sits the 5 ms the recorder declares.
+    def test_jitter_just_under_the_floor_is_not_a_step(self):
+        # Two `time` calls are not atomic, so every sample carries the gap
+        # between them. Reading that as a step would put a correction on every
+        # beat of every take on every box.
+        clock = sampled([0.0, 0.004, 0.0, -0.004, 0.0])
+        self.assertEqual(clock.steps, [])
+
+    def test_a_step_just_over_the_floor_is_a_step(self):
+        clock = sampled([0.0, 0.0, -0.006, -0.006])
+        self.assertEqual(len(clock.steps), 1)
+
+    def test_the_report_totals_its_own_steps(self):
+        clock = sampled([0.0, 0.0, -0.78, -0.78])
+        report = clock.report()
+        self.assertAlmostEqual(
+            report["total"], sum(s["delta"] for s in report["steps"]), places=4
+        )
+        self.assertEqual(report["sample_interval"], _CaptureClock.INTERVAL_S)
+        self.assertEqual(report["min_step"], _CaptureClock.MIN_STEP_S)
+
+    def test_a_clock_that_held_still_says_nothing_to_the_author(self):
+        self.assertIsNone(sampled([0.0] * 6).warning())
+
+    def test_a_step_under_one_frame_of_the_encode_says_nothing(self):
+        # 25 fps, so under 40 ms the video and the log still agree about which
+        # frame a beat is on and there is nothing for an author to act on.
+        clock = sampled([0.0, 0.0, -0.02, -0.02])
+        self.assertIsNone(clock.warning())
+
+    def test_a_backwards_step_tells_the_author_the_video_is_short(self):
+        warning = sampled([0.0, 0.0, -0.78, -0.78]).warning()
+        self.assertIsNotNone(warning)
+        assert warning is not None
+        self.assertIn("shorter", warning)
+        self.assertIn("ahead of", warning)
+        self.assertIn("capture_clock", warning)
+        self.assertIn("-780 ms", warning)
+
+    def test_a_forward_step_tells_the_author_the_opposite(self):
+        # The direction is the whole content of the warning, and a message
+        # that says "shorter" either way is worse than none: it sends the
+        # reader looking for lost frames that are not lost.
+        warning = sampled([0.0, 0.0, 0.78, 0.78]).warning()
+        assert warning is not None
+        self.assertIn("longer", warning)
+        self.assertIn("behind", warning)
+        self.assertNotIn("shorter", warning)
+
+    def test_the_take_carries_the_measurement_into_its_timeline(self):
+        rec = recorder(self)
+        rec._capture_clock = sampled([0.0, 0.0, -0.78, -0.78])
+        doc = rec._timeline_doc()
+        self.assertIn("capture_clock", doc)
+        self.assertAlmostEqual(doc["capture_clock"]["total"], -0.78, places=4)
+        self.assertEqual(len(doc["capture_clock"]["steps"]), 1)
+
+    def test_a_take_on_a_steady_clock_still_carries_the_field(self):
+        # Empty and absent are different answers. A consumer that cannot tell
+        # "the clock held still" from "nobody looked" has to assume the worst
+        # of every timeline ever written.
+        rec = recorder(self)
+        doc = rec._timeline_doc()
+        self.assertEqual(doc["capture_clock"]["steps"], [])
+        self.assertEqual(doc["capture_clock"]["total"], 0.0)
+
+
 # --------------------------------------------------------------------------
 # Fault injection
 # --------------------------------------------------------------------------
 
 # (name, module, exact text to replace, replacement, tests that must then fail)
 INJECTIONS = [
+    (
+        # The correction a consumer would apply to a beat timestamp, with its
+        # sign flipped. The field is still there and still lists the right
+        # number of steps, which is what makes this the shape worth grading.
+        "the recorded wall-clock step carries the wrong sign",
+        "core.py",
+        '                        "delta": round(delta, 4),',
+        '                        "delta": round(-delta, 4),',
+        [
+            "CaptureClock.test_a_backwards_step_is_recorded_once_with_its_size_and_time",
+            "CaptureClock.test_a_forward_step_is_recorded_with_its_sign",
+            "CaptureClock.test_a_backwards_step_tells_the_author_the_video_is_short",
+        ],
+    ),
+    (
+        # The sampler records the *offset* instead of the change in it, so
+        # every sample after a step reads as another step and the total grows
+        # for as long as the take lasts.
+        "every sample after a step is recorded as another step",
+        "core.py",
+        "            previous = offset\n            self._stop.wait(self.INTERVAL_S)",
+        "            self._stop.wait(self.INTERVAL_S)",
+        [
+            "CaptureClock.test_a_backwards_step_is_recorded_once_with_its_size_and_time",
+            "CaptureClock.test_two_steps_in_one_take_accumulate",
+        ],
+    ),
+    (
+        # The floor that tells a step from the gap between two `time` calls,
+        # widened past any real step. `capture_clock` then reads zero on every
+        # take on every box, and nothing downstream can tell that from a host
+        # whose clock held still.
+        "the step floor is widened past the steps it exists to catch",
+        "core.py",
+        "    MIN_STEP_S = 0.005",
+        "    MIN_STEP_S = 5.0",
+        [
+            "CaptureClock.test_a_backwards_step_is_recorded_once_with_its_size_and_time",
+            "CaptureClock.test_a_step_just_over_the_floor_is_a_step",
+            "CaptureClock.test_the_take_carries_the_measurement_into_its_timeline",
+        ],
+    ),
+    (
+        # The measurement is taken and the artifact does not carry it, which
+        # is the state everything was in before issue #215: the recorder knows
+        # the video slid under the beats and nobody reading the take can.
+        "the timeline stops carrying the clock the video is on",
+        "core.py",
+        '            "capture_clock": self._capture_clock.report(),',
+        '            "capture_clock_unwritten": self._capture_clock.report(),',
+        [
+            "CaptureClock.test_the_take_carries_the_measurement_into_its_timeline",
+            "CaptureClock.test_a_take_on_a_steady_clock_still_carries_the_field",
+        ],
+    ),
+    (
+        # The author is told nothing about a take whose video came out 0.8 s
+        # short of its own beat log. Everything written to disk is unchanged.
+        "a take whose host clock stepped says nothing on the way out",
+        "core.py",
+        "        if abs(self.total) < self.WARN_S:",
+        "        if True:",
+        [
+            "CaptureClock.test_a_backwards_step_tells_the_author_the_video_is_short",
+            "CaptureClock.test_a_forward_step_tells_the_author_the_opposite",
+        ],
+    ),
     (
         "coverage accumulates criteria from the tags instead of the declaration",
         "coverage.py",

--- a/tests/unit
+++ b/tests/unit
@@ -1264,6 +1264,13 @@ DOC_SYMBOL_ALLOWED = {
     # graded where.
     "check_coverage": "a function in tests/smoke",
     "check_coverage_merge": "a function in tests/smoke",
+    # Bars, same reason. These were named by limits.md before this entry
+    # existed, but written `MAX_CAPTURE_LOSS_S = 0.75` — a span the extractor
+    # does not read as a symbol. Naming them bare is clearer for a reader and
+    # brought them into scope, which is the check working rather than a
+    # regression in it.
+    "MAX_CAPTURE_LOSS_S": "a constant in tests/smoke",
+    "MAX_SKEW_DRIFT_S": "a constant in tests/smoke",
 }
 
 


### PR DESCRIPTION
## The mechanism

`#215`'s bimodality was the clue, and it was a discrete state: **the host's wall
clock stepping.**

Chromium stamps every screencast frame with `Page.screencastFrame`'s
`metadata.timestamp`, which the protocol defines as `Network.TimeSinceEpoch` —
the wall clock. Playwright's `FfmpegVideoRecorder._writeFrame` turns that
straight into the frame's position in the webm (`frameNumber = (ts -
firstFrameTs) * 25`). The beat log is `time.monotonic()`. So the video is on
CLOCK_REALTIME and the log is on CLOCK_MONOTONIC, and a host that steps its wall
clock moves them apart by exactly the size of the step, at exactly the instant
of it.

Caught in the act, with the Playwright driver patched to log every frame
(**Playwright 1.62.0, Chromium 151.0.7922.34**, WSL2):

```
ARRIVE 1146491075.755  ts=1785603308090.391
ARRIVE 1146491159.407  ts=1785603307379.542
```

Two consecutive frames, **84 ms apart on the monotonic clock and 711 ms
backwards on Chromium's**.

A sampler that opens no browser at all shows the host stepping **-0.75 to
-0.81 s every 32.2 s**, like a metronome:

```
STEP at + 22.311s    -773.2 ms
STEP at + 54.567s    -748.0 ms
STEP at + 86.796s    -801.7 ms
STEP at +119.053s    -798.4 ms
STEP at +151.294s    -808.8 ms
watched 180s, 5 steps over 20 ms
spacing [32.3, 32.2, 32.3, 32.2]
```

Run the two together and they coincide: steps at monotonic 1146845.873
(-780.3 ms) and 1146878.109 (-770.6 ms) from the browserless sampler; drift
steps in the frame log at t0+6.960 (+781.3 ms) and t0+39.172 (+770.6 ms) — same
instants within one inter-frame gap, same sizes to the tenth of a millisecond.

**The rate.** 32.2 s between steps against a 19 s take is a coin flip, which is
the whole of `#215`'s "under 120 ms or 800-880 ms, nothing between, at loads
that look idle". Seven takes of one storyboard with the sampler beside them: the
four whose window contained a step encoded **0.78 s less video** than the three
that did not, to within 12 ms, every time.

**It is not the ticker, and `TICKER_JS`'s stated reason was wrong.** An idle page
loses no wall time on this build: 30 s of a take with nothing painting — seven
screencast frames in total — came back the full 30 s long, because Playwright
numbers frames from their timestamps and writes the gaps into the webm's cluster
timestamps. The 3/3-idle-stalled measurement that justified the ticker was six
samples of the wall-clock step. The ticker stays for the frames it buys a
*measurement* (a caption can only be timed to the nearest frame the screencast
sent); its claim is reduced to that in the code and the README.

## Fixable, or a browser property?

Neither, exactly: it is a **host** property surfaced through a **protocol**
choice. The clock is the machine's, the timestamp is CDP's, and the recorder
never sees the frame. What it can do — and now does — is measure the same clock,
which needs no browser.

## Is #78 the same defect?

**No.** Two independent reasons:

- Its two named bars move the *opposite* way. A backwards step makes the video
  shorter, pushing `REDACT_DURATION_S` away from the high bound it fails on, and
  shortens rather than lengthens the opening blank run `MAX_BLANK_RUN_S` grades.
- Its spotlight symptom: **5/5 `--polish-only` runs passed at idle**, including
  one whose host stepped at 5.755 s, inside the spotlight beats (4.40-5.01 and
  the pause after). The spotlight failures in this session appeared only at
  loads 1.7 and 3.1. That is #78's load sensitivity, and #78 stays open.

## What this changes

**`core.py`** — `_CaptureClock`, a daemon sampler of
`time.time() - time.monotonic()` for the life of the capture. `timeline.json`
gains `capture_clock`: every step with its offset into the take and its size,
their total, and the sampler's own grid. A take whose host stepped prints a
warning naming the size and the instant. On a host that does not step it is an
empty list — which is a different answer from the field being absent, and both
are graded.

**`tests/smoke`** — `HostClock` measures the same clock in this process, rebased
onto the recorder's `_t0` so a step lands on the right side of a beat, and
**every correction uses the harness's own reading, never the recorder's**.
`capture_clock` is graded *against* it, both directions, over the storyboard's
own window. Corrected: the two caption probes and the window they are searched
in, the "beats fit inside the mp4" check, the review-frame caption guard, and
each segment of the stitched demo on its own capture's clock (`joined_clock`,
including that an earlier part's step must **not** move a later part's beats).

## No bar was widened, and one got sharp

`MAX_CAPTURE_LOSS_S` is **still 0.75 s**. What it bounds is now only the gap
before the screencast's *first* frame, which the video's zero is: 20-140 ms over
fifteen idle takes, **500-540 ms at load 3.1**. That is how fast Chromium
paints, and tightening it would be #78's shape, so it was left alone.

What the correction buys is `MAX_SKEW_DRIFT_S` at 250 ms. #215's run 3 was
680 ms of drift on a healthy recorder with a message blaming the beat log's
clock; that cause is now subtracted per probe and cannot reach the bar. The
sharp claim is finally about the thing it names.

## Measured after

Six consecutive `--web-only` runs: **6/6 clean on the timing bars**, three with a
step inside the take and one of those *between* the probes. Two went red on the
spotlight windows at loads 1.7 and 3.1 (see #78 above). Full `tests/smoke`
passed end to end.

## Fault injection

`tests/unit --fault-inject`, five new entries, all caught:

```
PASS  break: the recorded wall-clock step carries the wrong sign
      FAIL: CaptureClock.test_a_backwards_step_is_recorded_once_with_its_size_and_time
      FAIL: CaptureClock.test_a_backwards_step_tells_the_author_the_video_is_short
      FAIL: CaptureClock.test_a_forward_step_is_recorded_with_its_sign
PASS  break: every sample after a step is recorded as another step
PASS  break: the step floor is widened past the steps it exists to catch
PASS  break: the timeline stops carrying the clock the video is on
PASS  break: a take whose host clock stepped says nothing on the way out
```

The floor injection **failed first**, and the finding was mine: the boundary
tests read `_CaptureClock.MIN_STEP_S` and scaled it, so widening the floor to
five seconds left them passing. They are hand-written at 4 ms and 6 ms now.

`tests/smoke-inject`, four new entries against `--segments-only`, all caught —
and none of them depends on the box's clock stepping, because each breaks the
*recorder* while `tests/smoke` watches a real clock:

```
PASS  break: the timeline stops carrying the clock the video is on  [29s]
      caught: segments/part1: part1.seg.timeline.json has no `capture_clock` record...
PASS  break: the recorder reports a wall-clock step that never happened  [29s]
      caught: segments/part1: inside the 5.7s the storyboard ran, this harness saw 0
              wall-clock step(s) ... and timeline.json records 1 — `capture_clock` is
              not measuring the clock the video is on...
PASS  break: the recorded clock total stops being the total of its own steps  [29s]
      caught: segments/part1: capture_clock.total is 0.5 but its own steps sum to
              +0.0000 — the field disagrees with itself
PASS  break: every beat is stamped 0.9s after the frame it describes  [29s]
      caught: segments: timeline.json puts the first caption 'One demo, in two parts.'
              at 3.50s, the host's measured wall-clock steps put that at 3.50s in the video...
```

`tests/README.md` recorded that the wall-clock class of bug "cannot be
fault-injected". Half of it now can, and the README says which half.

## Stated limits

- **The terminal arm loses about one more step than its host clock explains**
  ([#224](https://github.com/rogvid/skills/issues/224)). Four `--terminal-only`
  runs: the two whose step landed inside the storyboard failed, the two whose
  did not passed. Run 3 subtracts a measured -839 ms and is still -900 ms out,
  while the file's *length* lost only the one step. No bar was widened for it —
  a drift bar wide enough for -800 ms grades nothing.
- **`stitch()` does not merge `capture_clock`**
  ([#225](https://github.com/rogvid/skills/issues/225)), so a reader of a
  stitched demo has nothing to correct with. The harness works around it; a
  consumer cannot.
- **Narration is still mixed on the wall clock**
  ([#226](https://github.com/rogvid/skills/issues/226)) — #18 measured +0.70 s
  of lag on a stepped take, and it is now correctable from `capture_clock`.
- The corrections themselves cannot be fault-injected on a box whose clock never
  steps. The *mechanism* can (above); the arithmetic's effect cannot.
- `timeline.py`'s envelope contract does not document `capture_clock` (the key
  is documented where it is built, in `core.py`). Text to apply is in the
  hand-off; `timeline.py` was outside this change's scope.

## Doc text this makes false

`SKILL.md` and `reference/limits.md` were out of scope and still say the loss is
idle stretches and bounded at 0.75 s. Both are false: the cause is the host
clock, and the size is **one step per 32 s of take**, so a two-minute demo can
lose several. Replacement text is in the hand-off note.

Fixes #18
Fixes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)