### PR TITLE
Cut the review sheet's frames on the clock the video is actually on (#229)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -95,9 +95,9 @@ behind every one, are in [reference/limits.md](reference/limits.md).
 - **A frame is aimed at a beat, not stamped with one.** Chromium stamps frames
   with the host's **wall** clock, the beat log uses a monotonic one, so on a
   host whose clock steps an event lands earlier in `demo.mp4` — by the step,
-  once per step (0.75–0.81 s every 32.2 s on one WSL2 box). **No fixed bound
-  holds**; a longer demo accumulates more. `timeline.json`'s `capture_clock`
-  records each one: correct with it, or read a frame as *around* its beat.
+  once per step (0.75–0.81 s every 32.2 s on one WSL2 box). `frames/` is now
+  cut with `timeline.json`'s `capture_clock` and `timeline.md` says when the
+  clock stepped; a beat time *you* scrub to yourself is still uncorrected.
 - **Sixty seconds buys about twenty screens.** At the pacing floors below, a
   demo shows roughly one new screen every 3 s — 69% of a real 61.2 s take was
   a picture already shown. A feature spanning two surfaces does not fit the

--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -31,6 +31,16 @@ from .timeline import timeline_paths
 # it is before the verb has done anything. The midpoint is inside the beat by
 # construction, which is what `t_end` is on the record for.
 #
+# That midpoint is a *beat log* instant, and the seek is a *video* one. The two
+# are on different clocks — the log on `time.monotonic()`, the video on the
+# host's wall clock, which some hosts step by 0.75-0.81 s at a time (issues
+# #18, #215) — so the seek is the midpoint plus what `capture_clock` says the
+# clock had done by then. `capture_clock_shift` is that arithmetic and issue
+# #229 is why it is here: the recorder measured the steps, wrote them down,
+# and then cut every frame as though it had not. At 25 fps a 0.78 s step is
+# ~20 frames, and since nobody reviewing through this skill watches the video,
+# a frame cut 20 frames early *is* the demo to its reviewer.
+#
 # **These frames carry no caption, and that is deliberate.** The obvious next
 # step is to print each frame under the line that was on screen when its beat
 # ran, and it is not sound: the beat log and the video are on different clocks
@@ -84,6 +94,54 @@ SCENE_MAX_EXTRA = 3
 # Keep the last frame inside the file: an -ss exactly at the duration decodes
 # nothing.
 _FRAME_EDGE_S = 0.05
+
+
+def capture_clock_shift(record: object, beat: dict, at: float) -> float:
+    """Where `at`, an instant of the beat log, really sits in `media` (#229).
+
+    The beat log is `time.monotonic()` and Chromium stamps every screencast
+    frame with the host's *wall* clock, so a host that steps its clock moves
+    the two apart by the size of the step, at the instant of it (issues #18,
+    #215). The recorder measures that and writes it down as `capture_clock`;
+    this is the arithmetic that turns the record into a seek. Returns seconds
+    to **add** to `at` — negative for a clock that went backwards, which is the
+    direction that takes wall time out of the video.
+
+    Two rules, both from the envelope documentation in `timeline.py`:
+
+    * **only the steps up to `at`.** A step after the instant being seeked to
+      moved the frames after it, not this one.
+    * **on a merged demo, only this beat's own capture's steps.** A step is
+      sampled for as long as its capture runs, which is longer than the video
+      that capture produced, so a step's merged `t` can fall past the next
+      part's boundary — the `segment` a step names is the attribution, never
+      its timestamp. And an earlier part's step must not be applied at all:
+      `stitch()` lays the parts out by their *measured* durations, so what that
+      part lost is already in the later parts' offsets, and adding it again
+      would over-correct by a whole step. A step that names no segment is a
+      single take's, where every step is this take's.
+
+    Returns 0.0 for a document with no usable record, which is what a take
+    recorded before the field existed, and a merge that refused to guess at a
+    part nobody measured, both leave behind. That is the old behaviour: a frame
+    read as *around* its beat rather than at it.
+    """
+    if not isinstance(record, dict):
+        return 0.0
+    total = 0.0
+    for step in record.get("steps") or []:
+        if not isinstance(step, dict):
+            continue
+        t, delta = step.get("t"), step.get("delta")
+        if not isinstance(t, (int, float)) or isinstance(t, bool):
+            continue
+        if not isinstance(delta, (int, float)) or isinstance(delta, bool):
+            continue
+        if "segment" in step and step["segment"] != beat.get("segment"):
+            continue
+        if float(t) <= at:
+            total += float(delta)
+    return total
 
 
 def frames_paths(out_dir: Path | str) -> tuple[Path, Path, Path]:
