### PR TITLE
Catalogue the trap #245 walked into: correct arithmetic, untrusted input

### DIFF
--- a/wip/verified-review/SKILL.md
+++ b/wip/verified-review/SKILL.md
@@ -217,6 +217,22 @@ rather than hiding, which is the direction you want.
 nearly free to satisfy and says almost nothing. Assert that output K
 corresponds to input K.
 
+**The faithful transformation of an untrusted input.** A check that proves code
+applies its record correctly, when the open question is whether the record
+describes the world. A change corrected each review frame's seek by the
+wall-clock steps the recorder had measured; five fault injections graded that
+arithmetic against a scripted record and all five were caught. The record was
+an aliased sample of a clock oscillating faster than the sampler, the video
+never followed it, and the correction moved frames *away* from their beats —
+caught only by the one check that read pixels. Note where this would have
+landed: on CI the clock is steady, every take reports no step, the correction
+is a no-op, and all five injections still pass. Green there was guaranteed and
+meaningless.
+*Detect:* ask what the assertion would say if the input were pure noise. If it
+would still pass, it grades the transformation and not the claim — something
+in the suite has to compare the output against the world rather than against
+the input.
+
 ## Working the loop
 
 1. **Author** states the acceptance criterion, implements, and fault-injects


### PR DESCRIPTION
The catalogue in `wip/verified-review/SKILL.md` states that every entry in it came from a change in this repo with green CI and an honest author. #229/#245 is the newest such change, and nothing already in the list covers it.

## The entry

A check that proves code applies its record faithfully, when the open question is whether the record describes the world.

#229 corrected each review frame's seek by the wall-clock steps the recorder had measured. Five fault injections graded that arithmetic against a scripted record and **all five were caught**. The record was an aliased sample of a clock oscillating faster than the sampler (#245), the video never followed it, and the correction moved frames *away* from their beats — caught only by the one check that reads pixels.

The part worth recording is where it would have landed: **a CI runner's clock is steady**, so every take there reports no step, the correction is a no-op, and all five injections pass regardless. Green on CI was guaranteed in advance and carried no information about the claim.

It is deliberately distinguished from *the environment-agreeing assertion* already in the catalogue, which is about a check passing because the machine already satisfies it. Here the check was correct and the injections were real — the **input** was fiction.

## Provenance

Reported by the agent that built and then reverted #229, in its own words: *"Five green fault injections against a scripted record said nothing about whether the record describes the world. Only the check that reads pixels caught it."*

Docs only — `wip/verified-review/SKILL.md`, one entry. `./tests/unit` **OK**, `./tests/lint` **All checks passed!**. No assertion added, so nothing to fault-inject.