### PR TITLE
capture_clock is real; its sampler was captured by the clock it sampled (#245, #247)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -95,9 +95,9 @@ behind every one, are in [reference/limits.md](reference/limits.md).
 - **A frame is aimed at a beat, not stamped with one.** Chromium stamps frames
   with the host's **wall** clock, the beat log uses a monotonic one, so on a
   host whose clock steps an event lands earlier in `demo.mp4` — by the step,
-  once per step (0.75–0.81 s every 32.2 s on one WSL2 box). **No fixed bound
-  holds**; a longer demo accumulates more. `timeline.json`'s `capture_clock`
-  records each one: correct with it, or read a frame as *around* its beat.
+  once per step, and no measured figure keeps — one WSL2 box gave −0.78 s
+  every 32.2 s, then −0.50 s every 5.5 s. `timeline.json`'s `capture_clock`
+  records each: correct with it once its `measured` flag says it watched.
 - **Sixty seconds buys about twenty screens.** At the pacing floors below, a
   demo shows roughly one new screen every 3 s — 69% of a real 61.2 s take was
   a picture already shown. A feature spanning two surfaces does not fit the

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -457,14 +457,25 @@ def _clock_epoch_ms(value: str) -> int:
 #                                                 monotonic clock and 711 ms
 #                                                 *backwards* on Chromium's
 #
-# That host steps -0.75 to -0.81 s every 32.2 s, like a metronome, which in a
-# 19 s take is a coin flip — and is why the same storyboard loses ~0.8 s of
-# video on some runs and none on others with nothing else different. Seven
-# takes of one storyboard with this sampler beside them: the four whose window
-# contained a step encoded 0.78 s less video than the three that did not, to
-# within 12 ms, every time. An idle page does not do this — 30 s of a take
-# with nothing painting at all, seven screencast frames in total, lost nothing
-# but the one step.
+# **What that host does, re-measured on 2026-08-08** (issue #247; the numbers
+# below are this file's own, taken with a 1 ms sampler over 300 s, and they
+# replace the "-0.75 to -0.81 s every 32.2 s" this comment used to state as a
+# constant). The wall clock is a **rectangular pulse train**: the offset jumps
+# +10.03 to +10.10 s, holds flat for 40-230 ms, then falls 10.53-10.60 s, and
+# lands 0.43-0.56 s *below* where it started. Period 5.509 s (5.500-5.517
+# across 55 pulses), and between pulses the offset is flat to under 10 us.
+# CLOCK_REALTIME_COARSE moves with it, so this is the kernel's timekeeper
+# being written, not a vDSO read glitch.
+#
+# The permanent part of that is a **rate error, not a metronome**: against an
+# NTP server over 90 s, CLOCK_MONOTONIC ran +10.01 % fast and CLOCK_REALTIME
+# kept true time to -0.40 %, and `adjtimex` reports `tick = 11000` — the
+# kernel's +10 % clamp. Something (Hyper-V/`systemd-timesyncd` on WSL2) is
+# re-stepping the wall clock every 5.5 s to undo a monotonic clock that is
+# running fast. **So the size and the period are properties of one sick host
+# on one day, not of this recorder** — #215's 0.78 s every 32.2 s and this
+# 0.50 s every 5.5 s are the same shape at different settings. Nothing here
+# may be tuned to either.
 #
 # None of that is fixable here. The clock is the host's, the timestamp is the
 # protocol's, and the recorder cannot re-stamp a frame it never sees. What it
@@ -473,6 +484,15 @@ def _clock_epoch_ms(value: str) -> int:
 # beat at `t_start` can work out that the beat really sits at
 # `t_start + (sum of the steps before it)` in the video, instead of
 # discovering it as an unexplained 0.8 s.
+#
+# **That correction was verified against the encode, and it is exact.** Six
+# takes, seven caption transitions each, the transitions read off `demo.mp4`'s
+# pixels and compared with the beat log: uncorrected, the video ran up to
+# 1.50 s ahead of the log by 13.5 s into the take; corrected by a *correctly
+# sampled* wall-clock offset, every one of the 38 transitions landed within
+# 101 ms, and within 40 ms at the caption-on edges (a caption fade takes two
+# frames to cross, which is the other 60). #245 read the same field as noise;
+# it was not the field, it was the sampler — see `INTERVAL_S` below.
 class _CaptureClock:
     """CLOCK_REALTIME against CLOCK_MONOTONIC, for the life of one capture.
 
@@ -484,6 +504,28 @@ class _CaptureClock:
     # A step is instantaneous, so this bounds only *where* it gets reported,
     # and 20 ms is inside the 40 ms one frame of the 25 fps encode covers —
     # under the resolution anything reading the answer has.
+    #
+    # **The sleep between samples must not be timed on the clock being
+    # sampled, and `threading.Event.wait` is** (issue #247, and this cost a
+    # whole issue's worth of wrong diagnosis). On the interpreter `uv`
+    # installs — CPython 3.13.11 from python-build-standalone, built against
+    # a glibc without `sem_clockwait` — a lock acquire with a timeout falls
+    # back to `sem_timedwait`, whose deadline is an absolute CLOCK_REALTIME
+    # instant. So a sampler that happens to call `wait()` while the host's
+    # +10 s pulse is up has set a deadline 10 s in the future, the pulse ends,
+    # and it sleeps until the wall clock climbs back — which on this host is
+    # the *next* pulse, 5.5 s later. Measured directly: 81 waits of 20 ms in
+    # 25 s instead of ~1140, five of them 5.44-5.49 s long, every one entered
+    # with the offset elevated.
+    #
+    # Once trapped the sampler is phase-locked into the pulses and every
+    # sample it takes from then on is taken *inside* one, so it reports the
+    # top of the transient it exists to reject. Eight idle 20 s runs of the
+    # old loop against a 1 ms reference: `total` wrong by +10.59 to +10.60 s,
+    # every time. Six recorded takes: `total` +9.09 s where the truth was
+    # -2.00 s. `time.sleep` is `clock_nanosleep(CLOCK_MONOTONIC)` and is not
+    # affected; `stop()` therefore costs up to one interval of latency, which
+    # is the whole price.
     INTERVAL_S = 0.02
     # Under this a reading is the scheduling gap between the two `time` calls,
     # not a step. Measured idle: below 0.4 ms, four orders under a real one.
@@ -492,15 +534,32 @@ class _CaptureClock:
     # loud. One frame of the encode: below that the video and the log still
     # agree about which frame a beat is on.
     WARN_S = 0.04
+    # **The record only means anything if the sampler kept its interval.** A
+    # step is found by differencing consecutive samples, so a sampler that was
+    # away for a second cannot say when — or whether — the clock moved inside
+    # it, and a consumer summing `steps` before a beat would be adding up
+    # something nobody watched. So the widest gap between samples is measured
+    # and reported, and over this bound the record refuses to answer instead
+    # of guessing. 250 ms is 12x the nominal interval, and 22x under the
+    # 5.5 s the trapped sampler above produced: the two populations are an
+    # order of magnitude apart, not a comfortable margin.
+    MAX_GAP_S = 0.25
 
     def __init__(self) -> None:
         self.steps: list[dict] = []
+        # The widest interval between two consecutive samples, and how many
+        # were taken. Both are the sampler grading its own coverage; see
+        # MAX_GAP_S.
+        self.max_gap = 0.0
+        self.samples = 0
         self._t0 = 0.0
+        self._started = False
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
 
     def start(self, t0: float) -> None:
         self._t0 = t0
+        self._started = True
         self._thread = threading.Thread(
             target=self._run, name="demo-video-clock", daemon=True
         )
@@ -508,18 +567,24 @@ class _CaptureClock:
 
     def _run(self) -> None:
         previous = time.time() - time.monotonic()
+        last = time.monotonic()
         while not self._stop.is_set():
+            now = time.monotonic()
+            self.max_gap = max(self.max_gap, now - last)
+            last = now
+            self.samples += 1
             offset = time.time() - time.monotonic()
             delta = offset - previous
             if abs(delta) >= self.MIN_STEP_S:
                 self.steps.append(
                     {
-                        "t": round(time.monotonic() - self._t0, 3),
+                        "t": round(now - self._t0, 3),
                         "delta": round(delta, 4),
                     }
                 )
             previous = offset
-            self._stop.wait(self.INTERVAL_S)
+            # Not `self._stop.wait(...)` — see INTERVAL_S.
+            time.sleep(self.INTERVAL_S)
 
     def stop(self) -> None:
         self._stop.set()
@@ -531,16 +596,57 @@ class _CaptureClock:
     def total(self) -> float:
         return sum(step["delta"] for step in self.steps)
 
+    @property
+    def measured(self) -> bool:
+        """Did the sampler cover the take closely enough to be believed?"""
+        return self._started and self.samples > 1 and self.max_gap <= self.MAX_GAP_S
+
+    def note(self) -> str | None:
+        """Why the record is refusing to answer, or None when it is not."""
+        if self.measured:
+            return None
+        if not self._started or self.samples <= 1:
+            return (
+                "the wall-clock sampler never ran, so nothing here knows "
+                "whether the video's clock moved under the beat log"
+            )
+        return (
+            f"the wall-clock sampler was away for up to {self.max_gap:.2f}s "
+            f"against its {self.INTERVAL_S:.2f}s interval, so it cannot say "
+            f"when — or whether — the clock moved inside that gap. Reporting "
+            f"nothing rather than a total nobody watched (issue #247)"
+        )
+
     def report(self) -> dict:
+        """The `capture_clock` envelope field. See timeline.py for the schema.
+
+        `measured` first, and `steps`/`total` empty and null when it is false:
+        a consumer that reaches straight for `total` gets `None` and fails
+        loudly, rather than correcting a beat by a number the sampler did not
+        see. Same shape as `content`, for the same reason.
+        """
+        ok = self.measured
         return {
-            "steps": list(self.steps),
-            "total": round(self.total, 4),
+            "measured": ok,
+            "note": self.note(),
+            "steps": list(self.steps) if ok else [],
+            "total": round(self.total, 4) if ok else None,
             "sample_interval": self.INTERVAL_S,
             "min_step": self.MIN_STEP_S,
+            "max_gap": round(self.max_gap, 4),
+            "max_gap_limit": self.MAX_GAP_S,
         }
 
     def warning(self) -> str | None:
         """What to tell the author, or None when the two clocks agreed."""
+        if not self.measured:
+            return (
+                f"demo-video: WARNING — this take's wall clock could not be "
+                f"measured: {self.note()}. demo.mp4 is on the host's wall "
+                f"clock and the beat log is on the monotonic one, so if they "
+                f"parted company during the take, nothing in timeline.json "
+                f"can tell you by how much. `capture_clock.measured` is false."
+            )
         if abs(self.total) < self.WARN_S:
             return None
         when = ", ".join(
@@ -555,7 +661,8 @@ class _CaptureClock:
             f"{'shorter' if self.total < 0 else 'longer'} than the take's own "
             f"wall time and every beat after the step sits that far "
             f"{'ahead of' if self.total < 0 else 'behind'} the frame it names. "
-            f"timeline.json records it as `capture_clock`; issues #18 and #215."
+            f"timeline.json records it as `capture_clock`; issues #18, #215, "
+            f"#247."
         )
 
 

--- a/skills/demo-video/helpers/demo_recording/stitching.py
+++ b/skills/demo-video/helpers/demo_recording/stitching.py
@@ -77,11 +77,19 @@ def _merge_capture_clock(docs: list[dict], records: list[dict]) -> dict | None:
     that quietly treated a missing one as "the clock held still" would state,
     in an artifact somebody corrects timestamps with, that a part nobody
     measured was measured — and `total` would be short by whatever it stepped.
+
+    **A part whose own record says `measured: false` is exactly that case**,
+    and it is the one that looks harmless: its `steps` is a well-formed empty
+    list, so a merge that only checked the shape would fold "nobody watched
+    this part" into a stitched record indistinguishable from "this part's
+    clock held still" (issue #247).
     """
     steps: list[dict] = []
     for doc, record in zip(docs, records, strict=True):
         clock = doc.get("capture_clock")
-        listed = clock.get("steps") if isinstance(clock, dict) else None
+        if not isinstance(clock, dict) or clock.get("measured") is not True:
+            return None
+        listed = clock.get("steps")
         if not isinstance(listed, list):
             return None
         for step in listed:
@@ -100,7 +108,12 @@ def _merge_capture_clock(docs: list[dict], records: list[dict]) -> dict | None:
                 {**step, "t": at, "delta": float(delta), "segment": record["segment"]}
             )
     clocks = [doc.get("capture_clock") or {} for doc in docs]
