### PR TITLE
Land the caption clear in the beat that follows the click, not the next one (#214)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1323,7 +1323,7 @@ class _DemoBase:
             return None
         return beat
 
-    def _pump_events(self) -> None:
+    def _pump_events(self, force: bool = False) -> None:
         """Give Playwright a chance to deliver queued page events.
 
         The sync API dispatches `console`/`pageerror`/`requestfailed`/`response`
@@ -1333,9 +1333,19 @@ class _DemoBase:
         keeps delivery inside the beat the event belongs to. It paints nothing,
         touches no DOM, and is skipped if it fails — a pump is a diagnostic
         convenience, never a reason to lose a take.
+
+        `force` skips the interval, and `_beat` is the one caller that passes
+        it (issue #214). The interval is a *rate limit on a hold*, and at a
+        beat boundary it is exactly wrong: a click returns roughly a
+        millisecond after the `pause(0.4)` inside it pumped, so the beat that
+        follows the click — the one carrying a caption the navigation just
+        took off the screen — is the beat the interval would skip. Measured
+        against Chromium 151 with a recording context attached: 0.955 ms mean,
+        1.37 ms p95 per round trip (0.899 / 1.14 under 8-way CPU contention),
+        so a 40-beat storyboard pays about 38 ms for it.
         """
         now = time.monotonic() - self._t0
-        if now - self._pumped_at < PUMP_INTERVAL_S:
+        if not force and now - self._pumped_at < PUMP_INTERVAL_S:
             return
         try:
             self.page.evaluate("0")
@@ -1526,6 +1536,27 @@ class _DemoBase:
             )
         record.update(extra)
         self._beats.append(record)
+        if caption is None:
+            # **The line this beat inherited, re-read after the page has had
+            # its say** (issue #214). `goto()` waits for the load, so the
+            # caption is already cleared when it returns; a click is not —
+            # measured identically on Chromium 136, 147 and 151, a link click,
+            # a form submit and a `location.href` button all return after
+            # `framenavigated` alone, and the `domcontentloaded` that clears
+            # the caption arrives during whichever Playwright call comes next.
+            # That call used to be this beat's verb, one stamp too late, so
+            # the first beat after a click-driven navigation reported a line
+            # the load had already taken off the screen — #134's artifact, one
+            # beat wide.
+            #
+            # Pumped *after* the record is appended and `_in_beat` is set, so
+            # anything the pump delivers is attributed to this beat and not to
+            # the closed one before it (`_attributed_beat`). Only an inherited
+            # caption is re-read: a beat carrying its own — `caption()`,
+            # `interlude()` — is about to put that line on the screen itself,
+            # and the load it just learned about took away the *previous* one.
+            self._pump_events(force=True)
+            record["caption"] = self._caption
         try:
             yield record
         except BaseException as raised:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1660,14 +1660,19 @@ exactly where `--strict-only` came from.
 Things a pass does **not** prove. They are listed because an assertion nobody
 knows is missing is worse than one that is openly absent.
 
