### PR TITLE
Record that capture_clock is an aliased sample, not a step the video followed

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1963,6 +1963,50 @@ knows is missing is worse than one that is openly absent.
   [#18](https://github.com/rogvid/skills/issues/18) is that boundary, and it
   matters most to [#8](https://github.com/rogvid/skills/issues/8).
 
+- **…and the correction above rests on a premise that did not reproduce on
+  2026-08-08.** `capture_clock` and `HostClock` both sample
+  `time.time() - time.monotonic()` every 20 ms and call a change a step. On a
+  host whose wall clock *oscillates faster than that*, what they record is an
+  aliased fragment of the oscillation, and the video does not follow it.
+  Measured on `main` @ `bae7f74`, on the same Playwright 1.62.0 / Chromium
+  151.0.7922.34 [#215](https://github.com/rogvid/skills/issues/215) used —
+  a standalone sampler, no browser, 180 s, **66 events in 33 identical pairs**:
+  `time.time()` jumps **+10.08 to +10.36 s and returns −10.58 to −10.60 s about
+  60 ms later, every ~5.5 s**, with `d_monotonic` a steady 20 ms throughout. A
+  take competing with Playwright catches a fragment of that ~60 ms pulse, which
+  is why `capture_clock` reports a single step of −1.72 to −1.81 s and never
+  the ±10 s edges an idle sampler sees.
+
+  What the video did about it: eight `--segments-only` runs, four with a
+  recorded step, the closing caption's onset read off `demo.mp4` against
+  `timeline.json`. Stepped runs **0, +20, −70, −60 ms**; step-free runs **0,
+  +40, +10, +20 ms**; durations 14.44–14.52 s either way. Runs whose step
+  landed *six seconds before* the caption still put the caption within 20 ms of
+  the log, where the documented consequence predicts 1.7 s — 43 frames. One
+  excursion did reach the video and is the exception that explains the rule: a
+  run whose record held two **+10.36 s** steps encoded a 24.96 s demo, part2 at
+  18.32 s against a usual 7.9 s, with the closing caption +10.25 s past the
+  log. That pulse lasted long enough for Chromium to stamp frames across it;
+  the aliased fragments are not pulses at all.
+
+  **So this harness subtracts a number that means nothing, and goes red about
+  it.** Six `--segments-only` runs on `main`: the four with no recorded step
+  passed, and **both runs with one failed** — the caption search window centred
+  at `3.07 − 1.771 = 1.30 s` while the caption sat at 2.56 s, where a step-free
+  run puts it, reported as "the window is already centred on where the host's
+  measured wall-clock steps put this beat in the video, so this slide is
+  something else". The bars were not widened for it, and should not be: a bar
+  that absorbs an arbitrary aliased offset grades nothing.
+
+  It is also why [#229](https://github.com/rogvid/skills/issues/229) is not
+  buildable yet. Correcting a review frame's seek with the record was
+  implemented and measured: **three of those four stepped runs then failed
+  `_check_frame_captions`**, with `beat-12.png` cut at 10.53 s instead of
+  12.27 s and showing the screen before its caption arrived — the correction
+  making the review sheet wrong, caught by the one check that reads pixels
+  rather than timestamps. Not landed. The whole measurement, and what would
+  settle it, is [#245](https://github.com/rogvid/skills/issues/245).
+
 - **The terminal arm loses roughly a second more than its host clock explains,
   and nothing here knows why.** The correction is exact on the web arm — six
   consecutive `--web-only` runs after it, residual 20-140 ms, three of them


### PR DESCRIPTION
## What this is

[#229](https://github.com/rogvid/skills/issues/229) asked for two things: that
`write_beat_frames` correct a review frame's seek with `capture_clock`, and that
`timeline.md` say when the clock stepped. **Both were built. Neither is landed,
because measuring the first against the pixels showed it makes the review sheet
wrong.** What ships here is the measurement, as a *Known gaps* entry, and
[#245](https://github.com/rogvid/skills/issues/245) with the full workings.

`tests/README.md` is the only file changed. 193 tests / 124 injections, the same
as `main` — nothing was added that could grade a claim this branch is no longer
making.

## The acceptance criterion, and why it is not met

> On a take recorded while the host's clock stepped, the frame `beat-NN.png`
> shows the beat's midpoint to within the residual `tests/smoke` measures — not
> the step.

Implemented as the envelope documents it: the seek is the beat's midpoint plus
that beat's **own segment's** steps up to it, never `total` and never an earlier
part's. `tests/smoke` was given the matching expectation from its *own*
`HostClock` rather than from the record, and `tests/smoke-inject` got an entry
that adds a step nobody measured so it is caught on a steady host — the
`merged` entries' answer to the environment-agreeing shape.

Then eight `--segments-only` runs, four of which recorded a step:

| run | recorded step | caption, log | caption, `demo.mp4` | Δ | duration |
|---|---|---|---|---|---|
| 1 | −1.717 s at 4.9 s | 11.24 | 11.24 | **0 ms** | 14.48 |
| 2 | −1.806 s at 5.7 s | 11.26 | 11.28 | **+20 ms** | 14.52 |
| 5 | −1.738 s at 9.3 s | 11.27 | 11.20 | **−70 ms** | 14.44 |
| 6 | −1.762 s at 11.9 s | 11.34 | 11.28 | **−60 ms** | 14.48 |
| 3, 4, 7, 8 | none | — | — | 0, +40, +10, +20 ms | 14.44–14.52 |

Runs 1 and 2 are the sharp ones: the step landed **six seconds before** the
caption and the caption is still within 20 ms of the log. The documented
consequence predicts 1.7 s — 43 frames at 25 fps. Stepped and step-free runs are
the same distribution, and the encoded durations are identical.

So the correction moves a frame *away* from its beat, and three of those four
runs went red on the one check that reads pixels rather than timestamps:

```
smoke: FAILED
  - segments: beat-12.png should show the caption 'Recorded end to end.' and
    its caption band is only 17.07 from the take's caption-off baseline —
    beat-05.png, which should show no caption at all, is 18.54 from it. The two
    are -1.47 apart, under the 6.0 floor: the frames do not show the beats they
    are named for, or the caption bar is not being drawn
```

`beat-12.png` was cut at 10.53 s instead of 12.27 s. That is the artifact-lies
shape in the one document a reviewer of this skill reads, so the change was
reverted rather than shipped. The patch is preserved in
[#245](https://github.com/rogvid/skills/issues/245)'s checklist discussion.

## Why the field cannot be corrected with

A standalone sampler — no browser, the rule `_CaptureClock` uses, 180 s —
found **66 events in 33 identical pairs**:

```
   (2.577,  10.3475,  10.3678, 0.0204)     (t, delta_offset, d_wall, d_monotonic)
   (2.638, -10.5914, -10.5711, 0.0203)
   ...
   (177.890,  10.0847,  10.1054, 0.0207)
   (177.954, -10.5950, -10.5743, 0.0207)
```

The wall clock jumps **+10.1 s and returns −10.6 s about 60 ms later, every
~5.5 s**, with `d_monotonic` a steady 20 ms throughout. Both samplers in this
repo run at 20 ms, so inside a take they alias that pulse and report a single
phantom step of −1.7 s. The number is an artifact of the sampling rate.

One excursion *did* reach the video, and it is what shows the arithmetic is
sound and the input is not: a run whose record held two **+10.36 s** steps
encoded a 24.96 s demo — part2 at 18.32 s against a usual 7.9 s — with the
closing caption +10.25 s past the log, which the correction would have placed
correctly.

## The injection failure output

The rule is that an assertion I have not seen fail is not evidence, so both
halves were broken and watched. The five entries registered against
`tests/unit` were all caught, and the placement assertion in `tests/smoke` was
seen failing for its own reason — the paragraph moved below the beat table
rather than deleted:

```
FAIL: test_it_sits_above_the_timestamps_it_is_about
    self.assertLess(text.index("-780 ms"), text.index(self.TABLE))
AssertionError: 343 not less than 159
```

```
PASS  break: a frame is corrected by the steps that came after it
      FAIL: FrameSeekCorrection.test_a_step_after_the_instant_does_not_move_it
PASS  break: the seek correction is applied backwards
      FAIL: FrameSeekCorrection.test_a_step_before_the_instant_moves_the_seek_by_its_size
PASS  break: a merged frame is corrected by every part's steps, not its own part's
      FAIL: FrameSeekCorrection.test_an_earlier_parts_step_never_reaches_a_later_parts_frame
PASS  break: timeline.md stops saying the clock its timestamps are not on stepped
      FAIL: CaptureClockMd.test_a_stepped_clock_is_stated_with_its_total
PASS  break: timeline.md says the video came out short whichever way the clock went
      FAIL: CaptureClockMd.test_a_forward_step_says_the_video_is_longer
```

They all passed, and they graded a correction whose premise is false. That is
the point worth keeping: **five green injections against a scripted record said
nothing about whether the record describes the world.** Only the pixel check
did.

## A regression this did not introduce, and does not fix

`main` @ `bae7f74` is already red on this box whenever a take aliases a step
before a probe, because `HostClock` subtracts the same number. Six
`--segments-only` runs on `main`: the four with no recorded step passed, and
**both runs with one failed**.

```
  - segments: part1's probe caption could not be timed in its own segment
    (part1.seg.mp4) — the caption band did not move in the 2.3s around 1.30s
    ..., but the band does change at 2.56s — +1259 ms away, outside the 1.5s
    search window. ... The window is already centred on where the host's
    measured wall-clock steps put this beat in the video, so this slide is
    something else — see issues #18 and #215.
```

The window is centred at `3.07 − 1.771 = 1.30 s`; the caption is at 2.56 s,
where a step-free run puts it. **No bar was widened for it** — a bar that
absorbs an arbitrary aliased offset grades nothing. It is recorded as a gap and
tracked in #245.

## CI would have merged the broken correction green

Worth stating plainly, because it is the reason this needed a box that misbehaves.
`smoke-full` is on this PR and green, and every take in it reports:

```
smoke: web capture_clock agrees with the harness (the host's wall clock did not step during this take)
smoke: terminal capture_clock agrees with the harness (the host's wall clock did not step during this take)
smoke: segments/part1 capture_clock agrees with the harness (the host's wall clock did not step during this take)
smoke: segments/part2 capture_clock agrees with the harness (the host's wall clock did not step during this take)
```

On a runner whose clock never steps the correction is a no-op, so the change
that cuts `beat-12.png` 1.7 s early passes every arm. The `tests/smoke-inject`
entry written for it would have passed too — it adds a step nobody measured, so
it grades *"the frames apply the record"*, which the change did correctly. What
no assertion in this repo grades is whether the record describes the world, and
that is the gap #245 is really about.

## Stated limits

- **This is one host, over one evening.** Everything above is WSL2 on
  Playwright 1.62.0 / Chromium 151.0.7922.34 — the same versions #215 used, so
  it is not a version drift. Whether the same box behaved differently when #215
  was measured is not something this branch can answer, and #245 lists
  re-measuring that as a checklist item.
- **#229's second half is not shipped either**, though it is less obviously
  wrong: a `timeline.md` paragraph naming a step of −1.77 s would be printing an
  aliased number into the artifact, and the wording that made it useful
  ("the times below are not the times in the video") is the claim that failed.
- **No demo video**, judged before the work per `CLAUDE.md`: the criterion is a
  frame's timestamp against a beat's midpoint, and a frame cut 20 frames early
  looks like a perfectly good frame. That invisibility is exactly why it needed
  measuring rather than watching.
- `smoke-full` is on this PR even though no product code changed, because the
  measurement above should be reproducible from CI's own arms.

Refs #229, #245