+    gaps = [c.get("max_gap") for c in clocks]
     return {
+        # True by construction: every part was checked above, and a merge is
+        # refused outright when any of them was not measured.
+        "measured": True,
+        "note": None,
         "steps": steps,
         # The sum across the whole recording session, which is **not** the
         # correction for any single beat — see above. It is here because a
@@ -108,6 +121,14 @@ def _merge_capture_clock(docs: list[dict], records: list[dict]) -> dict | None:
         "total": round(sum(step["delta"] for step in steps), 4),
         "sample_interval": _common([c.get("sample_interval") for c in clocks]),
         "min_step": _common([c.get("min_step") for c in clocks]),
+        # The worst coverage any part managed, not an average: a stitched
+        # record is only as believable as its shakiest capture.
+        "max_gap": max(
+            (g for g in gaps if isinstance(g, (int, float))
+             and not isinstance(g, bool)),
+            default=None,
+        ),
+        "max_gap_limit": _common([c.get("max_gap_limit") for c in clocks]),
         "boundaries": [record["offset"] for record in records],
     }
 

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -51,14 +51,29 @@ from .markdown import _fmt_t, _md_cell
 #                          frame with the host's *wall* clock; the beat log is
 #                          `time.monotonic()`. So the recorder samples the
 #                          difference for the take's whole life and writes down
-#                          every step it saw: `steps` (each `t`, seconds into
-#                          the take, and `delta`, seconds the wall clock
-#                          jumped), `total`, `sample_interval` and `min_step`
-#                          (the sampler's own settings; the smallest jump it
-#                          calls a step). An empty `steps` means the clock held
-#                          still, which is a different answer from the field
-#                          being absent. **A beat the log puts at `t` sits at
+#                          every step it saw: `measured` (bool — see below),
+#                          `note` (why not, when it is false), `steps` (each
+#                          `t`, seconds into the take, and `delta`, seconds
+#                          the wall clock jumped), `total`, `sample_interval`
+#                          and `min_step` (the sampler's own settings; the
+#                          smallest jump it calls a step), and `max_gap` /
+#                          `max_gap_limit` (the widest interval the sampler
+#                          actually left between two readings, and the bound
+#                          over which it refuses to answer).
+#                          **Read `measured` first.** When it is false,
+#                          `steps` is empty and `total` is null on purpose:
+#                          the sampler was away long enough that it cannot say
+#                          when — or whether — the clock moved, and a consumer
+#                          correcting a beat with a number nobody watched is
+#                          the failure this field grew a flag to prevent
+#                          (issue #247). An empty `steps` with `measured` true
+#                          means the clock held still, which is a different
+#                          answer again from the field being absent.
+#                          **A beat the log puts at `t` sits at
 #                          `t + (the steps before it)` in the video** —
+#                          measured against the encode over six takes and 38
+#                          caption transitions, residual under 101 ms where
+#                          the uncorrected log was out by up to 1.50 s.
 #                          reference/limits.md has the measurement.
 #                          On a merged demo (`stitch`) every part's steps are
 #                          here, moved onto the stitched clock by that part's

--- a/skills/demo-video/reference/failures.md
+++ b/skills/demo-video/reference/failures.md
@@ -147,11 +147,17 @@ holding back, so the dump is of the screen the recording ends on.
 complete demo — it stops where the storyboard did, and it does not diagnose
 the crash.
 