-- **A click-driven navigation clears the caption one beat later than a `goto()`
-  does.** A beat stamps its caption when it opens, and `click()` returns after
-  `framenavigated` alone — the document event lands during the next Playwright
-  call, so the first beat after the click still reports the line the load took
-  away. Measured identical on Chromium 136, 147 and 151. This is today's
-  behaviour rather than a fix, so it is pinned rather than hidden, by
-  `MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_one_beat_late`
-  ([#214](https://github.com/rogvid/skills/issues/214)).
+- **That a real Chromium hands a click's deferred document event to
+  `evaluate("0")`.** [#214](https://github.com/rogvid/skills/issues/214) is
+  closed: a beat now forces one pump before it stamps the caption it inherited,
+  so the `domcontentloaded` a click left in the connection lands *inside* that
+  beat instead of one beat later.
+  `MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat`
+  grades it by queueing the measured late half of each stream on a page that
+  releases it when the recorder calls — which is Playwright's documented sync
+  dispatch, and is a *stand-in* for it. What no assertion here can see is a
+  build that stopped delivering the queued event on a trivial `evaluate`, or
+  delivered it later than the beat that pumped. That is a claim about a browser
+  and belongs to `tests/smoke`, which has no arm for it
+  ([#228](https://github.com/rogvid/skills/issues/228)).
 
 - **The take-level sentence both cursor fixes were accepted on is ungraded.**
   [#186](https://github.com/rogvid/skills/issues/186) and

--- a/tests/unit
+++ b/tests/unit
@@ -2330,6 +2330,29 @@ class FakePage:
         return None
 
 
+class NoisyPage(FakePage):
+    """A page that delivers its queued events the next time it is called.
+
+    Playwright's sync API dispatches page events only while it is inside a
+    call — the whole reason `_pump_events` exists — so an event arrives during
+    whichever verb happened to touch the browser next. Reproducing that timing
+    rather than firing from outside a beat is what makes the attribution these
+    tests grade the attribution the recorder really makes, and it is the only
+    way to show what a click's late `domcontentloaded` does to the caption the
+    next beat inherits (#214).
+    """
+
+    def __init__(self, *events) -> None:
+        super().__init__()
+        self.queued = list(events)
+
+    def evaluate(self, *args, **kwargs):
+        while self.queued:
+            event, payload = self.queued.pop(0)
+            self.fire(event, payload)
+        return None
+
+
 class UnreadablePage(FakePage):
     """A page whose URL cannot be read — one dying mid-navigation."""
 
@@ -2635,17 +2658,37 @@ NAVIGATIONS_REQUIRED = frozenset(
 )
 
 
+def payloads(page, stream) -> list[tuple]:
+    """`(event, argument)` pairs, as Playwright hands this stream to a handler.
+
+    Split out from `replay` because the two halves of a click's stream are
+    delivered at different moments: the first when the click returns, the rest
+    on whatever the recorder calls next. The second half has to be *queued* on
+    the page rather than fired at it, and queuing needs the same arguments
+    firing does.
+    """
+    out = []
+    for event, target in stream:
+        if event == "framenavigated":
+            out.append(
+                (
+                    event,
+                    FakeFrame(
+                        LOADED_URL,
+                        None if target == _MAIN else FakeFrame("about:blank"),
+                    ),
+                )
+            )
+        else:
+            out.append((event, page))
+    return out
+
+
 def replay(rec, stream) -> int:
     """Deliver one measured page-event stream. Returns handler calls made."""
     taken = 0
-    for event, target in stream:
-        if event == "framenavigated":
-            frame = FakeFrame(
-                LOADED_URL, None if target == _MAIN else FakeFrame("about:blank")
-            )
-            taken += rec.page.fire(event, frame)
-        else:
-            taken += rec.page.fire(event, rec.page)
+    for event, arg in payloads(rec.page, stream):
+        taken += rec.page.fire(event, arg)
     return taken
 
 
@@ -2730,40 +2773,89 @@ class MeasuredNavigations(unittest.TestCase):
                 f"that the two signals are distinguishable",
             )
 
-    def test_a_load_the_verb_did_not_wait_for_reaches_the_log_one_beat_late(self):
-        # A **known gap**, pinned rather than wished away (issue #214).
+    def deferring(self):
+        """A prepared recorder on a page that holds events until it is called.
+
+        The timing a click really has (issue #214): `goto()` waits for the
+        load, so the clear has already happened when it returns, but a link
+        click, a form submit and a `location.href` button all return after
+        `framenavigated` alone — measured, all three builds — and the
+        `domcontentloaded` that takes the caption off the screen is still
+        sitting in the connection. It lands on the next round trip somebody
+        makes, and the beat that follows the click is what has to make it.
+        """
+        rec = recorder(self, page=NoisyPage())
+        rec._watch_page(rec.page)
+        rec.caption(STALE_CAPTION)
+        rec.pause(0)
+        self.assertEqual(
+            rec._beats[-1]["caption"],
+            STALE_CAPTION,
+            "the beat before the navigation does not carry the caption, so "
+            "this test is not exercising the stamping it grades",
+        )
+        return rec
+
+    def test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat(self):
+        # Issue #214's acceptance criterion, one navigation at a time:
+        # `caption(...)`, a click, `pause(3)` — and no beat after the click
+        # carrying the line the load took away.
         #
-        # `goto()` waits for the load, so by the time it returns the clear has
-        # already happened — measured, all three builds. A click does not: a
-        # link click, a form submit and a `location.href` button return after
-        # `framenavigated` only, and the document event arrives during
-        # whichever Playwright call comes next. A beat's caption is stamped
-        # when the beat *opens*, before its verb touches the browser, so the
-        # first beat after a click-driven navigation still carries the line.
-        #
-        # Both halves are asserted: the stale beat, so a fix has to come here
-        # and say so, and the clean one after it, which is the claim that the
-        # clear does land.
+        # The late half of each measured stream is *queued* on the page rather
+        # than fired at the recorder, so the only thing that can deliver it is
+        # a round trip the recorder makes for itself. That is the whole claim:
+        # a beat stamps its caption when it opens, before its verb touches the
+        # browser, so unless the beat asks the page first it inherits a line
+        # that is no longer on screen.
         for name in ("link_click", "form_submit", "location_href"):
             with self.subTest(navigation=name):
                 row = next(r for r in NAVIGATIONS if r[0] == name)
-                _, _, stream, at_return, _ = row
+                _, did, stream, at_return, _ = row
                 self.assertLess(
                     at_return,
                     len(stream),
                     "this navigation was measured as fully delivered before "
                     "its verb returned, so there is no late half to grade",
                 )
-                rec = self.prepared()
+                rec = self.deferring()
                 before = len(rec._beats)
                 replay(rec, stream[:at_return])
-                rec.pause(0)  # opens before the document event lands
-                replay(rec, stream[at_return:])
-                rec.pause(0)
+                # The control for the queueing: what the click itself
+                # delivered leaves the caption alone, so anything the beat
+                # below reports comes from the half that had not arrived yet.
                 self.assertEqual(
-                    [b["caption"] for b in rec._beats[before:]],
-                    [STALE_CAPTION, ""],
+                    rec._caption,
+                    STALE_CAPTION,
+                    f"{did} cleared the caption before its late half was "
+                    f"delivered at all, so the deferral grades nothing",
                 )
+                rec.page.queued = payloads(rec.page, stream[at_return:])
+                # As a click leaves the clock: `click()` holds for 0.4 s
+                # before it clicks, so the last pump is about a millisecond
+                # old when the next beat opens and a rate-limited pump would
+                # skip exactly this beat. Stamped rather than left to how fast
+                # this suite happens to run.
+                rec._pumped_at = time.monotonic() - rec._t0
+                # `pause(0)`, not the criterion's `pause(3)`: the hold length
+                # is not part of the claim — the caption is stamped when the
+                # beat *opens* — and three seconds times three navigations is
+                # nine seconds this suite would spend proving nothing.
+                rec.pause(0)
+                after = rec._beats[before:]
+                # One claim, with the reason in its message rather than in a
+                # second assertion: what is still queued can only be non-empty
+                # when this one fails, so asserting it separately would be a
+                # check that cannot fire on its own.
+                self.assertEqual(
+                    [b["caption"] for b in after],
+                    [""],
+                    f"{did} replaced the document, and the beat right after "
+                    f"it still reports the line the load took off the screen "
+                    f"(never delivered: {[e for e, _a in rec.page.queued]})",
+                )
+                # Broader than the field on purpose: what a reader of this
+                # take's timeline can recover, whichever key it travelled in.
+                self.assertNotIn(STALE_CAPTION, json.dumps(after))
 
 
 # --------------------------------------------------------------------------
@@ -3622,25 +3714,9 @@ class PageResponse:
         self.url = url
 
 
-class NoisyPage(FakePage):
-    """A page that delivers its queued events the next time it is called.
-
-    Playwright's sync API dispatches page events only while it is inside a
-    call — the whole reason `_pump_events` exists — so an event arrives during
-    whichever verb happened to touch the browser next. Reproducing that timing
-    rather than firing from outside a beat is what makes the attribution these
-    tests grade the attribution the recorder really makes.
-    """
-
-    def __init__(self, *events) -> None:
-        super().__init__()
-        self.queued = list(events)
-
-    def evaluate(self, *args, **kwargs):
-        while self.queued:
-            event, payload = self.queued.pop(0)
-            self.fire(event, payload)
-        return None
+# `NoisyPage` — the page that holds its events until it is called — sits with
+# `FakePage` above, because `MeasuredNavigations` needs the same timing to show
+# what a click's *late* half does to a caption (#214).
 
 
 # The line on screen when the problems below fire. Distinctive, so an issue
@@ -4732,7 +4808,54 @@ INJECTIONS = [
         [
             "CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption",
             "MeasuredNavigations.test_every_measured_document_load_takes_the_line_off_the_beat_log",
-            "MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_one_beat_late",
+            "MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat",
+        ],
+    ),
+    (
+        # Issue #214: the clear is right and lands one beat too late. A click
+        # returns after `framenavigated` alone, so the beat that follows it
+        # inherits a caption the document event — still in the connection —
+        # is about to take away.
+        "a beat stops asking the page before it stamps the line it inherited",
+        "core.py",
+        "            self._pump_events(force=True)\n"
+        '            record["caption"] = self._caption\n',
+        "            pass  # the beat keeps whatever line it inherited\n",
+        [
+            "MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat"
+        ],
+    ),
+    (
+        # The `force` on its own, which is the whole difference between the
+        # pump landing and not: `click()` holds for 0.4 s before it clicks, so
+        # the interval `_idle` pumps on is a millisecond old when the next
+        # beat opens and would skip exactly the beat that needed it.
+        "the pump at beat open goes back to being rate-limited",
+        "core.py",
+        "            self._pump_events(force=True)",
+        "            self._pump_events()",
+        [
+            "MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat"
+        ],
+    ),
+    (
+        # The measured fact the whole of #214 rests on, graded from its own
+        # side: a click returns *before* the document event. A table that said
+        # otherwise would leave the deferral in the test delivering nothing
+        # late, and "the beat after the click is clean" would be graded
+        # against a caption that was already gone when the beat opened.
+        "a click is filed as having delivered the document event before it returned",
+        "tests/unit",
+        '        "link_click",\n'
+        "        'click(\"#link\") on an <a href> to another document',\n"
+        '        [("framenavigated", _MAIN), ("domcontentloaded", _PAGE), ("load", _PAGE)],\n'
+        "        1,\n",
+        '        "link_click",\n'
+        "        'click(\"#link\") on an <a href> to another document',\n"
+        '        [("framenavigated", _MAIN), ("domcontentloaded", _PAGE), ("load", _PAGE)],\n'
+        "        2,\n",
+        [
+            "MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat"
         ],
     ),
     (
@@ -5363,15 +5486,17 @@ def fault_inject() -> int:
 #   sending a document event for a `pushState` route change, or none for a form
 #   submit, would leave this suite green. Re-driving the real thing is still
 #   smoke's, and the arm is not there yet (see the two gaps below).
-# - **That the clear lands before the beat that follows a *click*.** Measured,
-#   identical on all three builds: `goto()` waits for the load, so the caption
-#   is already gone when it returns, but a link click, a form submit and a
-#   `location.href` return after `framenavigated` alone. A beat stamps its
-#   caption when it opens, so the first beat after a click-driven navigation
-#   still carries the line that left the screen.
-#   `MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log
-#   _one_beat_late` **pins that gap** rather than hiding it: it is today's
-#   behaviour asserted, so closing it has to be a deliberate edit here.
+# - **That a real browser hands a click's deferred document event to the pump.**
+#   #214 is closed here: `goto()` waits for the load, but a link click, a form
+#   submit and a `location.href` return after `framenavigated` alone, so `_beat`
+#   forces one `evaluate("0")` before it stamps an inherited caption and the
+#   `domcontentloaded` still in the connection lands inside that beat.
+#   `test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat`
+#   grades it by queueing the measured late half on a page that releases it when
+#   the recorder calls — Playwright's documented sync dispatch, stood in for. A
+#   build that stopped delivering on a trivial evaluate, or delivered later than
+#   the beat that pumped, would leave this green. Smoke's, and not there yet
+#   (#228).
 # - **That Chromium's events still look the way `event()` says they do.** The
 #   cursor rule (#186, #202) is graded here as a rule read out of the shipped
 #   overlay and run over measured event streams, so a rule that changed meaning


### PR DESCRIPTION
Fixes #214.

## Acceptance criterion

> A storyboard of the shape `caption(...)`, `click("#link")`, `pause(3)` records
> **no beat carrying the caption after the click**.

## What was wrong

A beat stamps its `caption` when it **opens** (`_beat`), before its verb touches
the browser. `goto()` waits for the load, so `_note_document_replaced` has
already cleared the line when it returns. A click does not: measured identically
on Chromium 136 (Playwright 1.52), 147 (1.59) and 151 (1.62), a link click, a
GET form submit and a `location.href` button all return after `framenavigated`
alone, and the `domcontentloaded` that takes the caption bar off the screen
arrives during whichever Playwright call comes next. That call used to be the
*next beat's verb* — one stamp too late — so the first beat after a click-driven
navigation carried a line the load had already removed. #134's artifact, one
beat wide.

## The fix

`_beat` forces one pump before it stamps an inherited caption, then re-reads it:

```python
record.update(extra)
self._beats.append(record)
if caption is None:
    self._pump_events(force=True)
    record["caption"] = self._caption
```

Three deliberate details:

- **`force`.** `_pump_events` is rate-limited to one round trip per
  `PUMP_INTERVAL_S` (0.1 s). That is a rate limit on a *hold*, and at a beat
  boundary it is exactly wrong: `click()` holds for 0.4 s before it clicks, so
  the last pump is about a millisecond old when the next beat opens and an
  interval-limited pump would skip precisely the beat that needed it.
- **Pumped after the record is appended and `_in_beat` is set,** so anything the
  pump delivers is attributed to *this* beat and not to the closed one before
  it. `_attributed_beat` is unchanged: the same events used to arrive a few
  hundred microseconds later, inside the same beat.
- **Only an inherited caption is re-read.** A beat carrying its own line
  (`caption()`, `interlude()`) is about to put that line on the screen itself;
  the load it just learned about took away the *previous* one, which is still
  reported as a `caption_lost` issue.

No new hook and no change to `MEDIUM_HOOKS` — `_pump_events` and `_beat` are
both already sealed, and the state moved rather than the permit opening.

## The cost, measured before taking it

The issue asked for this number before the lever was pulled. One
`page.evaluate("0")` round trip, real Chromium 151.0.7922.34, on a page with a
recording context attached, n=400 after 20 warm-up trips:

| | idle | under 8-way CPU contention (16-core box) |
|---|---|---|
| mean | **0.955 ms** | 0.899 ms |
| median | 0.866 ms | 0.847 ms |
| p95 | 1.369 ms | 1.141 ms |
| max | 5.291 ms | 4.980 ms |

**About 38 ms for a 40-beat storyboard**, and only on beats that inherit their
caption — `caption()` and `interlude()` beats do not pump. Against beats that
hold for seconds that is not a cost worth declining, so the lever was taken. The
probe is not committed; the numbers are in `_pump_events`'s docstring so a
re-measurement has somewhere to land.

## The pinned test, updated deliberately

`MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_one_beat_late`
asserted `[STALE, ""]` — today's wrong behaviour, pinned on purpose by #179's PR
so that closing the gap could not happen by accident. It is renamed
`…_reaches_the_log_in_the_same_beat` and now grades the new claim:

- The **late half** of each measured stream is *queued* on a `NoisyPage` — the
  page that releases what it holds when the recorder next calls it — instead of
  being fired at the recorder from outside. So the only thing that can deliver
  it is a round trip the beat makes for itself. (`NoisyPage` already existed for
  `TakeIssues`; it moved up next to `FakePage` to be shared. `replay` gained a
  `payloads` helper so queueing and firing build the same arguments.)
- `_pumped_at` is stamped to *now* before the beat opens, modelling the clock a
  click really leaves behind, so the interval is definitively inside its skip
  window rather than depending on how fast this suite happens to run.
- A **control** asserts the caption is still up after the early half, so the
  deferral is real and the clean beat is not clean because the click had already
  cleared it.
- The queue-drained check was deliberately **not** written as a second
  assertion: it can only be non-empty when the caption assertion fails, so it
  would have been the catalogue's *dominated assertion*. Its content is in the
  failure message instead.

## Fault injection

`./tests/unit --fault-inject` → **`All 111 injections were caught.`** Three
entries are new or re-pointed; each was applied, watched fail, and undone.

### 1. `a beat stops asking the page before it stamps the line it inherited` (`core.py`)

Replaces the pump and the re-read with `pass  # the beat keeps whatever line it inherited`.

```
FAIL: test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat (__main__.MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat) (navigation='link_click')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./tests/unit", line 2849, in test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat
    self.assertEqual(
        [b["caption"] for b in after],
        ...<3 lines>...
        f"(never delivered: {[e for e, _a in rec.page.queued]})",
    )
AssertionError: Lists differ: ['The dashboard shows every open order.'] != ['']

First differing element 0:
'The dashboard shows every open order.'
''

- ['The dashboard shows every open order.']
+ [''] : click("#link") on an <a href> to another document replaced the document, and the beat right after it still reports the line the load took off the screen (never delivered: ['domcontentloaded', 'load'])
```

…and the same for `form_submit` and `location_href` (three subtests, three
failures).

### 2. `the pump at beat open goes back to being rate-limited` (`core.py`)

`self._pump_events(force=True)` → `self._pump_events()`. This is the entry that
grades `force` on its own; without it `PUMP_INTERVAL_S` would be an ungraded
constant that could be reintroduced with the suite green.

```
FAIL: test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat (__main__.MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat) (navigation='link_click')
AssertionError: Lists differ: ['The dashboard shows every open order.'] != ['']

- ['The dashboard shows every open order.']
+ [''] : click("#link") on an <a href> to another document replaced the document, and the beat right after it still reports the line the load took off the screen (never delivered: ['domcontentloaded', 'load'])
```

### 3. `a click is filed as having delivered the document event before it returned` (`tests/unit`)

The measured fact the whole issue rests on, graded from its own side:
`link_click`'s "delivered by the time the call returned" column `1` → `2`. If
the table said the document event had already arrived, the deferral would
deliver nothing late and "the beat after the click is clean" would be graded
against a caption that was gone before the beat opened. The control catches it:

```
FAIL: test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat (__main__.MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat) (navigation='link_click')
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./tests/unit", line 2826, in test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat
    self.assertEqual(
        rec._caption,
        ...<2 lines>...
        f"delivered at all, so the deferral grades nothing",
    )
AssertionError: '' != 'The dashboard shows every open order.'
+ The dashboard shows every open order.
 : click("#link") on an <a href> to another document cleared the caption before its late half was delivered at all, so the deferral grades nothing
```

The pre-existing injection `a document load stops invalidating the caption` was
re-pointed at the renamed test and still catches it.

## Verdict lines

```
tests/unit                   Ran 177 tests in 0.345s / OK
tests/unit --fault-inject    All 111 injections were caught.
tests/unit --budget          SKILL.md: 600 lines (~14,114 tokens), budget 600 lines
tests/lint                   All checks passed! / 14 files already formatted
ruff format --check . && ruff check .   (repo root) — clean
tests/smoke --issues-only    smoke: PASSED
tests/smoke --polish-only    smoke: PASSED
tests/smoke --web-only     smoke: FAILED — spotlight only, its own control failed (see below)
tests/smoke (full, local)  smoke: FAILED — four timing findings on a contended box, see below
tests/smoke (full, CI)     pass, 8m32s — the uncontended run, and the one to read
```

`--issues-only` is the arm that matters most here: it records a real web take
against a page that throws and a real terminal take, and grades exactly what the
pump is for — which beat each recorded problem is attributed to. The
between-beats console error is still attributed to nobody (`console_error in
before the first beat`), so forcing the pump did not make a beat claim an event
that was not its.

### The full `tests/smoke` run was red *on this box* and green in CI

**CI's `smoke (record against the fixture app)` passed in 8m32s** on an
uncontended runner, together with lint, mypy, gitleaks, actionlint and both unit
jobs. What follows is the local run, kept because a red run I saw is not
something to omit.

Reported honestly rather than quietly omitted. A full run finished
`smoke: FAILED` with four findings, all timing:

```
  - terminal: timeline.json puts the closing caption 'Recorded end to end.' at 11.95s, the
    host's measured wall-clock steps put that at 11.10s in the video, and demo.mp4 shows it
    at 10.20s (-900 ms) … the host's wall clock stepped -843 ms at 2.9s.
  - terminal: the first caption is -500 ms off the video and the closing caption is -900 ms —
    they have drifted -400 ms apart, over the 250 ms bar … the host's wall clock stepped
    -843 ms at 2.9s.
  - terminal: 3 of 18 review frames (2 captioned, 1 not) sit more than 0.75s clear of a
    caption change, under the 5 this check needs to mean anything
  - spotlight: clearing the spotlight passed through 0 intermediate frame(s) [], under the
    2 bar, while the enter passed through 4.
```

What I can show about them:

- **The spotlight one does not reproduce when the arm runs alone.**
  `tests/smoke --polish-only` on this branch: `smoke: spotlight eases both ways
  (enter 4 intermediate frames, exit 3)`, `smoke: PASSED`. Under contention it
  fails *its own control*, which is the check saying its measurement is
  invalid rather than the recorder wrong:
  `spotlight: the *enter* transition passed through 0 intermediate frame(s) [],
  under the 2 bar. This is the control, not the thing under test … Until it
  passes, the exit reading below proves nothing.`
- **`--web-only` reached every phase this change touches, and they all passed** —
  spotlight was the only failure in that arm:
  ```
  smoke: web caption is visible on screen (delta 26.2)
  smoke: web first caption 'A small dashboard.' logged at 3.09s, on screen at 3.03s (-60 ms)
  smoke: web closing caption 'Recorded end to end.' logged at 24.45s, on screen at 24.43s (-20 ms)
  smoke: web beat clock holds across the take (+40 ms)
  smoke: web each review frame shows its own beat's caption state (17 captioned frames from 11.2, 4 bare ones to 2.9; …)
  smoke: web timeline.json ok (31 beats)
  smoke: web frames/ ok (31 beat frames, each byte-identical to the demo.mp4 frame it claims to be)
  smoke: web evidence ok (31 beats, 59 kB, largest 2450 bytes)
  smoke: coverage ok (3 criteria, 4 tagged beats, unclaimed ['AC-3'])
  smoke: web-problems timeline.json records 8 problem(s), 6 of them fatal under strict — take still passed
  smoke: web-strict strict=True refused the take, naming beat 0 (goto) (4 fatal issues, artifacts kept)
  smoke: narration ok (2 lines spoken from a seeded cache at 0.99s, 3.25s, …)
  ```
  Those caption-timing lines are the ones that would move if the forced pump
  had shifted where a beat is stamped. They did not.
- **The three terminal ones name a host clock step of -843 ms** on a WSL2 box
  that was, at the time, also running another agent's `tests/smoke-inject --only
  merged` and `tests/unit --fault-inject`. That is issue #78's stated failure
  mode — "two suites on one machine share the CPU and the software encoder, and
  the timing bars in this file fail on a recorder that is working".
- **The arithmetic does not fit this change either way.** The forced pump adds
  ~1 ms per inherited-caption beat; the terminal take has single-digit tens of
  beats, so at most a few tens of milliseconds, against a 900 ms skew and a
  400 ms drift.
- `tests/smoke --terminal-only` on this branch also produced a *different*,
  non-reproducing finding between two consecutive runs of identical code
  (`content-toured` held 28.0s and was correct in one run, 29.0s and swallowed
  the `run` beat in the next), which is the same instability from the same
  contention.

I could not get an uncontended full run: this box was shared with another
agent's `tests/smoke-inject --only merged` and `tests/unit --fault-inject` for
the whole window, and the host's wall clock stepped -843 ms and -862 ms in two
separate runs. **CI's full `tests/smoke` on this pull request is the run to
read, and it passed in 8m32s.**

## Stated limits, and what was filed

- **The delivery mechanism is a stand-in, not a measurement.** The event names
  and the "delivered by the time the call returned" counts in `NAVIGATIONS` are
  a recording of three Chromium builds, but *that a queued `domcontentloaded` is
  handed to a trivial `evaluate("0")`* is Playwright's documented sync dispatch
  reproduced by `NoisyPage`. A build that stopped delivering on a trivial
  evaluate, or delivered later than the beat that pumped, would leave this suite
  green. Recorded in `tests/README.md`'s *Known gaps* — replacing the #214 entry,
  which is now closed — and filed as **#228** with an acceptance criterion for a
  `tests/smoke` arm.
- **The `caption_lost` issue quotes the line that was up at the instant of the
  load,** which is now one field different from the beat it is attributed to
  (that beat reports `""` after the re-read). Deliberate: the issue's `t` is the
  moment of the event and the line *was* on screen then, and `lost_caption`
  names it explicitly either way.
- **`pause(3)` in the criterion is exercised as `pause(0)`.** The hold length is
  not part of the claim — the caption is stamped when the beat opens — and three
  seconds times three navigations is nine seconds this suite would spend proving
  nothing.
- **No demo video.** By CLAUDE.md's test the acceptance criterion is a field in a
  committed `timeline.json`, verifiable only by reading the file. A recording of
  it would be ceremony.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
