### PR TITLE
Correct the record: the timeline gap #110 and #206 propose does not discriminate the flash

### DIFF
--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -128,13 +128,22 @@ _TERM_BG = "linear-gradient(135deg, #f6d5f0 0%, #d7e3fb 52%, #cdeede 100%)"
 # -- opening on a card (issue #110) ------------------------------------------
 #
 # A terminal segment that opens with `interlude()` shows a flash of bare
-# terminal first, and the gap is structural rather than a pacing mistake:
+# terminal first, and it is structural rather than a pacing mistake:
 # `__enter__` starts Chromium's screencast when it creates the page, and a
 # storyboard cannot paint anything before its own first statement. Measured on
-# the reference demo: the segment's first frame at 37.76 s, the card at
-# 38.05 s, and an empty window with a lone prompt in between. The web recorder
-# does not show it only because it has nothing on screen until `goto()` — there
-# is no "before" to flash.
+# the reference demo: six frames — ~0.30 s — of an empty window with a lone
+# prompt at the head of part2. The web recorder does not show it only because
+# it has nothing on screen until `goto()` — there is no "before" to flash.
+#
+# Measured in *frames*, and not in the timeline, which is where #110 first
+# wrote it down (part2's offset at 37.76 s against the interlude beat at
+# 38.05 s). That gap is this recorder's own setup cost — `_t0` is set before
+# `_start()`, which goes to about:blank, injects xterm.js, opens the PTY and
+# waits for the first prompt before `_open_on_card` runs — so it survives the
+# fix: 0.358 s before and 0.365 s after, on the same storyboard one line
+# apart, while the first part2 frame went 226.5 (bare) to 25.8 (card). See
+# issue #207. A beat's timestamp says when the card was *logged*; only the
+# pixels say when it was up.
 #
 # So the card stops being something a storyboard has to remember to do first
 # and becomes a property of the recorder: `TerminalRecorder(interlude="…")`

--- a/tests/README.md
+++ b/tests/README.md
@@ -1204,6 +1204,34 @@ The recorder has no fade-in path (the element is appended already opaque, so no
 transition can run), but the suite is relying on setup cost for that and would
 not notice if it changed.
 