-**Timestamps are wall-clock offsets, and the video can drift under them.**
-Chromium's screencast emits a frame when the page paints and nothing pads the
-gap when it does not, so an idle stretch costs the recording ~0.6 s of wall
-time and every frame after it lands that much earlier than the timestamps say.
-The beat log itself is good to ~100–200 ms of the frame it describes; the drift
-is the capture's, and it shows up as `duration` being shorter than the take
-really was. Tracked in [issue #18](https://github.com/rogvid/skills/issues/18)
-— read it before relying on a beat timestamp to extract a frame.
+**Timestamps are monotonic offsets, and the video runs on a different clock.**
+Beat timestamps are `time.monotonic()`; `demo.mp4` is on the host's **wall**
+clock, because that is what Chromium stamps every screencast frame with. On a
+host whose wall clock moves during a take, every frame after the move lands
+that much earlier than the timestamps say. (An earlier version of this
+paragraph blamed idle stretches — a screencast emitting no frames when nothing
+paints. That was measured and is not what happens; see `limits.md`.) The beat
+log itself is good to ~100–200 ms of the frame it describes on a host whose
+clock holds still. `timeline.json`'s `capture_clock` records the movement, and
+`capture_clock.measured` says whether the recorder could watch for it at all.
+Tracked in [#18](https://github.com/rogvid/skills/issues/18),
+[#215](https://github.com/rogvid/skills/issues/215) and
+[#247](https://github.com/rogvid/skills/issues/247) — read them before relying
+on a beat timestamp to extract a frame.

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -88,13 +88,35 @@ produced seven frames and came back the full 30 s. The evidence that looked
 like idle loss was six samples of the clock step, and the ticker both
 storyboards inject was credited with preventing something it does not affect.
 
-Measured on one WSL2 host: **−0.75 to −0.81 s every 32.2 s**, confirmed by a
-sampler that opens no browser and by a patched Playwright driver that caught
-two consecutive frames 84 ms apart on the monotonic clock and 711 ms backwards
-on Chromium's. Seven takes of one storyboard: the four whose window contained a
-step encoded 0.78 s less video than the three that did not, to within 12 ms.
-A 19 s take against a 32.2 s interval is a coin flip, which is exactly the
-bimodality [#209](https://github.com/rogvid/skills/issues/209) measured.
+Measured on one WSL2 host in April: **−0.75 to −0.81 s every 32.2 s**,
+confirmed by a sampler that opens no browser and by a patched Playwright driver
+that caught two consecutive frames 84 ms apart on the monotonic clock and
+711 ms backwards on Chromium's. Seven takes of one storyboard: the four whose
+window contained a step encoded 0.78 s less video than the three that did not,
+to within 12 ms. A 19 s take against a 32.2 s interval is a coin flip, which is
+exactly the bimodality
+[#209](https://github.com/rogvid/skills/issues/209) measured.
+
+**Do not read those two numbers as constants.** The same host, re-measured on
+2026-08-08 with a 1 ms sampler over 300 s, was doing something else entirely
+([#247](https://github.com/rogvid/skills/issues/247)): a **+10.03 to +10.10 s
+rectangular pulse, 40–230 ms wide, every 5.509 s**, each one leaving the offset
+0.43–0.56 s lower than it found it. `CLOCK_REALTIME_COARSE` moved with it, so
+the kernel's timekeeper was being written, not a clock read glitching. The
+permanent part of it is a **rate error, not a metronome**: against NTP over
+90 s, `CLOCK_MONOTONIC` ran **+10.01 % fast** while `CLOCK_REALTIME` kept true
+time to −0.40 %, and `adjtimex` reported `tick = 11000` — the kernel's +10 %
+clamp. Something on the host (Hyper-V / `systemd-timesyncd` under WSL2) was
+re-stepping the wall clock every 5.5 s to undo a monotonic clock running fast.
+Same shape as April's, different size and period. **The recorder is not tuned
+to either, and nothing you build on top of it should be.**
+
+**The correction is exact when the record is.** Six takes, seven caption
+transitions each, transitions located by luma straight off `demo.mp4` and
+compared with the beat log: uncorrected, the video was up to **−1.50 s** from
+the log by 13.5 s into the take; corrected by the wall-clock offset before each
+beat, all 38 landed within **101 ms**, and within 40 ms at the caption-on edges
+(a caption fade takes two frames to cross, which is the rest).
 
 The suite's bars are asymmetric because the two directions have different
 causes: `MAX_LOG_EARLY_S = 0.25` for the log running ahead of the frame
@@ -110,7 +132,20 @@ restored at 250 ms after being deleted in
 [#217](https://github.com/rogvid/skills/issues/217).
 
 What to do: prefer `timeline.json`'s `capture_clock`, which records every step
-with its offset and size, and correct with it. On a **stitched** demo the same
+with its offset and size, and correct with it — **after checking
+`capture_clock.measured`**. That flag is false when the recorder's sampler
+could not keep its interval, and then `steps` is empty and `total` is `null`
+on purpose: a record that says "I did not watch this" is the one thing worth
+more than a number that might be wrong. `max_gap` and `max_gap_limit` are the
+measurement behind the flag. This exists because the sampler *was* wrong once,
+silently, for a whole issue: it slept on `threading.Event.wait`, whose deadline
+on the interpreter `uv` installs is an absolute `CLOCK_REALTIME` instant, so a
+sampler that read the clock during one of those +10 s pulses set a deadline
+10 s ahead, slept until the wall clock climbed back, and from then on only ever
+sampled *inside* the pulses. It reported `total: +9.09 s` on takes whose clock
+had moved −2.00 s. Nothing downstream could tell.
+
+On a **stitched** demo the same
 field carries every part's steps, each naming the `segment` it was measured in:
 correct a beat with the steps of *its own* segment up to its `t_start`, never
 with `total` and never with an earlier part's — that part's lost wall time is

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -20,14 +20,22 @@ They are aligned to **beats, not to a clock**. The old advice was
 static one twice. Each frame is taken at its beat's **midpoint** — `t_start` is
 0% into the caption bar's fade and before the verb has done anything.
 
-**How accurate that aim is, honestly.** The beat log is wall-clock; the video
-is whatever Chromium's screencast managed to record, and it drops wall time
-during idle stretches ([#18](https://github.com/rogvid/skills/issues/18)). So a
-frame cut at a beat's midpoint shows a moment slightly *ahead* of that beat in
-the demo's own story — measured at **80–200 ms** on instrumented takes, and up
-to the **~0.7 s** of browser start-up no test code can cover, on a take that
-loses that window whole (about 1 in 12, which is why `tests/smoke` bounds this
-direction at 750 ms). The practical consequence: for a beat comfortably longer
+**How accurate that aim is, honestly.** The beat log is `time.monotonic()`;
+the video is on the host's **wall** clock, because that is what Chromium
+stamps every screencast frame with
+([#18](https://github.com/rogvid/skills/issues/18),
+[#215](https://github.com/rogvid/skills/issues/215)). (It is *not* dropped
+idle time — that explanation was measured and retracted; see
+`limits.md`.) So a frame cut at a beat's midpoint shows a moment slightly
+*ahead* of that beat in the demo's own story — measured at **80–200 ms** on
+instrumented takes with a steady host clock, and by however much the host's
+wall clock moved during the take on one that does not: **1.50 s** by 13.5 s
+into a take on the WSL2 box of
+[#247](https://github.com/rogvid/skills/issues/247), with no fixed bound. The
+size is in `timeline.json`'s `capture_clock`, and nothing in the recorder
+applies it to these frames yet
+([#229](https://github.com/rogvid/skills/issues/229)). The practical
+consequence: for a beat comfortably longer
 than that, the frame is of that beat; **for a beat shorter than the drift — a
 bare `shot()`, a `wait_for()` that returned immediately — the frame can be of
 the beat after it.** `tests/smoke` measures exactly this and shows it: with the

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,7 +38,7 @@ below for what it covers and what it does not.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~40 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~41 min, nightly)
 ├── unit               # the browser-free half (~0.07 s, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
@@ -183,7 +183,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~48 s)
-tests/smoke-inject                # all 45 entries, ~40 min
+tests/smoke-inject                # all 48 entries, ~41 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -1671,7 +1671,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-45 entries, 12 arms, ~39.5 min of takes
+48 entries, 12 arms, ~41.0 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -1704,7 +1704,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
-| `--segments-only` | 10 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)) |
+| `--segments-only` | 13 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
@@ -1713,7 +1713,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **16 of `tests/smoke`'s 39 check functions have no entry**, and the harness
+- **16 of `tests/smoke`'s 40 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -1989,10 +1989,13 @@ knows is missing is worse than one that is openly absent.
   frame with the host's *wall* clock and Playwright turns that into the frame's
   position in the webm; the beat log is `time.monotonic()`. A host that steps
   its wall clock therefore takes that much wall time out of `demo.mp4` and
-  leaves the log where it was. The box this was found on steps **-0.75 to
-  -0.81 s every 32.2 s**, which is a coin flip inside a 19 s take and is the
-  whole of the bimodality
-  [#215](https://github.com/rogvid/skills/issues/215) reported.
+  leaves the log where it was. The box this was found on stepped **-0.75 to
+  -0.81 s every 32.2 s** in April, which is a coin flip inside a 19 s take and
+  is the whole of the bimodality
+  [#215](https://github.com/rogvid/skills/issues/215) reported — and **-0.50 s
+  every 5.5 s** when it was re-measured in August
+  ([#247](https://github.com/rogvid/skills/issues/247)). Same shape, different
+  settings. Nothing here is tuned to either number.
 
   What is fixed: the recorder measures the same clock and writes it into
   `timeline.json` as `capture_clock`, warns on the way out, and this harness
@@ -2007,49 +2010,49 @@ knows is missing is worse than one that is openly absent.
   [#18](https://github.com/rogvid/skills/issues/18) is that boundary, and it
   matters most to [#8](https://github.com/rogvid/skills/issues/8).
 
-- **…and the correction above rests on a premise that did not reproduce on
-  2026-08-08.** `capture_clock` and `HostClock` both sample
-  `time.time() - time.monotonic()` every 20 ms and call a change a step. On a
-  host whose wall clock *oscillates faster than that*, what they record is an
-  aliased fragment of the oscillation, and the video does not follow it.
-  Measured on `main` @ `bae7f74`, on the same Playwright 1.62.0 / Chromium
-  151.0.7922.34 [#215](https://github.com/rogvid/skills/issues/215) used —
-  a standalone sampler, no browser, 180 s, **66 events in 33 identical pairs**:
-  `time.time()` jumps **+10.08 to +10.36 s and returns −10.58 to −10.60 s about
-  60 ms later, every ~5.5 s**, with `d_monotonic` a steady 20 ms throughout. A
-  take competing with Playwright catches a fragment of that ~60 ms pulse, which
-  is why `capture_clock` reports a single step of −1.72 to −1.81 s and never
-  the ±10 s edges an idle sampler sees.
+- **~~…and the correction above rests on a premise that did not reproduce on
+  2026-08-08.~~ Retracted; the premise holds and the *sampler* was broken**
+  ([#247](https://github.com/rogvid/skills/issues/247)). The entry that stood
+  here read the field as an aliased fragment of an oscillation the video did
+  not follow. Both halves of that are wrong, and the way it went wrong is
+  worth keeping:
 
-  What the video did about it: eight `--segments-only` runs, four with a
-  recorded step, the closing caption's onset read off `demo.mp4` against
-  `timeline.json`. Stepped runs **0, +20, −70, −60 ms**; step-free runs **0,
-  +40, +10, +20 ms**; durations 14.44–14.52 s either way. Runs whose step
-  landed *six seconds before* the caption still put the caption within 20 ms of
-  the log, where the documented consequence predicts 1.7 s — 43 frames. One
-  excursion did reach the video and is the exception that explains the rule: a
-  run whose record held two **+10.36 s** steps encoded a 24.96 s demo, part2 at
-  18.32 s against a usual 7.9 s, with the closing caption +10.25 s past the
-  log. That pulse lasted long enough for Chromium to stamp frames across it;
-  the aliased fragments are not pulses at all.
+  - **It is not aliasing.** The waveform, at 1 ms over 300 s, is a
+    *rectangular* pulse: the offset jumps +10.03 to +10.10 s, holds flat for
+    40–230 ms, falls 10.53–10.60 s, and lands 0.43–0.56 s below where it
+    started, every 5.509 s. Sub-sampling that 1 ms record at 20 ms — the rate
+    `capture_clock` uses — recovers **110 of 110 edges** and a total within
+    2 % of the truth. A 20 ms sampler is entirely adequate to this waveform.
+  - **The sampler was captured by the clock it was sampling.** Both
+    `_CaptureClock` and `HostClock` slept on `threading.Event.wait`, whose
+    deadline on the interpreter `uv` installs (CPython 3.13.11 from
+    python-build-standalone, built without `sem_clockwait`) is an absolute
+    `CLOCK_REALTIME` instant. Measured directly: 81 waits of 20 ms in 25 s
+    instead of ~1140, five of them **5.44–5.49 s** long, every one entered
+    while the +10 s pulse was up. A sampler that reads the clock inside a
+    pulse sleeps until the wall clock climbs back — the *next* pulse — and is
+    then phase-locked, sampling only ever inside pulses. Eight idle 20 s runs
+    of the old loop against a 1 ms reference: `total` wrong by **+10.59 to
+    +10.60 s**, every time. Six recorded takes: `total` **+9.09 s** where the
+    truth was **−2.00 s**.
+  - **The video does follow the wall clock.** Six takes, seven caption
+    transitions each, located by luma straight off `demo.mp4`: uncorrected,
+    the video was up to **−1.50 s** from the beat log by 13.5 s in; corrected
+    by a correctly sampled offset, **all 38 landed within 101 ms**, and within
+    40 ms at the caption-on edges.
+  - **And this file's own check could not catch it**, because `HostClock` had
+    the recorder's bug line for line. Two samplers, two processes, no shared
+    import — and they agreed on `+9.09 s` because they failed the same way.
+    That is the catalogue's *check that shares the bug's blind spot*, and it
+    is the reason `covered` / `max_gap` now exist on both sides: a reading
+    that cannot state how well it covered the take is not a reading.
 
-  **So this harness subtracts a number that means nothing, and goes red about
-  it.** Six `--segments-only` runs on `main`: the four with no recorded step
-  passed, and **both runs with one failed** — the caption search window centred
-  at `3.07 − 1.771 = 1.30 s` while the caption sat at 2.56 s, where a step-free
-  run puts it, reported as "the window is already centred on where the host's
-  measured wall-clock steps put this beat in the video, so this slide is
-  something else". The bars were not widened for it, and should not be: a bar
-  that absorbs an arbitrary aliased offset grades nothing.
-
-  It is also why [#229](https://github.com/rogvid/skills/issues/229) is not
-  buildable yet. Correcting a review frame's seek with the record was
-  implemented and measured: **three of those four stepped runs then failed
-  `_check_frame_captions`**, with `beat-12.png` cut at 10.53 s instead of
-  12.27 s and showing the screen before its caption arrived — the correction
-  making the review sheet wrong, caught by the one check that reads pixels
-  rather than timestamps. Not landed. The whole measurement, and what would
-  settle it, is [#245](https://github.com/rogvid/skills/issues/245).
+  What is left of the earlier entry is one real limit, restated: **a frame
+  stamped inside the ~50 ms pulse inflates the encode and costs the tail.**
+  Two of the six takes above encoded 17.2 s instead of 13.96 s and lost their
+  last three transitions. `capture_clock` records the pulse honestly (both
+  edges, so the cumulative sum still telescopes correctly), but it cannot tell
+  a consumer that the encoder padded. Nothing grades that yet.
 
 - **The terminal arm loses roughly a second more than its host clock explains,
   and nothing here knows why.** The correction is exact on the web arm — six
@@ -2181,9 +2184,12 @@ knows is missing is worse than one that is openly absent.
   **What it turned out to be.** Playwright's driver, instrumented to log every
   screencast frame, caught two consecutive frames 84 ms apart on the monotonic
   clock and **711 ms backwards** on Chromium's. Chromium's frame timestamps are
-  the host's wall clock; a separate sampler that never opens a browser shows
-  that clock stepping -0.75 to -0.81 s every 32.2 s on this box, at the same
-  instants and the same sizes to the tenth of a millisecond. Seven takes of one
+  the host's wall clock; a separate sampler that never opens a browser showed
+  that clock stepping -0.75 to -0.81 s every 32.2 s on this box **on the day
+  that was measured**, at the same instants and the same sizes to the tenth of
+  a millisecond. (Four months later the same box was doing -0.50 s every
+  5.5 s. The size and the period are the host's; only the shape is stable.
+  See [#247](https://github.com/rogvid/skills/issues/247).) Seven takes of one
   storyboard: the four whose window contained a step encoded 0.78 s less video
   than the three that did not, to within 12 ms. The bars are now on the
   residual after that is subtracted, and the residual is 20-140 ms on an idle

--- a/tests/README.md
+++ b/tests/README.md
@@ -2054,6 +2054,33 @@ knows is missing is worse than one that is openly absent.
   edges, so the cumulative sum still telescopes correctly), but it cannot tell
   a consumer that the encoder padded. Nothing grades that yet.
 
+- **`--segments-only` is red on that WSL2 box, before and after #247, and its
+  three new injections therefore could not be run there.** Measured both ways
+  on 2026-08-09, same host, same arm, one after the other:
+
+  - `origin/main` @ `3c71130`: FAILED, 5 problems. Its own artifact carried
+    the bug — the recorder warned `+10105 ms in total` and "demo.mp4 is 10.11s
+    longer than the take's own wall time" for a take whose clock had moved
+    **−501 ms**, and `check_capture_clock` caught *that* one only because this
+    harness's watcher happened not to be trapped on the same run.
+  - this branch: FAILED too, and differently — on run 1 the take's video
+    genuinely lost its tail (frozen from 6.56 s to 17.88 s, part2's content
+    never encoded) and on run 2 the beat-time coverage floor, from a ~9.5 s
+    stall inside the storyboard. Both runs printed `capture_clock agrees with
+    the harness` for **both** parts, with honest paired pulse edges and totals
+    of −0.49/−0.49 and −0.51/−1.00.
+
+  So the arm is red for host reasons either way, and `smoke-inject` — rightly
+  — refuses to grade an injection whose clean baseline already fails. The
+  three `--segments-only` entries added for the coverage claim are registered
+  and match the tree, and **on this box they have not been run**. What was run
+  instead: `_check_clock_coverage` is a pure function of a record and a
+  watcher, so `ClockCoverageCheck` in `tests/unit` exercises all four of its
+  branches plus a control, and four `tests/unit` injections break each branch
+  in `tests/smoke` itself and were seen failing. That is a weaker claim than
+  the arm passing — it does not prove the guard is *reached* on a real take —
+  and it is the strongest one this host allows.
+
 - **The terminal arm loses roughly a second more than its host clock explains,
   and nothing here knows why.** The correction is exact on the web arm — six
   consecutive `--web-only` runs after it, residual 20-140 ms, three of them

--- a/tests/smoke
+++ b/tests/smoke
@@ -862,6 +862,19 @@ MAX_CLOCK_STEP_TIME_DISAGREEMENT_S = 0.25
 # code being graded agrees with that code no matter what it says.
 HOST_CLOCK_MIN_STEP_S = 0.005
 
+# The widest this harness's own sampler may leave between two readings before
+# its reading of the take stops meaning anything. Same reasoning and same
+# number as `_CaptureClock.MAX_GAP_S`, hand-written here rather than imported
+# for the reason above — and it is here at all because in issue #247 *this
+# watcher had the recorder's bug*, exactly, down to the line: both slept on
+# `threading.Event.wait`, whose deadline on the interpreter `uv` installs is
+# an absolute CLOCK_REALTIME instant, so both were trapped by the clock they
+# were sampling and both agreed on the same wrong answer. `check_capture_clock`
+# passed throughout. That is the catalogue's "check that shares the bug's
+# blind spot", and structural independence — a different file, no import — did
+# nothing about it, which is precisely what the catalogue says to expect.
+HOST_CLOCK_MAX_GAP_S = 0.25
+
 # The rate the window is sampled at (the recorders encode at 25 fps, so this is
 # every frame and the measurement quantises to 40 ms), and how far past the
 # beat it runs.
@@ -1944,13 +1957,26 @@ class Beats:
 # Chromium timestamps every screencast frame with the host's *wall* clock, and
 # Playwright turns that timestamp straight into the frame's position in the
 # webm. The beat log is `time.monotonic()`. On a host that steps its wall
-# clock — a WSL2 box was measured stepping -0.75 to -0.81 s **every 32.2 s**,
-# which in a 19 s take is a coin flip — the two clocks part company by exactly
-# the size of the step, at exactly the instant of it, and every reading of
-# "how far has the video slid under the beat log" inherits it.
+# clock the two part company by exactly the size of the step, at exactly the
+# instant of it, and every reading of "how far has the video slid under the
+# beat log" inherits it.
+#
+# **How big and how often is a property of the sick host, not of this
+# recorder, and nothing here may be tuned to either.** #215 measured one WSL2
+# box at -0.75 to -0.81 s every 32.2 s; on 2026-08-08 the same box was a
+# +10.1 s pulse 40-230 ms wide every 5.509 s, leaving -0.50 s behind each
+# time, because CLOCK_MONOTONIC was running +10.01 % fast (NTP-checked;
+# `adjtimex tick = 11000`) and something was re-stepping the wall clock to
+# undo it. Same shape, different settings, four months apart.
+#
+# That the video really is on that clock was checked against the encode
+# (issue #247): six takes, seven caption transitions each read off `demo.mp4`
+# by luma, compared with the beat log. Uncorrected, the video was up to
+# **-1.50 s** from the log by 13.5 s into the take; corrected by a correctly
+# sampled wall clock, all 38 transitions landed within **101 ms**.
 #
 # So this harness measures the same clock, itself, around every recorded take,
-# and subtracts it before grading. Three things about that are deliberate:
+# and subtracts it before grading. Four things about that are deliberate:
 #
 #   * **It is measured, not assumed.** Nothing here is tuned to 0.8 s or to
 #     32 s; a host that never steps produces an empty list and every bar below
@@ -1962,6 +1988,12 @@ class Beats:
 #   * **It runs in this process**, not the recorder's, and watches a clock the
 #     recorder cannot influence. The two readings agreeing is therefore a
 #     claim about the recorder, not a tautology.
+#   * **...and none of the three saved it**, which is why the fourth exists:
+#     `covered` below. Both samplers slept on `Event.wait`, both were trapped
+#     by the pulse (see HOST_CLOCK_MAX_GAP_S), both reported `total: +9.09 s`
+#     on takes whose clock had moved **-2.00 s**, and this file's assertion
+#     that they agree passed on every one. A reading that cannot say how well
+#     it covered the take is not a reading, and neither sampler could.
 class HostClock:
     """CLOCK_REALTIME against CLOCK_MONOTONIC, sampled for a take's lifetime.
 
@@ -1979,6 +2011,10 @@ class HostClock:
 
     def __init__(self) -> None:
         self.raw: list[tuple[float, float]] = []  # (absolute monotonic, delta)
+        # The widest interval this sampler left between two readings, and how
+        # many it took. See `covered`.
+        self.max_gap = 0.0
+        self.samples = 0
         self._t0: float | None = None
         # Where one capture ends and the next begins, on this clock. Empty for
         # a take recorded in one piece; on a stitched demo it is where each
@@ -1990,13 +2026,35 @@ class HostClock:
 
     def _run(self) -> None:
         previous = time.time() - time.monotonic()
+        last = time.monotonic()
         while not self._stop.is_set():
+            now = time.monotonic()
+            self.max_gap = max(self.max_gap, now - last)
+            last = now
+            self.samples += 1
             offset = time.time() - time.monotonic()
             delta = offset - previous
             if abs(delta) >= HOST_CLOCK_MIN_STEP_S:
-                self.raw.append((time.monotonic(), delta))
+                self.raw.append((now, delta))
             previous = offset
-            self._stop.wait(self.INTERVAL_S)
+            # **`time.sleep`, never `self._stop.wait`** — see
+            # HOST_CLOCK_MAX_GAP_S. `Event.wait`'s deadline is CLOCK_REALTIME
+            # on this interpreter, so sleeping on it inside a wall-clock
+            # sampler makes the sampler a function of the thing it measures.
+            time.sleep(self.INTERVAL_S)
+
+    @property
+    def covered(self) -> bool:
+        """Did this sampler stay close enough to its interval to be believed?
+
+        Nothing below may correct with an uncovered reading. A step is found
+        by differencing consecutive samples, so a watcher that was away for
+        seconds cannot say whether the clock moved inside the gap — and
+        subtracting a number nobody watched moves a search window *away* from
+        the frame it is looking for, which is how issue #245's runs went red
+        about something untrue.
+        """
+        return self.samples > 1 and self.max_gap <= HOST_CLOCK_MAX_GAP_S
 
     def rebase(self, t0: float) -> None:
         """Put the steps on this take's own clock — `t0` is its frame zero."""
@@ -2071,6 +2129,10 @@ def joined_clock(parts: list[tuple[HostClock, float]]) -> HostClock:
     """
     joined = HostClock()
     joined._t0 = 0.0
+    # Coverage joins as the *worst* part's, so a joined clock is only believed
+    # when every watcher that fed it kept its interval — see `covered`.
+    joined.max_gap = max((clock.max_gap for clock, _o in parts), default=0.0)
+    joined.samples = min((clock.samples for clock, _o in parts), default=0)
     ends = [offset for _clock, offset in parts[1:]] + [None]
     joined.raw = [
         (at + offset, delta)
@@ -2098,6 +2160,75 @@ def watch_wall_clock() -> Iterator[HostClock]:
         clock._thread.join(timeout=1.0)
 
 
+def _check_clock_coverage(
+    label: str, name: str, record: dict, clock: HostClock
+) -> list[str]:
+    """Does `capture_clock` say honestly how well it watched the take?
+
+    Three claims, and the first is the one that had to be added (issue #247):
+
+    1. the record **states** its coverage at all — `measured` is a bool and
+       `max_gap` is a number. A record with no coverage claim is a record that
+       can be wrong by ten seconds and say nothing;
+    2. `measured` **agrees with its own `max_gap`** against the recorder's own
+       published limit, so the flag cannot be true while the number that
+       decides it says otherwise;
+    3. `measured` **agrees with this harness's independent coverage**. This is
+       the cross-check that does not share a mechanism: two samplers in two
+       processes both stalling on the same take is a real possibility (a
+       loaded box), but one stalling for seconds while the other kept a 20 ms
+       interval means the stalled one is broken rather than the box is busy.
+    """
+    stated = record.get("measured")
+    gap = record.get("max_gap")
+    limit = record.get("max_gap_limit")
+    if not isinstance(stated, bool):
+        return [
+            f"{label}: {name}'s capture_clock has no `measured` flag "
+            f"({stated!r}). A wall-clock record that cannot say whether it "
+            f"watched the take is one a consumer corrects a beat timestamp "
+            f"with and cannot check (issue #247)"
+        ]
+    numeric = (
+        isinstance(gap, (int, float))
+        and not isinstance(gap, bool)
+        and isinstance(limit, (int, float))
+        and not isinstance(limit, bool)
+    )
+    if not numeric:
+        return [
+            f"{label}: {name}'s capture_clock states max_gap={gap!r} against "
+            f"limit={limit!r} — the two numbers `measured` is derived from, "
+            f"and without them the flag is an assertion rather than a "
+            f"measurement"
+        ]
+    if stated != (gap <= limit):
+        return [
+            f"{label}: {name}'s capture_clock says measured={stated} while "
+            f"its own max_gap is {gap:.3f}s against a {limit:.3f}s limit. The "
+            f"flag and the number that decides it disagree, and the flag is "
+            f"what a consumer reads"
+        ]
+    if stated and not clock.covered:
+        return [
+            f"{label}: {name}'s capture_clock claims it measured this take "
+            f"(max_gap {gap:.3f}s) while this harness's own sampler was away "
+            f"for up to {clock.max_gap:.3f}s over the same take. One of the "
+            f"two was not watching, and the recorder's is the one whose "
+            f"number ships in the artifact"
+        ]
+    if not stated and clock.covered:
+        return [
+            f"{label}: {name}'s capture_clock refuses to report (max_gap "
+            f"{gap:.3f}s, limit {limit:.3f}s) on a take this harness sampled "
+            f"cleanly (max gap {clock.max_gap:.3f}s, {clock.samples} "
+            f"samples). The host was watchable and the recorder did not watch "
+            f"it, so every consumer of this take is told nothing when there "
+            f"was something to say"
+        ]
+    return []
+
+
 def check_capture_clock(
     label: str, out_dir: Path, clock: HostClock, name: str = "timeline.json"
 ) -> list[str]:
@@ -2114,6 +2245,13 @@ def check_capture_clock(
     not cover the same seconds — this one keeps running through conversion,
     which the capture is not part of — so a step out there is neither's error
     and is reported rather than graded.
+
+    **Coverage is graded before content** (issue #247). The version of this
+    function that only compared totals passed on takes where both samplers
+    reported `+9.09 s` against a truth of `-2.00 s`, because both were trapped
+    by the same clock and therefore agreed. What that could not have caught,
+    this can: `measured` false when this watcher covered the take, or
+    `measured` true when the recorder's own `max_gap` says it did not.
     """
     path = out_dir / name
     try:
@@ -2128,6 +2266,19 @@ def check_capture_clock(
             f"(issues #18, #215); without this field nothing downstream can "
             f"tell a stepped clock from a recorder that mis-stamped a beat"
         ]
+    problems = _check_clock_coverage(label, name, record, clock)
+    if problems:
+        return problems
+    if record.get("measured") is not True:
+        # Honest, and nothing further is gradeable: the recorder is saying it
+        # could not watch the clock, and it has already been checked above
+        # that this harness could not either.
+        print(
+            f"smoke: {label} capture_clock says it could not measure this "
+            f"take ({record.get('note')}) — and neither could this harness "
+            f"(max gap {clock.max_gap:.2f}s). Nothing to compare"
+        )
+        return []
     reported = record.get("total")
     if not isinstance(reported, (int, float)):
         return [
@@ -2275,6 +2426,23 @@ def check_merged_capture_clock(
                 f"were measured (issue #225)"
             )
     record = doc.get("capture_clock")
+    # A part that could not watch its own clock is the one case where a null
+    # merged record is the *right* answer rather than a lost one — see
+    # `_merge_capture_clock`. Say which part, and stop: there is nothing here
+    # to attribute (issue #247).
+    unmeasured = [
+        name
+        for name, _clock, _offset, own in parts
+        if not isinstance(own, dict) or own.get("measured") is not True
+    ]
+    if unmeasured and record is None:
+        print(
+            f"smoke: segments the merged capture_clock is null because "
+            f"{', '.join(unmeasured)} could not measure its own wall clock — "
+            f"which is the merge refusing to say a part nobody watched held "
+            f"still"
+        )
+        return failures
     if not isinstance(record, dict):
         return failures + [
             f"segments: the stitched timeline.json has no merged `capture_clock` "
@@ -2283,6 +2451,15 @@ def check_merged_capture_clock(
             f"clock, a video on the host's wall clock, and nothing to reconcile "
             f"them with (issues #18, #215, #225)"
         ]
+    if unmeasured:
+        failures.append(
+            f"segments: the merged capture_clock reports "
+            f"measured={record.get('measured')!r} while "
+            f"{', '.join(unmeasured)} could not measure its own clock. A "
+            f"merged record that folds an unwatched part into a total reads "
+            f"as 'that part's clock held still', which nobody established "
+            f"(issue #247)"
+        )
     steps, total = record.get("steps"), record.get("total")
     if not isinstance(steps, list) or not isinstance(total, (int, float)):
         return failures + [
@@ -5981,6 +6158,24 @@ def check_timeline(
     # The video is on that clock and the beats are not (issue #215), so every
     # comparison between the two below goes through this. Absent a reading the
     # correction is zero and every bar is what it was.
+    #
+    # **An uncovered reading is worse than no reading**, and this is where
+    # issue #245's runs went red about something untrue: a watcher that was
+    # away for seconds still hands out a `before()`, and subtracting it moved
+    # the caption search window 1.26 s away from the caption. So an uncovered
+    # clock is refused here, loudly, rather than used or silently zeroed —
+    # zeroing it would grade the take against a bar it no longer meets and
+    # blame the recorder for the harness's own blind spot.
+    if clock is not None and not clock.covered:
+        failures.append(
+            f"{label}: this harness's own wall-clock watcher was away for up "
+            f"to {clock.max_gap:.2f}s (limit {HOST_CLOCK_MAX_GAP_S:.2f}s, "
+            f"{clock.samples} samples), so it cannot say where the video sat "
+            f"under the beat log for this take. Nothing below is corrected "
+            f"and nothing below is graded on alignment. This is the harness "
+            f"refusing to measure, not the recorder failing (issue #247)"
+        )
+        clock = None
     stepped = clock.before if clock is not None else (lambda _t: 0.0)
     mp4 = out_dir / "demo.mp4"
     duration = doc.get("duration")

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -480,14 +480,56 @@ INJECTIONS = [
         sites=("check_capture_clock",),
         must_contain=("is not measuring the clock",),
     ),
+    # -- what the record says about its own coverage (issue #247) ------------
+    #
+    # These three are the ones that would have caught #245 four weeks earlier,
+    # and none of them depends on the box's clock stepping — they break the
+    # *coverage claim*, which every take makes on every host. `--segments-only`
+    # is the arm because it is the cheap one that already records and stitches.
+    Injection(
+        # The claim removed. A record with no `measured` flag is one a
+        # consumer corrects a beat timestamp with and cannot check, which is
+        # the state the field was in for the whole of #245.
+        name="the recorded clock stops saying whether it watched the take",
+        module="core.py",
+        old='            "measured": ok,',
+        new='            "measured_unstated": ok,',
+        arm="--segments-only",
+        sites=("check_capture_clock", "_check_clock_coverage"),
+        must_contain=("has no `measured` flag",),
+    ),
+    Injection(
+        # The flag says one thing and the number it is derived from says
+        # another. A consumer reads the flag; nothing but this reads both.
+        name="the recorded clock claims it watched a take its own gap says it missed",
+        module="core.py",
+        old='            "max_gap": round(self.max_gap, 4),',
+        new='            "max_gap": round(self.max_gap + 1.0, 4),',
+        arm="--segments-only",
+        sites=("check_capture_clock", "_check_clock_coverage"),
+        must_contain=("The flag and the number that decides it disagree",),
+    ),
+    Injection(
+        # The other direction, and the one that would go unnoticed forever
+        # because silence looks safe: the recorder refuses to report on a
+        # host that was perfectly watchable. Every consumer of every take is
+        # then told nothing, and no bar anywhere moves.
+        name="the recorder refuses to report a clock it could have measured",
+        module="core.py",
+        old="    MAX_GAP_S = 0.25",
+        new="    MAX_GAP_S = 0.0",
+        arm="--segments-only",
+        sites=("check_capture_clock", "_check_clock_coverage"),
+        must_contain=("The host was watchable and the recorder did not watch",),
+    ),
     Injection(
         # The total and the steps it is a total of, disagreeing. A consumer
         # reading only `total` and one reading only `steps` then correct a
         # beat by different amounts, and neither can tell.
         name="the recorded clock total stops being the total of its own steps",
         module="core.py",
-        old='            "total": round(self.total, 4),',
-        new='            "total": round(self.total + 0.5, 4),',
+        old='            "total": round(self.total, 4) if ok else None,',
+        new='            "total": round(self.total + 0.5, 4) if ok else None,',
         arm="--segments-only",
         sites=("check_capture_clock",),
         must_contain=("the field disagrees with itself",),

--- a/tests/unit
+++ b/tests/unit
@@ -4316,32 +4316,51 @@ class _ScriptedTime:
     def time(self) -> float:
         return self.mono + self.offsets[min(self.index, len(self.offsets) - 1)]
 
+    def sleep(self, _seconds: float) -> None:
+        """One sampling interval, driven by the sampler's own sleep.
+
+        The sampler sleeps on `time.sleep` rather than on its stop Event, and
+        for a reason a scripted clock has to respect rather than paper over:
+        `Event.wait`'s deadline is CLOCK_REALTIME on the interpreter `uv`
+        installs, which made the real sampler a function of the clock it was
+        sampling (issue #247). Advancing here, and `_ScriptedStop` counting
+        down separately, keeps this harness honest about which call does
+        which job.
+        """
+        self.index += 1
+        self.mono += self.step_by if self.step_by is not None else self.interval
+
+    step_by: float | None = None
+
 
 class _ScriptedStop:
-    """Stands in for the sampler's stop Event, driving `_ScriptedTime`."""
+    """Stands in for the sampler's stop Event, counting the samples out."""
 
-    def __init__(self, clock: _ScriptedTime, samples: int) -> None:
-        self.clock = clock
+    def __init__(self, samples: int) -> None:
         self.left = samples
 
     def is_set(self) -> bool:
-        return self.left <= 0
+        self.left -= 1
+        return self.left < 0
 
     def set(self) -> None:
-        self.left = 0
-
-    def wait(self, _timeout: float) -> None:
-        self.left -= 1
-        self.clock.index += 1
-        self.clock.mono += self.clock.interval
+        self.left = -1
 
 
-def sampled(offsets: list[float]) -> _CaptureClock:
-    """Run the capture-clock sampler over a scripted wall clock."""
+def sampled(offsets: list[float], step_by: float | None = None) -> _CaptureClock:
+    """Run the capture-clock sampler over a scripted wall clock.
+
+    `step_by` is how much monotonic time each sleep really costs — the
+    sampler's own coverage measurement, and the thing that decides whether the
+    record it produces is allowed to claim anything at all. Left None it is
+    the nominal interval, i.e. a sampler that kept up.
+    """
     clock = _CaptureClock()
     fake = _ScriptedTime(offsets)
+    fake.step_by = step_by
     clock._t0 = fake.mono
-    clock._stop = _ScriptedStop(fake, len(offsets))  # type: ignore[assignment]
+    clock._started = True
+    clock._stop = _ScriptedStop(len(offsets))  # type: ignore[assignment]
     real = core_module.time
     core_module.time = fake  # type: ignore[assignment]
     try:
@@ -4461,9 +4480,76 @@ class CaptureClock(unittest.TestCase):
         # "the clock held still" from "nobody looked" has to assume the worst
         # of every timeline ever written.
         rec = recorder(self)
+        rec._capture_clock = sampled([0.0] * 6)
         doc = rec._timeline_doc()
+        self.assertIs(doc["capture_clock"]["measured"], True)
         self.assertEqual(doc["capture_clock"]["steps"], [])
         self.assertEqual(doc["capture_clock"]["total"], 0.0)
+
+    # -- and the third answer, which is the one that had to be added ---------
+    #
+    # "The clock held still", "nobody looked" and "somebody looked and cannot
+    # vouch for what they saw" are three different things, and issue #247 is
+    # what the third one costs when it is reported as the first. The real
+    # sampler slept on `threading.Event.wait`, whose deadline is CLOCK_REALTIME
+    # on the interpreter `uv` installs, so a sampler that read the clock during
+    # one of the host's +10 s pulses slept until the wall clock climbed back —
+    # 5.5 s on that box — and was phase-locked into the pulses from then on.
+    # It reported `total: +9.09 s` on takes whose clock had moved -2.00 s, and
+    # the whole of what was missing was a record able to say "my samples were
+    # 5.5 s apart, do not correct anything with this".
+
+    def test_a_sampler_that_kept_its_interval_is_believed(self):
+        clock = sampled([0.0] * 4 + [-0.5] * 4)
+        self.assertTrue(clock.measured)
+        self.assertIsNone(clock.note())
+        report = clock.report()
+        self.assertIs(report["measured"], True)
+        self.assertAlmostEqual(report["total"], -0.5, places=4)
+        self.assertEqual(len(report["steps"]), 1)
+        # Hand-written, not read off MAX_GAP_S: a gap of one nominal interval
+        # is what a sampler that kept up leaves, whatever the bound says.
+        self.assertLess(report["max_gap"], 0.05)
+
+    def test_a_sampler_that_was_away_refuses_to_report(self):
+        # Same wall clock, same step. The only difference is that each sleep
+        # really cost 5.5 s — which is exactly the trapped sampler's shape,
+        # and it must not produce a usable-looking record.
+        clock = sampled([0.0] * 4 + [-0.5] * 4, step_by=5.5)
+        self.assertFalse(clock.measured)
+        report = clock.report()
+        self.assertIs(report["measured"], False)
+        self.assertIsNone(report["total"])
+        self.assertEqual(report["steps"], [])
+        self.assertGreater(report["max_gap"], 5.0)
+        note = report["note"]
+        assert note is not None
+        self.assertIn("away for up to", note)
+
+    def test_an_unmeasured_take_says_so_to_the_author(self):
+        # Not silence: an author whose host could not be watched has to be
+        # told, because it is the one condition under which the timestamps in
+        # front of them carry no correction at all.
+        warning = sampled([0.0] * 4 + [-0.5] * 4, step_by=5.5).warning()
+        assert warning is not None
+        self.assertIn("could not be measured", warning)
+        self.assertIn("measured` is false", warning)
+
+    def test_a_sampler_that_never_ran_is_not_a_steady_clock(self):
+        clock = _CaptureClock()
+        self.assertFalse(clock.measured)
+        self.assertIsNone(clock.report()["total"])
+        note = clock.note()
+        assert note is not None
+        self.assertIn("never ran", note)
+
+    def test_the_take_of_an_unwatchable_clock_carries_the_refusal(self):
+        rec = recorder(self)
+        rec._capture_clock = sampled([0.0] * 4 + [-0.5] * 4, step_by=5.5)
+        record = rec._timeline_doc()["capture_clock"]
+        self.assertIs(record["measured"], False)
+        self.assertIsNone(record["total"])
+        self.assertEqual(record["steps"], [])
 
 
 def merged_of(clocks: list[object], durations: list[float]) -> dict:
@@ -4535,13 +4621,22 @@ class MergedCaptureClock(unittest.TestCase):
     graded against a real measurement.
     """
 
-    def clock(self, *steps: tuple[float, float], interval: float = 0.02) -> dict:
+    def clock(
+        self,
+        *steps: tuple[float, float],
+        interval: float = 0.02,
+        measured: bool = True,
+    ) -> dict:
         """One part's own record: (seconds into that part, size of the step)."""
         return {
+            "measured": measured,
+            "note": None if measured else "the sampler was away",
             "steps": [{"t": t, "delta": delta} for t, delta in steps],
             "total": round(sum(delta for _, delta in steps), 4),
             "sample_interval": interval,
             "min_step": 0.005,
+            "max_gap": 0.021 if measured else 5.5,
+            "max_gap_limit": 0.25,
         }
 
     def test_each_parts_steps_are_moved_onto_the_stitched_clock(self):
@@ -4622,6 +4717,30 @@ class MergedCaptureClock(unittest.TestCase):
         doc = merged_of([self.clock((1.5, -0.78)), None], [7.5, 6.0])
         self.assertEqual(doc["segments"][0]["capture_clock"]["total"], -0.78)
         self.assertIsNone(doc["segments"][1]["capture_clock"])
+
+    def test_a_part_that_could_not_watch_its_clock_makes_the_merged_record_null(self):
+        # The case that looks harmless and is not (issue #247): this part's
+        # record is *well formed* — `steps` is a list, `total` is a number —
+        # and the only thing wrong with it is that it says so itself, in
+        # `measured`. A merge that checked the shape and not the flag folds
+        # "nobody watched this part" into a stitched total that reads exactly
+        # like "this part's clock held still".
+        unwatched = self.clock(measured=False)
+        self.assertIsInstance(unwatched["steps"], list)
+        doc = merged_of([self.clock((1.5, -0.78)), unwatched], [7.5, 6.0])
+        self.assertIsNone(doc["capture_clock"])
+        # ...and it must not cost the part that *was* measured its own record.
+        self.assertAlmostEqual(
+            doc["segments"][0]["capture_clock"]["total"], -0.78, places=4
+        )
+
+    def test_a_merged_record_states_the_worst_coverage_any_part_managed(self):
+        # Not the average and not the first: a stitched record is only as
+        # believable as its shakiest capture, and `max_gap` is what a consumer
+        # checks the merged `measured` against.
+        doc = merged_of([self.clock(), self.clock()], [7.5, 6.0])
+        self.assertIs(doc["capture_clock"]["measured"], True)
+        self.assertAlmostEqual(doc["capture_clock"]["max_gap"], 0.021, places=4)
 
     def test_the_samplers_settings_survive_agreement_and_null_on_a_disagreement(self):
         # Same rule as `determinism`: a value every part agrees on is that
@@ -4725,8 +4844,8 @@ INJECTIONS = [
         # for as long as the take lasts.
         "every sample after a step is recorded as another step",
         "core.py",
-        "            previous = offset\n            self._stop.wait(self.INTERVAL_S)",
-        "            self._stop.wait(self.INTERVAL_S)",
+        "            previous = offset\n            # Not `self._stop.wait",
+        "            # Not `self._stop.wait",
         [
             "CaptureClock.test_a_backwards_step_is_recorded_once_with_its_size_and_time",
             "CaptureClock.test_two_steps_in_one_take_accumulate",
@@ -4804,12 +4923,81 @@ INJECTIONS = [
         # short by whatever the unmeasured part stepped, and nothing in the
         # document says so — the artifact-lies shape, in the one field whose
         # whole job is correcting other fields.
+        # Aimed at the *missing-record* guard rather than at the `steps`
+        # shape check below it: since #247 the shape check is dominated —
+        # a part with no record at all never reaches it — and an injection
+        # into a dominated guard proves nothing, which is how this one was
+        # found (`--fault-inject` reported it unnoticed the moment the
+        # `measured` guard landed above it).
         "a part that measured no clock is merged as a part whose clock held still",
         "stitching.py",
-        "        if not isinstance(listed, list):\n            return None",
-        "        if not isinstance(listed, list):\n            listed = []",
+        '        if not isinstance(clock, dict) or clock.get("measured") is not True:'
+        "\n            return None",
+        "        if not isinstance(clock, dict):"
+        '\n            clock = {"measured": True, "steps": []}',
         [
             "MergedCaptureClock.test_a_part_that_measured_nothing_makes_the_merged_record_null",
+        ],
+    ),
+    # -- the coverage the record states about itself (issue #247) ------------
+    #
+    # Four entries, and between them they are the whole of what stopped #245
+    # from being caught: a sampler that could not say how badly it had been
+    # away, and a record that shipped its numbers anyway.
+    (
+        # The coverage measurement removed. `max_gap` then reads 0.0 on every
+        # take, `measured` is true on every take, and a sampler that woke up
+        # once every 5.5 s produces a record indistinguishable from one that
+        # kept a 20 ms interval — which is exactly the artifact #245 read as
+        # noise.
+        "the sampler stops measuring how far apart its own samples were",
+        "core.py",
+        "            self.max_gap = max(self.max_gap, now - last)",
+        "            self.max_gap = max(self.max_gap, 0.0)",
+        [
+            "CaptureClock.test_a_sampler_that_was_away_refuses_to_report",
+            "CaptureClock.test_the_take_of_an_unwatchable_clock_carries_the_refusal",
+        ],
+    ),
+    (
+        # The bound widened past the failure it exists to catch — the
+        # catalogue's ungraded constant, aimed at the one constant in this
+        # class that had no test at all until now. 100 s admits the 5.5 s
+        # trapped sampler and everything worse.
+        "the coverage bound is widened past the sampler stall it exists to catch",
+        "core.py",
+        "    MAX_GAP_S = 0.25",
+        "    MAX_GAP_S = 100.0",
+        [
+            "CaptureClock.test_a_sampler_that_was_away_refuses_to_report",
+            "CaptureClock.test_an_unmeasured_take_says_so_to_the_author",
+        ],
+    ),
+    (
+        # The flag is set honestly and the numbers ship regardless. A consumer
+        # that reaches straight for `total` — which is every consumer that has
+        # not read the schema note — corrects a beat by a figure nobody
+        # watched, and gets no error doing it.
+        "an unmeasured record ships its total anyway",
+        "core.py",
+        '            "total": round(self.total, 4) if ok else None,',
+        '            "total": round(self.total, 4),',
+        [
+            "CaptureClock.test_a_sampler_that_was_away_refuses_to_report",
+            "CaptureClock.test_the_take_of_an_unwatchable_clock_carries_the_refusal",
+        ],
+    ),
+    (
+        # The merge checks the *shape* of each part's record and not its own
+        # verdict on itself. The unmeasured part's `steps` is a well-formed
+        # empty list, so this reads as "that part's clock held still".
+        "the merge folds a part that could not watch its clock into the total",
+        "stitching.py",
+        '        if not isinstance(clock, dict) or clock.get("measured") is not True:',
+        "        if not isinstance(clock, dict):",
+        [
+            "MergedCaptureClock."
+            "test_a_part_that_could_not_watch_its_clock_makes_the_merged_record_null",
         ],
     ),
     (

--- a/tests/unit
+++ b/tests/unit
@@ -4755,6 +4755,143 @@ class MergedCaptureClock(unittest.TestCase):
 # Fault injection
 # --------------------------------------------------------------------------
 
+
+class _StubWatcher:
+    """Enough of `tests/smoke`'s `HostClock` for its coverage cross-check.
+
+    Hand-written rather than constructed from the real class: what is being
+    graded is `_check_clock_coverage`'s reading of a watcher, and a stub is
+    the only way to present it with the one state a real watcher on a healthy
+    box will not produce — having been away for five seconds.
+    """
+
+    def __init__(self, max_gap: float, samples: int = 900) -> None:
+        self.max_gap = max_gap
+        self.samples = samples
+
+    @property
+    def covered(self) -> bool:
+        return self.samples > 1 and self.max_gap <= 0.25
+
+
+class ClockCoverageCheck(unittest.TestCase):
+    """`tests/smoke`'s guard on whether the record watched the take (#247).
+
+    This lives here rather than in `tests/smoke-inject` for a reason worth
+    stating: the arm that runs `check_capture_clock` is `--segments-only`, and
+    on the WSL2 box #247 was measured on that arm's **clean baseline** is red
+    — the host's +10 s pulses land in the encode and cost the take its tail.
+    `smoke-inject` refuses to grade an injection whose baseline already fails,
+    correctly, so the three entries added to the manifest for this guard could
+    not be run there on that box. `_check_clock_coverage` is a pure function of
+    a record and a watcher, so it can be run here, on any box, in 0.2 s.
+    """
+
+    def setUp(self):
+        self.check = _smoke_module()._check_clock_coverage
+
+    def one(self, problems: list) -> str:
+        """The single complaint these cases must produce.
+
+        Asserted rather than unpacked, so a guard that stopped firing reads as
+        'reported nothing' in the failure output instead of as a ValueError
+        from a tuple assignment — which is what `--fault-inject` showed the
+        first version of these doing.
+        """
+        self.assertEqual(len(problems), 1, f"expected one complaint, got {problems!r}")
+        return problems[0]
+
+    def record(self, **over) -> dict:
+        base = {
+            "measured": True,
+            "note": None,
+            "steps": [],
+            "total": 0.0,
+            "sample_interval": 0.02,
+            "min_step": 0.005,
+            "max_gap": 0.021,
+            "max_gap_limit": 0.25,
+        }
+        base.update(over)
+        return base
+
+    def test_a_watched_take_and_a_watching_harness_agree_silently(self):
+        # The control. Without it every assertion below is satisfied by a
+        # check that complains about everything.
+        self.assertEqual(
+            self.check("web", "timeline.json", self.record(), _StubWatcher(0.021)),
+            [],
+        )
+
+    def test_a_record_with_no_coverage_claim_is_refused(self):
+        problem = self.one(
+            self.check(
+                "web", "timeline.json", self.record(measured=None), _StubWatcher(0.021)
+            )
+        )
+        self.assertIn("no `measured` flag", problem)
+
+    def test_a_record_whose_coverage_numbers_are_missing_is_refused(self):
+        problem = self.one(
+            self.check(
+                "web", "timeline.json", self.record(max_gap=None), _StubWatcher(0.021)
+            )
+        )
+        self.assertIn("the two numbers `measured` is derived from", problem)
+
+    def test_a_flag_that_contradicts_its_own_gap_is_refused(self):
+        # The shape the trapped sampler would have shipped if it had measured
+        # its gap and then ignored it.
+        problem = self.one(
+            self.check(
+                "web", "timeline.json", self.record(max_gap=5.5), _StubWatcher(0.021)
+            )
+        )
+        self.assertIn("The flag and the number that decides it disagree", problem)
+
+    def test_a_recorder_that_watched_nothing_while_the_harness_watched_is_refused(self):
+        # Both samplers stalling on a loaded box is real; one stalling for
+        # 5.5 s while the other kept a 20 ms interval is not the box.
+        problem = self.one(
+            self.check(
+                "web",
+                "timeline.json",
+                self.record(measured=True),
+                _StubWatcher(5.5),
+            )
+        )
+        self.assertIn("One of the", problem)
+        self.assertIn("two was not watching", problem)
+
+    def test_a_recorder_that_refused_on_a_watchable_host_is_refused(self):
+        # The direction that looks like safety and is not: silence, on a host
+        # there was something to say about.
+        problem = self.one(
+            self.check(
+                "web",
+                "timeline.json",
+                self.record(measured=False, max_gap=5.5, note="away"),
+                _StubWatcher(0.021),
+            )
+        )
+        self.assertIn("The host was watchable and the recorder did not watch", problem)
+
+    def test_both_samplers_away_is_reported_as_neither_watching(self):
+        # Not a failure: a genuinely loaded box, where the honest answer is
+        # that nobody measured this take and both records say so.
+        self.assertEqual(
+            self.check(
+                "web",
+                "timeline.json",
+                self.record(measured=False, max_gap=5.5, note="away"),
+                _StubWatcher(5.5),
+            ),
+            [],
+        )
+
+
+# --------------------------------------------------------------------------
+
 # Issue #203, as the overlay shipped before it was fixed and after it was.
 # Nothing below is rewritten by hand: the two are the same region of
 # `_CURSOR_JS` — from the dot's creation to its insertion — in the two orders,
@@ -4998,6 +5135,62 @@ INJECTIONS = [
         [
             "MergedCaptureClock."
             "test_a_part_that_could_not_watch_its_clock_makes_the_merged_record_null",
+        ],
+    ),
+    # -- and the harness's own reading of that claim (issue #247) ------------
+    #
+    # `tests/smoke-inject` carries three entries aimed at these, and on the box
+    # #247 was measured on they cannot be run: `--segments-only`'s clean
+    # baseline is red there, so the harness refuses to grade anything aimed at
+    # that arm. These break the same guard where it costs 0.2 s and needs no
+    # browser.
+    (
+        # The guard stops reading the flag at all, so a record that says
+        # nothing about its own coverage passes — the state the field was in
+        # throughout #245.
+        "smoke stops checking whether the record says it watched the take",
+        "tests/smoke",
+        "    if not isinstance(stated, bool):",
+        "    if False:",
+        [
+            "ClockCoverageCheck.test_a_record_with_no_coverage_claim_is_refused",
+        ],
+    ),
+    (
+        # The flag is read and the number behind it is not, so `measured: true`
+        # over a five-second gap sails through — which is exactly what the
+        # trapped sampler would have shipped.
+        "smoke stops checking the flag against the gap it is derived from",
+        "tests/smoke",
+        "    if stated != (gap <= limit):",
+        "    if False:",
+        [
+            "ClockCoverageCheck.test_a_flag_that_contradicts_its_own_gap_is_refused",
+        ],
+    ),
+    (
+        # The cross-check between the two watchers dropped. Two samplers that
+        # fail the same way still agree, so this is the one comparison that is
+        # not a tautology — and the one whose absence let #245 run.
+        "smoke stops comparing the record's coverage against its own watcher's",
+        "tests/smoke",
+        "    if stated and not clock.covered:",
+        "    if False:",
+        [
+            "ClockCoverageCheck."
+            "test_a_recorder_that_watched_nothing_while_the_harness_watched_is_refused",
+        ],
+    ),
+    (
+        # Silence accepted. A recorder that reports nothing on every take
+        # changes no bar anywhere, which is why this direction needs its own
+        # guard rather than being the safe default.
+        "smoke accepts a recorder that refuses to report on a watchable host",
+        "tests/smoke",
+        "    if not stated and clock.covered:",
+        "    if False:",
+        [
+            "ClockCoverageCheck.test_a_recorder_that_refused_on_a_watchable_host_is_refused",
         ],
     ),
     (


### PR DESCRIPTION
**Verdict: `capture_clock` measures something real, the video does follow it, and
correcting with it works to ±101 ms. The field stays. What was broken is the
sampler — it was captured by the clock it was sampling — and what was missing is
a record able to say so.** #245's diagnosis is retracted, with the measurement.

Every number below is mine, taken on this WSL2 box on 2026-08-08/09. Figures
attributed to #215, #224 and #245 are named as theirs.

---

## 1. The waveform, at 1 ms instead of 20 ms

#245 called it "an aliased fragment of a wall clock oscillating +10.1 / −10.6 s
every ~5.5 s, sampled at 20 ms". The oscillation is real. The aliasing is not.

A standalone sampler, `clock_gettime` on four clocks, **1 ms for 300 s**
(300,000 samples). It is a **rectangular pulse train**, not an oscillation:

| | measured |
|---|---|
| up edge | **+10.03 to +10.10 s** (55 pulses) |
| hold, flat to <10 µs | **40–230 ms** |
| down edge | **−10.53 to −10.60 s** |
| net left behind, per pulse | **−0.43 to −0.56 s** |
| period | **5.509 s** (5.500–5.517) |
| net over the window | **−27.04 s / 297.5 s = −90,878 ppm** |

`CLOCK_REALTIME_COARSE` tracks `CLOCK_REALTIME` exactly through every edge, so
the kernel's timekeeper is being written — not a vDSO read glitching.

**Sub-sampling that same 1 ms record at 20 ms recovers 110 of 110 edges** and a
total within 2 % of the truth. A 20 ms sampler is entirely adequate to this
waveform. Aliasing was the wrong diagnosis.

## 2. What is causing it — and it is one sick host, not a class of user

Against `pool.ntp.org`, two reads 90 s apart:

```
true elapsed (NTP)        81.8983 s
CLOCK_MONOTONIC elapsed   90.0964 s  error +100101 ppm (+10.01 %)
CLOCK_REALTIME elapsed    81.5745 s  error  -3954 ppm (-0.40 %)
```

`adjtimex` reports **`tick = 11000`** — the kernel's +10 % clamp. So
`CLOCK_MONOTONIC` is running 10 % fast, `CLOCK_REALTIME` is being held to true
time, and the "steps" are something (Hyper-V / `systemd-timesyncd` under WSL2)
re-stepping the wall clock every 5.5 s to undo it. Clocksource is
`hyperv_clocksource_tsc_page`.

**Verdict on #215's metronome:** the *shape* survives, the *numbers* do not.
#215 measured −0.75 to −0.81 s every 32.2 s; today the same box gives −0.50 s
every 5.5 s. Both are "a periodic permanent negative step of realtime against
monotonic". Neither figure is a property of this recorder, and three documents
stated them as fact — that is fixed below.

## 3. The sampler was captured by the clock it was sampling

This is the finding. `_CaptureClock` slept on `self._stop.wait(0.02)`.
`threading.Event.wait` acquires a lock with a timeout, and on the interpreter
`uv` installs — **CPython 3.13.11, python-build-standalone, built against a
glibc without `sem_clockwait`** — that falls back to `sem_timedwait`, whose
deadline is an **absolute CLOCK_REALTIME instant**.

Measured directly, 20 ms waits in a tight loop for 25 s:

```
python 3.12.3 @ /usr/bin/python3            (Ubuntu, glibc 2.39)
1143 waits of 20 ms over 25.0s; 0 took over 100 ms

python 3.13.11 @ ~/.local/share/uv/python/cpython-3.13.11-linux-x86_64-gnu
81 waits of 20 ms over 25.0s; 5 took over 100 ms
   entered t=   1.435  took    5489.3 ms  offset before= +10.1035 after=  +9.6025
   entered t=   6.967  took    5459.6 ms  offset before=  +9.6025 after=  +9.1023
   entered t=  12.494  took    5440.7 ms  offset before=  +9.1023 after=  +8.6016
   entered t=  18.001  took    5443.8 ms  offset before=  +8.6016 after=  +8.1006
   entered t=  23.490  took    5471.6 ms  offset before=  +8.1006 after=  +7.5991
```

A wait entered while the +10 s pulse is up sets a deadline 10 s ahead; the pulse
ends; the wall clock only reaches that deadline when the **next** pulse lifts it,
5.5 s later. From then on the sampler is phase-locked into the pulses and every
sample it takes is taken *inside* one — it reads only the top of the transient it
exists to reject.

**Eight idle 20 s runs of the shipped `_CaptureClock` against a 1 ms reference:**

| run | reference total | `capture_clock.total` | error |
|---|---|---|---|
| 0 | −1.996 | **+8.598** | +10.594 |
| 1 | −2.001 | **+8.591** | +10.592 |
| 2 | −1.514 | **+9.089** | +10.603 |
| 3 | −2.003 | **+8.599** | +10.602 |
| 4 | −1.994 | **+8.599** | +10.593 |
| 5 | −2.012 | **+8.589** | +10.601 |
| 6 | −1.495 | **+9.099** | +10.594 |
| 7 | −2.013 | **+8.591** | +10.605 |

8/8. Every record is one bare `+10.09` up-edge followed by clean `−0.50` nets —
one sample per pulse, 5.5 s apart, exactly as the trap predicts. Six real
recorded takes gave `total: +9.09 s` where the truth was **−2.00 s**, and the
recorder printed *"demo.mp4 is 9.09s longer than the take's own wall time"* about
an mp4 that was 17.88 s long from a 17.9 s take.

**`tests/smoke`'s `HostClock` had the same bug, line for line.** Two samplers,
two processes, no shared import — the catalogue's *check that shares the bug's
blind spot*, in its purest form. `check_capture_clock` printed
`capture_clock agrees with the harness` throughout.

## 4. The encode corroboration — #245's decisive experiment, done right

Six takes flipping the caption on and off, with a **correct** 1 ms reference
beside them (`time.sleep`, which is `clock_nanosleep(CLOCK_MONOTONIC)`).
Transitions located by luma straight off `demo.mp4` at 25 fps — no recorder code
in the measurement. Take 3, representative:

| beat t (log) | video t | video − beat | reference wall-offset change | residual |
|---|---|---|---|---|
| 1.502 | 1.44 | −0.062 | −0.000 | **−0.062** |
| 3.501 | 2.92 | −0.581 | −0.502 | **−0.079** |
| 5.505 | 5.00 | −0.505 | −0.502 | **−0.003** |
| 7.504 | 6.44 | −1.064 | −0.991 | **−0.073** |
| 9.502 | 8.52 | −0.982 | −0.991 | **+0.009** |
| 11.504 | 10.44 | −1.064 | −0.991 | **−0.073** |
| 13.500 | 12.00 | −1.500 | −1.501 | **+0.001** |

**38 of 38 transitions across six takes: residual −0.101 to +0.035 s**, and
within 40 ms at every caption-*on* edge (the systematic −80 ms at the *off* edges
is a two-frame caption fade). Uncorrected, the video is **1.50 s** from the log by
13.5 s in. The video is on `CLOCK_REALTIME`, the beat log is on
`CLOCK_MONOTONIC`, and summing the steps before a beat places it in `demo.mp4`.

So the claim `capture_clock` documents is true. The record it shipped was not.

## 4b. And the suite says it too, on this host, unprompted

`tests/smoke --web-only`, run locally on the pathological box after the fix.
This line is the whole argument in one sentence, and the harness printed it:

```
smoke: web capture_clock agrees with the harness (the host's wall clock stepped -494 ms at 18.8s)
smoke: web first caption 'A small dashboard.' logged at 3.09s, on screen at 2.99s (-100 ms)
smoke: web closing caption 'Recorded end to end.' logged at 24.46s, on screen at 23.95s
       (-20 ms, raw -514 ms of which -494 ms is the host's wall clock stepping)
```

A −494 ms step at 18.8 s; the closing caption **514 ms** from the log raw;
**−20 ms** once the measured step is subtracted. The first caption, before the
step, is uncorrected at −100 ms. Every timing bar passed.

(The arm still went red, on one thing unrelated to any of this: the spotlight
*enter* transition control passing through 1 intermediate frame against a bar
of 2 — [#78](https://github.com/rogvid/skills/issues/78), a load-dependent
flake on this box.)

## 5. What changed

**`_CaptureClock` (core.py)**
- sleeps on `time.sleep`, never `Event.wait`, with the measurement in the comment;
- measures its own coverage — `max_gap`, `samples` — and **refuses to report over
  `MAX_GAP_S = 0.25`**: `measured: false`, `steps: []`, `total: null`, and a
  `note` saying how far it was away. 0.25 s is 12× the nominal interval and 22×
  under the 5.5 s stall, so the populations are an order of magnitude apart
  rather than a comfortable margin;
- `warning()` distinguishes "could not measure" from "the clock stepped".

Verified: **6/6 idle 20 s runs of the fixed sampler agree with the 1 ms
reference to −0.0001 … +0.0001 s** (was +10.59 … +10.60).

**`stitching._merge_capture_clock`** refuses a part whose own record says
`measured: false` — the case that looks harmless, because its `steps` is a
well-formed empty list and folding it in reads as "that part's clock held still".
The merged record carries `measured`, and `max_gap` as the **worst** part's.

**`tests/smoke`** — `HostClock` gets the same fix and a `covered` property;
`joined_clock` joins coverage as the worst part's; the correction site **refuses
to correct with an uncovered watcher** and says so, rather than silently zeroing
(zeroing would grade the take against a bar it no longer meets and blame the
recorder). New `_check_clock_coverage` grades the claim four ways.

**Documentation** — `SKILL.md`, `reference/limits.md` and `tests/README.md`
stated 0.75–0.81 s / 32.2 s as fact; they now state it as one host on one day,
beside today's. `reference/review.md` and `reference/failures.md` had the two
clocks *backwards* ("the beat log is wall-clock") and still blamed idle
stretches, which `limits.md` had already retracted. `SKILL.md` is back at exactly
600 lines.

## 6. Fault injection

`tests/unit`: **207 tests, 132/132 injections caught** (was 193 / 124).
`tests/ci-unit`: 49 tests, 12/12. `tests/lint`: all checks passed.
`tests/smoke-inject --self-test`: *Every guard refused what it exists to refuse.*
`tests/smoke-inject --list`: 48 entries, *every entry still matches the tree*.

Eight new injections, all seen failing. Four on the recorder's record:

```
PASS  break: the sampler stops measuring how far apart its own samples were
      in core.py: self.max_gap = max(self.max_gap, now - last)…
      FAIL: test_a_sampler_that_was_away_refuses_to_report
      FAIL: test_an_unmeasured_take_says_so_to_the_author
      FAIL: test_the_take_of_an_unwatchable_clock_carries_the_refusal

PASS  break: the coverage bound is widened past the sampler stall it exists to catch
      in core.py: MAX_GAP_S = 0.25…
      FAIL: test_a_sampler_that_was_away_refuses_to_report
      FAIL: test_an_unmeasured_take_says_so_to_the_author
      FAIL: test_the_take_of_an_unwatchable_clock_carries_the_refusal

PASS  break: an unmeasured record ships its total anyway
      in core.py: "total": round(self.total, 4) if ok else None,…
      FAIL: test_a_sampler_that_never_ran_is_not_a_steady_clock
      FAIL: test_a_sampler_that_was_away_refuses_to_report
      FAIL: test_the_take_of_an_unwatchable_clock_carries_the_refusal

PASS  break: the merge folds a part that could not watch its clock into the total
      in stitching.py: if not isinstance(clock, dict) or clock.get("measured") is not True:…
      FAIL: test_a_part_that_could_not_watch_its_clock_makes_the_merged_record_null
```

Four on the harness's reading of it:

```
PASS  break: smoke stops checking whether the record says it watched the take
      in tests/smoke: if not isinstance(stated, bool):…
      FAIL: test_a_record_with_no_coverage_claim_is_refused

PASS  break: smoke stops checking the flag against the gap it is derived from
      in tests/smoke: if stated != (gap <= limit):…
      FAIL: test_a_flag_that_contradicts_its_own_gap_is_refused

PASS  break: smoke stops comparing the record's coverage against its own watcher's
      in tests/smoke: if stated and not clock.covered:…
      FAIL: test_a_recorder_that_watched_nothing_while_the_harness_watched_is_refused

PASS  break: smoke accepts a recorder that refuses to report on a watchable host
      in tests/smoke: if not stated and clock.covered:…
      FAIL: test_a_recorder_that_refused_on_a_watchable_host_is_refused
```

**One pre-existing injection went unnoticed the moment the `measured` guard
landed, and `--fault-inject` found it**: *"a part that measured no clock is
merged as a part whose clock held still"* broke a `steps`-shape check that the
new guard now dominates. Retargeted at the guard that actually catches it.

Three more entries were added to `tests/smoke-inject` for `--segments-only`.
**They have not been run on this box** — see the stated limits.

## 7. Stated limits

- **Green on CI proves nothing here, and I am not claiming it.** A runner's clock
  is steady, so `measured` is true on every take, `max_gap` is ~20 ms, the
  correction is a no-op and every injection above still passes. Everything in
  §1–§4 was run locally on the WSL2 host described, under the pathology.
- **`--segments-only` is red on this box, before and after.** Measured both ways,
  same host, back to back. `origin/main` @ `3c71130`: FAILED, 5 problems — and
  its own artifact carried the bug, warning `+10105 ms in total` and *"demo.mp4
  is 10.11s longer"* for a take whose clock had moved **−501 ms**. This branch:
  FAILED too, differently — run 1 lost the take's video tail outright (frozen
  6.56 s → 17.88 s), run 2 hit the beat-time coverage floor after a ~9.5 s stall
  in the storyboard. Both runs printed `capture_clock agrees with the harness`
  for **both** parts, with honest paired pulse edges and totals of −0.49/−0.49
  and −0.51/−1.00. Not a regression; not green either.
- **Therefore the three `--segments-only` injections are registered and unrun
  here.** `smoke-inject` refuses — rightly — to grade an injection whose clean
  baseline already fails. What replaced them: `_check_clock_coverage` is a pure
  function, so `ClockCoverageCheck` in `tests/unit` covers all four branches plus
  a control, and the four `tests/unit` injections above break each branch in
  `tests/smoke` itself. That is weaker — it does not prove the guard is
  *reached* on a real take — and it is the strongest claim this host allows.
  Recorded as a Known gap.
- **A frame stamped inside the ~50 ms pulse inflates the encode and costs the
  tail.** Two of the six takes in §4 encoded 17.2 s instead of 13.96 s and lost
  their last three transitions; one earlier take froze for 10.2 s of a 17.88 s
  file. `capture_clock` records the pulse honestly and its cumulative sum still
  telescopes correctly, but nothing tells a consumer the encoder padded.
  Recorded as a Known gap; **not** filed separately, since it is the mechanism
  #224 is already open about.
- **`MAX_GAP_S = 0.25` has not been measured under contention on a 2-core
  runner.** Idle it is 20–22 ms; the recorded takes here stayed well inside it.
  If a loaded runner exceeds it the take reports `measured: false` and the
  harness refuses to grade alignment — honest, but noisier than intended.
- **The terminal arm was not re-measured.** #224's extra ~1 s is plausibly the
  same trapped sampler, and I did not check.

## 8. Issues

- **Closes #245** (`Fixes` in the first commit). The question it asked is
  answered: not aliasing, the video does follow, the sampler was the fault.
- **#224 left open.** Its acceptance criterion is an end-to-end wall-to-video map
  of a *terminal* take, which I did not record. Its −900 ms residual was computed
  from a `capture_clock` that is now known to have been wrong, so the number
  wants re-taking before anyone works it.
- **#226 left open.** Narration is unchanged by this. What changes is that the
  record it wants to mix against is now trustworthy, and carries a flag saying
  when it is not.
- **#229 left open, and no longer blocked.** It was parked because correcting a
  review frame's seek with the record made the sheet wrong; §4 shows the
  correction is right to ±101 ms when the record is. The reason it was blocked is
  removed; the work is not done.
- **Nothing new filed.** The encoder-padding limit is #224's mechanism and the
  rest is stated above.
