### PR TITLE
Reap the old smoke output directories, and point limits.md at the cursor (#218, #244)

### DIFF
--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -14,10 +14,12 @@ newly found gap outside it is a line in this file, and an author who knows the
 boundary can work around it. Each section names the issue it supersedes, and
 carries that issue's numbers, so the evidence outlives the issue.
 
-Two limits live elsewhere and are not repeated. The recorder hides nothing that
+Some limits live elsewhere and are not repeated. The recorder hides nothing that
 reaches the screen — the top of [SKILL.md](../SKILL.md), and the reason there
 is no masking verb. A frozen clock changes what an app does and usually does it
-silently — [determinism.md](determinism.md).
+silently, and every boundary about the recorder's own cursor sits beside it —
+when the dot is drawn at all, why a verb landing on exactly `(0, 0)` draws
+nothing, and when a move can be dropped outright — [determinism.md](determinism.md).
 
 ## What the recorder will not notice about your app
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -11025,6 +11025,60 @@ def main() -> int:
     return 0
 
 
+# How many previous ephemeral output directories survive a new run, and the
+# age under which one is never touched however many there are (issue #218).
+#
+# A failed run keeps its directory on purpose — that is what makes a failure
+# debuggable, and `main()` only removes an ephemeral `out_root` when there were
+# no failures. Nothing ever reaped them, so the pile was 134 directories when
+# #218 was filed. It is bounded in practice by the host clearing `/tmp` on
+# restart, which is why this is keep-last-N rather than anything cleverer:
+# the directory somebody is about to look at is the one that just failed, and
+# the four before it cover going back to compare.
+#
+# `REAP_MIN_AGE_S` is the concurrency guard. The machine lock means one suite
+# at a time, but `--allow-concurrent` exists and a run that has been going for
+# under an hour may still be writing. Young directories are never removed
+# *and* they use up the budget, so a burst of concurrent runs reaps nothing.
+KEEP_OUT_ROOTS = 5
+REAP_MIN_AGE_S = 3600.0
+
+
+def out_roots_to_reap(
+    entries: list[tuple[Path, float]],
+    now: float,
+    keep: int = KEEP_OUT_ROOTS,
+    min_age_s: float = REAP_MIN_AGE_S,
+) -> list[Path]:
+    """Which previous runs' directories this run may remove.
+
+    Pure, and separated from the filesystem for exactly that reason: the
+    interesting behaviour is the budget arithmetic, and a test that had to
+    stage real directories with faked mtimes would grade the staging.
+    """
+    young = [(p, m) for p, m in entries if now - m < min_age_s]
+    old = sorted(
+        ((p, m) for p, m in entries if now - m >= min_age_s),
+        key=lambda pm: pm[1],
+        reverse=True,
+    )
+    room = max(0, keep - len(young))
+    return [p for p, _ in old[room:]]
+
+
+def reap_previous_out_roots() -> None:
+    """Apply `out_roots_to_reap` to this host's temp directory."""
+    entries: list[tuple[Path, float]] = []
+    for path in Path(tempfile.gettempdir()).glob("demo-video-smoke-*"):
+        try:
+            if path.is_dir():
+                entries.append((path, path.stat().st_mtime))
+        except OSError:
+            continue  # vanished under us, or not ours to read
+    for stale in out_roots_to_reap(entries, time.time()):
+        shutil.rmtree(stale, ignore_errors=True)
+
+
 def open_output(args: argparse.Namespace) -> tuple[Path, bool]:
     """This run's output directory, and whether the run owns it.
 
@@ -11039,6 +11093,8 @@ def open_output(args: argparse.Namespace) -> tuple[Path, bool]:
         out_root = args.out_dir.resolve()
         out_root.mkdir(parents=True, exist_ok=True)
         return out_root, False
+    # Before this run's own directory exists, so it is never a candidate.
+    reap_previous_out_roots()
     return Path(tempfile.mkdtemp(prefix="demo-video-smoke-")), True
 
 

--- a/tests/unit
+++ b/tests/unit
@@ -2249,6 +2249,77 @@ def _smoke_guards():
     return guards, flags
 
 
+class ReapedOutRoots(unittest.TestCase):
+    """The keep-last-N policy for `/tmp/demo-video-smoke-*` (issue #218).
+
+    A failed run keeps its directory deliberately, and nothing ever removed
+    them — 134 on the box that filed #218. The pile is bounded in practice by
+    the host clearing `/tmp` on restart, so what matters is not that the
+    reaper is aggressive but that it never takes the one somebody is about to
+    read, and never takes a directory a concurrent run is still writing to.
+    """
+
+    def setUp(self):
+        self.smoke = _smoke_module()
+        self.now = 1_000_000.0
+
+    def aged(self, count, age_s, prefix="old"):
+        return [
+            (Path(f"/tmp/{prefix}-{i}"), self.now - age_s - i) for i in range(count)
+        ]
+
+    def reap(self, entries, **kw):
+        return self.smoke.out_roots_to_reap(entries, self.now, **kw)
+
+    def test_the_five_most_recent_survive_and_the_rest_go(self):
+        entries = self.aged(9, 7200)
+        reaped = self.reap(entries, keep=5, min_age_s=3600.0)
+        self.assertEqual(
+            [p.name for p in reaped],
+            ["old-5", "old-6", "old-7", "old-8"],
+            "the reaper should keep the five newest by mtime and remove the "
+            "rest — anything else and the directory a run just failed in is "
+            "not reliably the one that survives",
+        )
+
+    def test_nothing_young_is_removed_however_many_there_are(self):
+        # Twenty concurrent runs, all started minutes ago. A reaper that went
+        # by count alone would delete fifteen directories being written to.
+        entries = self.aged(20, 60, prefix="live")
+        self.assertEqual(
+            self.reap(entries, keep=5, min_age_s=3600.0),
+            [],
+            "a directory younger than the age floor must never be reaped, "
+            "whatever the count — --allow-concurrent means a young directory "
+            "may still be receiving a take",
+        )
+
+    def test_a_young_directory_spends_the_budget_it_occupies(self):
+        """The subtle one, and the reason `keep` is not applied to old alone.
+
+        Four live runs plus five old directories is nine on disk. If `keep`
+        counted only the old ones, the floor would be nine and the pile would
+        grow by one for every concurrent run ever made.
+        """
+        entries = self.aged(4, 60, prefix="live") + self.aged(5, 7200)
+        reaped = self.reap(entries, keep=5, min_age_s=3600.0)
+        self.assertEqual(
+            [p.name for p in reaped],
+            ["old-1", "old-2", "old-3", "old-4"],
+            "four young directories should leave room for exactly one old "
+            "one, so the total on disk settles at `keep`",
+        )
+
+    def test_fewer_than_the_budget_reaps_nothing(self):
+        self.assertEqual(self.reap(self.aged(3, 7200), keep=5, min_age_s=3600.0), [])
+        self.assertEqual(self.reap([], keep=5, min_age_s=3600.0), [])
+
+    def test_the_shipped_constants_are_the_ones_the_policy_was_argued_for(self):
+        # An ungraded constant is one nothing pins. These two are the policy.
+        self.assertEqual(self.smoke.KEEP_OUT_ROOTS, 5)
+        self.assertEqual(self.smoke.REAP_MIN_AGE_S, 3600.0)
+
+
 class CheapArm(unittest.TestCase):
     def setUp(self):
         self.guards, self.flags = _smoke_guards()
@@ -5588,6 +5659,40 @@ INJECTIONS = [
         'POINTER_PATH_RE = re.compile(r"\\breference/[A-Za-z0-9_-]+\\.md\\b")',
         'POINTER_PATH_RE = re.compile(r"\\breference/[A-Za-z0-9_-]{80,}\\.md\\b")',
         ["DocPointers.test_every_reference_document_the_skill_names_exists"],
+    ),
+    (
+        # The concurrency guard removed. Every directory becomes a candidate,
+        # so a run started five minutes ago and still recording has its output
+        # deleted underneath it by the next run to start.
+        "the reaper treats a directory a live run is writing to as reapable",
+        "tests/smoke",
+        "        ((p, m) for p, m in entries if now - m >= min_age_s),",
+        "        ((p, m) for p, m in entries),",
+        [
+            "ReapedOutRoots.test_nothing_young_is_removed_however_many_there_are",
+            "ReapedOutRoots.test_a_young_directory_spends_the_budget_it_occupies",
+        ],
+    ),
+    (
+        # The budget applied to the old directories alone. Nothing is deleted
+        # that should not be, so every count-based check still passes — the
+        # pile simply never stops growing, one per concurrent run, which is
+        # the failure #218 is about rather than the destructive one above.
+        "young directories are kept without spending the budget they occupy",
+        "tests/smoke",
+        "    room = max(0, keep - len(young))",
+        "    room = keep",
+        ["ReapedOutRoots.test_a_young_directory_spends_the_budget_it_occupies"],
+    ),
+    (
+        # Oldest-first. Exactly `keep` directories survive, so a check that
+        # counted what was left would pass, and the one a run just failed in
+        # is the first thing deleted.
+        "the reaper keeps the oldest directories instead of the newest",
+        "tests/smoke",
+        "        key=lambda pm: pm[1],\n        reverse=True,",
+        "        key=lambda pm: pm[1],",
+        ["ReapedOutRoots.test_the_five_most_recent_survive_and_the_rest_go"],
     ),
     (
         "a deletion leaves a constant in tests/smoke that nothing reads",


### PR DESCRIPTION
Two small things, folded into one change rather than carried as issues.

## #218 — the reaper

`open_output` keeps the **five most recent** `/tmp/demo-video-smoke-*` directories and removes the rest, before it creates this run's own so that one is never a candidate.

**Two corrections to the issue's framing, found while implementing it.**

The pile is bounded by the host clearing `/tmp` on restart. #218 measured 134 directories; there are **zero** on this box today. So this is hygiene, not the leak the issue describes — worth doing, not worth what the issue implies.

And the issue does not mention the guard the reaper actually needs: `--allow-concurrent` means a directory minutes old may still be receiving a take. Nothing under an hour is touched, **and young directories spend the budget they occupy** — otherwise the floor rises with every concurrent run and the pile grows forever.

## The injections

The selection is a pure function, so the budget arithmetic is graded without staging real directories with faked mtimes — which would have graded the staging. Five cases, three injections, all seen to fail:

```
PASS  break: the reaper treats a directory a live run is writing to as reapable
PASS  break: young directories are kept without spending the budget they occupy
PASS  break: the reaper keeps the oldest directories instead of the newest
All 127 injections were caught.
```

The last two matter most: **both leave exactly the right number of directories on disk**, so a check that counted survivors would pass while the reaper deleted the one somebody was about to read.

One injection was rejected by the harness before it landed, and that is worth recording. I first broke the guard as `young = []`, which reads like removing the concurrency protection but does not — the age filter on `old` still excludes young directories, so nothing young could be reaped and only one of the two tests I had named failed. The exactly-once contract caught the mismatch. The guard actually lives in the `old` comprehension, and the injection now targets it.

## #244 — the pointer

`limits.md` said "Two limits live elsewhere" and named the frozen clock, while `determinism.md` carried three cursor boundaries it did not mention — four since #243. Named in one clause, not restated, so the cursor's limits stay in one file.

## Verification

| suite | verdict |
|---|---|
| `./tests/unit` | `Ran 198 tests` → **OK** |
| `./tests/unit --fault-inject` | **All 127 injections were caught.** |
| `./tests/lint` | **All checks passed!** |
| `ruff format --check .` / `ruff check .` (root) | clean |
| `./tests/smoke-inject --self-test` | **Every guard refused what it exists to refuse.** |
| `./tests/unit --budget` | `SKILL.md: 600 lines` — untouched |

No `tests/smoke` arm run locally: this host's wall clock is currently oscillating ±10 s every ~5.5 s (#245), so no recorded take is gradeable here. The reaper's behaviour is graded browser-free by the cases above; CI records the arms.