### PR TITLE
Record the cheap arms on every push and the long takes on merge (#61)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,12 @@ name: CI
 on:
   push:
     branches: [main]
+  # `labeled` is here for one job: `smoke-full` below runs the three expensive
+  # arms on a pull request that asks for them by label, and without this event
+  # the label would only take effect on the next commit. The cost is that
+  # labelling a pull request re-runs the cheap jobs too, which is seconds.
   pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
@@ -203,10 +208,40 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # The per-push half of `tests/smoke` (issue #61). `--cheap` is every phase
+  # reachable from an arm other than `--web-only` (123 s), `--content-only`
+  # (148 s) and `--terminal-only` (186 s) — the three that are 74% of a whole
+  # run. It is a *complement* rather than a list, computed in `run_phases`, so a
+  # new cheap arm is on this job automatically; `tests/unit`'s `CheapArm` grades
+  # that and its four assertions are fault-injected in `tests/unit
+  # --fault-inject` above.
+  #
+  # **What this job does not see**, which is the cost of the split and is
+  # written out rather than implied: eight check functions are reachable only
+  # from those three arms, so they grade in `smoke-full` below and not here.
+  # Five have `tests/smoke-inject` entries and are exercised nightly; three —
+  # `check_opening`, `check_opening_gap`, `check_verb_classification` — have no
+  # entry, so between a pull request opening and its merge nothing runs them at
+  # all. That is issue #233, and `tests/README.md` carries it under *Known
+  # gaps*. Reviewers of a green pull request have not seen those three pass.
   smoke:
-    name: smoke (record against the fixture app)
+    name: smoke (cheap arms, every push)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Measured, not derived. Three consecutive `tests/smoke --cheap` runs on a
+    # 16-core developer box, one at a time behind the machine lock and with the
+    # load average read before each: **223.0 s, 221.5 s, 221.9 s** — 222 s, and
+    # a 1.5 s spread. Against the whole suite's measured 427 s that is a 48%
+    # cut. The table, the load averages and run 3's red (a host wall-clock step,
+    # #215/#224, not the selection) are in tests/README.md under "When each take
+    # runs".
+    #
+    # 12 is 222 s at the 1.16x a CI runner has measured against this box on the
+    # injection manifest (~4m18s), plus ~60 s of checkout, uv, ffmpeg and
+    # Chromium install, with about 2x headroom on top. The headroom is for
+    # runner variance, not for growth: an arm added to the cheap set lands here
+    # automatically, so if this job starts approaching the bar the thing to do
+    # is re-measure `--cheap` and update the table, not nudge this number.
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@v4
 
@@ -223,8 +258,8 @@ jobs:
         run: uv run --with playwright playwright install --with-deps chromium
 
       # Writes outside the checkout, at a path the upload step below knows.
-      - name: Record the web and terminal demo takes
-        run: tests/smoke --out-dir "$RUNNER_TEMP/smoke-out"
+      - name: Record every take except the web, content and terminal arms
+        run: tests/smoke --cheap --out-dir "$RUNNER_TEMP/smoke-out"
 
       # Only on failure: a green run's recordings are noise, a red run's are
       # the only way to see what the recorder actually produced.
@@ -233,6 +268,61 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: smoke-recordings
+          path: ${{ runner.temp }}/smoke-out
+          if-no-files-found: warn
+          retention-days: 7
+
+  # The other half: the three expensive arms, on merge to `main` and on a pull
+  # request labelled `smoke-full`.
+  #
+  # **Why the whole suite and not the three arms.** The arm flags are mutually
+  # exclusive, so "web, content and terminal" is three invocations —
+  # 123 + 148 + 186 = 457 s of takes against a measured 427 s for one whole
+  # run, because the arms share takes. A whole run is cheaper *and* is the only
+  # invocation that grades them together, so this job runs `tests/smoke` with
+  # no flag. It re-records the cheap arms; that is the price of the cheaper
+  # option and it is paid once per merge.
+  #
+  # **Why a label and not only a schedule.** A take that runs after the review
+  # is a take that fails after the review, which is the argument #61 was open
+  # against for months. The label is what puts it back in front of the review
+  # for the diffs where it matters — anything in `skills/demo-video/helpers/`
+  # that touches the web or terminal recorders, or `tests/smoke` itself.
+  smoke-full:
+    name: smoke (web, content and terminal takes)
+    # On a pull request only when it is labelled `smoke-full`. A push to `main`
+    # — which is what a merge is — always goes. Same shape as
+    # .github/workflows/smoke-inject.yml's `fault-inject` label.
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'smoke-full')
+    runs-on: ubuntu-latest
+    # The 20 this job inherited from the undivided `smoke`, unchanged: it runs
+    # the same whole suite that number was set for (~7m30s on a runner).
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ffmpeg
+
+      - name: Install Chromium for Playwright
+        run: uv run --with playwright playwright install --with-deps chromium
+
+      - name: Record every take, including the web and terminal demos
+        run: tests/smoke --out-dir "$RUNNER_TEMP/smoke-out"
+
+      - name: Upload recordings for debugging
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-full-recordings
           path: ${{ runner.temp }}/smoke-out
           if-no-files-found: warn
           retention-days: 7

--- a/tests/README.md
+++ b/tests/README.md
@@ -170,6 +170,8 @@ tests/smoke --issues-only         # just the broken page and the failing
                                   #   grades (issue #197)
 tests/smoke --lock-only           # records nothing: what a run the machine
                                   #   lock refuses leaves behind (issue #105)
+tests/smoke --cheap               # every arm except web/content/terminal —
+                                  #   what CI records per push (issue #61)
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -352,6 +354,118 @@ voice would still find every clip. Here a divergence is a cache *miss*, and a
 miss fails the take.
 
 Still ungraded: the HTTP call itself and its retry ladder. See "Known gaps".
