### PR TITLE
Correct #230's reach, and state the dropped-move boundary where an author reads

### DIFF
--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -124,8 +124,9 @@ _FRAME_HTML = """<!doctype html><meta charset="utf-8">
 # `mousemove` dispatched before that used to be delivered to no handler at
 # all. Nothing replaces it: the pointer is where it was asked to be, the
 # browser has no reason to say so again, and the dot stays at the stylesheet's
-# off-screen park for the rest of the document. Reachable through the escape
-# hatch `SKILL.md` documents:
+# off-screen park for the rest of the document. Reachable only by combining
+# two `rec.page` calls, neither of which `SKILL.md` or `reference/` documents —
+# what they document is the escape hatch itself, `rec.page`:
 #
 #     rec.page.goto(url, wait_until="commit")   # Recorder.goto waits for load
 #     rec.page.mouse.move(60, 640)

--- a/skills/demo-video/reference/determinism.md
+++ b/skills/demo-video/reference/determinism.md
@@ -133,3 +133,17 @@ no matter what this section does:
   it. One consequence worth knowing: a pointer verb that lands on exactly
   `(0, 0)` draws no cursor, because "moved to the origin" and "never moved" are
   the same state as far as the page can tell — move somewhere else first.
+- **Whether a pointer move issued before the document has loaded arrives at
+  all.** The rule above decides *where* the dot is drawn; this decides whether
+  the take has a cursor. Reaching the case takes two `rec.page` escape-hatch
+  calls in combination — `rec.page.goto(url, wait_until="commit")`, and then a
+  raw `rec.page.mouse.move(...)` before that document loads — and Chromium may
+  swallow the move outright: not delivered late, not delivered at the wrong
+  position, never delivered. No rule in the overlay can place a dot for an
+  event the page never sees, so the take records no cursor for its whole
+  length. [#230](https://github.com/rogvid/skills/issues/230) measured 12
+  `Recorder` takes per build against `tests/fixture`: the move never reached
+  the document in 3 of 12 takes on Chromium 136, 4 of 12 on 147, 2 of 12 on 149
+  and 7 of 12 on 151. The recorder's own verbs do not reach this — `rec.goto()`
+  waits for `load` before it returns, so `move_to`, `click` and `scroll_to` are
+  never dispatched into a document that is still loading.

--- a/tests/unit
+++ b/tests/unit
@@ -3792,10 +3792,12 @@ class CursorMotion(unittest.TestCase):
         # `attach` that was nothing at all. Nothing replaces it either: the
         # pointer is already where the storyboard put it, so the browser has
         # no reason to report it again, and the dot sits at the stylesheet's
-        # off-screen park for the rest of the document. Reachable through the
-        # escape hatch SKILL.md documents, `goto(..., wait_until="commit")`
-        # followed by `page.mouse.move`, which is what #202's determinism arm
-        # drives the pointer with.
+        # off-screen park for the rest of the document. Reachable only by
+        # combining `goto(..., wait_until="commit")` with a raw
+        # `page.mouse.move`, and neither of those two is documented — what
+        # SKILL.md documents is `rec.page` itself, as the escape hatch. #202's
+        # determinism arm uses the raw move but parks *after* `Recorder.goto()`,
+        # which waits for `load`, so that arm never reaches this.
         #
         # So the subscription is established while the init script is
         # evaluated, and the element it writes to is created there too; only


### PR DESCRIPTION
## Acceptance criterion

Two things, both verifiable by reading:

1. **#230's stated reach is corrected** — its two overstatements are refuted
   against the tree, in a comment on the issue and in the two code comments that
   repeat them. The measurement and the diagnosis are untouched.
2. **The boundary is documented** where a storyboard author reads it: a pointer
   move issued into a document that has not loaded may be dropped by the browser
   entirely, so the take records no cursor.

Not demoable, by `CLAUDE.md`'s test — nothing here is watchable; it is prose and
comments. No behaviour changes.

## The two claims, verified at `bae7f74`

**"This is the documented way to park the pointer."** It is not documented.
`wait_until` appears nowhere in `skills/demo-video/SKILL.md` and nowhere under
`skills/demo-video/reference/`. Its only occurrences in the repo are code
comments (`web.py:130`, `tests/unit:3796`, `tests/unit:4643`) and
`tests/README.md:1856`, the Known-gaps entry for #230 itself. What `SKILL.md`
documents is the escape hatch — `rec.page`, one table row at `SKILL.md:263` —
and for the pointer, the verbs `move_to` / `click` / `click_fast` / `scroll_to`
at `SKILL.md:254`. The defect needs **two escape-hatch calls in combination**,
`rec.page.goto(url, wait_until="commit")` and then a raw `rec.page.mouse.move`
into the still-loading document. Neither is documented, so a storyboard written
from `SKILL.md` cannot reach it.

**"It is what `tests/smoke`'s determinism arm uses."** That arm is not exposed.
It parks with `rec.page.mouse.move(*PARKED_POINTER)` at `tests/smoke:3712`, nine
lines after `rec.goto("/?entropy=1")` at `tests/smoke:3703`, and
`Recorder.goto()` waits for load — `web.py:851-865` calls `page.goto` at
Playwright's default `wait_until="load"` and then `wait_for_load_state("networkidle")`.
The arm shares the raw move; it does not share the `wait_until="commit"` half,
which is the whole mechanism. #230's own later paragraph says exactly this, and
contradicts its earlier sentence. `tests/README.md:1866-1872` already has it
right and is unaffected.

## What is not being touched

#230's four-build measurement — 12 takes each, move never delivered in 3/12 on
Chromium 136, 4/12 on 147, 2/12 on 149, 7/12 on 151 — and its three eliminations
(not the listener timing, rates identical across #203's fix; not the overlay, a
second move places the dot in 33/33 dropped takes; not first paint, the move
precedes paint in every take, dropped and delivered alike) are good work and
stand. **What changes is the priority, not the diagnosis.** The defect is real
and stays open; it is reachable only by an author who has gone through
`rec.page` twice, deliberately, in a specific order.

## Where the boundary text went, and why

**`reference/determinism.md`**, as a new bullet immediately after the `(0, 0)`
trap, not `reference/limits.md`.

`reference/limits.md` contains **zero** mentions of cursor or pointer; the
cursor's limits already live at `determinism.md:126-135`, and the `(0, 0)` trap
— "moved to the origin" and "never moved" are the same state to the page — is
the nearest neighbour in the same voice. Putting the new boundary in `limits.md`
would be the split the brief forbids. Keeping the cursor's limits in one file
wins over the file whose title reads "The boundary", and `limits.md` already
accepts that some limits live in `determinism.md` (its own header says so).

The text states what can happen and that the recorder's verbs are unaffected
because `rec.goto()` waits for `load`. **It does not tell an author to move
twice** — #230's refusal of "a workaround a storyboard author has to remember is
a defect with a manual" is correct and is honoured here. Measurements are
attributed to #230, not presented as this change's.

`SKILL.md` is untouched and still at exactly 600 lines.

## Beyond the two parts of the brief

The same overstatement was in the tree in two places, phrased as *"the escape
hatch `SKILL.md` documents"* immediately above `goto(..., wait_until="commit")`:

- `skills/demo-video/helpers/demo_recording/web.py:127-128`
- `tests/unit:3795-3798`, which additionally said the raw move "is what #202's
  determinism arm drives the pointer with" in a way that reads as attaching to
  the pair.

Both corrected in place, comment text only. Leaving them would have left the
issue and the tree disagreeing about the same sentence, which is the failure
`bae7f74` (#207) was about. Easy to drop from the diff if unwanted.

## Verification

No assertion was written or changed, so there is nothing to fault-inject: the
diff is one reference-doc bullet and two comments. The `tests/unit` edit is a
comment inside `test_the_pointer_is_listened_for_before_the_document_has_loaded`;
its assertion is byte-identical, and the suite runs the same **193** tests before
and after (checked by stashing the diff).

```
$ ruff format --check .          # from the repo root
14 files already formatted
$ ruff check .                   # from the repo root
All checks passed!

$ ./tests/unit
OK

$ ./tests/lint
lint: ruff 0.16.1, pinned by .github/workflows/ci.yml
All checks passed!
14 files already formatted
docs: 10 python fence(s) parse; 29 fence(s) skipped by language ((none) 8, bash 2, html 1, json 5, sh 11, yaml 2)

$ ./tests/unit --budget
SKILL.md: 600 lines (~14,114 tokens), budget 600 lines
```

No browser was driven and nothing was recorded, per the brief.

## Stated limits

- The correction rests on reading the tree, not on re-measuring the defect. The
  drop rates are #230's and are quoted, not reproduced.
- The new bullet is not graded by anything. No suite reaches the
  `wait_until="commit"` route — that is the point of the correction — so nothing
  can regress it into being wrong except a change to the recorder, and any such
  change would be closing #230.
- The `(0, 0)` trap it now sits beside is likewise ungraded prose; this does not
  make that worse or better.

**Not `Fixes #230`.** The defect stays open. This corrects its record and
documents its boundary.
