### PR TITLE
Merge capture_clock into a stitched demo, per capture (#225)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/stitching.py
+++ b/skills/demo-video/helpers/demo_recording/stitching.py
@@ -45,6 +45,73 @@ def _merge_determinism(records: list[dict]) -> dict:
     }
 
 
+def _merge_capture_clock(docs: list[dict], records: list[dict]) -> dict | None:
+    """Every part's wall-clock steps, moved onto the stitched video's clock.
+
+    Chromium stamps each screencast frame with the host's *wall* clock while
+    the beat log is `time.monotonic()`, so a host that steps its clock parts
+    the two by the size of the step (issues #18, #215). Each take records its
+    own steps as `capture_clock`; those files are removed by the merge, so
+    without this a reader of a stitched `demo.mp4` has a beat log on one clock,
+    a video on another, and nothing to reconcile them with (issue #225).
+
+    Two things make the merged record usable, and both are about **which steps
+    apply to which beats**:
+
+    * every step carries the `segment` it was measured in, and that is the
+      attribution to trust. A step is sampled for as long as the capture runs,
+      which is longer than the video it produced — losing wall time is the
+      whole phenomenon — so a step's merged `t` can legitimately fall past the
+      next part's `offset`, and a reader keying on time alone would hand it to
+      the wrong capture.
+    * `boundaries` records where each capture starts on the stitched clock.
+
+    The correction for one beat is therefore the steps of **its own** segment
+    up to its own `t_start`, never the running total: each capture's first
+    frame restarts its clock, and `_merged_timeline` already lays the parts out
+    by their measured durations, so a step in an earlier part is *already* in
+    the later parts' offsets. Adding it again would over-correct by a whole
+    step.
+
+    Returns **null** unless every part carries a well-formed record. A merge
+    that quietly treated a missing one as "the clock held still" would state,
+    in an artifact somebody corrects timestamps with, that a part nobody
+    measured was measured — and `total` would be short by whatever it stepped.
+    """
+    steps: list[dict] = []
+    for doc, record in zip(docs, records, strict=True):
+        clock = doc.get("capture_clock")
+        listed = clock.get("steps") if isinstance(clock, dict) else None
+        if not isinstance(listed, list):
+            return None
+        for step in listed:
+            if not isinstance(step, dict):
+                return None
+            at = _shift(step.get("t"), record["offset"])
+            delta = step.get("delta")
+            unusable = (
+                at is None
+                or not isinstance(delta, (int, float))
+                or isinstance(delta, bool)
+            )
+            if unusable:
+                return None
+            steps.append(
+                {**step, "t": at, "delta": float(delta), "segment": record["segment"]}
+            )
+    clocks = [doc.get("capture_clock") or {} for doc in docs]
+    return {
+        "steps": steps,
+        # The sum across the whole recording session, which is **not** the
+        # correction for any single beat — see above. It is here because a
+        # non-zero total is what tells a reader to look at `steps` at all.
+        "total": round(sum(step["delta"] for step in steps), 4),
+        "sample_interval": _common([c.get("sample_interval") for c in clocks]),
+        "min_step": _common([c.get("min_step") for c in clocks]),
+        "boundaries": [record["offset"] for record in records],
+    }
+
+
 # How far a segment's recorded `duration` may sit from what its .seg.mp4
 # measures now. The recorder probed the same file with the same tool moments
 # after writing it, so anything past this is not rounding — it is a log paired
@@ -235,6 +302,11 @@ def _merged_timeline(
                 # may join two media with two different geometries. See
                 # `merge_content`.
                 "content": doc.get("content"),
+                # This part's own record, on its own clock, untouched. The
+                # merged one above is null the moment any part is missing
+                # theirs, and the parts that *were* measured should not go
+                # with it — see `_merge_capture_clock`.
+                "capture_clock": doc.get("capture_clock"),
             }
         )
         offset = round(offset + duration, 3)
@@ -253,6 +325,11 @@ def _merged_timeline(
         "duration": total,
         "determinism": _merge_determinism([r["determinism"] for r in records]),
         "content": merge_content(records),
+        # The clock demo.mp4 is on, which is not the clock the beats above are
+        # on. Merged the way the beats are — by the parts' measured durations —
+        # and attributed per capture, because a step in an earlier part must
+        # not be applied to a later part's beats (issue #225).
+        "capture_clock": _merge_capture_clock(docs, records),
         # Recomputed over the *merged* beat list, not unioned from the
         # segments' own reports: `index` is renumbered by the merge, and a
         # report assembled from per-segment ones would point a reviewer at beat

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -46,11 +46,42 @@ from .markdown import _fmt_t, _md_cell
 #                          On a merged demo each value is the one every segment
 #                          agrees on, or null where they disagree — the
 #                          per-segment truth is in `segments`.
+#   capture_clock dict?  — the clock `media` is on, which is **not** the clock
+#                          `beats` are on. Chromium stamps every screencast
+#                          frame with the host's *wall* clock; the beat log is
+#                          `time.monotonic()`. So the recorder samples the
+#                          difference for the take's whole life and writes down
+#                          every step it saw: `steps` (each `t`, seconds into
+#                          the take, and `delta`, seconds the wall clock
+#                          jumped), `total`, `sample_interval` and `min_step`
+#                          (the sampler's own settings; the smallest jump it
+#                          calls a step). An empty `steps` means the clock held
+#                          still, which is a different answer from the field
+#                          being absent. **A beat the log puts at `t` sits at
+#                          `t + (the steps before it)` in the video** —
+#                          reference/limits.md has the measurement.
+#                          On a merged demo (`stitch`) every part's steps are
+#                          here, moved onto the stitched clock by that part's
+#                          `offset`, and each step also carries the `segment`
+#                          it was measured in. **That `segment` is the
+#                          attribution to trust**, not the timestamp: a step is
+#                          sampled for as long as the capture runs, which is
+#                          longer than the video it produced, so a step's `t`
+#                          can fall past the next part's `boundaries` entry.
+#                          The correction for a beat is the steps of *its own*
+#                          segment up to its `t_start` — never `total`, and
+#                          never an earlier part's, whose loss is already in
+#                          the offsets. `boundaries` (merged demos only) is
+#                          where each capture starts on the stitched clock.
+#                          **Null** on a merged demo any of whose parts carried
+#                          no usable record: a partial answer here would say a
+#                          part nobody measured held still.
 #   segments      list?   — merged demos only (`stitch`): one record per part,
 #                          in order, each `segment`, `media`, `duration`
 #                          (ffprobe), `offset` (where it starts in `media`),
-#                          `beats`, `recorder`, `determinism`. Absent from a
-#                          timeline a single take wrote.
+#                          `beats`, `recorder`, `determinism`, `content` and
+#                          that part's own `capture_clock`, on its own clock.
+#                          Absent from a timeline a single take wrote.
 #   content       dict?  — what the *picture* turned out to be, measured off
 #                          the encoded mp4 over the region the app occupies:
 #                          `measured` (bool), `note` (why not, when it is

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -110,7 +110,13 @@ restored at 250 ms after being deleted in
 [#217](https://github.com/rogvid/skills/issues/217).
 
 What to do: prefer `timeline.json`'s `capture_clock`, which records every step
-with its offset and size, and correct with it. Failing that, read a review
+with its offset and size, and correct with it. On a **stitched** demo the same
+field carries every part's steps, each naming the `segment` it was measured in:
+correct a beat with the steps of *its own* segment up to its `t_start`, never
+with `total` and never with an earlier part's — that part's lost wall time is
+already in the offset `stitch()` laid it out by, and applying it twice moves the
+beat by a whole extra step ([#225](https://github.com/rogvid/skills/issues/225)).
+Failing all that, read a review
 frame as *around* its beat, do not build anything that needs a beat timestamp
 to be exact to the frame, and when a frame and its caption disagree by a
 fraction of a second, suspect the capture before the

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,7 +38,7 @@ below for what it covers and what it does not.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~37 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~39 min, nightly)
 ├── unit               # the browser-free half (~0.07 s, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
@@ -181,7 +181,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~48 s)
-tests/smoke-inject                # all 38 entries, ~37 min
+tests/smoke-inject                # all 42 entries, ~39 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -1521,7 +1521,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-38 entries, 12 arms, ~37.2 min of takes
+42 entries, 12 arms, ~39.1 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -1554,7 +1554,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
-| `--segments-only` | 6 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; or the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)) |
+| `--segments-only` | 10 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)) |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
@@ -1563,7 +1563,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **19 of `tests/smoke`'s 38 check functions have no entry**, and the harness
+- **19 of `tests/smoke`'s 39 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -1818,14 +1818,50 @@ knows is missing is worse than one that is openly absent.
   time, and it is red about something true and now says which part of it is
   the host and which is not.
 