+**The corner is the discriminator; the timeline gap is not, and it was written
+down twice as though it were.** [#110](https://github.com/rogvid/skills/issues/110)
+measured the flash as part2's offset against the interlude beat's timestamp
+(37.76 s against 38.05 s), and
+[#206](https://github.com/rogvid/skills/issues/206) restated that gap as the
+measurement that would let the fix be graded without watching — *"the gap
+should be absent rather than merely smaller"*. It is neither.
+[#207](https://github.com/rogvid/skills/issues/207) measured both takes of the
+same storyboard, one line apart, on one box:
+
+| | before the fix | after |
+|---|---:|---:|
+| timeline gap | 0.358 s | 0.365 s |
+| corner luma, first part2 frame | 226.5 (bare) | 25.8 (card) |
+| bare-terminal frames before the card | 6 (0.30 s) | 0 |
+
+The defect is gone and the gap moved **+7 ms the wrong way**, so the proposed
+check would have reported the fixed take as marginally worse. The gap is
+`TerminalRecorder`'s setup cost, not the flash: `_t0` is set before `_start()`,
+which goes to `about:blank`, injects xterm.js, opens the PTY and waits for the
+first prompt before it raises the card, so the first beat lands ~0.36 s into
+the segment either way. A beat's timestamp says when the card was *logged*;
+only the pixels say when it was up. The corner sweep discriminates it 226 → 26
+at the boundary frame, across four re-records including one under load. This is
+recorded here because nothing asserts on that gap today, and a number written
+into two closed issues as *the* check is the kind that becomes an assertion
+later — one that would look green forever.
+
 ### What a web take opens on (issue #119)
 
 The third defect in this file found by a human watching, and the most plausible-
@@ -1842,6 +1870,32 @@ knows is missing is worse than one that is openly absent.
   cursor. `check_parked_pointer` cannot catch it — the determinism storyboard
   parks after `Recorder.goto()`, which waits for `load`. Tracked with its
   measurement in [#230](https://github.com/rogvid/skills/issues/230).
+
+- **Nothing grades the opening frame of a demo anybody ships.**
+  `check_opening_card` sweeps the corner of `terminal-opening/`, a take this
+  suite records itself, so what passes is a claim about the *recorder*.
+  `examples/ticket-queue/demos/2026-07-26-status-filter` — the take
+  [#110](https://github.com/rogvid/skills/issues/110) and
+  [#206](https://github.com/rogvid/skills/issues/206) were reported against —
+  is graded by a person watching, and always has been: demo directories commit
+  `record.py`, `timeline.json`, `timeline.md` and `images/` but never
+  `demo.mp4` or its `.seg.mp4` parts, so no committed artifact carries the
+  first frame of part2. Three human sightings of the same flash is what that
+  costs. **The timeline gap does not stand in for it** — see the
+  `terminal-opening/` section above, and
+  [#207](https://github.com/rogvid/skills/issues/207) for the two takes it was
+  measured on. What would close it is the same corner strip read off the live
+  `#__term_win` box at *record* time, on the segment's own first frame, written
+  into the take's report where a reviewer reads a number instead of squinting
+  — card `<= 60` mean luma, bare `>= 150`, the constants `check_opening_card`
+  already uses. That is
+  [#235](https://github.com/rogvid/skills/issues/235). Separately, the sweep
+  itself has no `tests/smoke-inject` entry — it is in the ungraded roster
+  above, it was fault-injected by hand when it was written, and since
+  [#61](https://github.com/rogvid/skills/issues/61) the per-push
+  `--polish-only` run is its only exercise in the repo (see **Why the four
+  middle arms stayed on the push**, which is the measurement that kept it
+  there).
 
 - **Nothing calls the ElevenLabs API.** The narration take grades everything a
   cache hit reaches — the key, the pacing, the mix — and by construction never

--- a/tests/smoke
+++ b/tests/smoke
@@ -1286,14 +1286,30 @@ MIN_SPOTLIGHT_CLEAR_S = 0.45
 #
 # `TerminalRecorder.__enter__` starts capturing before a storyboard can paint
 # anything, so a segment whose first statement was `interlude()` opened on
-# ~290 ms of empty terminal — measured on the reference demo, part2 starting at
-# 37.76 s and the card painting at 38.05 s. `TerminalRecorder(interlude="…")`
-# raises the card from an init script instead, before the page has a frame.
+# ~0.30 s of empty terminal — six frames of it at the head of the reference
+# demo's part2. `TerminalRecorder(interlude="…")` raises the card from an init
+# script instead, before the page has a frame.
 #
-# Graded on frames, because the acceptance criterion is about frames: *no
-# bare-terminal frames before the card*. A timestamp comparison is a proxy for
-# that and would still pass on a card that was painted on time and drawn
-# transparent.
+# **The timeline gap is not that measurement, and does not discriminate it.**
+# #110 wrote the defect down as part2's offset against the interlude beat's
+# timestamp (37.76 s against 38.05 s), and #206 restated that gap as the way
+# to grade the fix without watching. Measured on one box, same storyboard, one
+# line apart, before and after the fix
+# ([#207](https://github.com/rogvid/skills/issues/207)): the gap read 0.358 s
+# before and 0.365 s after, while the first part2 frame went 226.5 (bare) to
+# 25.8 (card) and the six bare frames went to none. The gap is
+# `TerminalRecorder`'s setup cost — `_t0` is set before `_start()`, which goes
+# to about:blank, injects xterm.js, opens the PTY and waits for the first
+# prompt before `_open_on_card` runs — so the first beat lands ~0.36 s into
+# the segment either way, and the proposed check would have graded the fixed
+# take as marginally worse. What the fix changed is that all of that now
+# happens *behind* an opaque card: the pixels, not the clock.
+#
+# So this is graded on frames, because the acceptance criterion is about
+# frames: *no bare-terminal frames before the card*. A timestamp comparison is
+# blind in both directions — it passes on a card painted on time and drawn
+# transparent, and it says nothing about a card painted late, because a beat's
+# timestamp is when the recorder logged the card, not when a viewer saw it.
 #
 # The discriminator is one corner of the frame, outside the terminal window:
 #


### PR DESCRIPTION
Fixes #207.

#110 measured the bare-terminal flash as a **timeline gap** — part2's offset
against the interlude beat's timestamp — and #206 restated that gap as the
measurement that would let the fix be graded without watching: *"the gap should
be absent rather than merely smaller."* It never measured the flash.

Per #207, on one box, same storyboard, one line apart, before and after the fix:

| | before | after |
|---|---:|---:|
| timeline gap | 0.358 s | 0.365 s |
| corner luma, first part2 frame | 226.5 (bare) | 25.8 (card) |
| bare-terminal frames before the card | 6 (0.30 s) | 0 |

The defect is gone and the proposed measurement moved **+7 ms the wrong way** —
it would have reported the fixed take as marginally worse. The gap is
`TerminalRecorder`'s setup cost, not the flash: `_t0` is set before `_start()`,
which goes to `about:blank`, injects xterm.js, opens the PTY and waits for the
first prompt before `_open_on_card()` runs, so the first beat lands ~0.36 s into
the segment either way. What the fix changed is that all of that now happens
*behind* an opaque card — the pixels, not the clock.

**Every number above is #207's, measured there, not re-measured here.** No take
was recorded for this change.

## Why bother when nothing asserts on it

Nothing is broken today. The number is written into two closed issues as *the*
way to check #110 without watching, and that is exactly the kind of number
somebody turns into an assertion six months later — at which point the suite
gains a check that grades nothing and looks green forever. This is the
`wip/verified-review` catalogue's **check that shares the bug's blind spot**,
caught before it was written.

## Where the claim was repeated, and what happened to each

| where | what it said | done |
|---|---|---|
| **#110** (closed) | its "Measured" section: 37.76 s / 38.05 s *is* the ~290 ms | comment on the issue |
| **#206** (closed) | "the gap should be absent rather than merely smaller" | comment on the issue |
| `tests/smoke`, above `check_opening_card`'s constants | got it half right — "a timestamp comparison is a proxy … would still pass on a card painted on time and drawn transparent" — but still presented 37.76/38.05 as the measurement of the flash | corrected: the gap is not a *weaker* proxy, it does not move at all, and it is blind in both directions |
| `skills/demo-video/helpers/demo_recording/terminal.py`, the `issue #110` block | "Measured on the reference demo: the segment's first frame at 37.76 s, the card at 38.05 s" — the two timestamps were the whole of the measurement | corrected to the frame count, with the gap's fate across the fix recorded |
| `tests/README.md`, the `terminal-opening/` section | did not repeat it, but did not record that the gap fails to discriminate either | the before/after table added beside the corner sweep that does |

**Checked and deliberately left alone**, so the search is auditable rather than
implied:

- `skills/demo-video/reference/limits.md:154`, `reference/terminal.md:37` and
  `terminal.py:259` say the storyboard's first statement is "~290 ms too late".
  That is a statement about the defect's visible duration, not a proposal to
  measure it by timestamps, and #207's own frame count (6 frames, 0.30 s)
  corroborates it. `limits.md` is also explicitly out of scope for #207.
- `limits.md` already names the right measurement — corner luma 26 / 226 — for
  the loaded-runner residue (#128), so it needs no correction.
- `docs/` does not exist in this checkout (gitignored *and* absent), so nothing
  there could be read or changed. Stated as a limit, not as a clean result.
- Root `README.md` and `AGENTS.md` do not mention it.

## The Known gap

`check_opening_card` sweeps the corner of `terminal-opening/`, a take
`tests/smoke` records itself — so what passes is a claim about **the recorder**,
not about any demo. The take #110 and #206 were reported against
(`examples/ticket-queue/demos/2026-07-26-status-filter`) is graded by a person
watching, and structurally has to be: demo directories commit `record.py`,
`timeline.json`, `timeline.md` and `images/`, never `demo.mp4` or its
`.seg.mp4` parts, so no committed artifact carries the first frame of part2.
Three human sightings of the same flash is what that has cost.

Written up in **Known gaps** in `tests/README.md`, naming the measurement that
would close it — the same corner strip off the live `#__term_win` box, read at
*record* time on the segment's own first frame, card `<= 60` / bare `>= 150`.
That is now **#235**, which also states the question it leaves open: report,
warn, or refuse (#128 is why that is not obvious — one CI run in nine read 128
and 0.00 s of cover, which is neither state).

Separately noted there: the sweep itself has no `tests/smoke-inject` entry. It
is already in the ungraded roster and was fault-injected by hand when it was
written, so this repeats the roster rather than contradicting it.

## Out of scope, per #207

`reference/limits.md`, `SKILL.md`, `tests/smoke`'s behaviour, and #114's
question of enforcing the constructor argument. Nothing here touches any of
them — the two `tests/smoke` hunks are comment text above the constants, and no
constant, assertion or message moved.

## Verification

No assertion was added or changed, so there is nothing to fault-inject. That is
the honest reading of the authoring rule for a prose change, not a skipped step.
The invariant that keeps it true is checkable rather than asserted: `git diff
origin/main -- '*.py' tests/smoke`, with comment and blank lines filtered out,
is **empty**.

Rebased onto `5beba8a` (this branch was cut at `2e6061b`; #232, #234 and #237
landed in between). Totals are identical to `origin/main`'s own, which is what a
comment-and-prose change should cost. Main's figures were taken by extracting
`5beba8a` standalone with `git archive` and running the suites there, not on
trust:

| | `origin/main` @ `5beba8a` | this branch |
|---|---|---|
| `./tests/unit` | `Ran 193 tests` … `OK` | `Ran 193 tests` … `OK` |
| `./tests/unit --fault-inject` | `All 124 injections were caught.` | `All 124 injections were caught.` |
| `./tests/ci-unit` | `Ran 49 tests` … `OK` | `Ran 49 tests` … `OK` |
| `./tests/unit --budget` | `SKILL.md: 600 lines (~14,114 tokens), budget 600 lines` | unchanged |

```
$ ./tests/lint
lint: ruff 0.16.1, pinned by .github/workflows/ci.yml
All checks passed!
14 files already formatted
docs: 10 python fence(s) parse; 29 fence(s) skipped by language …

$ uvx ruff@0.16.1 format --check .    # CI's scope, from the repo root
14 files already formatted
$ uvx ruff@0.16.1 check .
All checks passed!

$ ./tests/smoke-inject --self-test
Every guard refused what it exists to refuse.
```

`smoke-inject --self-test` was re-run rather than trusted from before the
rebase, and that is not ceremony: it parses `tests/README.md` for the manifest's
figures, both per-arm tables and the ungraded roster, and `readme_ungraded_roster`
matches *any* line shaped `| ``check_…`` | … |` anywhere in the file. Three other
changes have added content to that document since this branch was cut, so the
question is about the merged result, not about this hunk alone. Clean.

And the arm that runs the code the corrected comment describes:

```
$ ./tests/smoke --polish-only
smoke: terminal-opening card covers the first 2.85s (corner 26 -> 226), then clears
smoke: PASSED
```

That is `check_opening_card`'s corner sweep reading the same two constants on the
rebased tree — 26 with the card up, 226 bare — taken *after* #237 restructured
the arm dispatch in that same file.

## The rebase, and how the conflict was resolved

`git rebase --onto origin/main 2e6061b`, not a merge, since this repo
squash-merges. One conflict, in `tests/README.md`, and it was an **insertion
collision**: #232 added two Known-gaps bullets about the cursor overlay at the
same anchor where this branch added its own, and the common parent between them
was empty. Both sides are keeps, so the resolution is both — main's first, so
#232's two bullets stay adjacent to the cursor bullet they continue, then this
branch's.

Read against the other two arrivals rather than assumed compatible:

- **#237 / #233** added a Known-gaps entry naming `check_opening`,
  `check_opening_gap` and `check_verb_classification` as merge-only. Those are
  three *different* functions — `check_opening_card` is reachable from
  `--polish-only`, which #237 deliberately kept on the push. No duplication and
  no displacement.
- #237 also states independently, under *Why the four middle arms stayed on the
  push*, that `check_opening_card` has no injection anywhere and the per-push run
  is its only exercise in the repo. That is the same fact this branch's gap entry
  records, so the entry now **cross-references** it instead of asserting it a
  second time in different words.
- **#234**'s `capture_clock` entries sit elsewhere in the section, untouched.
- #237 edited `tests/smoke`'s arm dispatch (`selects()`, `EXPENSIVE_ARMS`), not
  the comment block above `check_opening_card`'s constants, so that hunk applied
  cleanly — and the `--polish-only` run above is the check that it really did,
  rather than the assumption that it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
