### PR TITLE
Listen for the pointer from document_start, insert the dot at DOMContentLoaded (#203)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -117,6 +117,44 @@ _FRAME_HTML = """<!doctype html><meta charset="utf-8">
 # and no rule reading events can separate them. A storyboard that wants the
 # cursor at the very corner of the viewport has to pass through somewhere else.
 #
+# **The dot is built at `document_start` and inserted at `DOMContentLoaded`,
+# and that split is issue #203.** All of the above is a rule about events, and
+# a rule about events is worth nothing while nothing is listening. `attach`
+# needs `document.body`, so it can only run at `DOMContentLoaded` — and a
+# `mousemove` dispatched before that used to be delivered to no handler at
+# all. Nothing replaces it: the pointer is where it was asked to be, the
+# browser has no reason to say so again, and the dot stays at the stylesheet's
+# off-screen park for the rest of the document. Reachable through the escape
+# hatch `SKILL.md` documents:
+#
+#     rec.page.goto(url, wait_until="commit")   # Recorder.goto waits for load
+#     rec.page.mouse.move(60, 640)
+#
+# Measured against `tests/fixture` with the position rule above already in
+# place, 12 takes per build, counting only the takes where a probe confirmed
+# the move was delivered while `document.readyState` was still `'loading'`:
+# the dot was placed in **0 of 17** such takes before this split and **13 of
+# 13** after, on Chromium 136, 147 and 149. Chromium 151 never reached the
+# window in 24 takes — its `DOMContentLoaded` lands at 11-17 ms and
+# Playwright's move at 39-68 ms — so it is untested rather than passing.
+#
+# So the listeners are registered while the script itself is evaluated, which
+# for a Playwright init script is `document_start`, and the element they write
+# to is created there too. **A detached element can be styled**: the inline
+# `left`/`top` a `mousemove` writes is still on the div when `attach` puts it
+# in the document, so the dot appears at `DOMContentLoaded` already standing
+# where the pointer went. Nothing is drawn any earlier than it used to be —
+# the stylesheet and the insertion are both still at `DOMContentLoaded`, and
+# an untouched pointer still leaves the parked-off-screen dot #186 is about.
+#
+# What is deliberately *not* covered: a move dispatched before the navigation.
+# That one lands in the previous document, which had its own overlay and its
+# own dot, and no rule in the new document can recover it. Nor is the move
+# Chromium drops on the floor — in the same 48 takes the document received no
+# `mousemove` at all in 3 of 12 on 136, 4 of 12 on 147, 2 of 12 on 149 and 7
+# of 12 on 151, identically before and after this change, and a dot cannot be
+# placed for an event that never arrives. That is issue #230.
+#
 # What this does not do: place the dot after a navigation. A document that
 # replaces the one the dot lived in gets a fresh, parked dot, and Chromium
 # sends its hover-recompute move only for the *first* document — measured, two
@@ -126,6 +164,18 @@ _FRAME_HTML = """<!doctype html><meta charset="utf-8">
 # about that.
 _CURSOR_JS = """
 (() => {
+  const dot = document.createElement('div');
+  dot.id = '__demo_cursor';
+  let atX = 0, atY = 0;
+  window.addEventListener('mousemove', (e) => {
+    if (e.clientX === atX && e.clientY === atY) return;
+    atX = e.clientX;
+    atY = e.clientY;
+    dot.style.left = e.clientX + 'px';
+    dot.style.top = e.clientY + 'px';
+  }, true);
+  window.addEventListener('mousedown', () => dot.classList.add('__down'), true);
+  window.addEventListener('mouseup', () => dot.classList.remove('__down'), true);
   const attach = () => {
     if (document.getElementById('__demo_cursor')) return;
     const style = document.createElement('style');
@@ -138,19 +188,7 @@ _CURSOR_JS = """
       #__demo_cursor.__down { width: 12px; height: 12px; }
     `;
     document.head.appendChild(style);
-    const dot = document.createElement('div');
-    dot.id = '__demo_cursor';
     document.body.appendChild(dot);
-    let atX = 0, atY = 0;
-    window.addEventListener('mousemove', (e) => {
-      if (e.clientX === atX && e.clientY === atY) return;
-      atX = e.clientX;
-      atY = e.clientY;
-      dot.style.left = e.clientX + 'px';
-      dot.style.top = e.clientY + 'px';
-    }, true);
-    window.addEventListener('mousedown', () => dot.classList.add('__down'), true);
-    window.addEventListener('mouseup', () => dot.classList.remove('__down'), true);
   };
   if (document.readyState === 'loading')
     document.addEventListener('DOMContentLoaded', attach);

--- a/tests/README.md
+++ b/tests/README.md
@@ -1690,6 +1690,34 @@ knows is missing is worse than one that is openly absent.
   measurement, and the one route that might still work, are in
   [#210](https://github.com/rogvid/skills/issues/210).
 
+- **That a pointer move made before `DOMContentLoaded` places the dot is graded
+  as a shape, not in a browser.**
+  [#203](https://github.com/rogvid/skills/issues/203) moved the overlay's
+  pointer subscriptions to `document_start` and left only the dot's insertion
+  at `DOMContentLoaded`. What `tests/unit`'s `CursorMotion` grades is exactly
+  that: the region the script defers holds no `addEventListener(`, read out of
+  the shipped `_CURSOR_JS`. It is a **textual** claim, and a subscription
+  registered through an indirection — a `const listen = () => window.add…`
+  called from `attach` — would satisfy it while the defect was back. The
+  browser measurement is in the pull request, not in any suite: 12 `Recorder`
+  takes per build through `goto(wait_until="commit")` plus a raw
+  `page.mouse.move`, counting only the takes where a probe confirmed the move
+  was delivered at `readyState: 'loading'`. Dot placed 0 of 17 such takes
+  before, 13 of 13 after, on Chromium 136, 147 and 149. **Chromium 151 could
+  not be measured at all**: its `DOMContentLoaded` lands at 11-17 ms and
+  Playwright's move at 39-68 ms, so 0 of 24 takes reached the window. Nothing
+  re-runs any of this, and a smoke arm for it would inherit
+  [#210](https://github.com/rogvid/skills/issues/210)'s problem — the browser,
+  not the storyboard, decides whether a take exercises the path.
+
+- **The same escape hatch loses the move outright in some takes, and no suite
+  sees that either.** Measured while grading #203 and unchanged by it: the
+  document receives no `mousemove` at all in 3 of 12 takes on Chromium 136, 4
+  of 12 on 147, 2 of 12 on 149 and **7 of 12 on 151**, so the take records no
+  cursor. `check_parked_pointer` cannot catch it — the determinism storyboard
+  parks after `Recorder.goto()`, which waits for `load`. Tracked with its
+  measurement in [#230](https://github.com/rogvid/skills/issues/230).
+
 - **Nothing calls the ElevenLabs API.** The narration take grades everything a
   cache hit reaches — the key, the pacing, the mix — and by construction never
   takes the miss path, which is the point. So `tts_clip`'s request, its 429/5xx

--- a/tests/unit
+++ b/tests/unit
@@ -3405,6 +3405,13 @@ _JS_TOKEN = re.compile(
 # assumed: a seed anywhere other than where the pointer starts would either
 # let the load-time event through (#186) or swallow a real move.
 _JS_SEED_RE = re.compile(r"let atX = (-?\d+), atY = (-?\d+);")
+# What the overlay puts off until the document has a `<body>` to hang the dot
+# on. Everything else in the script runs at `document_start`, and issue #203 is
+# the difference: a rule about `mousemove` grades nothing while nothing is
+# subscribed, and a move dispatched before `DOMContentLoaded` has no
+# replacement — the pointer is where it was asked to be, so the browser never
+# reports it again.
+_JS_DEFER_RE = re.compile(r"document\.addEventListener\('DOMContentLoaded', (\w+)\)")
 
 
 class _JsEvent:
@@ -3464,6 +3471,64 @@ def cursor_seed() -> tuple[int, int]:
     return int(found[0][0]), int(found[0][1])
 
 
+def _js_block(text: str, start: int) -> str:
+    """The source between an already-opened `{` and the `}` that closes it.
+
+    Template literals are skipped whole rather than scanned: the overlay's
+    stylesheet lives in one, and a counter that read its braces would close
+    the function early and hand every assertion below a slice of CSS.
+    """
+    depth, i = 1, start
+    while i < len(text):
+        ch = text[i]
+        if ch in "'\"":
+            i += 1
+            while i < len(text) and text[i] != ch:
+                i += 2 if text[i] == "\\" else 1
+        elif ch == "`":
+            i += 1
+            while i < len(text) and text[i] != "`":
+                if text[i] == "$" and text[i + 1 : i + 2] == "{":
+                    raise AssertionError(
+                        "the cursor overlay interpolates into a template "
+                        "literal; this reader skips template literals whole "
+                        "and would mis-count the braces inside one"
+                    )
+                i += 2 if text[i] == "\\" else 1
+        elif ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i]
+        i += 1
+    raise AssertionError(
+        "the cursor overlay has an unbalanced block, so nothing below could "
+        "read what it defers to DOMContentLoaded"
+    )
+
+
+def cursor_deferred_body() -> str:
+    """The part of the overlay that does not run until `DOMContentLoaded`."""
+    found = _JS_DEFER_RE.findall(_CURSOR_JS)
+    if len(found) != 1:
+        raise AssertionError(
+            f"the cursor overlay defers {len(found)} functions to "
+            f"DOMContentLoaded, expected exactly 1 — this suite reads the "
+            f"deferred region out of the script rather than assuming it, "
+            f"because what is inside it is unreachable to a pointer move "
+            f"dispatched earlier in the document (#203)"
+        )
+    opening = f"const {found[0]} = () => {{"
+    if opening not in _CURSOR_JS:
+        raise AssertionError(
+            f"the overlay defers {found[0]!r} to DOMContentLoaded but does not "
+            f"declare it as `{opening}`, so this suite cannot say what runs "
+            f"late and what runs at document_start (#203)"
+        )
+    return _js_block(_CURSOR_JS, _CURSOR_JS.index(opening) + len(opening))
+
+
 class CursorMotion(unittest.TestCase):
     """Which `mousemove` moves the recorder's cursor dot (#186, #202)."""
 
@@ -3519,6 +3584,54 @@ class CursorMotion(unittest.TestCase):
             f"the guard {expr!r} never reads the position the overlay "
             f"remembers, so it cannot be telling an event that reports a new "
             f"position from one that repeats the old one (#186, #202)",
+        )
+
+    def test_what_the_overlay_defers_to_domcontentloaded_is_the_insertion(self):
+        # The control for the assertion below, which is "X is *not* in this
+        # string" and would be satisfied just as happily by an extraction that
+        # returned an empty one. What is legitimately late is putting the dot
+        # and its stylesheet in the document, because neither can happen
+        # before there is a `<body>` and a `<head>` to put them in.
+        deferred = cursor_deferred_body()
+        for statement in (
+            "document.head.appendChild(style);",
+            "document.body.appendChild(dot);",
+        ):
+            self.assertIn(
+                statement,
+                deferred,
+                f"the overlay never runs `{statement}` at DOMContentLoaded, so "
+                f"either the dot is never put on the page — no cursor in any "
+                f"take — or this suite is reading the wrong region and the "
+                f"assertion below grades nothing (#203)",
+            )
+
+    def test_the_pointer_is_listened_for_before_the_document_has_loaded(self):
+        # #203. `attach` cannot run before `document.body` exists, so a
+        # `mousemove` dispatched earlier in the document is delivered to
+        # whatever was subscribed *then* — and with the subscription inside
+        # `attach` that was nothing at all. Nothing replaces it either: the
+        # pointer is already where the storyboard put it, so the browser has
+        # no reason to report it again, and the dot sits at the stylesheet's
+        # off-screen park for the rest of the document. Reachable through the
+        # escape hatch SKILL.md documents, `goto(..., wait_until="commit")`
+        # followed by `page.mouse.move`, which is what #202's determinism arm
+        # drives the pointer with.
+        #
+        # So the subscription is established while the init script is
+        # evaluated, and the element it writes to is created there too; only
+        # the insertion waits. A detached div keeps the inline `left`/`top` a
+        # handler wrote on it, so the dot enters the document already standing
+        # where the pointer went.
+        deferred = cursor_deferred_body()
+        self.assertNotIn(
+            "addEventListener(",
+            deferred,
+            "the overlay subscribes to pointer events inside the function it "
+            "defers to DOMContentLoaded, so a move dispatched before the "
+            "document finished loading is delivered to no handler and no later "
+            "event replaces it — the dot stays off screen for the whole take "
+            "(#203)",
         )
 
     def test_chromiums_load_time_hover_event_does_not_move_the_dot(self):
@@ -4175,6 +4288,73 @@ class CaptureClock(unittest.TestCase):
 # --------------------------------------------------------------------------
 # Fault injection
 # --------------------------------------------------------------------------
+
+# Issue #203, as the overlay shipped before it was fixed and after it was.
+# Nothing below is rewritten by hand: the two are the same region of
+# `_CURSOR_JS` — from the dot's creation to its insertion — in the two orders,
+# and swapping them puts the pointer subscriptions back inside the function
+# that cannot run until `document.body` exists. A `mousemove` dispatched
+# before that is then delivered to no handler, and no later event replaces it:
+# measured against `tests/fixture` with `goto(wait_until="commit")` and a raw
+# `page.mouse.move`, Chromium 147 placed the dot in 2 takes of 4 and left it
+# off screen in the other 2.
+#
+# Written out in full rather than as a one-line edit because there is no
+# one-line version: the fix *is* the order, and an injection that only looked
+# like it would leave the suite grading a script nobody ships.
+_CURSOR_LISTENS_AT_DOCUMENT_START = """\
+  const dot = document.createElement('div');
+  dot.id = '__demo_cursor';
+  let atX = 0, atY = 0;
+  window.addEventListener('mousemove', (e) => {
+    if (e.clientX === atX && e.clientY === atY) return;
+    atX = e.clientX;
+    atY = e.clientY;
+    dot.style.left = e.clientX + 'px';
+    dot.style.top = e.clientY + 'px';
+  }, true);
+  window.addEventListener('mousedown', () => dot.classList.add('__down'), true);
+  window.addEventListener('mouseup', () => dot.classList.remove('__down'), true);
+  const attach = () => {
+    if (document.getElementById('__demo_cursor')) return;
+    const style = document.createElement('style');
+    style.textContent = `
+      #__demo_cursor { position: fixed; top: -40px; left: -40px; width: 18px;
+        height: 18px; border-radius: 50%; background: rgba(__ACCENT__,.45);
+        border: 2px solid rgba(__ACCENT__,.95); pointer-events: none;
+        z-index: 2147483647; transform: translate(-50%,-50%);
+        transition: width .1s, height .1s; }
+      #__demo_cursor.__down { width: 12px; height: 12px; }
+    `;
+    document.head.appendChild(style);
+    document.body.appendChild(dot);"""
+
+_CURSOR_LISTENS_AT_DOMCONTENTLOADED = """\
+  const attach = () => {
+    if (document.getElementById('__demo_cursor')) return;
+    const style = document.createElement('style');
+    style.textContent = `
+      #__demo_cursor { position: fixed; top: -40px; left: -40px; width: 18px;
+        height: 18px; border-radius: 50%; background: rgba(__ACCENT__,.45);
+        border: 2px solid rgba(__ACCENT__,.95); pointer-events: none;
+        z-index: 2147483647; transform: translate(-50%,-50%);
+        transition: width .1s, height .1s; }
+      #__demo_cursor.__down { width: 12px; height: 12px; }
+    `;
+    document.head.appendChild(style);
+    const dot = document.createElement('div');
+    dot.id = '__demo_cursor';
+    document.body.appendChild(dot);
+    let atX = 0, atY = 0;
+    window.addEventListener('mousemove', (e) => {
+      if (e.clientX === atX && e.clientY === atY) return;
+      atX = e.clientX;
+      atY = e.clientY;
+      dot.style.left = e.clientX + 'px';
+      dot.style.top = e.clientY + 'px';
+    }, true);
+    window.addEventListener('mousedown', () => dot.classList.add('__down'), true);
+    window.addEventListener('mouseup', () => dot.classList.remove('__down'), true);"""
 
 # (name, module, exact text to replace, replacement, tests that must then fail)
 INJECTIONS = [
@@ -5169,7 +5349,7 @@ INJECTIONS = [
         # deterministic take's opening stills are a coin flip.
         "the cursor dot follows every mousemove again",
         "web.py",
-        "      if (e.clientX === atX && e.clientY === atY) return;\n",
+        "    if (e.clientX === atX && e.clientY === atY) return;\n",
         "",
         [
             "CursorMotion.test_the_rule_is_one_condition_that_reads_the_event",
@@ -5210,11 +5390,38 @@ INJECTIONS = [
         # event reports a "new" position and #186 is back.
         "the overlay starts out believing the pointer is somewhere else",
         "web.py",
-        "    let atX = 0, atY = 0;",
-        "    let atX = -1, atY = -1;",
+        "  let atX = 0, atY = 0;",
+        "  let atX = -1, atY = -1;",
         [
             "CursorMotion.test_chromiums_load_time_hover_event_does_not_move_the_dot",
             "CursorMotion.test_the_remembered_position_is_where_the_pointer_starts",
+        ],
+    ),
+    (
+        # Issue #203: the overlay does not start listening until the document
+        # has a body, so the pointer move a storyboard makes before that is
+        # heard by nothing. Silent everywhere else — the rule is unchanged, the
+        # seed is unchanged, and a take recorded this way looks exactly like a
+        # take whose storyboard never moved the pointer.
+        "the cursor overlay waits for the document before it listens",
+        "web.py",
+        _CURSOR_LISTENS_AT_DOCUMENT_START,
+        _CURSOR_LISTENS_AT_DOMCONTENTLOADED,
+        [
+            "CursorMotion.test_the_pointer_is_listened_for_before_the_document_has_loaded",
+        ],
+    ),
+    (
+        # The control under the assertion above, and a real defect on its own:
+        # a dot that is built and positioned but never inserted is no cursor at
+        # all, in every take. It is also what an extraction that returned the
+        # wrong slice of the script would look like.
+        "the dot is built and positioned but never put on the page",
+        "web.py",
+        "    document.body.appendChild(dot);\n",
+        "",
+        [
+            "CursorMotion.test_what_the_overlay_defers_to_domcontentloaded_is_the_insertion",
         ],
     ),
     (
@@ -5224,7 +5431,7 @@ INJECTIONS = [
         # a fiction.
         "the overlay never records where it last saw the pointer",
         "web.py",
-        "      atX = e.clientX;\n      atY = e.clientY;\n",
+        "    atX = e.clientX;\n    atY = e.clientY;\n",
         "",
         ["CursorMotion.test_nothing_moves_the_dot_except_through_the_rule"],
     ),
@@ -5512,6 +5719,16 @@ def fault_inject() -> int:
 #   byte-identical stills"), need Chromium and belong to `tests/smoke` — where
 #   the storyboard that never moves the pointer is still missing (#193). A
 #   re-measurement lands in `event()`.
+# - **That the subscription is *established* early enough (#203) is a claim
+#   about this file's text, not about a browser.** `cursor_deferred_body`
+#   reads the region the overlay puts off until `DOMContentLoaded` and requires
+#   no `addEventListener(` in it; a subscription reached through an
+#   indirection — `const listen = () => window.addEventListener(...)`, called
+#   from `attach` — would satisfy that while the defect was back. The browser
+#   half was measured once, over 12 takes per build on Chromium 136, 147 and
+#   149, and nothing re-runs it; `tests/README.md`'s Known gaps carries the
+#   numbers, and the separate mode where Chromium delivers no `mousemove` at
+#   all is #230.
 # - **Anything measured off real frames.** `content_report`'s ffmpeg sampling,
 #   `opening_gap`, `_luma_stddev` and `_moved_pixels` need a video to be true
 #   about. What is graded here is the logic *around* them: the warning


### PR DESCRIPTION
Fixes #203.

## Acceptance criterion

From the issue: **a pointer move dispatched before `DOMContentLoaded` places the
dot, measured over repeated takes on at least two Chromium builds.** Repeated
takes because #203 measured it as a race, not a rule.

Deliberately not covered, per the issue: a move dispatched before the
*navigation*. That one lands in the previous document and is #194's "lost
entirely".

## The change

`_CURSOR_JS` registered its `mousemove` listener inside `attach()`, which runs
at `DOMContentLoaded` because it needs `document.body`. A move dispatched
before that was delivered to no handler, and nothing replaced it — the pointer
is already where the storyboard put it, so the browser never reports it again,
and the dot stayed at the stylesheet's off-screen park for the rest of the
document.

The listeners are now registered while the init script is evaluated, which for
Playwright is `document_start`, and the div they write to is created there too.
Only the stylesheet and the insertion stay at `DOMContentLoaded`. **A detached
element keeps the inline `left`/`top` a handler wrote on it**, so the dot enters
the document already standing where the pointer went. The rule itself — #202's
positional guard, #186's `(0, 0)` seed, the single positioning path — is
untouched, character for character; only its indentation moved.

Nothing is drawn earlier than before, so `SKILL.md`'s *"the dot stays undrawn
until the pointer first moves, and after each `goto()`"* is still true and does
not change.

## Measurement: per build, repeated takes

12 real `Recorder` takes per build per overlay, against `tests/fixture`, through
the escape hatch the issue names:

```python
rec.page.goto(url, wait_until="commit")
rec.page.mouse.move(60, 640)
```

A probe added with `page.add_init_script` records every `pointerover`,
`pointermove`, `mouseover` and `mousemove` the document sees, with
`document.readyState` at each, plus `DOMContentLoaded`, `load` and
`first-paint`. **Only takes where the probe confirmed the move arrived at
`readyState: 'loading'` count** — a take where it arrived later does not
exercise the path and grades nothing. `before` is `_CURSOR_JS` read out of
`git show HEAD:…/web.py`, driven by the same harness in the same browser, so
the two rows differ in nothing but the script.

| Chromium | overlay | takes | move delivered pre-DCL | dot at (60, 640) in those |
|---|---|---|---|---|
| 136.0.7103.25 (playwright 1.52) | before | 12 | 1 | **0/1** |
| 136.0.7103.25 | after | 12 | 2 | **2/2** |
| 147.0.7727.15 (playwright 1.59) | before | 12 | 5 | **0/5** |
| 147.0.7727.15 | after | 12 | 4 | **4/4** |
| 149.0.7827.55 (playwright 1.61) | before | 12 | 11 | **0/11** |
| 149.0.7827.55 | after | 12 | 7 | **7/7** |
| 151.0.7922.34 (playwright 1.62) | before | 12 | 0 | – |
| 151.0.7922.34 | after | 12 | 0 | – |

Three builds, 0 of 17 before and 13 of 13 after. In the losing takes the dot was
at (-40, -40), the stylesheet's park.

**Chromium 151 is untested, not passing.** Its `DOMContentLoaded` lands at
11–17 ms and Playwright's move at 39–68 ms, so 0 of 24 takes reached the window
at all. Calling 151 green here would be the *environment-agreeing assertion*:
the build satisfies the check by never taking the path.

Every take, including the ones the control excludes:

| Chromium | overlay | move never delivered | delivered pre-DCL | delivered post-DCL |
|---|---|---|---|---|
| 136.0.7103.25 | before | 3 takes, placed 0 | 1 take, placed 0 | 8 takes, placed 8 |
| 136.0.7103.25 | after | 3 takes, placed 0 | 2 takes, placed 2 | 7 takes, placed 7 |
| 147.0.7727.15 | before | 3 takes, placed 0 | 5 takes, placed 0 | 4 takes, placed 4 |
| 147.0.7727.15 | after | 4 takes, placed 0 | 4 takes, placed 4 | 4 takes, placed 4 |
| 149.0.7827.55 | before | 1 take, placed 0 | 11 takes, placed 0 | – |
| 149.0.7827.55 | after | 2 takes, placed 0 | 7 takes, placed 7 | 3 takes, placed 3 |
| 151.0.7922.34 | before | 7 takes, placed 0 | – | 5 takes, placed 5 |
| 151.0.7922.34 | after | 7 takes, placed 0 | – | 5 takes, placed 5 |

The post-DCL column is the not-regressed check: it worked before, it works
after, on all four builds. The first column is #230, below.

## What is graded in CI, and what is not

`tests/unit`'s `CursorMotion` gains the structural half, read out of the shipped
`_CURSOR_JS`:

- `test_the_pointer_is_listened_for_before_the_document_has_loaded` — the region
  the overlay defers to `DOMContentLoaded` holds no `addEventListener(`.
- `test_what_the_overlay_defers_to_domcontentloaded_is_the_insertion` — the
  control under it, because the assertion above is "X is *not* in this string"
  and an extraction returning an empty one would satisfy it just as happily. The
  deferred region must hold both `appendChild` calls.

`cursor_deferred_body()` refuses rather than guesses: it aborts if the script
defers other than exactly one function, if that function is not declared in the
form it reads, or if a template literal grew an interpolation the brace reader
skips whole.

## Fault injection

Both new assertions were watched failing. `tests/unit --fault-inject` aborts the
whole run unless the search string matches exactly once.

**1. `the cursor overlay waits for the document before it listens`** — the
pre-#203 ordering, written out in full because there is no one-line version: the
fix *is* the order.

```
FAIL: test_the_pointer_is_listened_for_before_the_document_has_loaded (__main__.CursorMotion.test_the_pointer_is_listened_for_before_the_document_has_loaded)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit", line 3535, in test_the_pointer_is_listened_for_before_the_document_has_loaded
    self.assertNotIn(
    ~~~~~~~~~~~~~~~~^
        "addEventListener(",
        ^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
        "(#203)",
        ^^^^^^^^^
    )
    ^
AssertionError: 'addEventListener(' unexpectedly found in "\n    if (document.getElementById('__demo_cursor')) return;\n    const style = document.createElement('style');\n    style.textContent = `\n      #__demo_cursor { position: fixed; top: -40px; left: -40px; width: 18px;\n        height: 18px; border-radius: 50%; background: rgba(__ACCENT__,.45);\n        border: 2px solid rgba(__ACCENT__,.95); pointer-events: none;\n        z-index: 2147483647; transform: translate(-50%,-50%);\n        transition: width .1s, height .1s; }\n      #__demo_cursor.__down { width: 12px; height: 12px; }\n    `;\n    document.head.appendChild(style);\n    const dot = document.createElement('div');\n    dot.id = '__demo_cursor';\n    document.body.appendChild(dot);\n    let atX = 0, atY = 0;\n    window.addEventListener('mousemove', (e) => {\n      if (e.clientX === atX && e.clientY === atY) return;\n      atX = e.clientX;\n      atY = e.clientY;\n      dot.style.left = e.clientX + 'px';\n      dot.style.top = e.clientY + 'px';\n    }, true);\n    window.addEventListener('mousedown', () => dot.classList.add('__down'), true);\n    window.addEventListener('mouseup', () => dot.classList.remove('__down'), true);\n  " : the overlay subscribes to pointer events inside the function it defers to DOMContentLoaded, so a move dispatched before the document finished loading is delivered to no handler and no later event replaces it — the dot stays off screen for the whole take (#203)

----------------------------------------------------------------------
Ran 179 tests in 0.450s

FAILED (failures=1)
```

**2. `the dot is built and positioned but never put on the page`** — deletes
`document.body.appendChild(dot);`. A real defect (no cursor in any take), and
also the shape an extraction reading the wrong slice would have.

```
FAIL: test_what_the_overlay_defers_to_domcontentloaded_is_the_insertion (__main__.CursorMotion.test_what_the_overlay_defers_to_domcontentloaded_is_the_insertion)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/unit", line 3508, in test_what_the_overlay_defers_to_domcontentloaded_is_the_insertion
    self.assertIn(
    ~~~~~~~~~~~~~^
        statement,
        ^^^^^^^^^^
    ...<4 lines>...
        f"assertion below grades nothing (#203)",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
AssertionError: 'document.body.appendChild(dot);' not found in "\n    if (document.getElementById('__demo_cursor')) return;\n    const style = document.createElement('style');\n    style.textContent = `\n      #__demo_cursor { position: fixed; top: -40px; left: -40px; width: 18px;\n        height: 18px; border-radius: 50%; background: rgba(__ACCENT__,.45);\n        border: 2px solid rgba(__ACCENT__,.95); pointer-events: none;\n        z-index: 2147483647; transform: translate(-50%,-50%);\n        transition: width .1s, height .1s; }\n      #__demo_cursor.__down { width: 12px; height: 12px; }\n    `;\n    document.head.appendChild(style);\n  " : the overlay never runs `document.body.appendChild(dot);` at DOMContentLoaded, so either the dot is never put on the page — no cursor in any take — or this suite is reading the wrong region and the assertion below grades nothing (#203)

----------------------------------------------------------------------
Ran 179 tests in 0.395s

FAILED (failures=1)
```

Both injections were undone. Three of the five existing `_CURSOR_JS` injections
— #186's guard, the `(0, 0)` seed and the state update — needed their search
strings re-indented to the script's new nesting, which is exactly the case the
exactly-once abort exists for; all five still match once and all five still
fire.

## Stated limits

- **The CI half is textual.** `cursor_deferred_body()` proves the *string*
  `addEventListener(` is not in the deferred region. A subscription reached
  through an indirection — `const listen = () => window.addEventListener(...)`
  called from `attach` — would satisfy it while the defect was back. Grading it
  behaviourally needs a JS engine, which `tests/unit` deliberately does not have
  (`dependencies = []`).
- **The browser measurement runs nowhere.** It is 96 takes across four
  Playwright installs, and an arm for it would inherit #210's problem: the
  *browser*, not the storyboard, decides whether a take reaches the pre-DCL
  window — 11 of 12 on Chromium 149, 0 of 24 on 151. A control that refuses a
  take it did not reach would make the suite red for a reason that is not a
  defect, which #210 already measured and rejected.
- **Chromium 151 is unmeasured for this criterion**, as above.

All three are written into `tests/README.md`'s **Known gaps**, and the first
into `tests/unit`'s "What this suite does NOT cover".

## Filed rather than fixed here

**#230 — the move Chromium never delivers at all.** In the same 48 takes the
document received *no* `mousemove` — no `pointermove` either, and on 151 no
pointer event whatsoever — in 3/12 takes on 136, 4/12 on 147, 2/12 on 149 and
**7/12 on 151**, so the take records no cursor. Rates are identical before and
after this change, so it is a separate mechanism and not a regression. It is not
first paint: the move precedes `first-paint` by 15–49 ms in *every* take
measured, delivered and dropped alike. It is not the overlay: a second
`page.mouse.move(300, 300)` after `load` placed the dot at (300, 300) in **all
33** dropped takes, on all four builds. Full measurement in the issue.

## Suites

Rebased onto `origin/main` at `2e6061b` (#231, issue #214) with
`git rebase --onto origin/main 8d831b5`, one commit, no merge commit. #231
edits `tests/unit` and `tests/README.md`, which this branch also edits; it does
**not** touch `web.py`. Every verdict below is from the rebased tree.

**Injection arithmetic**, checked rather than assumed. `origin/main` at
`2e6061b`, run standalone from a clean `git archive` of that tree: **177 tests,
111 injections**. This branch: **179 tests, 113 injections**. 177 + 2 = 179 and
111 + 2 = 113, which is what two added tests and two added injections should
cost. Both of this branch's injections still fire on the rebased tree, and each
still fires only the test it names.

The browser measurement above was taken before the rebase and is not re-run:
#231's change is one `page.evaluate("0")` pump inside `_beat`, and the probe
storyboard opens no beats at all (`rec.page.goto` / `rec.page.mouse.move`
directly, `timeline.json (0 beats)`), so the pump never runs on the measured
path. `_CURSOR_JS` and its init-script ordering are untouched by #231.


| | verdict |
|---|---|
| `./tests/unit` | `OK` (179 tests) |
| `./tests/unit --fault-inject` | `All 113 injections were caught.` |
| `./tests/ci-unit` | `OK` (49 tests) |
| `./tests/lint` | `All checks passed!` / `14 files already formatted` |
| `ruff format --check .` (repo root) | `14 files already formatted` |
| `ruff check .` (repo root) | `All checks passed!` |
| `./tests/unit --budget` | `SKILL.md: 600 lines (~14,114 tokens), budget 600 lines` |
| `./tests/smoke --determinism-only` | `smoke: PASSED` — `determinism ok (3 takes)`, stills reproduce byte for byte, `check_parked_pointer` green in both takes |

No demo video: the acceptance criterion is a dot's position under a load-timing
race, read off `getBoundingClientRect` rather than off a frame, and a take that
loses it looks identical to a take whose storyboard never moved the pointer. The
repo's "can the acceptance criterion be verified by watching?" test says no.