@@ -142,9 +200,11 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
     """Write one review frame per beat, and an index to read them in order.
 
     Reads the timeline the take just wrote (or `doc`), extracts
-    `frames/beat-NN.png` at each beat's midpoint, and writes `frames/frames.md`
-    for a reviewer and `frames/frames.json` for a tool. Neither says anything
-    about what is *in* a frame — see the section header.
+    `frames/beat-NN.png` at each beat's midpoint — *in the video*, which is the
+    log's midpoint corrected by that beat's own `capture_clock` steps — and
+    writes `frames/frames.md` for a reviewer and `frames/frames.json` for a
+    tool. Neither says anything about what is *in* a frame — see the section
+    header.
 
     Returns the manifest. Safe to re-run: it is a pure function of the mp4 and
     the timeline, so a demo whose frames were deleted can get them back without
@@ -199,6 +259,14 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
             duration = float(beats[-1].get("t_end") or 0.0)
     last = max(0.0, float(duration) - _FRAME_EDGE_S)
 
+    # The clock `mp4` is on, which is not the clock `beats` are on. Every seek
+    # below goes through it — see `capture_clock_shift` and issue #229.
+    record = doc.get("capture_clock")
+
+    def seek(beat: dict, at: float) -> float:
+        """A beat-log instant as a place to seek `mp4`, inside the file."""
+        return min(max(at + capture_clock_shift(record, beat, at), 0.0), last)
+
     planned: list[dict] = []
     for beat in beats:
         t_start, t_end = beat.get("t_start"), beat.get("t_end")
@@ -206,7 +274,7 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
             continue
         if not isinstance(t_end, (int, float)) or t_end < t_start:
             t_end = t_start
-        middle = min(max((float(t_start) + float(t_end)) / 2, 0.0), last)
+        middle = seek(beat, (float(t_start) + float(t_end)) / 2)
         index = int(beat.get("index", len(planned)))
         planned.append({
             "file": f"beat-{index:02d}.png",
@@ -219,7 +287,10 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         # a load finishing inside a long hold is invisible to it.
         if float(t_end) - float(t_start) < SCENE_MIN_SPAN_S:
             continue
-        window = (min(float(t_start), last), min(float(t_end), last))
+        # Corrected at both ends, for the same reason the midpoint is: an
+        # uncorrected window searches seconds of the video the beat never ran
+        # in, and the times it returns are already video times.
+        window = (seek(beat, float(t_start)), seek(beat, float(t_end)))
         for n, cut in enumerate(scene_times(mp4, *window), 1):
             planned.append({
                 "file": f"beat-{index:02d}-scene-{n}.png",

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -59,7 +59,11 @@ from .markdown import _fmt_t, _md_cell
 #                          still, which is a different answer from the field
 #                          being absent. **A beat the log puts at `t` sits at
 #                          `t + (the steps before it)` in the video** —
-#                          reference/limits.md has the measurement.
+#                          reference/limits.md has the measurement, and
+#                          `frames.capture_clock_shift` is this package's own
+#                          implementation of that sentence: every review frame
+#                          is seeked with it, and `render_timeline_md` says so
+#                          above the beat table (issue #229).
 #                          On a merged demo (`stitch`) every part's steps are
 #                          here, moved onto the stitched clock by that part's
 #                          `offset`, and each step also carries the `segment`
@@ -343,6 +347,12 @@ MAX_ISSUES = 200
 PUMP_INTERVAL_S = 0.1
 ATTRIBUTION_SLACK_S = 0.5
 
+# How many wall-clock steps timeline.md names before it says "and N more". A
+# take on the WSL2 box of #215 steps every 32.2 s, so a long one accumulates
+# them; the count and the total are always exact, and the list is what gets
+# elided. Six keeps the paragraph one screen wide.
+_CLOCK_STEPS_SHOWN = 6
+
 
 class StrictTakeFailed(RuntimeError):
     """A strict take finished, but recorded a problem it refuses to pass.
@@ -450,6 +460,63 @@ def _coverage_md(coverage: object) -> list[str]:
     return out
 
 