+
+## When each take runs — the per-push split (issue #61)
+
+A whole run is **427 s** on this box and three arms are 74% of it:
+`--terminal-only` (186 s), `--content-only` (148 s) and `--web-only` (123 s).
+Since #61, CI does not record those three on every push.
+
+| when | what CI runs | job in `ci.yml` |
+|---|---|---|
+| every pull-request commit, and every push to `main` | `tests/smoke --cheap` | `smoke (cheap arms, every push)` |
+| merge to `main`, or a pull request labelled `smoke-full` | `tests/smoke`, the whole suite | `smoke (web, content and terminal takes)` |
+
+The merge job runs the **whole suite** rather than the three arms, because the
+arm flags are mutually exclusive: three invocations cost 123 + 148 + 186 =
+457 s of takes against a measured 427 s for one whole run, since the arms share
+takes. A whole run is cheaper and is the only invocation that grades them
+together.
+
+### The number the split is justified by
+
+**Measured, not summed**, because summing per-arm figures is what produced
+every wrong number this issue has carried. Three consecutive
+`tests/smoke --cheap` runs on this 16-core box, one at a time behind the
+machine lock, with no other suite running and the 1-minute load average read
+off `/proc/loadavg` immediately before each:
+
+| run | loadavg before | wall clock | verdict |
+|---|---|---|---|
+| 1 | 0.31 | 223.0 s | PASSED |
+| 2 | 1.28 | 221.5 s | PASSED |
+| 3 | 1.25 | 221.9 s | FAILED — see below |
+
+So **~222 s**, spread 1.5 s across the three: a 48% cut against the whole
+suite's 427 s, or about 3.4 minutes off every push once the runner's ~1.1x is
+applied.
+
+Run 3's red is [#215](https://github.com/rogvid/skills/issues/215)/[#224](https://github.com/rogvid/skills/issues/224)
+and not this selection: the host's wall clock stepped **-875 ms at 0.6s inside
+`segments/part2`**, which is the bimodal failure *Known gaps* describes on this
+box, on an arm the whole suite already ran per push before this change. It is
+recorded here rather than re-rolled until green, because the wall-clock reading
+is what this table is for and 221.9 s is a reading. What the split does change
+about that exposure is that `--web-only` and `--terminal-only`, the other two
+arms sensitive to the same host clock, now run on merge instead of per push.
+
+**Why not the arm sums.** Adding up `ARM_SECONDS` for the eleven arms `--cheap`
+covers gives 216 s, which is an upper bound on *separate* invocations rather
+than a reading of this one — the arms share takes, and the fourteen per-arm
+figures sum to 672 s against the measured whole-suite 427 s. The 142 s that
+circulated on #61 before anybody ran this included an arm that was deleted
+before merge ([#210](https://github.com/rogvid/skills/issues/210)) and silently
+dropped five others; it was never a measurement of anything.
+
+### What `--cheap` is, and why it is a complement
+
+`run_phases` guards every phase with `selects(only, arms)`, and `--cheap` takes
+a phase when **any** arm reaching it is not one of the three above. It is not a
+list, deliberately: a list is a second place to forget, and an arm added to
+`run_phases` and not to the list would drop off the per-push run silently.
+`tests/unit`'s `CheapArm` grades the rule against the guards read out of
+`run_phases`' AST, names the four phases `--cheap` skips rather than counting
+them, and refuses a guard that names an arm `main()` does not define — which is
+what stops `--cheap` from being written into a guard by hand. Its four
+assertions have six injections in `tests/unit --fault-inject`, which runs on
+every push.
+
+### What now grades only at merge
+
+Four phases — `run_web`, `run_terminal`, `run_content` and `run_terminal_race`
+— and with them **eight check functions no other phase reaches**:
+
+- `check_content_pair` — content/terminal; 1 `smoke-inject` entry, so nightly
+- `check_content_toured` — content/terminal; 1 entry, so nightly
+- `check_form_pacing` — web; 4 entries, so nightly
+- `_check_scored_region` — content/terminal; covered by the content entries
+- `_check_occlusion` — content/terminal; no entry, and none before this either
+- `check_opening` — web; **no entry**
+- `check_opening_gap` — web; **no entry**
+- `check_verb_classification` — content/terminal; **no entry**
+
+The last three are the real cost of the split and are written up under *Known
+gaps*: no injection and no per-push take means nothing exercises them between a
+pull request opening and its merge, and `check_verb_classification` is the
+guard that caught `clear`/`press` going unclassified in #130.
+[#233](https://github.com/rogvid/skills/issues/233) is the entries that would
+close it.
+
+### Why the four middle arms stayed on the push
+
+`--polish-only` (26 s), `--segments-only` (29 s), `--overlay-only` (31 s) and
+`--failure-only` (48 s) are the arms the decision did not name, and the
+argument for keeping them is cost per check function moved. Dropping one from
+`--cheap` moves this much to merge-only:
+
+| arm | seconds | check functions it would move | seconds per check moved |
+|---|---|---|---|
+| segments | 29 | 11 | 2.6 |
+| polish | 26 | 2 | 13 |
+| overlay | 31 | 1 | 31 |
+| failure | 48 | 1 | 48 |
+| the three expensive arms | 457 | 8 | 57 |
+
+Every one of the four buys check coverage more cheaply than the arms the
+decision *did* move, so a second cut inside the cheap tier would be a worse
+trade than the first one, made on no measurement. Two specifics on top of the
+ratio: `--polish-only`'s two functions (`check_opening_card`,
+`check_spotlight_transitions`) have no injection anywhere, so the per-push run
+is their only exercise in the repo; and `--failure-only` is the only thing that
+runs the recorder's exception paths, which is where the catalogue's
+*clean-path-only assertion* lives. `--failure-only` is nonetheless the one to
+revisit first if the per-push budget ever binds — it is 22% of `--cheap` for
+one check function.
 
 ## What it asserts
 
@@ -1586,11 +1700,11 @@ paragraph whose job is to say what this manifest does not cover.
   | `check_content_healthy` | `ContentRect`, same six tests: the trim reaches the caption bar on both media, does not eat the app, and never comes back zero-sized |
   | `check_caption` | genuinely ungraded as a *picture*. `CaptionTruth` grades which caption a beat is stamped with across a navigation (#134), never that the bar was drawn |
   | `check_healthy` | `TakeIssues` — `test_an_app_talking_is_not_an_app_failing` and the HTTP bar graded at 400 rather than inside it are the over-reporting direction, off the browser. That a real page under `strict=True` produces none of them is this suite's |
-  | `check_verb_classification` | `VerbClassification` — every classified verb is one a recorder logs, and every verb a recorder logs is classified, with the set size asserted first so neither holds vacuously |
+  | `check_verb_classification` | `VerbClassification` — every classified verb is one a recorder logs, and every verb a recorder logs is classified, with the set size asserted first so neither holds vacuously. **Merge-only since #61**: the only arms that reach it are `--content-only` and `--terminal-only`, so nothing runs it on a pull request |
   | `check_determinism` | genuinely ungraded. It reads the clock, the locale and the motion setting *out of the page*, which is the whole point of it — a constructor that stored the flag and never wired it up satisfies anything asserted on the Python side |
   | `check_merge_offset` | genuinely ungraded. `MergeContent` grades the merge of the content *report* (#121); the per-segment caption timing this measures against two mp4s has no browser-free half |
-  | `check_opening_gap` | `OpeningWarning` — `held: null` against `held: 0.0`, and the blank floor that keeps the warning readable |
-  | `check_opening` | genuinely ungraded — the first frame of a web take, measured in pixels (#119) |
+  | `check_opening_gap` | `OpeningWarning` — `held: null` against `held: 0.0`, and the blank floor that keeps the warning readable. **Merge-only since #61**: `--web-only` is the only arm that reaches it |
+  | `check_opening` | genuinely ungraded — the first frame of a web take, measured in pixels (#119). **Merge-only since #61**: `--web-only` is the only arm that reaches it, so on a pull request nothing runs it and nothing injects against it |
   | `check_opening_card` | genuinely ungraded — three statements about one sweep of one corner of a frame (#110) |
   | `check_spotlight_transitions` | genuinely ungraded — the shape of the spotlight's exit, sampled frame by frame (#111) |
   | `check_narration_pacing` | genuinely ungraded. `TtsKey` covers the cache key a clip is stored under, not the beat spacing this measures |
@@ -1601,6 +1715,17 @@ paragraph whose job is to say what this manifest does not cover.
   | `_check_stale_frames` | genuinely ungraded. `FailureCleanup` is the same shape for the failure dump, not for `frames/` |
   | `_check_segment_refusal` | genuinely ungraded — an unmerged segment's document, graded against the frames a recorder did not write |
   | `_check_scene_fallback` | genuinely ungraded — measured straight off `demo.mp4`, because no beat in either storyboard is long enough to provoke it |
+
+  **Three rows above are worse off than the rest, and #61 is why.**
+  `check_opening`, `check_opening_gap` and `check_verb_classification` are
+  ungraded by this manifest *and* reachable only from the three arms that no
+  longer run per push, so between a pull request opening and its merge nothing
+  exercises them at all. The others in this table are either reached by an arm
+  `--cheap` still runs or covered by a `tests/unit` class that runs in a
+  second. This is the one real cost of the split, it was measured before the
+  split was made, and closing it means giving those three an entry — see
+  **When each take runs** near the top of this file, and the *Known gaps*
+  entry at the bottom.
 
   What is left in that list is there for cost or for pixels, and the two are
   different problems. #197 took the cost half as far as it goes for now: the
@@ -1982,6 +2107,19 @@ knows is missing is worse than one that is openly absent.
   `DEMO_VIDEO_EVIDENCE=0` env var behind it, are exercised nowhere — every
   take here writes evidence
   ([#48](https://github.com/rogvid/skills/issues/48)).
+- **Three checks are exercised by nothing between a pull request and its
+  merge.** `--cheap` is what CI records per push since
+  [#61](https://github.com/rogvid/skills/issues/61), and `check_opening`,
+  `check_opening_gap` and `check_verb_classification` are reachable only from
+  `--web-only`, `--content-only` and `--terminal-only`, which now run on merge.
+  They also have no `tests/smoke-inject` entry, so nightly injection does not
+  cover them either — the merge run is the whole of their exercise, and a
+  reviewer looking at a green pull request has not seen them pass. Five other
+  check functions moved to merge-only with them; those five do have injections
+  and are exercised nightly. Measured before the split rather than found after
+  it, and tracked in
+  [#233](https://github.com/rogvid/skills/issues/233), which is the entries
+  that would close it.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.

--- a/tests/smoke
+++ b/tests/smoke
@@ -10448,6 +10448,14 @@ def main() -> int:
         "leaves behind, against one that started and failed (issue #105)",
     )
     parser.add_argument(
+        "--cheap",
+        action="store_true",
+        help="record every phase that any arm other than --web-only, "
+        "--content-only and --terminal-only reaches — the per-push selection "
+        "(issue #61). Derived from the guards in run_phases, not listed: a "
+        "phase a new cheap arm reaches is in it automatically.",
+    )
+    parser.add_argument(
         "--allow-concurrent",
         action="store_true",
         help="run even when another suite holds the machine lock. The timing "
@@ -10485,6 +10493,7 @@ def main() -> int:
             ("--strict-only", args.strict_only),
             ("--issues-only", args.issues_only),
             ("--lock-only", args.lock_only),
+            ("--cheap", args.cheap),
         )
         if on
     ]
@@ -10564,6 +10573,39 @@ def open_output(args: argparse.Namespace) -> tuple[Path, bool]:
     return Path(tempfile.mkdtemp(prefix="demo-video-smoke-")), True
 
 
+# The three arms that record the long takes: 123 s, 148 s and 186 s against
+# 1-48 s for everything else, and 74% of a whole run between them. `--cheap` is
+# defined as their complement rather than as a list, because a list is a second
+# place to forget: an arm added to `run_phases` and not to the list would stop
+# running per push and nothing would say so. Here the only way to fall out of
+# `--cheap` is to be reachable from *nothing but* these three, which is the
+# same sentence as "this phase costs two minutes".
+#
+# What that costs is written down rather than implied: eight check functions —
+# `check_opening`, `check_opening_gap`, `check_verb_classification`,
+# `check_content_pair`, `check_content_toured`, `check_form_pacing`,
+# `_check_occlusion` and `_check_scored_region` — are reachable only from these
+# arms, so under `--cheap` they grade on merge and not on push. Three of them
+# have no `tests/smoke-inject` entry either. `tests/README.md` carries the
+# roster; `tests/unit`'s `CheapArm` is what keeps this comment honest.
+EXPENSIVE_ARMS = ("--web-only", "--content-only", "--terminal-only")
+
+
+def selects(only: str | None, arms: tuple[str, ...]) -> bool:
+    """Whether the chosen flag runs a phase the arms in `arms` reach.
+
+    `None` is a whole run and takes everything. `--cheap` takes a phase when
+    *any* arm reaching it is not one of `EXPENSIVE_ARMS` — so a phase only the
+    long takes reach is skipped, and one that a 26 s arm also reaches is not.
+    Every other flag is itself.
+    """
+    if only is None:
+        return True
+    if only == "--cheap":
+        return any(arm not in EXPENSIVE_ARMS for arm in arms)
+    return only in arms
+
+
 def run_phases(only: str | None, out_root: Path) -> list[str]:
     """Every phase the chosen flag selects, in order."""
     failures: list[str] = []
@@ -10571,13 +10613,13 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
     # reads what they say about their own output directory (issue #105). Two
     # seconds, before ten minutes of takes, so a full run's own report about
     # where its recordings are is graded before there are any.
-    if only in (None, "--lock-only"):
+    if selects(only, ("--lock-only",)):
         failures += check_lock_refusal(out_root)
-    if only in (None, "--web-only"):
+    if selects(only, ("--web-only",)):
         failures += run_web(out_root)
-    if only in (None, "--terminal-only"):
+    if selects(only, ("--terminal-only",)):
         failures += run_terminal(out_root)
-    if only in (None, "--segments-only"):
+    if selects(only, ("--segments-only",)):
         failures += run_segments(out_root)
     # After the graded takes, never instead of them: these five record
     # nothing worth looking at, and if a recorder is broken the messages
@@ -10585,24 +10627,24 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
     # How the recording *looks* (issues #110/#111). Reachable from the medium
     # flags as well as from --polish-only, because whoever is changing the
     # spotlight is running --web-only.
-    if only in (None, "--web-only", "--polish-only"):
+    if selects(only, ("--web-only", "--polish-only")):
         failures += run_spotlight(out_root)
-    if only in (None, "--terminal-only", "--polish-only"):
+    if selects(only, ("--terminal-only", "--polish-only")):
         failures += run_terminal_opening(out_root)
     # Whether the recorder notices a recording that shows nothing (issue #97).
     # Reachable from --terminal-only as well as its own flag: it is a terminal
     # take, and the card it leaves up is the terminal recorder's card.
-    if only in (None, "--terminal-only", "--content-only"):
+    if selects(only, ("--terminal-only", "--content-only")):
         failures += run_content(out_root)
     # Clearing a `light` interlude, and noticing one left up (#162/#163). A web
     # take, and reachable from --content-only as well as its own flag: it
     # grades the other half of the same question the pair above does.
-    if only in (None, "--web-only", "--content-only", "--overlay-only"):
+    if selects(only, ("--web-only", "--content-only", "--overlay-only")):
         failures += run_overlay(out_root)
     # Acceptance-criterion coverage (issue #12). Reachable from --web-only as
     # well as its own flag: it is a web take, and whoever is changing the
     # recorder's beat record is running --web-only.
-    if only in (None, "--web-only", "--coverage-only"):
+    if selects(only, ("--web-only", "--coverage-only")):
         failures += run_coverage(out_root)
     # What the recorder saw behind the pixels (`check_issues`). Reachable from
     # --issues-only as well as from the medium flags, and that split is the
@@ -10610,7 +10652,7 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
     # were reachable only from arms costing 123 s and 186 s. An assertion is
     # only as gradeable as its cheapest arm — `--strict-only` is the worked
     # example, and issue #197 is where this one is written down with numbers.
-    if only in (None, "--web-only", "--issues-only"):
+    if selects(only, ("--web-only", "--issues-only")):
         failures += run_web_problems(out_root)
     # The two takes strict=True must refuse. Reachable on their own as well as
     # from the medium flags, because they are the cheapest graded takes in this
@@ -10618,31 +10660,31 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
     # against — and the arm that reaches them otherwise costs 186 s. That
     # matters for `tests/smoke-inject`, where an assertion is only as gradeable
     # as its cheapest arm.
-    if only in (None, "--web-only", "--strict-only"):
+    if selects(only, ("--web-only", "--strict-only")):
         failures += run_strict_web(out_root)
-    if only in (None, "--web-only", "--evidence-only"):
+    if selects(only, ("--web-only", "--evidence-only")):
         failures += run_evidence(out_root)
     # Speech end to end (issue #157). A web take, so it is reachable from
     # --web-only as well as its own flag — whoever changes the narration path
     # is running one of the two.
-    if only in (None, "--web-only", "--narration-only"):
+    if selects(only, ("--web-only", "--narration-only")):
         failures += run_narration(out_root)
-    if only in (None, "--terminal-only", "--issues-only"):
+    if selects(only, ("--terminal-only", "--issues-only")):
         failures += run_terminal_problems(out_root)
     # Not on --issues-only: `run_terminal_race` manufactures its condition with
     # a shell that sleeps before exec'ing, and its assertions are its own —
     # `check_issues` never sees this take.
-    if only in (None, "--terminal-only"):
+    if selects(only, ("--terminal-only",)):
         failures += run_terminal_race(out_root)
-    if only in (None, "--terminal-only", "--strict-only"):
+    if selects(only, ("--terminal-only", "--strict-only")):
         failures += run_strict_terminal(out_root)
-    if only in (None, "--determinism-only"):
+    if selects(only, ("--determinism-only",)):
         failures += run_determinism(out_root)
     # What a take that did *not* finish leaves behind. Last, because every
     # phase above records a take that works, and reading "crash-web wrote no
     # demo.mp4" before "web wrote no demo.mp4" would send somebody to the
     # wrong place.
-    if only in (None, "--failure-only"):
+    if selects(only, ("--failure-only",)):
         failures += run_failure(out_root)
     return failures
 

--- a/tests/unit
+++ b/tests/unit
@@ -2152,6 +2152,184 @@ class SmokeResidue(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# What `tests/smoke --cheap` runs, and what it stops running (issue #61)
+# --------------------------------------------------------------------------
+#
+# `--cheap` is the per-push selection: every phase reachable from an arm other
+# than `--web-only`, `--content-only` and `--terminal-only`. ci.yml runs it on a
+# pull request and the whole suite on merge, so what falls out of `--cheap` is
+# exactly what stops being checked before a review — which makes the selection
+# a thing to grade rather than to trust.
+#
+# It is graded here, off the browser, because the question is a function of
+# `run_phases`' guards and one small predicate, and answering it by running the
+# suite costs the ~7 minutes the split exists to avoid.
+#
+# **Why the expensive three are written out again here.** `tests/smoke` has its
+# own `EXPENSIVE_ARMS`, and importing it would make this agree with whatever
+# that tuple says — including with an arm quietly added to it, which is the
+# cheapest possible way to empty the per-push run. The three names below are
+# hand-written, and a fourth name appearing in the tuple over there is a
+# failure here.
+#
+# **What this does not grade:** that a phase does what its name says, or that
+# the takes pass. It grades *selection*. `tests/smoke` itself is the only thing
+# that can say a take is healthy.
+
+# The phases `--cheap` skips, named rather than counted. Each one is reachable
+# only from the three expensive arms, so each is a take that stops running on a
+# pull request. Editing this set is a decision about what a reviewer no longer
+# sees, and it should be made in an issue and not in a rebase.
+CHEAP_SKIPS = frozenset(
+    {
+        "run_web",  # 123 s
+        "run_terminal",  # 186 s
+        "run_content",  # 148 s, and reachable only from those two
+        "run_terminal_race",  # a terminal take, --terminal-only alone
+    }
+)
+
+# Written here so this suite disagrees with a change to smoke's own tuple.
+CHEAP_EXCLUDES = frozenset({"--web-only", "--content-only", "--terminal-only"})
+
+# Below this, `run_phases` was not read: an extraction that matched nothing
+# makes every "every phase …" below true over an empty set. 18 guards today.
+SMOKE_PHASE_FLOOR = 14
+
+
+def _smoke_module():
+    """`tests/smoke` imported as a module, so `selects` can be called."""
+    import importlib.util
+    from importlib.machinery import SourceFileLoader
+
+    loader = SourceFileLoader("_smoke_under_test", str(SMOKE))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _smoke_guards():
+    """[(arms, phase)] read out of `run_phases`, and the flags argparse defines.
+
+    The extraction is this file's own: it walks the AST rather than asking
+    `tests/smoke` what it runs, so a guard that names an arm nobody can pass is
+    visible here and invisible to the script itself.
+    """
+    import ast
+
+    tree = ast.parse(SMOKE.read_text(encoding="utf-8"))
+    funcs = {n.name: n for n in tree.body if isinstance(n, ast.FunctionDef)}
+    guards = []
+    for node in funcs["run_phases"].body:
+        if not isinstance(node, ast.If):
+            continue
+        call = node.test
+        if not (
+            isinstance(call, ast.Call) and getattr(call.func, "id", "") == "selects"
+        ):
+            continue
+        arms = tuple(e.value for e in call.args[1].elts)
+        for sub in ast.walk(node):
+            if (
+                isinstance(sub, ast.Call)
+                and isinstance(sub.func, ast.Name)
+                and sub.func.id.startswith(("run_", "check_"))
+            ):
+                guards.append((arms, sub.func.id))
+    flags = {
+        node.args[0].value
+        for node in ast.walk(funcs["main"])
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "add_argument"
+        and isinstance(node.args[0], ast.Constant)
+    }
+    return guards, flags
+
+
+class CheapArm(unittest.TestCase):
+    def setUp(self):
+        self.guards, self.flags = _smoke_guards()
+        # The haystack, before anything is claimed about it.
+        self.assertGreaterEqual(
+            len(self.guards),
+            SMOKE_PHASE_FLOOR,
+            f"only {len(self.guards)} guard(s) were read out of run_phases — "
+            f"either the suite shrank or this extraction stopped extracting, "
+            f"and every claim below would hold over what it did not read",
+        )
+        self.smoke = _smoke_module()
+
+    def test_cheap_runs_every_phase_a_non_expensive_arm_reaches(self):
+        """The rule, applied to each guard and compared per phase.
+
+        Per phase and not as a count: "the same number of phases" is satisfied
+        by swapping a 26 s arm for a 186 s one.
+        """
+        wanted = {
+            phase: any(arm not in CHEAP_EXCLUDES for arm in arms)
+            for arms, phase in self.guards
+        }
+        got = {
+            phase: self.smoke.selects("--cheap", arms) for arms, phase in self.guards
+        }
+        self.assertEqual(
+            got,
+            wanted,
+            "--cheap disagrees with 'every phase an arm other than "
+            f"{sorted(CHEAP_EXCLUDES)} reaches' at: "
+            + ", ".join(sorted(k for k in wanted if got[k] != wanted[k])),
+        )
+
+    def test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip(self):
+        """Named, because this is the list of what a reviewer stops seeing."""
+        skipped = {
+            phase
+            for arms, phase in self.guards
+            if not self.smoke.selects("--cheap", arms)
+        }
+        self.assertEqual(
+            skipped,
+            set(CHEAP_SKIPS),
+            f"--cheap skips {sorted(skipped)}; the set this repo decided on in "
+            f"issue #61 is {sorted(CHEAP_SKIPS)}. A phase leaving the per-push "
+            f"run is a decision, not a diff.",
+        )
+
+    def test_every_arm_a_guard_names_is_a_flag_the_script_accepts(self):
+        """A guard naming `--cheap`, or a typo, would be a phase nothing runs.
+
+        `--cheap` is a *selection over* arms, so a guard that names it is the
+        hand-maintained list this design exists to avoid — and it would put a
+        123 s take back on every push while the rule above still passed.
+        """
+        named = {arm for arms, _ in self.guards for arm in arms}
+        self.assertTrue(named, "no guard named any arm")
+        unknown = sorted(named - (self.flags - {"--cheap"}))
+        self.assertEqual(
+            unknown,
+            [],
+            f"run_phases guards name {unknown}, which is not an arm flag "
+            f"main() defines (or is --cheap itself, which selects arms rather "
+            f"than being one)",
+        )
+
+    def test_a_whole_run_still_takes_everything_and_a_named_arm_still_itself(self):
+        """The regression half: `--cheap` must not have changed the old flags."""
+        for arms, phase in self.guards:
+            self.assertTrue(
+                self.smoke.selects(None, arms), f"a whole run skipped {phase}"
+            )
+            for arm in arms:
+                self.assertTrue(self.smoke.selects(arm, arms), f"{arm} skipped {phase}")
+            self.assertFalse(
+                self.smoke.selects("--no-such-arm", arms),
+                f"an arm no guard names still ran {phase}",
+            )
+
+
+# --------------------------------------------------------------------------
 # helpers/assets/ — the vendored files, the manifest, and the loader (issue #54)
 # --------------------------------------------------------------------------
 #
@@ -5240,6 +5418,94 @@ INJECTIONS = [
         '            "## Notes",',
         [
             "TimelineMd.test_every_recorded_problem_is_listed_with_the_beat_it_fired_during"
+        ],
+    ),
+    # -- what `tests/smoke --cheap` selects (issue #61) ---------------------
+    #
+    # Five breaks, because the selection can go wrong in five places that look
+    # nothing like each other: the arm list, one guard, the predicate's cheap
+    # branch, the predicate's named-arm branch, and this file's own extraction.
+    # A take falling off the per-push run is silent by construction — the suite
+    # still passes, faster — so each of these is a change that would otherwise
+    # be noticed only by somebody wondering why a bug reached main.
+    (
+        # The cheapest possible way to empty the per-push run: one name added
+        # to the list of arms `--cheap` excludes. Nothing else moves; every
+        # guard still reads exactly as it did.
+        "an arm is quietly added to smoke's expensive list, and stops running per push",
+        "tests/smoke",
+        'EXPENSIVE_ARMS = ("--web-only", "--content-only", "--terminal-only")',
+        'EXPENSIVE_ARMS = (\n    "--web-only",\n    "--content-only",\n'
+        '    "--terminal-only",\n    "--failure-only",\n)',
+        [
+            "CheapArm.test_cheap_runs_every_phase_a_non_expensive_arm_reaches",
+            "CheapArm.test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip",
+        ],
+    ),
+    (
+        # One phase re-gated behind an expensive arm. The rule still holds —
+        # the guard is consistent with itself — which is why the check that
+        # catches this is the one that names the four phases out loud.
+        "a phase is re-gated behind an expensive arm and leaves the per-push run",
+        "tests/smoke",
+        '    if selects(only, ("--failure-only",)):',
+        '    if selects(only, ("--terminal-only",)):',
+        ["CheapArm.test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip"],
+    ),
+    (
+        # The other direction, and the one a hand-maintained list would invite:
+        # `--cheap` written into a guard, putting a 123 s take back on every
+        # push. The complement rule cannot see it — the guard names an arm the
+        # rule counts as cheap — so the flag check is what has to.
+        "--cheap is hardcoded into a guard, putting a 123 s take back on every push",
+        "tests/smoke",
+        '    if selects(only, ("--web-only",)):',
+        '    if selects(only, ("--web-only", "--cheap")):',
+        [
+            "CheapArm.test_every_arm_a_guard_names_is_a_flag_the_script_accepts",
+            "CheapArm.test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip",
+        ],
+    ),
+    (
+        # The predicate's cheap branch stops selecting and starts agreeing:
+        # `--cheap` becomes a whole run, which passes everything and costs the
+        # seven minutes the split exists to avoid.
+        "--cheap stops selecting and runs everything, at whole-suite cost",
+        "tests/smoke",
+        '    if only == "--cheap":\n        return any(arm not in EXPENSIVE_ARMS for arm in arms)',
+        '    if only == "--cheap":\n        return True',
+        [
+            "CheapArm.test_cheap_runs_every_phase_a_non_expensive_arm_reaches",
+            "CheapArm.test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip",
+        ],
+    ),
+    (
+        # The regression half. `selects()` replaced fourteen `only in (None, …)`
+        # guards, so a bug in its *named-arm* branch would silently change what
+        # every existing `--x-only` flag runs — including the ones
+        # `tests/smoke-inject` aims its entries at, which would then certify an
+        # assertion against a take that never ran.
+        "every named arm starts running every phase, so --x-only stops selecting",
+        "tests/smoke",
+        "    return only in arms\n",
+        "    return True\n",
+        [
+            "CheapArm.test_a_whole_run_still_takes_everything_and_a_named_arm_still_itself"
+        ],
+    ),
+    (
+        # And the control. Every claim above is quantified over the guards this
+        # file reads out of `run_phases`; an extraction that matches nothing
+        # makes all of them true over an empty set, which is the catalogue's
+        # vacuous sweep with a suite-wide blast radius.
+        "the guard extraction matches nothing, so every --cheap claim goes vacuous",
+        "tests/unit",
+        '            isinstance(call, ast.Call) and getattr(call.func, "id", "") == "selects"\n',
+        '            isinstance(call, ast.Call) and getattr(call.func, "id", "") == "selected"\n',
+        [
+            "CheapArm.test_cheap_runs_every_phase_a_non_expensive_arm_reaches",
+            "CheapArm.test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip",
+            "CheapArm.test_every_arm_a_guard_names_is_a_flag_the_script_accepts",
         ],
     ),
 ]


### PR DESCRIPTION
Fixes #61.

## The decision, as given

**Cheap arms on every push; `web`, `content` and `terminal` on merge to `main`
and on a label.** The label is **`smoke-full`** (created with `gh label create
smoke-full`, purple, same shape as the existing `fault-inject` label).

Not relitigated here. What this pull request adds is the selector, the
measurement it is justified by, the CI wiring, and a written record of what the
split costs.

## Acceptance criterion

`tests/smoke --cheap` selects every phase reachable from an arm other than
`--web-only`, `--content-only` and `--terminal-only`; `ci.yml` records it on
every push and the whole suite on merge and on the label; `tests/README.md`
says when each check now grades.

## The measured number

**Measured, not summed.** Three consecutive `tests/smoke --cheap` runs on a
16-core WSL2 developer box, one at a time behind the machine lock, no other
suite running (checked with `ps` — see *Conditions* below), with the 1-minute
load average read off `/proc/loadavg` immediately before and after each:

| run | loadavg before | loadavg after | wall clock | verdict |
|---|---|---|---|---|
| 1 | 0.31 | 1.97 | **223.0 s** | `smoke: PASSED` |
| 2 | 1.28 | 2.37 | **221.5 s** | `smoke: PASSED` |
| 3 | 1.25 | 1.06 | **221.9 s** | `smoke: FAILED` — see below |

**~222 s, spread 1.5 s (0.7%)** against the whole suite's measured 427 s: a
**48% cut**. Runs 2 and 3 started at loadavg ~1.26, which is the decay of the
run before them and not another agent — the loop only starts a run when nothing
matching `tests/smoke` is in `ps` output.

### Conditions, stated because they decide whether the number means anything

Three other agents were working on this box when the task started, two of them
recording takes (`--terminal-only`, then `--web-only`, then a `--determinism-only`
poller). The measurement loop waited for all of them: **the first reading was
taken about 50 minutes after the request**, at loadavg 0.31, which is as idle as
this box gets. Nothing here was measured under contention, and no run used
`--allow-concurrent`.

The loop's first version never fired, and the reason is from the catalogue —
*the self-inflicted condition*. Its idle detector was
`pgrep -af 'tests/smoke' | grep -c '…'`, and the grep's own command line
contains the pattern, so the box counted itself as busy forever. Fixed to `ps
-eo args | grep -E 'tests/smoke( |$)' | grep -cv grep`, which reads 0 on an idle
box.

### Run 3's red, reported rather than re-rolled

```
smoke: FAILED
  - segments/part2: inside the 7.0s the storyboard ran, this harness saw 1
    wall-clock step(s) [the host's wall clock stepped -875 ms at 0.6s] and
    timeline.json records 0 …
  - segments: part2's probe caption could not be timed in its own segment …
  - segments: the closing caption could not be timed against demo.mp4 …
```

This is #215/#224 — the host wall clock stepping inside a take, which
`tests/README.md`'s *Known gaps* already records as bimodal on this box and
which the whole suite was equally exposed to on `--segments-only` before this
change. It is not the selection: this diff touches no assertion, no bar and no
recorder code. It is left in the table because 221.9 s is a wall-clock reading
and re-rolling until green is how a number stops meaning anything.

What the split *does* change about that exposure: `--web-only` and
`--terminal-only`, the other two arms sensitive to the same host clock, move to
merge.

### Why not the arm sums

Summing `ARM_SECONDS` over the eleven arms `--cheap` covers gives 216 s, which
is an upper bound on *separate* invocations and not a reading of this one — the
arms share takes, and the fourteen per-arm figures sum to 672 s against a
measured whole-suite 427 s. The **142 s** once quoted on #61 included
`--pointer-only`, deleted before merge in #210, and silently dropped five other
arms. It was never a measurement; this is the first one.

## The four undecided arms: all four stay on the push

The decision named the three expensive arms and left `polish` (26 s),
`segments` (29 s), `overlay` (31 s) and `failure` (48 s) open. Argued on cost
per check function moved, computed from `tests/smoke`'s AST by resolving
`check_*` calls transitively through each `run_*` and intersecting with each
guard's arms:

| arm | seconds | check functions it would move to merge-only | s per check moved |
|---|---|---|---|
| `--segments-only` | 29 | 11 | 2.6 |
| `--polish-only` | 26 | 2 | 13 |
| `--overlay-only` | 31 | 1 | 31 |
| `--failure-only` | 48 | 1 | 48 |
| the three expensive arms | 457 | 8 | 57 |

Every one of the four buys coverage more cheaply than the arms the decision did
move, so cutting further inside the cheap tier is a strictly worse trade than
the first cut — and it would be made on no measurement, which is what #61 has
been open to avoid.

Two specifics on top of the ratio:

- **`--polish-only`** carries `check_opening_card` and
  `check_spotlight_transitions`, and neither has an injection anywhere. The
  per-push run is their only exercise in the repo; moving it would leave them
  graded by nothing until a merge.
- **`--failure-only`** is the only thing that runs the recorder's exception
  paths — the crash dumps, the stale-media take, the marker cleanup. That is
  exactly the *clean-path-only assertion* entry in the catalogue.

Stated as a limit rather than hidden: **`--failure-only` is 22% of `--cheap`
for one check function**, and it is the first thing to revisit if the per-push
budget ever binds. Written into `tests/README.md` so the next person does not
have to re-derive it.

## The cost of the split, stated

Four phases stop running per push — `run_web`, `run_terminal`, `run_content`,
`run_terminal_race` — and with them **eight check functions no other phase
reaches**:

| check function | reachable only from | `smoke-inject` entry |
|---|---|---|
| `check_content_pair` | content/terminal | yes (1) — nightly |
| `check_content_toured` | content/terminal | yes (1) — nightly |
| `check_form_pacing` | web | yes (4) — nightly |
| `_check_scored_region` | content/terminal | yes — nightly |
| `_check_occlusion` | content/terminal | no, and none before this either |
| `check_opening` | web | **none** |
| `check_opening_gap` | web | **none** |
| `check_verb_classification` | content/terminal | **none** |

The last three are the real cost: no injection and no per-push take means
**nothing exercises them between a pull request opening and its merge**, and
`check_verb_classification` is the guard that caught `clear`/`press` going
unclassified in #130. This was computed before the split was made, not
discovered after it. It is recorded in three places: `tests/README.md`'s *Known
gaps*, the three annotated rows of the ungraded roster, and a comment at
`EXPENSIVE_ARMS` in `tests/smoke`. Follow-up filed as **#233**, whose acceptance
criterion is an entry for each of the three.

The earlier claim on #61 that the per-push subset "loses no check function's
coverage" is what this replaces.

## What `--cheap` is

`run_phases` now guards every phase with `selects(only, arms)` instead of
`only in (None, …)`, and `--cheap` is the **complement** of the three expensive
arms rather than a list of the cheap ones. A list is a second place to forget:
an arm added to `run_phases` and not to the list would drop off the per-push run
and nothing would say so. Here the only way to fall out of `--cheap` is to be
reachable from nothing but the long takes, which is the same sentence as "this
phase costs two minutes".

`tests/unit`'s new `CheapArm` grades it, off the browser, in 4 ms:

- the rule applied **per phase** (not as a count) against guards read out of
  `run_phases`' AST by this file's own extraction;
- the four skipped phases **by name**, because a count is satisfied by swapping
  a 26 s arm for a 186 s one;
- every arm a guard names must be a flag `main()` defines — which refuses
  `--cheap` written into a guard by hand, the failure mode the complement design
  exists to prevent;
- the regression half: a whole run still takes everything, every `--x-only`
  still selects itself, and an unknown arm still selects nothing.

`CHEAP_EXCLUDES` is hand-written in `tests/unit` rather than imported from
`tests/smoke`, so a fourth name quietly added to `EXPENSIVE_ARMS` — the cheapest
possible way to empty the per-push run — is a failure and not an agreement.

## Fault injection

Six new entries in `tests/unit`'s `INJECTIONS`, all caught. Verdict line:

```
All 114 injections were caught.
```

```
PASS  break: an arm is quietly added to smoke's expensive list, and stops running per push
      in tests/smoke: EXPENSIVE_ARMS = ("--web-only", "--content-only", "--terminal-only")…
      FAIL: test_cheap_runs_every_phase_a_non_expensive_arm_reaches (…CheapArm…)
      FAIL: test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip (…CheapArm…)

PASS  break: a phase is re-gated behind an expensive arm and leaves the per-push run
      in tests/smoke: if selects(only, ("--failure-only",)):…
      FAIL: test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip (…CheapArm…)

PASS  break: --cheap is hardcoded into a guard, putting a 123 s take back on every push
      in tests/smoke: if selects(only, ("--web-only",)):…
      FAIL: test_every_arm_a_guard_names_is_a_flag_the_script_accepts (…CheapArm…)
      FAIL: test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip (…CheapArm…)

PASS  break: --cheap stops selecting and runs everything, at whole-suite cost
      in tests/smoke: if only == "--cheap":…
      FAIL: test_cheap_runs_every_phase_a_non_expensive_arm_reaches (…CheapArm…)
      FAIL: test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip (…CheapArm…)
      FAIL: test_no_module_level_definition_in_tests_smoke_goes_unread (…SmokeResidue…)

PASS  break: every named arm starts running every phase, so --x-only stops selecting
      in tests/smoke: return only in arms…
      FAIL: test_a_whole_run_still_takes_everything_and_a_named_arm_still_itself (…CheapArm…)

PASS  break: the guard extraction matches nothing, so every --cheap claim goes vacuous
      in tests/unit: isinstance(call, ast.Call) and getattr(call.func, "id", "") == "sele…
      FAIL: test_a_whole_run_still_takes_everything_and_a_named_arm_still_itself (…CheapArm…)
      FAIL: test_cheap_runs_every_phase_a_non_expensive_arm_reaches (…CheapArm…)
      FAIL: test_every_arm_a_guard_names_is_a_flag_the_script_accepts (…CheapArm…)
      FAIL: test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip (…CheapArm…)
```

The last one is the control the catalogue asks for: every claim `CheapArm`
makes is quantified over guards it reads out of `run_phases`, so an extraction
that matched nothing would make all of them true over an empty set. `setUp`
asserts a floor of 14 guards (18 today) before anything else runs.

The harness aborts unless each `old` matches **exactly once** in its target,
and that guard was exercised rather than assumed. The extraction entry's search
string is the line `ruff format` split across three when this was written, so
the pre-format single-line version is a genuinely stale string; put back, the
run aborts at exit 3 instead of reporting a pass:

```
ABORT: injection 'the guard extraction matches nothing, so every --cheap claim
goes vacuous' matched 0 times in tests/unit, expected exactly 1. The injection
did not land, so nothing it would have proven is proven.
       looked for: 'if not (isinstance(call, ast.Call) and getattr(call.func,
       "id", "") == "selects"):\n'
```

Undone, and `All 114 injections were caught.` again.

And the assertion text itself, reproduced by hand against a temp copy so the
message is visible rather than only the `FAIL:` line:

```
### a phase re-gated behind an expensive arm
    -     if selects(only, ("--failure-only",)):
    +     if selects(only, ("--terminal-only",)):

FAIL: test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip
AssertionError: Items in the first set but not the second:
'run_failure' : --cheap skips ['run_content', 'run_failure', 'run_terminal',
'run_terminal_race', 'run_web']; the set this repo decided on in issue #61 is
['run_content', 'run_terminal', 'run_terminal_race', 'run_web']. A phase leaving
the per-push run is a decision, not a diff.

### --cheap hardcoded into a guard
    -     if selects(only, ("--web-only",)):
    +     if selects(only, ("--web-only", "--cheap")):

FAIL: test_every_arm_a_guard_names_is_a_flag_the_script_accepts
AssertionError: Lists differ: ['--cheap'] != []
…run_phases guards name ['--cheap'], which is not an arm flag main() defines
(or is --cheap itself, which selects arms rather than being one)

FAIL: test_the_phases_cheap_skips_are_the_four_it_is_meant_to_skip
AssertionError: Items in the second set but not the first:
'run_web' : --cheap skips ['run_content', 'run_terminal', 'run_terminal_race']…
```

## Verdict lines

Read off the verdict, not the `Ran N tests` line:

```
tests/unit                    Ran 181 tests in 0.580s / OK
tests/unit --fault-inject     All 114 injections were caught.
tests/ci-unit                 Ran 49 tests in 0.129s / OK
tests/lint                    All checks passed! / 14 files already formatted
tests/lint --self-test        One pin, one file set, one command: tests/lint runs exactly what CI runs.
tests/smoke-inject --self-test  Every guard refused what it exists to refuse.
tests/smoke --cheap           smoke: PASSED (runs 1 and 2), smoke: FAILED (run 3, #215/#224)
actionlint .github/workflows/*.yml   (silent)
```

`tests/smoke-inject --list` is **unchanged at 38 entries, 12 arms, ~37.2 min**.
Nothing here adds, removes or re-arms an injection in that manifest, and
`--cheap` deliberately does **not** go in `ARM_SECONDS` — it is a selection over
arms, not an arm, and no entry can be aimed at it.

`ruff format --check .` and `ruff check .` were run from the repo root, via
`tests/lint`, which is what CI runs.

## Stated limits, non-blocking

- **The merge job runs the whole suite, not the three arms.** The arm flags are
  mutually exclusive, so "web, content and terminal" is three invocations at
  123 + 148 + 186 = 457 s against 427 s for one whole run. A whole run is
  cheaper and is the only invocation that grades them together. It does re-record
  the cheap arms; that is the price, paid once per merge.
- **`pull_request: types:` now includes `labeled`**, so that the `smoke-full`
  label takes effect immediately instead of on the next commit. The cost is that
  labelling a pull request re-runs the cheap jobs, which is seconds. Same trade
  `smoke-inject.yml` already makes.
- **`timeout-minutes: 12` on the cheap job** is 222 s at the 1.16x a runner has
  measured against this box, plus ~60 s of installs, with ~2x headroom. It is
  headroom for runner variance, not for growth — a new cheap arm lands on this
  job automatically, so the response to it approaching the bar is to re-measure
  `--cheap`, not to nudge the number.
- **`CheapArm` grades selection, not takes.** That a phase does what its name
  says, and that its take is healthy, is `tests/smoke`'s and nothing here
  weakens it.
- **The 427 s whole-suite figure is inherited**, not re-measured here. It is
  `tests/README.md`'s existing reading and already carries its own caveat (it
  included the since-deleted `--pointer-only`, so the tree is nearer 410 s). Only
  the `--cheap` number is new.

## Not demoable

Per CLAUDE.md's test: this can only be verified by reading a workflow, an
assertion and a stopwatch. A video of it would be ceremony.