-- **`stitch()` does not merge `capture_clock`.** Each part's own
-  `<segment>.seg.timeline.json` carries its own measurement and is graded
-  against this harness's, per part — but the merged envelope has no such field,
-  so a consumer of a stitched `demo.mp4` has nothing to correct with. The
-  harness works around it by keeping each part's clock and laying them on the
-  merged video itself; a reader of the artifact cannot. `stitching.py` is
-  outside the change that added the field. Tracked in
-  [#225](https://github.com/rogvid/skills/issues/225).
+- **~~`stitch()` does not merge `capture_clock`.~~ Fixed**
+  ([#225](https://github.com/rogvid/skills/issues/225)). The merged envelope
+  now carries every part's steps moved onto the stitched clock by that part's
+  ffprobe offset, each naming the `segment` that measured it, plus the capture
+  `boundaries` — so `check_merge_offset`'s stitched reading is corrected from
+  the artifact alone while its per-part reading is corrected from this
+  harness's own measurement, and the differential between them is the claim.
+  What remains true of the *measured* half: **on a host whose wall clock never
+  steps, every step list is empty and the per-beat agreement in
+  `check_merged_capture_clock` compares nothing to nothing.** That is the
+  environment-agreeing shape, and it is why the merge's arithmetic — the
+  offsets, the per-capture attribution, and the rule that a step in an earlier
+  part must not correct a later part's beats — is graded on a *scripted* clock
+  by `MergedCaptureClock` in `tests/unit`, where five injections cost 0.2 s
+  each. What this arm adds on any host is the structure a reader needs:
+  the field exists, totals its own steps, names its captures, and puts their
+  boundaries where ffprobe puts them.
+
+  **One entry had to be rewritten for exactly that reason, and the manifest is
+  what caught it.** The injection for "a step that names no capture" first
+  stripped the `segment` off every merged step — which is a no-op on a run
+  where the clock never stepped, and the arm passed against it. It now *adds* a
+  step nobody measured, with a `delta` of 0.0 so the record still totals its
+  own steps: one fault, on any host.
+
+  **The harness had the bug it was the reference for.** `joined_clock()` laid
+  every part's steps onto the merged clock, including the ones its watcher
+  sampled *after* that part's last frame — the encode, the conversion and the
+  timeline write all run inside the `with`, and a step there sits past the next
+  part's boundary. `before()` keys on time, so it handed those to the next
+  part's beats. Measured on the run that found it: a -876 ms step at 7.2 s of a
+  part whose video is 6.88 s moved the closing caption's search window 876 ms
+  off the frame and failed `--segments-only` about something untrue — while the
+  *same* caption in the *same* file timed to -20 ms through
+  `check_merge_offset`, which corrects from the merged `timeline.json`, where
+  the recorder had already stopped sampling and the merge attributes per
+  capture. `joined_clock()` now drops a step that lands past its own part's
+  video; each part's own clock is untouched.
+
+  One more beat is ungraded per step: a
+  beat starting within `MAX_CLOCK_STEP_TIME_DISAGREEMENT_S` of one is skipped
+  and counted in the arm's output, because two samplers on their own 20 ms
+  grids do not both know which side of that beat the step fell on — and the
+  alternative, a bar as wide as a step, would grade nothing.
 
 - **~~`--web-only` still goes red when the capture loses more than 0.75 s, and
   the bars were not widened to stop it.~~ Diagnosed and fixed** — the cause was

--- a/tests/smoke
+++ b/tests/smoke
@@ -2010,7 +2010,9 @@ class HostClock:
         out by their real durations, so that shortening is already in the
         offset. Adding it again to a later part's beats would over-correct by
         a whole step. For a single take there are no boundaries and this is
-        the whole list.
+        the whole list. The half a boundary cannot express — a step sampled
+        *after* its own part's last frame, which sits past the next part's
+        boundary and is nobody's — is kept out of the list by `joined_clock`.
 
         Hand-written here rather than shared with the recorder: the two have
         to be able to disagree, or `capture_clock` is not being graded.
@@ -2032,11 +2034,33 @@ def joined_clock(parts: list[tuple[HostClock, float]]) -> HostClock:
     `parts` is (that capture's clock, where its video starts in the joined
     one). Nothing is mutated: each part keeps its own clock, because that is
     what grades that part's own `capture_clock` and its own `.seg.mp4`.
+
+    **A step past the end of its own part's video is dropped**, and that is the
+    whole of what `before()`'s boundaries cannot express. Each watcher runs for
+    its part's whole `with` block, which outlives the frames: the encode, the
+    conversion and the timeline write all happen after the last one. A step
+    landing in that tail moved nothing — the next capture's first frame starts
+    its own clock, which is `record_segments`' own reason for one watcher per
+    segment — but on the joined clock it sits past the next part's boundary,
+    and `before()` keys on time, so it would be handed to that part's beats.
+
+    Measured, on the run that found it: a -876 ms step at 7.2 s of a part whose
+    video is 6.88 s put the closing caption's search window 876 ms away from the
+    frame, and the arm went red about something untrue. The same caption, in the
+    same file, was timed to -20 ms by `check_merge_offset` — which corrects from
+    the stitched `timeline.json`, where the recorder had stopped sampling before
+    the step and the merge attributes what is left per capture (issue #225).
+    Nothing is dropped from the *part's own* clock, which still grades that
+    part's `capture_clock` over the window both watchers cover.
     """
     joined = HostClock()
     joined._t0 = 0.0
+    ends = [offset for _clock, offset in parts[1:]] + [None]
     joined.raw = [
-        (at + offset, delta) for clock, offset in parts for at, delta in clock.steps
+        (at + offset, delta)
+        for (clock, offset), end in zip(parts, ends, strict=True)
+        for at, delta in clock.steps
+        if end is None or at + offset < end
     ]
     joined.boundaries = [offset for _clock, offset in parts]
     return joined
@@ -2150,6 +2174,206 @@ def check_capture_clock(
             ]
     print(f"smoke: {label} capture_clock agrees with the harness ({clock.describe()})")
     return []
+
+
+def merged_clock_correction(record: object, beat: dict) -> float:
+    """What a reader of a stitched `timeline.json` **alone** corrects a beat by.
+
+    Hand-written from the envelope's documentation in `timeline.py`, never
+    imported from `stitching.py`: a reader assembled out of the merge's own
+    code agrees with that code whatever it says, which is the catalogue's
+    "check that shares the bug's blind spot". The documented rule is the steps
+    of *this beat's own capture*, up to this beat — not the running total, and
+    not an earlier part's, whose lost wall time is already in the offsets the
+    merge laid the parts out by.
+    """
+    if not isinstance(record, dict):
+        return 0.0
+    t_start = beat.get("t_start")
+    if not isinstance(t_start, (int, float)):
+        return 0.0
+    total = 0.0
+    for step in record.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        at, delta = step.get("t"), step.get("delta")
+        if not isinstance(at, (int, float)) or not isinstance(delta, (int, float)):
+            continue
+        if step.get("segment") == beat.get("segment") and at <= float(t_start):
+            total += float(delta)
+    return total
+
+
+def check_merged_capture_clock(
+    out_dir: Path, parts: list[tuple[str, HostClock, float, object]]
+) -> list[str]:
+    """A stitched demo's own answer to "where in the video is this beat" (#225).
+
+    Graded off `demo.mp4`'s `timeline.json` and nothing else, because that is
+    all a consumer has: `stitch()` removes the parts and their beat logs, so a
+    measurement that only ever reached a `<segment>.seg.timeline.json` is one
+    nobody downstream will read. `parts` is (name, that capture's clock, where
+    its video starts in the stitched one, that part's own record as its log
+    held it before the merge) — the offsets taken with ffprobe off the parts
+    rather than read out of the file being graded.
+
+    The last claim is the measured one: for every beat, what a reader
+    reconstructs from the merged record has to be what this harness measured on
+    that beat's *own* capture — which includes a step in an earlier part
+    correcting nothing here, the half a merge gets wrong by accumulating (see
+    `joined_clock`). It says nothing on a host whose wall clock never steps, so
+    the merge's arithmetic is *also* graded directly, on a scripted clock, by
+    `MergedCaptureClock` in `tests/unit`. Everything above it holds on any host.
+
+    A beat that starts within `MAX_CLOCK_STEP_TIME_DISAGREEMENT_S` of a step is
+    skipped and counted, not graded: two samplers on their own 20 ms grids do
+    not both know which side of that beat the step fell on, and widening the
+    bar to a step's width instead would leave it grading nothing.
+    """
+    path = out_dir / "timeline.json"
+    try:
+        doc = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"segments: timeline.json could not be read for capture_clock: {exc}"]
+    # Before the merged record, and whether or not there is one: that field
+    # goes null the moment any part is missing its own, and the parts that
+    # *were* measured must not go with it. Graded against each segment's log as
+    # it stood on disk before the merge, so a record that arrives empty, or
+    # belonging to the other part, fails the same way.
+    failures: list[str] = []
+    carried = doc.get("segments")
+    if not isinstance(carried, list) or len(carried) != len(parts):
+        return [
+            f"segments: the stitched timeline.json's `segments` is {carried!r}, "
+            f"expected one record per part — the per-part clocks live there and "
+            f"nothing below can be attributed without them"
+        ]
+    for (name, _clock, _offset, own), kept in zip(parts, carried, strict=True):
+        if kept.get("capture_clock") != own:
+            failures.append(
+                f"segments: the merged `segments` record for {name} carries "
+                f"capture_clock {kept.get('capture_clock')!r}, but "
+                f"{name}.seg.timeline.json measured {own!r}. That record is what "
+                f"is left to read when the merged one goes null, and a stitched "
+                f"demo that lost one part's clock must not lose the parts that "
+                f"were measured (issue #225)"
+            )
+    record = doc.get("capture_clock")
+    if not isinstance(record, dict):
+        return failures + [
+            f"segments: the stitched timeline.json has no merged `capture_clock` "
+            f"record ({record!r}). stitch() takes the parts and their beat logs "
+            f"away with it, so what is left is a beat log on the monotonic "
+            f"clock, a video on the host's wall clock, and nothing to reconcile "
+            f"them with (issues #18, #215, #225)"
+        ]
+    steps, total = record.get("steps"), record.get("total")
+    if not isinstance(steps, list) or not isinstance(total, (int, float)):
+        return failures + [
+            f"segments: the merged `capture_clock` is steps={steps!r}, "
+            f"total={total!r} — a reader correcting a beat timestamp with that "
+            f"gets nothing"
+        ]
+    summed = sum(float(s.get("delta", 0.0)) for s in steps if isinstance(s, dict))
+    if abs(summed - float(total)) > 0.001:
+        failures.append(
+            f"segments: the merged capture_clock.total is {total!r} but its own "
+            f"steps sum to {summed:+.4f} — the merged field disagrees with "
+            f"itself, and a consumer reading only the total corrects by a "
+            f"different amount from one reading the steps"
+        )
+    wanted = [round(offset, 3) for _name, _clock, offset, _own in parts]
+    boundaries = record.get("boundaries")
+    if (
+        not isinstance(boundaries, list)
+        or len(boundaries) != len(wanted)
+        or any(
+            not isinstance(b, (int, float))
+            or abs(float(b) - w) > SEGMENT_OFFSET_TOLERANCE_S
+            for b, w in zip(boundaries, wanted, strict=False)
+        )
+    ):
+        failures.append(
+            f"segments: the merged capture_clock says its captures start at "
+            f"{boundaries!r}; ffprobe puts them at {wanted!r}. Those are what "
+            f"tell a reader which steps apply to which beats, and a merged "
+            f"record whose captures all start at zero hands the first "
+            f"segment's steps to the second segment's beats — over-correcting "
+            f"every one of them by a whole step (issue #225)"
+        )
+    names = {name for name, _clock, _offset, _own in parts}
+    stray = [
+        step
+        for step in steps
+        if not isinstance(step, dict) or step.get("segment") not in names
+    ]
+    if stray:
+        failures.append(
+            f"segments: {len(stray)} of {len(steps)} merged capture_clock "
+            f"step(s) name no capture of this demo ({stray[:2]!r}; the parts "
+            f"are {sorted(names)}). A step is sampled for as long as its "
+            f"capture runs, which is longer than the video that capture "
+            f"produced, so a step's merged timestamp can fall past the next "
+            f"part's boundary — which capture measured it is the only "
+            f"attribution a reader can trust"
+        )
+
+    unresolvable = 0
+    for name, clock, offset, _own in parts:
+        # Both this harness's steps and the record's, on this part's own clock:
+        # a beat that starts within a sampler's reach of a step is one the two
+        # watchers genuinely cannot agree about — they are on their own 20 ms
+        # grids, so which *side* of the beat the step fell on is not a fact
+        # either of them has. Skipped rather than absorbed into a wider bar,
+        # because a bar wide enough for a whole step grades nothing at all: the
+        # beats after a step are still 0.78 s apart from the beats before it,
+        # and those are what carry the claim.
+        near = [at for at, _delta in clock.steps] + [
+            float(step["t"]) - offset
+            for step in steps
+            if isinstance(step, dict)
+            and step.get("segment") == name
+            and isinstance(step.get("t"), (int, float))
+        ]
+        for beat in doc.get("beats") or []:
+            if beat.get("segment") != name or not isinstance(
+                beat.get("t_start"), (int, float)
+            ):
+                continue
+            local = float(beat["t_start"]) - offset
+            if any(
+                abs(at - local) <= MAX_CLOCK_STEP_TIME_DISAGREEMENT_S for at in near
+            ):
+                unresolvable += 1
+                continue
+            measured = clock.before(local)
+            read = merged_clock_correction(record, beat)
+            if abs(measured - read) > MAX_CLOCK_RECORD_DISAGREEMENT_S:
+                failures.append(
+                    f"segments: beat {beat.get('index')} of {name} is logged at "
+                    f"{float(beat['t_start']):.2f}s, and a reader with only the "
+                    f"stitched timeline.json would place it {read * 1000:+.0f} "
+                    f"ms from there in demo.mp4 — this harness watched that "
+                    f"capture's own wall clock and makes it "
+                    f"{measured * 1000:+.0f} ms ({clock.describe()}). The "
+                    f"merged record is the only thing a consumer has, and a "
+                    f"step belongs to the capture that measured it: an earlier "
+                    f"part's is already in this part's offset (issue #225)"
+                )
+                break
+    if not failures:
+        print(
+            f"smoke: segments the stitched timeline.json places every beat on "
+            f"its own capture's clock ({len(steps)} step(s) merged, boundaries "
+            f"{boundaries}"
+            + (
+                f", {unresolvable} beat(s) too close to a step for the two "
+                f"samplers to resolve)"
+                if unresolvable
+                else ")"
+            )
+        )
+    return failures
 
 
 _CAPTION_JS = """() => {
@@ -8426,20 +8650,31 @@ def check_merge_offset(
             if segment_clock and isinstance(alone.get("t_start"), (int, float))
             else 0.0
         )
-        for what, media, t_start in (
-            ("in its own segment", part, alone.get("t_start")),
-            ("in the stitched demo", demo, stitched.get("t_start")),
+        # The stitched reading corrects with the **artifact's** own answer,
+        # rebuilt from the merged timeline.json alone, where the part's
+        # reading corrects with this harness's. That asymmetry is the point of
+        # issue #225: `stitch()` deletes the parts, so a consumer has only the
+        # merged record, and the differential below is what says the two agree.
+        # On a host whose clock never stepped both are zero and this measures
+        # exactly what it measured before — the merge's offset arithmetic.
+        merged_shift = merged_clock_correction(
+            json.loads(merged_json.read_text()).get("capture_clock"), stitched
+        )
+        for what, media, t_start, correction in (
+            ("in its own segment", part, alone.get("t_start"), shift),
+            ("in the stitched demo", demo, stitched.get("t_start"), merged_shift),
         ):
             if not isinstance(t_start, (int, float)):
                 readings.clear()
                 failures.append(f"segments: {name}'s probe has no t_start {what}")
                 break
-            # One shift for both readings, taken on this segment's own
-            # capture clock: `t_start` differs between the two files by the
-            # merge offset, but the frames are the same frames and the steps
-            # that moved them are this segment's either way.
+            # The same frames, moved by the same steps — this segment's, not
+            # the demo's running total. What differs between the two readings
+            # is *who says so*: the part is corrected by this harness's own
+            # measurement, the stitched demo by what its merged timeline.json
+            # tells a reader who has nothing else (issue #225).
             seen_at, note = caption_appearance_s(
-                "segments", media, band, float(t_start) + shift
+                "segments", media, band, float(t_start) + correction
             )
             if seen_at is None:
                 readings.clear()
@@ -8448,7 +8683,7 @@ def check_merge_offset(
                     f"({media.name}) — {note}"
                 )
                 break
-            readings[what] = seen_at - float(t_start) - shift
+            readings[what] = seen_at - float(t_start) - correction
         if len(readings) != 2:
             continue
 
@@ -8462,8 +8697,10 @@ def check_merge_offset(
                 f"away from the frame it names, past the "
                 f"{MAX_MERGE_OFFSET_ERROR_S * 1000:.0f} ms bar. Both readings are "
                 f"of the same frames, so capture loss (issue #18) cancels here "
-                f"and this is stitch()'s offset arithmetic for {name}: it must "
-                f"be the parts' real ffprobe durations, in order."
+                f"and what is left is what the merged artifact says about "
+                f"{name}: its offset, which must be the parts' real ffprobe "
+                f"durations in order, and the merged `capture_clock` the "
+                f"stitched reading above was corrected by (issue #225)."
             )
             continue
         # The other half, per capture: this segment's own video against this
@@ -8608,6 +8845,27 @@ def stitch_segments(
             "segments: re-stitching the same parts produced different beats — "
             "the merge is not a function of what is on disk, so a re-stitch "
             "after re-recording one segment cannot be trusted"
+        )
+
+    # What a consumer of the stitched artifact can do about the clock its
+    # video is on — graded here, after the parts and their own logs are gone,
+    # because that is the state a reader of demo.mp4 finds it in (issue #225).
+    # The offsets are the ffprobe durations measured above, before the merge,
+    # not the ones the file being graded wrote down.
+    if clocks:
+        offsets: list[float] = []
+        running = 0.0
+        for probed in durations:
+            offsets.append(running)
+            running += probed
+        failures += check_merged_capture_clock(
+            out_dir,
+            [
+                (name, clock, offset, doc.get("capture_clock"))
+                for name, clock, offset, doc in zip(
+                    SEGMENT_NAMES, clocks, offsets, segment_docs, strict=True
+                )
+            ],
         )
 
     # -- every field of the records the merge wrote, against its sources ------

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -448,6 +448,69 @@ INJECTIONS = [
         sites=("check_timeline",),
         must_contain=("with the host's wall-clock steps already taken",),
     ),
+    # `stitch()` takes the parts and their beat logs away with it, so a
+    # measurement that only ever reached a `<segment>.seg.timeline.json` is one
+    # no consumer of `demo.mp4` will ever read (issue #225). These three break
+    # the *merge* and are caught on any host, stepping clock or not: what they
+    # remove is the record's structure, not its values.
+    Injection(
+        name="the stitched demo carries no merged clock at all",
+        module="stitching.py",
+        old='        "capture_clock": _merge_capture_clock(docs, records),',
+        new='        "capture_clock_unmerged": _merge_capture_clock(docs, records),',
+        arm="--segments-only",
+        sites=("check_merged_capture_clock",),
+        must_contain=("has no merged `capture_clock` ",),
+    ),
+    Injection(
+        # Every capture starting at zero, which is what a single take's record
+        # says — so a reader hands the first segment's steps to the second
+        # segment's beats and over-corrects every one of them by a whole step.
+        name="the merged clock puts every capture boundary at the start of the demo",
+        module="stitching.py",
+        old='        "boundaries": [record["offset"] for record in records],',
+        new='        "boundaries": [0.0 for record in records],',
+        arm="--segments-only",
+        sites=("check_merged_capture_clock",),
+        must_contain=("tell a reader which steps apply to which beats",),
+    ),
+    Injection(
+        # A step belonging to nobody. A step outlives the video its capture
+        # produced, so its timestamp cannot be the attribution — the segment
+        # is, and a reader handed one without a segment cannot place it.
+        #
+        # A step is *added* rather than an existing one stripped of its
+        # segment, and that is the difference between an entry that grades
+        # something and one that grades the box: this arm records ~30 s and
+        # the host's wall clock steps once every 32 s, so stripping the
+        # attribution off the merged steps is a no-op on the runs where there
+        # are none. It was written that way first and the arm passed against
+        # it — the catalogue's environment-agreeing assertion, caught by this
+        # manifest rather than by a reviewer. Its delta is 0.0 so the record
+        # still totals its own steps: exactly one fault, and the failure that
+        # must fire is the attribution one.
+        name="the merged clock carries a step belonging to no capture",
+        module="stitching.py",
+        old='        "steps": steps,',
+        new='        "steps": steps + [{"t": 1.0, "delta": 0.0, "segment": None}],',
+        arm="--segments-only",
+        sites=("check_merged_capture_clock",),
+        must_contain=("name no capture of this demo",),
+    ),
+    Injection(
+        # The merged record goes null the moment one part is missing its own,
+        # and this is what is left to read when it does — per part, on that
+        # part's own clock. Graded against the segment's log as it was on disk
+        # before the merge, so a record that arrives empty or belonging to the
+        # other part fails the same way.
+        name="a part's own clock never reaches the merged segment records",
+        module="stitching.py",
+        old='                "capture_clock": doc.get("capture_clock"),',
+        new='                "capture_clock": None,',
+        arm="--segments-only",
+        sites=("check_merged_capture_clock",),
+        must_contain=("is left to read when the merged one goes null",),
+    ),
     # -- the beat log and the review sheet (issues #8/#22), 29 s an entry ------
     #
     # `check_timeline` and `check_beat_frames` grade *a* take, not specifically

--- a/tests/unit
+++ b/tests/unit
@@ -98,6 +98,7 @@ from demo_recording.narration import (  # noqa: E402
     TTS_KEY_SEP,
     _tts_key,
 )
+from demo_recording.stitching import _merged_timeline  # noqa: E402
 from demo_recording.timeline import (  # noqa: E402
     ISSUE_KINDS,
     MAX_ISSUES,
@@ -4285,6 +4286,172 @@ class CaptureClock(unittest.TestCase):
         self.assertEqual(doc["capture_clock"]["total"], 0.0)
 
 
+def merged_of(clocks: list[object], durations: list[float]) -> dict:
+    """A two-part merged timeline whose parts carry `clocks` as their records.
+
+    `_merged_timeline` reads the parts off disk nowhere — it is handed their
+    documents and their measured durations — so a stitched envelope can be
+    built here with no ffmpeg, no browser and no recording, which is what
+    makes the arithmetic below gradeable on a box whose clock never steps.
+    """
+    names = [f"part{n + 1}" for n in range(len(clocks))]
+    docs = [
+        {
+            "recorder": "Recorder",
+            "segment": name,
+            "beats": [
+                {
+                    "index": n,
+                    "segment": name,
+                    "verb": "caption",
+                    "t_start": t,
+                    "t_end": t + 0.1,
+                }
+                for n, t in enumerate((0.5, 2.0))
+            ],
+            "capture_clock": clock,
+        }
+        for name, clock in zip(names, clocks, strict=True)
+    ]
+    return _merged_timeline(
+        names,
+        [Path(f"{name}.seg.mp4") for name in names],
+        docs,
+        durations,
+        # Never created: `_merged_timeline` probes it only to fill `duration`,
+        # and falls back to null when it is not there.
+        Path("demo.mp4"),
+    )
+
+
+def reader_correction(doc: dict, beat: dict) -> float:
+    """What a consumer of a stitched timeline corrects one beat by.
+
+    **Hand-written from the envelope's documentation in `timeline.py`**, not
+    imported from `stitching.py`: a reader built out of the merge's own code
+    would agree with that code whatever it said. The documented rule is the
+    steps of *this beat's own capture*, up to this beat — and nothing else.
+    """
+    record = doc.get("capture_clock") or {}
+    return sum(
+        step["delta"]
+        for step in record.get("steps") or []
+        if step.get("segment") == beat.get("segment") and step["t"] <= beat["t_start"]
+    )
+
+
+class MergedCaptureClock(unittest.TestCase):
+    """What a stitched demo carries about the clock its video is on (#225).
+
+    `stitch()` removes the parts and their beat logs, so whatever is not in
+    the merged envelope is gone. Before this the field was one of those: the
+    merged document had a beat log on the monotonic clock, a video on the
+    host's wall clock, and nothing to reconcile them with.
+
+    Every case below is driven by a **scripted** record rather than a measured
+    one, for the reason `CaptureClock` gives: a box either steps its clock or
+    it does not, and an assertion that only bites on the ones that do grades
+    the box. `tests/smoke --segments-only` is where the merged record is
+    graded against a real measurement.
+    """
+
+    def clock(self, *steps: tuple[float, float], interval: float = 0.02) -> dict:
+        """One part's own record: (seconds into that part, size of the step)."""
+        return {
+            "steps": [{"t": t, "delta": delta} for t, delta in steps],
+            "total": round(sum(delta for _, delta in steps), 4),
+            "sample_interval": interval,
+            "min_step": 0.005,
+        }
+
+    def test_each_parts_steps_are_moved_onto_the_stitched_clock(self):
+        doc = merged_of([self.clock((1.5, -0.78)), self.clock((2.0, -0.8))], [7.5, 6.0])
+        self.assertEqual(
+            [(s["t"], s["delta"]) for s in doc["capture_clock"]["steps"]],
+            [(1.5, -0.78), (9.5, -0.8)],
+        )
+
+    def test_every_step_names_the_capture_that_measured_it(self):
+        doc = merged_of([self.clock((1.5, -0.78)), self.clock((2.0, -0.8))], [7.5, 6.0])
+        self.assertEqual(
+            [s["segment"] for s in doc["capture_clock"]["steps"]], ["part1", "part2"]
+        )
+
+    def test_the_boundaries_are_where_each_capture_starts(self):
+        doc = merged_of([self.clock(), self.clock()], [7.5, 6.0])
+        self.assertEqual(doc["capture_clock"]["boundaries"], [0.0, 7.5])
+
+    def test_a_step_in_an_earlier_part_does_not_correct_a_later_parts_beats(self):
+        """The one that matters, and the one that is easy to get wrong.
+
+        Each capture's first frame restarts its clock, and the merge already
+        lays the parts out by their measured durations — so part one losing
+        0.78 s of wall time is *already* in part two's offset. A reader that
+        applied it again would put every beat of part two 0.78 s from its
+        frame, which is worse than not correcting at all.
+        """
+        doc = merged_of([self.clock((1.5, -0.78)), self.clock()], [7.5, 6.0])
+        by_segment = {b["segment"]: b for b in doc["beats"] if b["t_start"] > 1.6}
+        self.assertAlmostEqual(
+            reader_correction(doc, by_segment["part1"]), -0.78, places=4
+        )
+        self.assertAlmostEqual(reader_correction(doc, by_segment["part2"]), 0.0)
+
+    def test_a_beat_before_its_own_parts_step_is_not_corrected_by_it(self):
+        # The other direction of the same rule: a step at 1.5 s into part two
+        # moved the frames after it, not the ones before it.
+        doc = merged_of([self.clock(), self.clock((1.5, -0.78))], [7.5, 6.0])
+        early, late = (b for b in doc["beats"] if b["segment"] == "part2")
+        self.assertAlmostEqual(reader_correction(doc, early), 0.0)
+        self.assertAlmostEqual(reader_correction(doc, late), -0.78, places=4)
+
+    def test_a_step_sampled_after_its_parts_last_frame_stays_with_that_part(self):
+        """Why the attribution is `segment` and not the timestamp.
+
+        A capture that loses 0.8 s of wall time produces a video shorter than
+        the time it ran, so a step sampled near the end of part one lands, on
+        the stitched clock, *past* where part two starts. Handing it to part
+        two on that basis would correct beats it never touched.
+        """
+        doc = merged_of([self.clock((8.0, -0.8)), self.clock()], [7.5, 6.0])
+        step = doc["capture_clock"]["steps"][0]
+        self.assertEqual(step["segment"], "part1")
+        self.assertGreater(step["t"], doc["capture_clock"]["boundaries"][1])
+        for beat in (b for b in doc["beats"] if b["segment"] == "part2"):
+            self.assertAlmostEqual(reader_correction(doc, beat), 0.0)
+
+    def test_the_total_is_every_parts_steps_and_totals_the_list_it_ships(self):
+        doc = merged_of([self.clock((1.5, -0.78)), self.clock((2.0, -0.8))], [7.5, 6.0])
+        record = doc["capture_clock"]
+        self.assertAlmostEqual(record["total"], -1.58, places=4)
+        self.assertAlmostEqual(
+            record["total"], sum(s["delta"] for s in record["steps"]), places=4
+        )
+
+    def test_a_part_that_measured_nothing_makes_the_merged_record_null(self):
+        # Not an empty step list. "The clock held still" and "nobody looked"
+        # are different answers, and a merge that returned the first for the
+        # second would understate `total` by whatever that part stepped — in
+        # a file whose entire purpose is correcting timestamps.
+        doc = merged_of([self.clock((1.5, -0.78)), None], [7.5, 6.0])
+        self.assertIsNone(doc["capture_clock"])
+
+    def test_a_part_that_measured_nothing_keeps_its_own_record_in_segments(self):
+        # The merged field going null must not take the parts that *were*
+        # measured with it: the per-segment records are what is left to read.
+        doc = merged_of([self.clock((1.5, -0.78)), None], [7.5, 6.0])
+        self.assertEqual(doc["segments"][0]["capture_clock"]["total"], -0.78)
+        self.assertIsNone(doc["segments"][1]["capture_clock"])
+
+    def test_the_samplers_settings_survive_agreement_and_null_on_a_disagreement(self):
+        # Same rule as `determinism`: a value every part agrees on is that
+        # value, and there is no honest single answer when they differ.
+        same = merged_of([self.clock(), self.clock()], [7.5, 6.0])
+        self.assertEqual(same["capture_clock"]["sample_interval"], 0.02)
+        mixed = merged_of([self.clock(), self.clock(interval=0.05)], [7.5, 6.0])
+        self.assertIsNone(mixed["capture_clock"]["sample_interval"])
+
+
 # --------------------------------------------------------------------------
 # Fault injection
 # --------------------------------------------------------------------------
@@ -4423,6 +4590,67 @@ INJECTIONS = [
         [
             "CaptureClock.test_a_backwards_step_tells_the_author_the_video_is_short",
             "CaptureClock.test_a_forward_step_tells_the_author_the_opposite",
+        ],
+    ),
+    (
+        # The parts are laid out by their measured durations, and their clocks
+        # are not: every step ends up on the first part's clock, so a reader
+        # correcting the last part's beats reaches for steps that are hundreds
+        # of seconds away from them.
+        "the merge leaves each part's steps on that part's own clock",
+        "stitching.py",
+        '            at = _shift(step.get("t"), record["offset"])',
+        '            at = _shift(step.get("t"), 0.0)',
+        [
+            "MergedCaptureClock.test_each_parts_steps_are_moved_onto_the_stitched_clock",
+            "MergedCaptureClock.test_a_beat_before_its_own_parts_step_is_not_corrected_by_it",
+        ],
+    ),
+    (
+        # A merged record whose steps belong to nobody. The field is there,
+        # the total is right, and the one thing a consumer has to know — which
+        # beats this step moved — is gone.
+        "a merged step stops saying which capture measured it",
+        "stitching.py",
+        '                {**step, "t": at, "delta": float(delta), "segment": record["segment"]}',
+        '                {**step, "t": at, "delta": float(delta), "segment": None}',
+        [
+            "MergedCaptureClock.test_every_step_names_the_capture_that_measured_it",
+            "MergedCaptureClock.test_a_step_in_an_earlier_part_does_not_correct_a_later_parts_beats",
+        ],
+    ),
+    (
+        # "Nobody looked" merged as "the clock held still". `total` is then
+        # short by whatever the unmeasured part stepped, and nothing in the
+        # document says so — the artifact-lies shape, in the one field whose
+        # whole job is correcting other fields.
+        "a part that measured no clock is merged as a part whose clock held still",
+        "stitching.py",
+        "        if not isinstance(listed, list):\n            return None",
+        "        if not isinstance(listed, list):\n            listed = []",
+        [
+            "MergedCaptureClock.test_a_part_that_measured_nothing_makes_the_merged_record_null",
+        ],
+    ),
+    (
+        # Every capture starting at zero, which is what the document says when
+        # `stitch()` has not run — so a reader hands part one's steps to part
+        # two's beats and over-corrects them by a whole step.
+        "the merged record puts every capture boundary at the start of the demo",
+        "stitching.py",
+        '        "boundaries": [record["offset"] for record in records],',
+        '        "boundaries": [0.0 for record in records],',
+        ["MergedCaptureClock.test_the_boundaries_are_where_each_capture_starts"],
+    ),
+    (
+        # The merged field going null takes the parts that *were* measured with
+        # it, and a stitched demo that lost one part's clock loses all of them.
+        "a part's own clock stops reaching the merged segment records",
+        "stitching.py",
+        '                "capture_clock": doc.get("capture_clock"),',
+        '                "capture_clock": None,',
+        [
+            "MergedCaptureClock.test_a_part_that_measured_nothing_keeps_its_own_record_in_segments",
         ],
     ),
     (


### PR DESCRIPTION
Closes #225.

## Acceptance criterion

> A stitched `demo.mp4` recorded on a host whose clock stepped during one of
> its parts carries enough in its merged `timeline.json` for a reader to place
> any beat in the video to within the residual `tests/smoke` measures per
> segment, **without reading the parts**. Graded by an entry in
> `tests/smoke-inject` against `--segments-only`.

## What it does

`stitch()` merges `capture_clock` the way it merges `beats`: each part's steps
moved onto the stitched clock by that part's ffprobe offset. Two things make
the result usable, and both are about *which steps apply to which beats*:

- **every step names the `segment` that measured it, and that is the
  attribution to trust.** A step is sampled for as long as its capture runs,
  which is longer than the video that capture produced — losing wall time is
  the whole phenomenon — so a step's merged `t` can legitimately fall past the
  next part's boundary. This is not hypothetical: one of the runs below has a
  -876 ms step at 7.2 s of a part whose video is 6.88 s.
- **`boundaries`** records where each capture starts on the stitched clock.

The correction for a beat is its own segment's steps up to its `t_start` —
never `total`, and never an earlier part's, whose lost wall time is already in
the offset `stitch()` laid it out by. Applying it twice over-corrects by a
whole step.

The merged record is **null** unless every part carries a usable one; each
`segments` record also keeps its own part's record untouched, so a null at the
top does not take the parts that *were* measured with it.

`timeline.py`'s envelope documentation gains `capture_clock` (it was documented
only where `core.py` builds it), and `reference/limits.md` gains the
stitched-demo rule.

## What I measured

Verdict lines, in full:

| suite | verdict |
|---|---|
| `./tests/unit` | `Ran 187 tests in 0.485s` -> **OK** |
| `./tests/unit --fault-inject` | **All 113 injections were caught.** |
| `./tests/ci-unit` | `Ran 49 tests in 0.129s` -> **OK** |
| `./tests/lint` | **All checks passed!** / 14 files already formatted |
| `ruff format --check .` + `ruff check .` (repo root) | 14 files already formatted / All checks passed! |
| `./tests/unit --budget` | `SKILL.md: 600 lines (~14,114 tokens), budget 600 lines` — unchanged |
| `./tests/smoke --segments-only` | **smoke: PASSED** |
| `./tests/smoke-inject --self-test` | **Every guard refused what it exists to refuse.** |
| `./tests/smoke-inject --only merged` | **All 4 injections were caught** (3 first pass, 1 after the fix below) |

The clean `--segments-only` run that matters is the one where the host's clock
actually stepped **inside a capture**:

```
smoke: segments/part1 capture_clock agrees with the harness (the host's wall clock did not step during this take)
smoke: segments/part2 capture_clock agrees with the harness (the host's wall clock stepped -858 ms at 6.1s)
smoke: segments part1's probe caption is +0 ms from where its own segment puts it (-100 ms in part1.seg.mp4, -100 ms in demo.mp4)
smoke: segments part2's probe caption is +0 ms from where its own segment puts it (-60 ms in part2.seg.mp4, -60 ms in demo.mp4)
smoke: segments the stitched timeline.json places every beat on its own capture's clock (1 step(s) merged, boundaries [0.0, 6.6])
smoke: segments first caption 'One demo, in two parts.' logged at 3.00s, on screen at 2.90s (-100 ms)
smoke: segments closing caption 'Recorded end to end.' logged at 11.23s, on screen at 11.17s (-60 ms)
smoke: PASSED
```

`check_merge_offset` is where the acceptance criterion is measured in pixels,
and its stitched-demo reading is now corrected **from the merged
`timeline.json` alone** while its per-segment reading keeps this harness's own
independent measurement. The `+0 ms` differential on both segments, with a
real -858 ms step in part2, is a reader placing every beat from the artifact
and landing where the harness does.

## The harness had the bug it was the reference for

The first clean run went red, and not on anything new:

```
smoke: FAILED
  - segments: the closing caption could not be timed against demo.mp4 — the caption band did not
    move in the 2.3s around 10.70s (0.60 mean luma, under the 6.0 floor), but the band does change
    at 8.54s — -2160 ms away, outside the 1.5s search window. [...] The window is already centred on
    where the host's measured wall-clock steps put this beat in the video, so this slide is
    something else — see issues #18 and #215.
```

`joined_clock()` carried every part's steps onto the merged clock, **including
the ones its watcher sampled after that part's last frame** — the encode, the
conversion and the timeline write all run inside the `with`. That run's step
was `-876 ms at 7.2s` in a part whose video is `6.88 s`, so on the joined clock
it sat past the next part's boundary, and `before()` — which keys on time —
handed it to that part's beats. The closing caption's search window went 876 ms
off the frame.

The tell is that the *same caption in the same file* timed to `-20 ms` through
`check_merge_offset`, which corrects from the merged `timeline.json`, where the
recorder had already stopped sampling and the merge attributes per capture. The
artifact was right and the harness was wrong. `joined_clock()` now drops a step
that lands past its own part's video; each part's own clock is untouched, and
`--segments-only` has been green on every run since (three, one with a step
inside a capture).

## Injection failure output

### `tests/unit --fault-inject` (5 new entries, `stitching.py`)

```
PASS  break: the merge leaves each part's steps on that part's own clock
      in stitching.py: at = _shift(step.get("t"), record["offset"])...
      FAIL: test_a_beat_before_its_own_parts_step_is_not_corrected_by_it (MergedCaptureClock)
      FAIL: test_each_parts_steps_are_moved_onto_the_stitched_clock (MergedCaptureClock)

PASS  break: a merged step stops saying which capture measured it
      in stitching.py: {**step, "t": at, "delta": float(delta), "segment": record["segment"...
      FAIL: test_a_beat_before_its_own_parts_step_is_not_corrected_by_it (MergedCaptureClock)
      FAIL: test_a_step_in_an_earlier_part_does_not_correct_a_later_parts_beats (MergedCaptureClock)
      FAIL: test_a_step_sampled_after_its_parts_last_frame_stays_with_that_part (MergedCaptureClock)
      FAIL: test_every_step_names_the_capture_that_measured_it (MergedCaptureClock)

PASS  break: a part that measured no clock is merged as a part whose clock held still
      in stitching.py: if not isinstance(listed, list):...
      FAIL: test_a_part_that_measured_nothing_makes_the_merged_record_null (MergedCaptureClock)

PASS  break: the merged record puts every capture boundary at the start of the demo
      in stitching.py: "boundaries": [record["offset"] for record in records],...
      FAIL: test_the_boundaries_are_where_each_capture_starts (MergedCaptureClock)

PASS  break: a part's own clock stops reaching the merged segment records
      in stitching.py: "capture_clock": doc.get("capture_clock"),...
      ERROR: test_a_part_that_measured_nothing_keeps_its_own_record_in_segments (MergedCaptureClock)
```

### `tests/smoke-inject --only merged` (4 new entries, `--segments-only`)

```
BASE  --segments-only passes clean (31s)

PASS  break: the stitched demo carries no merged clock at all  [31s]
      --segments-only, in stitching.py: "capture_clock": _merge_capture_clock(docs, records),...
      caught: segments: the stitched timeline.json has no merged `capture_clock` record (None).
              stitch() takes the parts and their beat logs away with it, so what is left is a beat
              log on the monotonic clock, a video on the host's wall clock, and nothing to
              reconcile them with (issues #18, #215, #225)

PASS  break: the merged clock puts every capture boundary at the start of the demo  [32s]
      --segments-only, in stitching.py: "boundaries": [record["offset"] for record in records],...
      caught: segments: the merged capture_clock says its captures start at [0.0, 0.0]; ffprobe
              puts them at [0.0, 6.64]. Those are what tell a reader which steps apply to which
              beats, and a merged record whose captures all start at zero hands the first
              segment's steps to the second segment's beats [...]

PASS  break: the merged clock carries a step belonging to no capture  [31s]
      --segments-only, in stitching.py: "steps": steps,...
      caught: segments: 1 of 2 merged capture_clock step(s) name no capture of this demo
              ([{'t': 1.0, 'delta': 0.0, 'segment': None}]; the parts are ['part1', 'part2']) [...]

PASS  break: a part's own clock never reaches the merged segment records  [33s]
      --segments-only, in stitching.py: "capture_clock": doc.get("capture_clock"),...
      caught: segments: the merged `segments` record for part1 carries capture_clock None, but
              part1.seg.timeline.json measured {'steps': [], 'total': 0, 'sample_interval': 0.02,
              'min_step': 0.005} [...]
```

### One injection did not fire, and that is in the diff

The third entry was first written as *strip the `segment` off every merged
step*. It is a no-op on a run where the clock never stepped, and the arm passed
against it:

```
FAIL  break: a merged clock step stops saying which capture measured it  [33s]
      --segments-only, in stitching.py: {**step, "t": at, "delta": float(delta), "segment": record["segm...
      the arm passed against a broken recorder
      the 0 failure(s) the arm did report:
      | (none — stderr tail) [...]
```

That is the catalogue's *environment-agreeing assertion*, caught by the
manifest rather than by a reviewer. The entry now **adds** a step nobody
measured, with `delta: 0.0` so the record still totals its own steps — one
fault, on any host — and is caught (above). The episode is written into
`tests/README.md`.

## Stated limits

- **On a host whose wall clock never steps, the per-beat agreement in
  `check_merged_capture_clock` compares nothing to nothing.** Every step list is
  empty and only the structural half bites: the field exists, totals its own
  steps, names its captures, and puts their boundaries where ffprobe puts them.
  That is why the merge's *arithmetic* — offsets, per-capture attribution, and
  the rule that an earlier part's step must not correct a later part's beats —
  is graded on a **scripted** clock by `MergedCaptureClock` in `tests/unit`,
  where five injections cost 0.2 s each. Recorded in `tests/README.md`.
- **One beat is ungraded per step.** A beat starting within
  `MAX_CLOCK_STEP_TIME_DISAGREEMENT_S` of a step is skipped and counted in the
  arm's output: two samplers on their own 20 ms grids do not both know which
  side of that beat the step fell on. Skipped rather than absorbed — a bar as
  wide as a step grades nothing. The count is printed.
- **Nothing in the recorder applies the correction yet.** `write_beat_frames`
  still cuts every review frame on the raw beat log, and `timeline.md` never
  mentions `capture_clock` at all — so the sheet a reviewer actually reads is
  cut ~20 frames early on a stepped host. Filed as #229 with its acceptance
  criterion; out of scope here, which is the artifact carrying the number.
- **#224 is untouched** — the terminal arm's extra ~1 s of loss is a different
  quantity and not a merge question, as the issue says.
- **The merged `total` is the sum across the whole session and is not a
  correction for any beat.** It is documented that way in `timeline.py` and is
  there because a non-zero total is what tells a reader to look at `steps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