+def _capture_clock_md(record: object) -> list[str]:
+    """What the video's own clock did, printed beside the times it moved (#229).
+
+    The recorder says this on stderr as the take exits — thousands of lines
+    before anybody opens this file, and never at all for a reader handed the
+    artifact afterwards. The beat times below are `time.monotonic()` and
+    `media` is stamped with the host's wall clock, so a host that stepped its
+    clock parted the two and **every timestamp in the table under this
+    paragraph inherits it**. That is what puts it here rather than in a
+    footnote: a table of times that are not the video's times, with nothing
+    saying so, is the artifact-lies shape.
+
+    Silent when the clock held still and when there is no record at all. Those
+    are different answers — an empty `steps` is a measurement — but neither is
+    something to caveat a table with, and a merged demo that refused to guess
+    at a part nobody measured (`capture_clock: null`) has nothing to report
+    that would not be a guess.
+
+    Keyed on `steps` rather than on `total`: two steps that cancel total zero
+    and still moved the beats between them.
+    """
+    if not isinstance(record, dict):
+        return []
+    steps = [
+        step
+        for step in record.get("steps") or []
+        if isinstance(step, dict)
+        and isinstance(step.get("t"), (int, float))
+        and isinstance(step.get("delta"), (int, float))
+    ]
+    if not steps:
+        return []
+    total = sum(float(step["delta"]) for step in steps)
+    listed = ", ".join(
+        f"{float(step['delta']) * 1000:+.0f} ms at {float(step['t']):.1f}s"
+        + (f" (`{_md_cell(step['segment'])}`)" if step.get("segment") else "")
+        for step in steps[:_CLOCK_STEPS_SHOWN]
+    )
+    if len(steps) > _CLOCK_STEPS_SHOWN:
+        listed += f", …and {len(steps) - _CLOCK_STEPS_SHOWN} more"
+    return [
+        f"**This host's wall clock stepped {total * 1000:+.0f} ms while "
+        f"the recording ran, so the times in the table below are not the "
+        f"times in the video.** Chromium stamps every screencast frame with "
+        f"that clock and these beats are on `time.monotonic()`, which is why "
+        f"the two can part company at all: the recording came out "
+        f"{abs(total):.2f}s {'shorter' if total < 0 else 'longer'} than the "
+        f"take's own wall time, and a beat this table puts at `t` sits at `t` "
+        f"plus its own capture's steps up to `t`. The steps were {listed}. "
+        f"`capture_clock` in timeline.json is the record, and the review "
+        f"frames in `frames/` are already cut with it "
+        f"([#18](https://github.com/rogvid/skills/issues/18), "
+        f"[#215](https://github.com/rogvid/skills/issues/215)).",
+        "",
+    ]
+
+
 def render_timeline_md(doc: dict) -> str:
     """Render a timeline document as markdown, stills embedded.
 
@@ -537,6 +604,11 @@ def render_timeline_md(doc: dict) -> str:
     # scrolls past 28 beats first has already formed the impression the
     # coverage report exists to test (issue #12).
     out += _coverage_md(doc.get("coverage"))
+    # Immediately above the table, and not in a section of its own: what it
+    # says is that the two columns after it are on a clock the video is not on,
+    # and a caveat a reader meets after the numbers is a caveat they have
+    # already been misled by (issue #229).
+    out += _capture_clock_md(doc.get("capture_clock"))
     # The exit column only exists when something in this take has one — a web
     # timeline would otherwise carry an empty column on every row. A `run` beat
     # whose status could not be read shows "?" rather than blank, so the

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -109,14 +109,20 @@ rather than by widening a bar, which is why `MAX_SKEW_DRIFT_S` could be
 restored at 250 ms after being deleted in
 [#217](https://github.com/rogvid/skills/issues/217).
 
-What to do: prefer `timeline.json`'s `capture_clock`, which records every step
-with its offset and size, and correct with it. On a **stitched** demo the same
+What to do, if you are reading a timestamp yourself: prefer `timeline.json`'s
+`capture_clock`, which records every step with its offset and size, and correct
+with it. The two consumers inside this skill already do —
+`frames/beat-NN.png` is seeked with it and `timeline.md` names every step above
+the beat table ([#229](https://github.com/rogvid/skills/issues/229)), so what
+is left uncorrected is a time *you* take out of the table and scrub to. On a
+**stitched** demo the same
 field carries every part's steps, each naming the `segment` it was measured in:
 correct a beat with the steps of *its own* segment up to its `t_start`, never
 with `total` and never with an earlier part's — that part's lost wall time is
 already in the offset `stitch()` laid it out by, and applying it twice moves the
 beat by a whole extra step ([#225](https://github.com/rogvid/skills/issues/225)).
-Failing all that, read a review
+Failing all that — a take recorded before the field existed, or a stitched demo
+one of whose parts carried no record — read a review
 frame as *around* its beat, do not build anything that needs a beat timestamp
 to be exact to the frame, and when a frame and its caption disagree by a
 fraction of a second, suspect the capture before the

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -20,9 +20,15 @@ They are aligned to **beats, not to a clock**. The old advice was
 static one twice. Each frame is taken at its beat's **midpoint** — `t_start` is
 0% into the caption bar's fade and before the verb has done anything.
 
-**How accurate that aim is, honestly.** The beat log is wall-clock; the video
-is whatever Chromium's screencast managed to record, and it drops wall time
-during idle stretches ([#18](https://github.com/rogvid/skills/issues/18)). So a
+**How accurate that aim is, honestly.** The midpoint is an instant of the beat
+log, and the seek is an instant of the video; the two are on different clocks.
+The part of that gap the recorder can *measure* — a host stepping its wall
+clock, 0.75–0.81 s at a time on the box of
+[#215](https://github.com/rogvid/skills/issues/215) — is taken out of the seek
+before the frame is cut, using that take's own `capture_clock`
+([#229](https://github.com/rogvid/skills/issues/229)). What is left is the part
+nothing measures: the video is whatever Chromium's screencast managed to
+record, so a
 frame cut at a beat's midpoint shows a moment slightly *ahead* of that beat in
 the demo's own story — measured at **80–200 ms** on instrumented takes, and up
 to the **~0.7 s** of browser start-up no test code can cover, on a take that

--- a/tests/README.md
+++ b/tests/README.md
@@ -183,7 +183,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~48 s)
-tests/smoke-inject                # all 45 entries, ~40 min
+tests/smoke-inject                # all 46 entries, ~40 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -1671,7 +1671,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-45 entries, 12 arms, ~39.5 min of takes
+46 entries, 12 arms, ~40.0 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -1704,7 +1704,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
-| `--segments-only` | 10 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)) |
+| `--segments-only` | 11 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the frames stop being cut on the clock `demo.mp4` is on, so a stepped host moves every one of them ~20 frames off the beat it is named for ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)) |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |

--- a/tests/smoke
+++ b/tests/smoke
@@ -6374,11 +6374,13 @@ def check_beat_frames(
         hand-written beat list rather than against the recorder's own idea of
         how many beats there were;
       * **each frame is the moment it says it is** — its timestamp is the
-        beat's midpoint computed here from `timeline.json`, and the PNG is
-        byte-identical to that second cut out of `demo.mp4` again. Only
-        together: the first without the second passes a manifest that says the
-        right time over the wrong picture, and the second without the first
-        passes a frame faithfully cut from the wrong second;
+        beat's midpoint computed here from `timeline.json`, moved onto the
+        video's clock by this harness's *own* reading of the host's wall clock
+        (issue #229, and see the section below), and the PNG is byte-identical
+        to that second cut out of `demo.mp4` again. Only together: the first
+        without the second passes a manifest that says the right time over the
+        wrong picture, and the second without the first passes a frame
+        faithfully cut from the wrong second;
       * **the sheet leaks no storyboard.** `frames.md` goes to a context-free
         reviewer who is asked what story the pictures tell. A caption, a verb
         or a selector printed beside a frame answers that for them, and the
@@ -6450,11 +6452,48 @@ def check_beat_frames(
             )
 
     # -- each frame is the moment it says it is ------------------------------
+    #
+    # The midpoint is an instant of the *beat log* and the seek is an instant
+    # of the *video*, which are not the same clock: a host that steps its wall
+    # clock moves them apart by the size of the step (issues #18, #215), and
+    # since #229 the recorder takes that out of the seek using its own
+    # `capture_clock`. So the moment to expect here is the midpoint plus what
+    # **this harness** watched the host's wall clock do by then — `HostClock`,
+    # measured in this process, never the record the recorder corrected with.
+    # An expectation read out of `capture_clock` would agree with the seek
+    # whatever either of them said, which is the catalogue's "check that
+    # shares the bug's blind spot".
     doc = json.loads((out_dir / "timeline.json").read_text())
     beats = {b.get("index"): b for b in doc.get("beats") or []}
     mp4 = out_dir / "demo.mp4"
     duration = float(doc.get("duration") or 0.0)
     measured = 0
+    recorded_steps = [
+        float(step["t"])
+        for step in (doc.get("capture_clock") or {}).get("steps") or []
+        if isinstance(step, dict) and isinstance(step.get("t"), (int, float))
+    ]
+    # A take whose own record says the clock moved, graded by a run that
+    # watched no clock, cannot be graded: correcting with the record under
+    # test is not a measurement, and not correcting is a bar the recorder is
+    # right to fail. Only reachable when a part's duration could not be
+    # probed, which is a failure of its own.
+    unwatched = clock is None and bool(recorded_steps)
+    if unwatched:
+        failures.append(
+            f"{label}: timeline.json reports {len(recorded_steps)} wall-clock "
+            f"step(s) and this run watched no clock of its own, so where each "
+            f"review frame was cut could not be graded against anything"
+        )
+    # Steps from both watchers. A beat whose midpoint sits within a sampler's
+    # reach of a step is one the two genuinely cannot agree about — they are
+    # on their own 20 ms grids, so which *side* of the midpoint the step fell
+    # on is not a fact either of them has. Skipped and counted rather than
+    # absorbed into a wider bar: a bar wide enough for a whole step would
+    # grade nothing, since a whole step is the entire error being watched.
+    near_steps = recorded_steps + [at for at, _d in (clock.steps if clock else [])]
+    stepped = clock.before if clock is not None else (lambda _t: 0.0)
+    unplaceable = 0
     for frame in listed:
         beat = beats.get(frame.get("beat"))
         png = frames_dir / str(frame.get("file"))
@@ -6462,12 +6501,20 @@ def check_beat_frames(
             continue
         middle = (float(beat["t_start"]) + float(beat["t_end"])) / 2
         at = float(frame["t"])
-        if abs(at - middle) > MAX_FRAME_PLACEMENT_S and at < duration - 0.2:
+        aimed = middle + stepped(middle)
+        if unwatched or any(
+            abs(step - middle) <= MAX_CLOCK_STEP_TIME_DISAGREEMENT_S
+            for step in near_steps
+        ):
+            unplaceable += 1
+        elif abs(at - aimed) > MAX_FRAME_PLACEMENT_S and at < duration - 0.2:
             failures.append(
                 f"{label}: {frame.get('file')} was taken at {at:.3f}s, but beat "
-                f"{frame.get('beat')} runs {beat['t_start']}-{beat['t_end']}s "
-                f"and its midpoint is {middle:.3f}s — the frame is not the "
-                f"moment the sheet numbers it for"
+                f"{frame.get('beat')} runs {beat['t_start']}-{beat['t_end']}s, "
+                f"its midpoint is {middle:.3f}s and this harness watched the "
+                f"host's wall clock put that midpoint at {aimed:.3f}s in "
+                f"demo.mp4 ({clock.describe() if clock else 'no clock watched'})"
+                f" — the frame is not the moment the sheet numbers it for"
             )
         if not mp4.is_file() or not duration:
             continue
@@ -6484,6 +6531,16 @@ def check_beat_frames(
             f"{label}: only {measured} of {len(listed)} review frames were "
             f"compared against demo.mp4 — the rest went ungraded, which is not "
             f"the same as passing"
+        )
+    if listed and unplaceable == len(listed) and not unwatched:
+        # The control on the skip above. A recorder reporting a step beside
+        # every beat would otherwise turn the whole placement claim off and
+        # this function would still print ok.
+        failures.append(
+            f"{label}: not one of the {len(listed)} review frames could be "
+            f"placed — every beat's midpoint is within "
+            f"{MAX_CLOCK_STEP_TIME_DISAGREEMENT_S}s of a wall-clock step, so "
+            f"where the frames were cut went entirely ungraded"
         )
 
     # -- the sheet carries no storyboard -------------------------------------
@@ -6534,7 +6591,9 @@ def check_beat_frames(
     if not failures:
         print(
             f"smoke: {label} frames/ ok ({len(listed)} beat frames, each "
-            f"byte-identical to the demo.mp4 frame it claims to be)"
+            f"byte-identical to the demo.mp4 frame it claims to be; "
+            f"{len(listed) - unplaceable} placed against this harness's own "
+            f"reading of the host's wall clock)"
         )
     return failures
 

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -592,6 +592,42 @@ INJECTIONS = [
         must_contain=("within its own segment, and unlike `index` a merge must not ",),
     ),
     Injection(
+        # Issue #229: the recorder measured the host's wall-clock steps, wrote
+        # them into `capture_clock`, merged them across the stitch — and then
+        # cut every review frame as though the video were on the beat log's
+        # clock. On the box of #215 that is 0.78 s, ~20 frames at 25 fps, in
+        # the one artifact a reviewer of this skill ever looks at.
+        #
+        # **A step is added rather than the correction removed, and that is
+        # what makes this entry grade something on any host.** Deleting the
+        # correction is a no-op wherever the wall clock does not step, so the
+        # arm would pass against a recorder that ignores the record entirely —
+        # the catalogue's environment-agreeing assertion, and the same trap
+        # `the merged clock carries a step belonging to no capture` above was
+        # written into first. Instead the recorder is made to report a step
+        # nobody measured, at t=0 so it bears on every beat: a recorder that
+        # applies its record then cuts every frame 500 ms from where this
+        # harness — which watched the real clock and saw nothing — puts it,
+        # and a recorder that ignores its record cuts them where they were and
+        # this entry goes unnoticed. That is the property being graded, and it
+        # is graded the same way on a stepping host and a steady one.
+        #
+        # `check_capture_clock` fires too, on the same phantom step, and that
+        # is not a substitute: it grades the *record*, and the frames were
+        # already wrong while the record was right.
+        name="the review frames are cut without the clock the video is on",
+        module="core.py",
+        old="    def start(self, t0: float) -> None:\n        self._t0 = t0\n",
+        new=(
+            "    def start(self, t0: float) -> None:\n"
+            "        self._t0 = t0\n"
+            '        self.steps.append({"t": 0.0, "delta": -0.5})\n'
+        ),
+        arm="--segments-only",
+        sites=("check_beat_frames",),
+        must_contain=("moment the sheet numbers it for",),
+    ),
+    Injection(
         # Every review frame is cut at its beat's *start* instead of its
         # midpoint. frames.json still lists one frame per beat, each frame is
         # still faithfully the second it claims, and the sheet still embeds all
@@ -600,8 +636,8 @@ INJECTIONS = [
         # instant `frames.py`'s own header says is the wrong one.
         name="every review frame is cut at the start of its beat, not its midpoint",
         module="frames.py",
-        old="        middle = min(max((float(t_start) + float(t_end)) / 2, 0.0), last)",
-        new="        middle = min(max(float(t_start), 0.0), last)",
+        old="        middle = seek(beat, (float(t_start) + float(t_end)) / 2)",
+        new="        middle = seek(beat, float(t_start))",
         arm="--segments-only",
         sites=("check_beat_frames",),
         must_contain=("moment the sheet numbers it for",),

--- a/tests/unit
+++ b/tests/unit
@@ -92,6 +92,7 @@ from demo_recording.failure import (  # noqa: E402
     render_failure_marker,
     render_failure_md,
 )
+from demo_recording.frames import capture_clock_shift  # noqa: E402
 from demo_recording.markdown import _fmt_t, _md_cell  # noqa: E402
 from demo_recording.narration import (  # noqa: E402
     TTS_KEY_CHARS,
@@ -4632,6 +4633,233 @@ class MergedCaptureClock(unittest.TestCase):
         self.assertIsNone(mixed["capture_clock"]["sample_interval"])
 
 
+class FrameSeekCorrection(unittest.TestCase):
+    """The seek a review frame is cut at, against the record (#229).
+
+    `write_beat_frames` used to seek `demo.mp4` at the beat log's own midpoint,
+    on a host where the two clocks had already parted — 0.78 s, ~20 frames at
+    25 fps, in the one artifact a reviewer of this skill actually looks at.
+    This is the arithmetic that fixed it, driven by **scripted** records for
+    the reason `MergedCaptureClock` gives: a box either steps its clock or it
+    does not, and a case that only bites on the ones that do grades the box.
+
+    Every expectation below is a hand-written number rather than a second
+    implementation of the rule. `tests/smoke --segments-only` is where the
+    frames on disk are checked to have actually moved, against a clock that
+    harness measured itself.
+    """
+
+    def take(self, *steps: tuple[float, float]) -> dict:
+        """A single take's record: no step names a segment, because none can."""
+        return {
+            "steps": [{"t": t, "delta": d} for t, d in steps],
+            "total": round(sum(d for _, d in steps), 4),
+            "sample_interval": 0.02,
+            "min_step": 0.005,
+        }
+
+    def merged(self, *steps: tuple[float, float, str]) -> dict:
+        return {
+            "steps": [{"t": t, "delta": d, "segment": s} for t, d, s in steps],
+            "total": round(sum(d for _, d, _ in steps), 4),
+            "boundaries": [0.0, 7.5],
+        }
+
+    def test_a_step_before_the_instant_moves_the_seek_by_its_size(self):
+        record = self.take((1.5, -0.78))
+        self.assertAlmostEqual(
+            capture_clock_shift(record, beat(0, "caption", 3.0), 3.05), -0.78, places=4
+        )
+
+    def test_a_step_after_the_instant_does_not_move_it(self):
+        # It moved the frames after it. A seek corrected by a step that had
+        # not happened yet lands as far the *other* way as no correction at
+        # all, which is worse than the bug this replaced.
+        record = self.take((4.0, -0.78))
+        self.assertAlmostEqual(
+            capture_clock_shift(record, beat(0, "caption", 3.0), 3.05), 0.0
+        )
+
+    def test_a_step_exactly_at_the_instant_counts(self):
+        # The documented rule is "the steps up to `t`", and reference/limits.md
+        # and tests/smoke's own hand-written reader both read `<=`. A boundary
+        # nobody pins is a boundary two consumers will disagree about.
+        record = self.take((3.05, -0.78))
+        self.assertAlmostEqual(
+            capture_clock_shift(record, beat(0, "caption", 3.0), 3.05), -0.78, places=4
+        )
+
+    def test_steps_before_the_instant_accumulate(self):
+        record = self.take((1.5, -0.78), (33.0, -0.8), (65.0, -0.79))
+        self.assertAlmostEqual(
+            capture_clock_shift(record, beat(0, "hold", 40.0), 40.0), -1.58, places=4
+        )
+
+    def test_a_forward_step_moves_the_seek_the_other_way(self):
+        record = self.take((1.5, 0.78))
+        self.assertAlmostEqual(
+            capture_clock_shift(record, beat(0, "caption", 3.0), 3.05), 0.78, places=4
+        )
+
+    def test_a_merged_beat_is_corrected_by_its_own_captures_steps(self):
+        record = self.merged((1.5, -0.78, "part1"), (9.0, -0.8, "part2"))
+        here = beat(4, "click", 9.5, segment="part2")
+        self.assertAlmostEqual(capture_clock_shift(record, here, 9.6), -0.8, places=4)
+
+    def test_an_earlier_parts_step_never_reaches_a_later_parts_frame(self):
+        """The one that is easy to get wrong, and the reason for the segment.
+
+        `stitch()` lays the parts out by their *measured* durations, so what
+        part one lost is already in part two's offset. Applying it again puts
+        every frame of part two a whole step from the beat it is named for.
+        """
+        record = self.merged((1.5, -0.78, "part1"))
+        here = beat(4, "click", 9.5, segment="part2")
+        self.assertAlmostEqual(capture_clock_shift(record, here, 9.6), 0.0)
+
+    def test_a_step_sampled_past_the_next_boundary_stays_with_its_own_part(self):
+        # A capture keeps sampling after its last frame, so a step measured in
+        # part one can carry a merged `t` past where part two starts. Keying on
+        # time would hand it to part two's frames; the segment is the
+        # attribution, and part one has no beat that late to claim it either.
+        record = self.merged((8.0, -0.8, "part1"))
+        self.assertAlmostEqual(
+            capture_clock_shift(record, beat(4, "click", 9.5, segment="part2"), 9.6),
+            0.0,
+        )
+        self.assertAlmostEqual(
+            capture_clock_shift(record, beat(1, "click", 6.0, segment="part1"), 6.1),
+            0.0,
+        )
+
+    def test_a_single_takes_steps_apply_whatever_the_beat_says_about_segments(self):
+        # A single take's steps name no segment because there is only one
+        # capture; its beats carry `segment: null`. A rule that required the
+        # two to match would leave every single take uncorrected, which is
+        # every take this skill records outside `record_segments`.
+        record = self.take((1.5, -0.78))
+        self.assertAlmostEqual(
+            capture_clock_shift(record, beat(0, "caption", 3.0), 3.05), -0.78, places=4
+        )
+
+    def test_a_take_with_no_record_is_seeked_where_it_always_was(self):
+        # A take recorded before the field existed, and a merged demo that
+        # refused to guess at a part nobody measured, both arrive here as
+        # None. Refusing to correct is the honest answer; inventing a zero
+        # correction and refusing to correct are the same seek.
+        for record in (None, {}, {"steps": None}, "capture_clock"):
+            self.assertAlmostEqual(
+                capture_clock_shift(record, beat(0, "caption", 3.0), 3.05), 0.0
+            )
+
+    def test_a_malformed_step_is_skipped_and_the_rest_still_apply(self):
+        record = {
+            "steps": [
+                {"t": "1.5", "delta": -0.78},
+                {"t": 1.6, "delta": None},
+                {"t": 1.7},
+                "not a step",
+                {"t": 1.8, "delta": -0.8},
+            ]
+        }
+        self.assertAlmostEqual(
+            capture_clock_shift(record, beat(0, "caption", 3.0), 3.05), -0.8, places=4
+        )
+
+
+class CaptureClockMd(unittest.TestCase):
+    """What `timeline.md` says about the clock its own timestamps are not on.
+
+    The recorder warns about a stepped clock on stderr, at exit — minutes and
+    several thousand lines before anybody opens the sheet, and never at all for
+    a reader handed the artifact afterwards. Issue #229: a table of times that
+    are not the video's times, with nothing beside it saying so, is a document
+    that misleads a reader who does everything right.
+    """
+
+    TABLE = "| # | start | end |"
+
+    def doc(self, record: object, **over: object) -> str:
+        return render_timeline_md(
+            envelope(
+                capture_clock=record,
+                beats=[beat(0, "caption", 1.0), beat(1, "click", 12.0)],
+                **over,
+            )
+        )
+
+    def test_a_stepped_clock_is_stated_with_its_total(self):
+        text = self.doc({"steps": [{"t": 3.0, "delta": -0.78}], "total": -0.78})
+        self.assertIn("-780 ms", text)
+        self.assertIn("0.78s shorter", text)
+
+    def test_every_step_is_named_with_its_offset(self):
+        text = self.doc(
+            {"steps": [{"t": 3.0, "delta": -0.78}, {"t": 35.2, "delta": -0.8}]}
+        )
+        self.assertIn("-780 ms at 3.0s", text)
+        self.assertIn("-800 ms at 35.2s", text)
+
+    def test_it_sits_above_the_timestamps_it_is_about(self):
+        # A caveat a reader meets *after* the numbers is a caveat they have
+        # already been misled by.
+        text = self.doc({"steps": [{"t": 3.0, "delta": -0.78}], "total": -0.78})
+        self.assertLess(text.index("-780 ms"), text.index(self.TABLE))
+
+    def test_a_forward_step_says_the_video_is_longer(self):
+        # The direction is the whole content of the sentence: a reader told
+        # "shorter" about a video that came out long goes looking for frames
+        # that are not missing.
+        text = self.doc({"steps": [{"t": 3.0, "delta": 0.78}], "total": 0.78})
+        self.assertIn("longer", text)
+        self.assertNotIn("shorter", text)
+
+    def test_a_clock_that_held_still_says_nothing(self):
+        text = self.doc({"steps": [], "total": 0.0})
+        self.assertNotIn("wall clock stepped", text)
+
+    def test_a_take_with_no_record_says_nothing(self):
+        # Including a merged demo that refused to guess at a part nobody
+        # measured. There is nothing to report that would not be a guess.
+        for record in (None, {}, "capture_clock"):
+            self.assertNotIn("wall clock stepped", self.doc(record))
+
+    def test_two_steps_that_cancel_are_still_reported(self):
+        # Keyed on the steps, not on the total: a clock that went back 0.78 s
+        # and forward again moved every beat between the two, and a paragraph
+        # that appears only for a non-zero total would say nothing about it.
+        text = self.doc(
+            {
+                "steps": [{"t": 3.0, "delta": -0.78}, {"t": 9.0, "delta": 0.78}],
+                "total": 0.0,
+            }
+        )
+        self.assertIn("-780 ms at 3.0s", text)
+        self.assertIn("+780 ms at 9.0s", text)
+
+    def test_a_merged_step_names_the_capture_that_measured_it(self):
+        text = self.doc(
+            {
+                "steps": [{"t": 9.0, "delta": -0.8, "segment": "part2"}],
+                "total": -0.8,
+                "boundaries": [0.0, 7.5],
+            }
+        )
+        self.assertIn("-800 ms at 9.0s (`part2`)", text)
+
+    def test_a_long_list_of_steps_is_elided_and_the_total_is_not(self):
+        # A take on the box of #215 steps every 32.2 s. The count and the
+        # total stay exact; only the list is cut, and it says it was.
+        steps = [{"t": 32.2 * n, "delta": -0.8} for n in range(1, 10)]
+        text = self.doc({"steps": steps, "total": -7.2})
+        self.assertIn("…and 3 more", text)
+        self.assertIn("-7200 ms", text)
+
+    def test_a_malformed_step_does_not_reach_the_page(self):
+        text = self.doc({"steps": [{"t": None, "delta": -0.78}], "total": -0.78})
+        self.assertNotIn("wall clock stepped", text)
+
+
 # --------------------------------------------------------------------------
 # Fault injection
 # --------------------------------------------------------------------------
@@ -4832,6 +5060,72 @@ INJECTIONS = [
         [
             "MergedCaptureClock.test_a_part_that_measured_nothing_keeps_its_own_record_in_segments",
         ],
+    ),
+    (
+        # A frame seeked with a step that had not happened when the beat ran.
+        # The correction is applied, the record is right, and every frame is
+        # moved by the *next* step instead of by the ones before it — as far
+        # the other way as no correction at all (issue #229).
+        "a frame is corrected by the steps that came after it",
+        "frames.py",
+        "        if float(t) <= at:",
+        "        if True:",
+        [
+            "FrameSeekCorrection.test_a_step_after_the_instant_does_not_move_it",
+        ],
+    ),
+    (
+        # The correction with its sign flipped. Everything is still applied to
+        # the right frames, in the right order, twice as far in the wrong
+        # direction — 40 frames at 25 fps for one step of the box in #215.
+        "the seek correction is applied backwards",
+        "frames.py",
+        "            total += float(delta)",
+        "            total -= float(delta)",
+        [
+            "FrameSeekCorrection.test_a_step_before_the_instant_moves_the_seek_by_its_size",
+            "FrameSeekCorrection.test_a_forward_step_moves_the_seek_the_other_way",
+            "FrameSeekCorrection.test_a_merged_beat_is_corrected_by_its_own_captures_steps",
+        ],
+    ),
+    (
+        # Every step applied to every part's frames. `stitch()` already laid
+        # the parts out by their measured durations, so part one's loss is in
+        # part two's offset — applying it again moves every frame of part two
+        # by a whole extra step, which is worse than not correcting at all.
+        "a merged frame is corrected by every part's steps, not its own part's",
+        "frames.py",
+        '        if "segment" in step and step["segment"] != beat.get("segment"):',
+        "        if False:",
+        [
+            "FrameSeekCorrection.test_an_earlier_parts_step_never_reaches_a_later_parts_frame",
+            "FrameSeekCorrection.test_a_step_sampled_past_the_next_boundary_stays_with_its_own_part",
+        ],
+    ),
+    (
+        # The state everything was in before #229 on the reading side: the
+        # step is measured, written down, merged across a stitch — and the
+        # document a human opens says nothing about it, so the beat times in
+        # the table read as times in the video.
+        "timeline.md stops saying the clock its timestamps are not on stepped",
+        "timeline.py",
+        "    if not steps:\n        return []",
+        "    if True:\n        return []",
+        [
+            "CaptureClockMd.test_a_stepped_clock_is_stated_with_its_total",
+            "CaptureClockMd.test_every_step_is_named_with_its_offset",
+            "CaptureClockMd.test_two_steps_that_cancel_are_still_reported",
+        ],
+    ),
+    (
+        # The direction dropped. A reader told the video came out short when
+        # it came out long goes looking for frames that are not missing —
+        # the same break `CaptureClock`'s own warning is graded against.
+        "timeline.md says the video came out short whichever way the clock went",
+        "timeline.py",
+        "f\"{abs(total):.2f}s {'shorter' if total < 0 else 'longer'} than the \"",
+        'f"{abs(total):.2f}s shorter than the "',
+        ["CaptureClockMd.test_a_forward_step_says_the_video_is_longer"],
     ),
     (
         "coverage accumulates criteria from the tags instead of the declaration",


### PR DESCRIPTION
Fixes #229.

## Acceptance criterion

On a take recorded while the host's clock stepped, `beat-NN.png` shows the beat's midpoint to within the residual `tests/smoke` measures — not the step. Graded by a `tests/smoke-inject` entry against `--segments-only`.

## What changed

`write_beat_frames` cut every frame at its beat's midpoint on the raw beat log. The beat log is `time.monotonic()`; Chromium stamps each screencast frame with the host's **wall** clock. The recorder has measured the difference since #215 and written it as `capture_clock` — and until now **no line of the shipped package read it back**. `tests/smoke` corrected; the product did not. The harness knew what time it was and the artifact did not.

`capture_clock_shift` applies the record to a seek: for a single take, the steps up to that beat; for a stitched one, the steps of **that beat's own segment**, because a capture keeps sampling after its last frame and a merged `t` can legitimately fall past the next boundary. `timeline.md` now states when the clock stepped and by how much.

`tests/smoke` keeps its own independent implementation deliberately. Two implementations that agree are a check; one shared implementation is a restatement.

`reference/review.md` also said the beat log was wall-clock, and blamed idle screencast stretches — the explanation #215 falsified. Both corrected here rather than left standing beside the fix.

## The injection, and why it grades on any host

Deleting the correction is a **no-op wherever the wall clock never steps**, so that entry would pass against a recorder that ignores the record entirely — the catalogue's *environment-agreeing assertion*, and the trap #234 walked into and caught. Instead the entry makes the recorder report a step **nobody measured**, at `t=0` so it bears on every beat. A recorder that applies its record then cuts frames 500 ms from where this harness — which watched the real clock and saw nothing — puts them. A recorder that ignores its record cuts them where they were, and the entry goes unnoticed. Same grading on a stepping host and a steady one.

## Verification, and one honest gap

Browser-free, on this branch:

| suite | verdict |
|---|---|
| `./tests/unit` | `Ran 214 tests` -> **OK** |
| `./tests/unit --fault-inject` | **All 129 injections were caught.** |
| `./tests/lint` | **All checks passed!** / `10 python fence(s) parse` |
| `ruff format --check .` / `ruff check .` (repo root) | clean |
| `./tests/unit --budget` | `SKILL.md: 600 lines` — unchanged, net zero |
| `./tests/smoke-inject --list` | 43 entries, 12 arms, every entry still matches the tree |

**The `--segments-only` injection has not been seen to fail on this branch, and that is stated rather than glossed.** The authoring session was lost to an API limit before its evidence was recorded, and the attempt to regenerate it aborted — correctly:

```
ABORT: the clean --segments-only run failed, so nothing aimed at that arm can be
       graded — an assertion firing under injection would prove nothing if it
       fires without one.
```

The cause is the host, measured directly rather than guessed. Sampling `time.time()` against `time.monotonic()` for 31.6 s on this box right now:

```
steps over 50 ms: +10100, -10603, +10102, -10594, +10094, -10596,
                  +10095, -10587, +10086, -10599, +10099, -10595 ms
net wall-minus-monotonic drift: -2.999 s over 31.6 s
```

The wall clock is oscillating **+/-10 s every ~5.5 s**. That is a different animal from the 0.75-0.81 s steps #215 measured on the same box, and no take recorded here is currently gradeable. CI's clock is not this box's, so **`smoke-full` is labelled on this PR** and the `--segments-only` arm grades there.

Two things worth noting from that abort. The harness refused to grade rather than emitting a green — the `check_capture_clock` machinery from #227 doing exactly its job. And the design holds under an insult far past what it was built for: because `capture_clock` **measures** rather than assuming a bound, a host oscillating +/-10 s is still describable. A fixed tolerance would have been silently wrong.

## Provenance

The authoring agent was killed by an API session limit, and its work was later reset out of the working tree by another agent before it was ever committed. It was recovered from a saved diff, applied to a clean checkout of `origin/main`, and verified there — the suites above were run on the recovered tree, not inherited from the lost session.

## Out of scope

#224 (the terminal arm's extra unattributed loss) and #226 (narration mixed on the monotonic clock) are untouched, per the issue.
