### PR TITLE
Cut the review frames on the video's clock, and say so (#229)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from .content import media_duration
 from .markdown import _fmt_t, _md_cell
-from .timeline import timeline_paths
+from .timeline import capture_clock_correction, timeline_paths
 
 # -- beat-aligned review frames ----------------------------------------------
 #
@@ -61,6 +61,21 @@ from .timeline import timeline_paths
 # sheet handed to a **context-free** reviewer who is asked what story the
 # pictures tell; a `click('#refresh')` in the margin answers the question for
 # them.
+#
+# **The midpoint is a beat-log instant, and the seek is a video one.** Those
+# are two different clocks: the log is `time.monotonic()`, the video is stamped
+# with the host's wall clock, and a host that steps that clock parts them by
+# the size of the step. So every cut below is the midpoint **plus the steps the
+# beat's own capture recorded before it**, read out of the timeline's
+# `capture_clock` by `capture_clock_correction` — measured at up to 1.50 s of
+# error uncorrected on the WSL2 box of #247, which at 25 fps is ~37 frames of a
+# sheet that *is* the demo as far as a reviewer is concerned (issue #229).
+#
+# When the record cannot supply that number — no field, or a sampler that says
+# it could not watch — the cut falls back to the bare midpoint, and the
+# manifest and the sheet say so in as many words. Zero is the only number
+# available there, but it is a fallback and not a correction, and a sheet that
+# let the two look alike would be claiming an accuracy nobody measured.
 FRAMES_DIRNAME = "frames"
 FRAMES_SCHEMA = 1
 
@@ -142,8 +157,11 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
     """Write one review frame per beat, and an index to read them in order.
 
     Reads the timeline the take just wrote (or `doc`), extracts
-    `frames/beat-NN.png` at each beat's midpoint, and writes `frames/frames.md`
-    for a reviewer and `frames/frames.json` for a tool. Neither says anything
+    `frames/beat-NN.png` at each beat's midpoint **on the video's clock** — the
+    midpoint plus that beat's own capture's recorded wall-clock steps, or the
+    bare midpoint with the reason stated when the record cannot say (see the
+    section header) — and writes `frames/frames.md` for a reviewer and
+    `frames/frames.json` for a tool. Neither says anything
     about what is *in* a frame — see the section header.
 
     Returns the manifest. Safe to re-run: it is a pure function of the mp4 and
@@ -175,6 +193,10 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         "duration": doc.get("duration"),
         "recorder": doc.get("recorder"),
         "frames": [],
+        # Filled in below, once there is a sheet for it to describe: whether
+        # these frames were cut on the video's clock or on the beat log's, and
+        # why not when they were not. Null on a manifest that wrote no frames.
+        "clock_correction": None,
         "skipped": None,
     }
     if doc.get("segment"):
@@ -199,6 +221,9 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
             duration = float(beats[-1].get("t_end") or 0.0)
     last = max(0.0, float(duration) - _FRAME_EDGE_S)
 
+    correct, clock = capture_clock_correction(doc)
+    manifest["clock_correction"] = clock
+
     planned: list[dict] = []
     for beat in beats:
         t_start, t_end = beat.get("t_start"), beat.get("t_end")
@@ -206,7 +231,11 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
             continue
         if not isinstance(t_end, (int, float)) or t_end < t_start:
             t_end = t_start
-        middle = min(max((float(t_start) + float(t_end)) / 2, 0.0), last)
+        # Onto the video's clock before anything is clamped: the correction is
+        # what puts the beat where the frames are, and clamping first would
+        # aim at the end of a file the beat does not reach.
+        slid = correct(beat)
+        middle = min(max((float(t_start) + float(t_end)) / 2 + slid, 0.0), last)
         index = int(beat.get("index", len(planned)))
         planned.append({
             "file": f"beat-{index:02d}.png",
@@ -219,7 +248,13 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         # a load finishing inside a long hold is invisible to it.
         if float(t_end) - float(t_start) < SCENE_MIN_SPAN_S:
             continue
-        window = (min(float(t_start), last), min(float(t_end), last))
+        # The same slide, for the same reason: this window is a search through
+        # the video, so it has to be the beat's span *in the video*. Left on
+        # the log's clock it would scan a stretch the beat had already left.
+        window = (
+            min(max(float(t_start) + slid, 0.0), last),
+            min(max(float(t_end) + slid, 0.0), last),
+        )
         for n, cut in enumerate(scene_times(mp4, *window), 1):
             planned.append({
                 "file": f"beat-{index:02d}-scene-{n}.png",
@@ -256,10 +291,14 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
             )
     manifest["frames"] = written
     # How far the video is *known* to have slid under the beat log, as a floor
-    # rather than a correction. A beat that ends after the video does can only
-    # mean capture loss (issue #18); it is usually zero, and when it is not it
-    # is the one number that says how stale a frame's aim may be.
-    over = float(beats[-1].get("t_end") or 0.0) - float(duration)
+    # rather than a correction: a beat that ends after the video does is wall
+    # time that never reached the file (issue #18). Measured against the last
+    # beat's **corrected** end, because a recorded wall-clock step already
+    # explains that much of the gap and is already applied above — reporting it
+    # here too would tell a reviewer their frames may be stale by the very
+    # amount they were just moved by.
+    tail = beats[-1]
+    over = float(tail.get("t_end") or 0.0) + correct(tail) - float(duration)
     manifest["capture_loss_at_least"] = round(max(0.0, over), 3)
     json_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
     md_path.write_text(render_frames_md(manifest))
@@ -298,6 +337,47 @@ def write_beat_frames(out_dir: Path | str, doc: dict, where: str) -> dict | None
         f"wrote {frames_paths(out_dir)[0]} ({len(manifest['frames'])} review frames)"
     )
     return manifest
+
+
+def _clock_md(clock: object) -> list[str]:
+    """What the sheet says about the clock its frames were cut on.
+
+    Three sentences for three states, and the reason all three are printed
+    rather than only the interesting one: a reviewer cannot tell a frame cut
+    with the host's steps applied from one cut without them by looking at it.
+    Saying nothing on the fallback would leave the sheet reading exactly like
+    a corrected one — which is the confidently-wrong artifact this whole field
+    exists to avoid, and it is why "the clock was watched and held still" is
+    also stated out loud instead of being inferred from silence.
+    """
+    if not isinstance(clock, dict):
+        return []
+    if not clock.get("applied"):
+        return [
+            f"**These frames were cut on the beat log, uncorrected**: "
+            f"{clock.get('note')}. The video is on the host's wall clock and "
+            f"the beat log is not, so if that clock stepped during this take "
+            f"every frame after the step is of a moment that much later in the "
+            f"demo — and nothing here knows by how much.",
+            "",
+        ]
+    total = clock.get("total") or 0.0
+    if not total:
+        return [
+            "The host's wall clock was watched for the length of this take and "
+            "did not step, so each frame is at its beat's midpoint.",
+            "",
+        ]
+    return [
+        f"**The host's wall clock stepped {total:+.2f}s while this was "
+        f"recorded**, over {clock.get('steps')} step(s), and the video is on "
+        f"that clock. Each frame below was therefore cut at its beat's "
+        f"midpoint **plus the steps its own capture recorded before it**, not "
+        f"at the midpoint itself — the timestamps in the table are where the "
+        f"frames came out of the video. `timeline.json`'s `capture_clock` has "
+        f"the steps.",
+        "",
+    ]
 
 
 def render_frames_md(manifest: dict) -> str:
@@ -341,6 +421,7 @@ def render_frames_md(manifest: dict) -> str:
     ]
     if manifest.get("skipped"):
         return "\n".join(out + [f"No frames were written: {manifest['skipped']}.", ""])
+    out += _clock_md(manifest.get("clock_correction"))
     loss = manifest.get("capture_loss_at_least") or 0.0
     if loss > 0.05:
         out += [

--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -126,17 +126,30 @@ def scene_times(
     # writes through ffmpeg's logger at INFO level, which `-v error` throws
     # away — a silent way for this whole function to always return nothing.
     proc = subprocess.run(
-        ["ffmpeg", "-v", "error", "-ss", f"{start:.3f}", "-t", f"{end - start:.3f}",
-         "-i", str(mp4),
-         "-vf", f"select='gt(scene,{threshold})',metadata=print:file=-",
-         "-an", "-f", "null", "-"],
-        capture_output=True, text=True,
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-ss",
+            f"{start:.3f}",
+            "-t",
+            f"{end - start:.3f}",
+            "-i",
+            str(mp4),
+            "-vf",
+            f"select='gt(scene,{threshold})',metadata=print:file=-",
+            "-an",
+            "-f",
+            "null",
+            "-",
+        ],
+        capture_output=True,
+        text=True,
     )
     if proc.returncode != 0:
         return []
     times = [
-        start + float(match)
-        for match in re.findall(r"pts_time:([0-9.]+)", proc.stdout)
+        start + float(match) for match in re.findall(r"pts_time:([0-9.]+)", proc.stdout)
     ]
     # The first decoded frame of a seek has nothing before it to be compared
     # with, and ffmpeg scores it 1.0. That is the seek, not a scene change.
@@ -146,8 +159,21 @@ def scene_times(
 def _extract(mp4: Path, at: float, path: Path) -> bool:
     """One frame of `mp4` at `at` seconds, written to `path`."""
     proc = subprocess.run(
-        ["ffmpeg", "-y", "-v", "error", "-ss", f"{at:.3f}", "-i", str(mp4),
-         "-frames:v", "1", "-update", "1", str(path)],
+        [
+            "ffmpeg",
+            "-y",
+            "-v",
+            "error",
+            "-ss",
+            f"{at:.3f}",
+            "-i",
+            str(mp4),
+            "-frames:v",
+            "1",
+            "-update",
+            "1",
+            str(path),
+        ],
         capture_output=True,
     )
     return proc.returncode == 0 and path.is_file()
@@ -225,6 +251,9 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
     manifest["clock_correction"] = clock
 
     planned: list[dict] = []
+    # Beats long enough for the unscripted-transition search whose span in the
+    # video turned out to be empty. See where it is appended.
+    skipped_scenes: list[int] = []
     for beat in beats:
         t_start, t_end = beat.get("t_start"), beat.get("t_end")
         if not isinstance(t_start, (int, float)):
@@ -244,12 +273,14 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         logged = (float(t_start) + float(t_end)) / 2
         middle = min(max(logged + correct(beat, logged), 0.0), last)
         index = int(beat.get("index", len(planned)))
-        planned.append({
-            "file": f"beat-{index:02d}.png",
-            "kind": "beat",
-            "beat": index,
-            "t": round(middle, 3),
-        })
+        planned.append(
+            {
+                "file": f"beat-{index:02d}.png",
+                "kind": "beat",
+                "beat": index,
+                "t": round(middle, 3),
+            }
+        )
         # Only for beats long enough to hide an unscripted transition. Beat
         # alignment sees what the storyboard wrote down; a redirect, a toast or
         # a load finishing inside a long hold is invisible to it.
@@ -260,17 +291,27 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         # the log's clock it would scan a stretch the beat had already left —
         # and each edge is corrected at its own instant, because a step inside
         # the beat moves its end and not its start.
-        window = (
-            min(max(float(t_start) + correct(beat, float(t_start)), 0.0), last),
-            min(max(float(t_end) + correct(beat, float(t_end)), 0.0), last),
-        )
-        for n, cut in enumerate(scene_times(mp4, *window), 1):
-            planned.append({
-                "file": f"beat-{index:02d}-scene-{n}.png",
-                "kind": "scene",
-                "beat": index,
-                "t": round(cut, 3),
-            })
+        lo = min(max(float(t_start) + correct(beat, float(t_start)), 0.0), last)
+        hi = min(max(float(t_end) + correct(beat, float(t_end)), 0.0), last)
+        # Correcting each edge at its own instant can put the end *before* the
+        # start: a step larger than the beat's span leaves none of that beat's
+        # wall time in the file, and a beat clamped past the end of the video
+        # collapses the same way. There is genuinely nothing to search, and
+        # `scene_times` answers an inverted window with an empty list — so the
+        # only wrong move is to let the sheet quietly carry fewer frames.
+        # Recorded here, printed in frames.md, and named by beat.
+        if hi <= lo:
+            skipped_scenes.append(index)
+            continue
+        for n, cut in enumerate(scene_times(mp4, lo, hi), 1):
+            planned.append(
+                {
+                    "file": f"beat-{index:02d}-scene-{n}.png",
+                    "kind": "scene",
+                    "beat": index,
+                    "t": round(cut, 3),
+                }
+            )
 
     # Take the previous run's sheet off disk before writing this one. A demo
     # whose storyboard lost beats would otherwise leave frames nobody planned
@@ -299,6 +340,7 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
                 file=sys.stderr,
             )
     manifest["frames"] = written
+    manifest["scene_search_skipped"] = skipped_scenes
     # How far the video is *known* to have slid under the beat log, as a floor
     # rather than a correction: a beat that ends after the video does is wall
     # time that never reached the file (issue #18). Measured against the last
@@ -343,9 +385,7 @@ def write_beat_frames(out_dir: Path | str, doc: dict, where: str) -> dict | None
             file=sys.stderr,
         )
         return manifest
-    print(
-        f"wrote {frames_paths(out_dir)[0]} ({len(manifest['frames'])} review frames)"
-    )
+    print(f"wrote {frames_paths(out_dir)[0]} ({len(manifest['frames'])} review frames)")
     return manifest
 
 
@@ -437,6 +477,21 @@ def render_frames_md(manifest: dict) -> str:
     if manifest.get("skipped"):
         return "\n".join(out + [f"No frames were written: {manifest['skipped']}.", ""])
     out += _clock_md(manifest.get("clock_correction"))
+    swallowed = manifest.get("scene_search_skipped") or []
+    if swallowed:
+        # Named, not counted: the reader's question is which beat is thinner
+        # than it looks, and "one beat" does not answer it.
+        beats = ", ".join(f"`beat-{int(i):02d}.png`" for i in swallowed)
+        out += [
+            f"{beats} covers a beat long enough for the recorder to look "
+            f"inside it for a change the storyboard did not script — and the "
+            f"host's wall clock stepped further during that beat than the beat "
+            f"is long, so none of its wall time is in the video and **no extra "
+            f"frames were looked for**. The sheet is that much thinner than it "
+            f"would be on a steady host; nothing is missing from the beat's "
+            f"own frame above.",
+            "",
+        ]
     loss = manifest.get("capture_loss_at_least") or 0.0
     if loss > 0.05:
         out += [

--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -234,8 +234,15 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         # Onto the video's clock before anything is clamped: the correction is
         # what puts the beat where the frames are, and clamping first would
         # aim at the end of a file the beat does not reach.
-        slid = correct(beat)
-        middle = min(max((float(t_start) + float(t_end)) / 2 + slid, 0.0), last)
+        #
+        # Every instant is corrected **by the steps before that instant** —
+        # `correct(beat, t)`, not one number per beat. A step landing inside a
+        # beat's own first half moved this frame and did not move the beat's
+        # start, and half of a take's wall time is inside some beat's first
+        # half, so a per-beat number leaves roughly one step in two applied to
+        # the wrong instants.
+        logged = (float(t_start) + float(t_end)) / 2
+        middle = min(max(logged + correct(beat, logged), 0.0), last)
         index = int(beat.get("index", len(planned)))
         planned.append({
             "file": f"beat-{index:02d}.png",
@@ -250,10 +257,12 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
             continue
         # The same slide, for the same reason: this window is a search through
         # the video, so it has to be the beat's span *in the video*. Left on
-        # the log's clock it would scan a stretch the beat had already left.
+        # the log's clock it would scan a stretch the beat had already left —
+        # and each edge is corrected at its own instant, because a step inside
+        # the beat moves its end and not its start.
         window = (
-            min(max(float(t_start) + slid, 0.0), last),
-            min(max(float(t_end) + slid, 0.0), last),
+            min(max(float(t_start) + correct(beat, float(t_start)), 0.0), last),
+            min(max(float(t_end) + correct(beat, float(t_end)), 0.0), last),
         )
         for n, cut in enumerate(scene_times(mp4, *window), 1):
             planned.append({
@@ -298,7 +307,8 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
     # here too would tell a reviewer their frames may be stale by the very
     # amount they were just moved by.
     tail = beats[-1]
-    over = float(tail.get("t_end") or 0.0) + correct(tail) - float(duration)
+    tail_end = float(tail.get("t_end") or 0.0)
+    over = tail_end + correct(tail, tail_end) - float(duration)
     manifest["capture_loss_at_least"] = round(max(0.0, over), 3)
     json_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
     md_path.write_text(render_frames_md(manifest))
@@ -361,21 +371,26 @@ def _clock_md(clock: object) -> list[str]:
             f"demo — and nothing here knows by how much.",
             "",
         ]
-    total = clock.get("total") or 0.0
-    if not total:
+    # On the **count**, never on the total. Two steps that cancel — a +0.9 s
+    # pulse and the -0.9 s that undoes it, which is the shape of the host this
+    # work exists for — total zero and still move every frame cut between
+    # them. Branching on the total would print "did not step" over a sheet
+    # whose frames had moved by nearly a second.
+    if not clock.get("steps"):
         return [
             "The host's wall clock was watched for the length of this take and "
             "did not step, so each frame is at its beat's midpoint.",
             "",
         ]
     return [
-        f"**The host's wall clock stepped {total:+.2f}s while this was "
-        f"recorded**, over {clock.get('steps')} step(s), and the video is on "
-        f"that clock. Each frame below was therefore cut at its beat's "
-        f"midpoint **plus the steps its own capture recorded before it**, not "
-        f"at the midpoint itself — the timestamps in the table are where the "
-        f"frames came out of the video. `timeline.json`'s `capture_clock` has "
-        f"the steps.",
+        f"**The host's wall clock stepped {clock.get('steps')} time(s) while "
+        f"this was recorded** ({clock.get('total') or 0.0:+.2f}s in total), and "
+        f"the video is on that clock. Each frame below was therefore cut at "
+        f"its beat's midpoint **plus the steps its own capture recorded before "
+        f"that instant**, not at the midpoint itself — the timestamps in the "
+        f"table are where the frames came out of the video, and the total "
+        f"above is the correction for none of them individually. "
+        f"`timeline.json`'s `capture_clock` has the steps.",
         "",
     ]
 

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -405,9 +405,11 @@ def timeline_paths(out_dir: Path | str, segment: str | None = None) -> tuple[Pat
 # beat's *start*; a consumer converting the beat's **midpoint** — which is what
 # a review frame is cut at — has to sum the steps before the *midpoint*, or a
 # step landing in the beat's own first half is left out and that frame does not
-# move at all. That is not a corner case: across this repo's three committed
-# demos, 49.2-49.6 % of take wall time lies inside some beat's first half, so
-# roughly one recorded step in two falls there. It was missed the first time
+# move at all. That is not a corner case: **46.9 %, 48.0 % and 48.8 % of each
+# take's `duration`** lies inside some beat's first half over this repo's three
+# committed demos, so roughly one recorded step in two falls there. (Of the
+# beats' own spans it is 50.0 % by construction, which is why the denominator
+# is stated.) It was missed the first time
 # because #250 validated the rule against *caption transitions*, which sit at
 # beat starts — the one instant at which the two readings cannot differ.
 #
@@ -448,6 +450,15 @@ def _usable_steps(doc: dict, record: dict) -> list[dict] | None:
     # directions matter — a merged step with no `segment` and a single take's
     # step that has one both match no beat, so they would correct nothing while
     # the sheet reported a correction.
+    #
+    # **Stated limit, and pre-existing**: this is inexact for one document
+    # shape it never sees — a single *segment*'s own timeline, whose beats do
+    # carry a segment while its steps do not, so `{None}` accepts every step
+    # and `correct` then matches no beat. Nothing reaches it: `beat_frames`
+    # returns `skipped` for a document with a `segment` before it asks for a
+    # correction at all, and `stitch()` re-derives the merged record from the
+    # parts rather than reading one part's. Written down so the next reader
+    # does not have to re-derive that.
     named = {s.get("segment") for s in doc.get("segments") or [] if isinstance(s, dict)}
     allowed = named or {None}
     steps = []

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -13,6 +13,7 @@ checkable without recording anything.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from pathlib import Path
 
 from .failure import FAILURE_DIR, FAILURE_MARKER
@@ -380,6 +381,173 @@ def timeline_paths(out_dir: Path | str, segment: str | None = None) -> tuple[Pat
     return out_dir / f"{stem}.json", out_dir / f"{stem}.md"
 
 
+# -- reading `capture_clock` back ---------------------------------------------
+#
+# `beats` are `time.monotonic()`; `media` is on the host's *wall* clock. So a
+# beat the log puts at `t` sits at `t + (the steps its own capture recorded
+# before it)` in the video — the rule the envelope documentation above states,
+# measured over six takes and 38 caption transitions: uncorrected the video was
+# up to 1.50 s from the log by 13.5 s in, corrected all 38 landed within 101 ms
+# (issue #229, reference/limits.md).
+#
+# **The record can give three different answers, and the third is the one that
+# is easy to lose:**
+#
+#   * `measured: true` with steps — correct by them, per capture.
+#   * `measured: true` with none — the clock *was watched* and held still. The
+#     correction is zero because somebody looked.
+#   * `measured: false`, or no record at all — **nobody knows.** `steps` is an
+#     empty list here too (issue #247), so a consumer reading only `steps`
+#     cannot tell this case from the one above it. Zero is still the number
+#     applied, because there is no other number available — but it is not a
+#     correction, and an artifact built on it has to say so. A sheet that
+#     implies a correction nobody could compute is exactly the confidently
+#     wrong attribution this field grew a `measured` flag to prevent.
+#
+# `state` below is what an artifact prints so its reader can tell the three
+# apart, and it is deliberately part of the return value rather than something
+# a caller re-derives.
+
+
+def _usable_steps(doc: dict, record: dict) -> list[dict] | None:
+    """`record`'s steps, or None if this record cannot honestly correct a beat.
+
+    Refuses rather than corrects by part of a record. A step missing its `t`
+    or its `delta` would silently drop out of every sum, and a merged record
+    whose steps have lost the `segment` they were measured in matches no beat
+    at all — both leave the arithmetic looking applied while it corrects
+    nothing, which is worse than declining out loud.
+    """
+    listed = record.get("steps")
+    if not isinstance(listed, list):
+        return None
+    merged = {s.get("segment") for s in doc.get("segments") or [] if isinstance(s, dict)}
+    steps = []
+    for step in listed:
+        if not isinstance(step, dict):
+            return None
+        at, delta = step.get("t"), step.get("delta")
+        for value in (at, delta):
+            if not isinstance(value, (int, float)) or isinstance(value, bool):
+                return None
+        if merged and step.get("segment") not in merged:
+            return None
+        steps.append(step)
+    return steps
+
+
+def _no_correction(beat: dict) -> float:
+    """The correction for a record that cannot supply one. Zero, and stated."""
+    return 0.0
+
+
+def capture_clock_correction(doc: dict) -> tuple[Callable[[dict], float], dict]:
+    """(correct, state) — how far each beat of `doc` slid under the video.
+
+    `correct(beat)` is the seconds to add to a timestamp taken from that beat
+    to reach the same moment in `media`: the steps of that beat's **own
+    capture** up to its `t_start`, never the running total and never an earlier
+    part's, whose loss is already in the merged offsets (see
+    `_merge_capture_clock`). On a take recorded in one piece neither the steps
+    nor the beats name a segment, and the same rule is then the whole list.
+
+    `state` is what the artifact says about the correction — `applied`,
+    `total`, `steps` (how many the record carries) and `note` (why not, when
+    `applied` is false). It exists so a document cannot show a corrected
+    timestamp without being able to say whether a correction was possible.
+    """
+    record = doc.get("capture_clock")
+    if not isinstance(record, dict):
+        return _no_correction, {
+            "applied": False,
+            "total": None,
+            "steps": 0,
+            "note": (
+                "this timeline carries no capture_clock, so nothing here knows "
+                "whether the host's wall clock moved under the beat log"
+            ),
+        }
+    if record.get("measured") is not True:
+        return _no_correction, {
+            "applied": False,
+            "total": None,
+            "steps": 0,
+            "note": record.get("note")
+            or (
+                "the take's wall clock was not measured, so nothing here knows "
+                "whether it moved under the beat log"
+            ),
+        }
+    steps = _usable_steps(doc, record)
+    if steps is None:
+        return _no_correction, {
+            "applied": False,
+            "total": None,
+            "steps": 0,
+            "note": (
+                "this timeline's capture_clock says it was measured, but its "
+                "steps are not in the shape this reader can attribute to a "
+                "beat — correcting by part of a record would look applied "
+                "while correcting nothing"
+            ),
+        }
+
+    def correct(beat: dict) -> float:
+        t_start = beat.get("t_start")
+        if not isinstance(t_start, (int, float)) or isinstance(t_start, bool):
+            return 0.0
+        return sum(
+            float(step["delta"])
+            for step in steps
+            if step.get("segment") == beat.get("segment")
+            and float(step["t"]) <= float(t_start)
+        )
+
+    return correct, {
+        "applied": True,
+        # Totalled from the steps that were **used**, not copied out of the
+        # record's own `total`. The two can disagree — `tests/smoke` has an
+        # injection for exactly that — and this number's job is to describe
+        # the correction that was applied, not to repeat a claim about it.
+        "total": round(sum(float(step["delta"]) for step in steps), 4),
+        "steps": len(steps),
+        "note": None,
+    }
+
+
+def _capture_clock_md(state: dict) -> list[str]:
+    """What `timeline.md` says about the clock its own timestamps are on.
+
+    Silent on the ordinary take — a measured clock that held still is what the
+    reader already assumes, and a line on every timeline is a line nobody
+    reads. It speaks in the two cases where the assumption is wrong: the clock
+    stepped, or nobody watched it.
+    """
+    if not state.get("applied"):
+        return [
+            f"**The clock this take's video is on was not measured.** "
+            f"{state.get('note')}. The times below are `time.monotonic()` and "
+            f"the recording is on the host's wall clock, so if the two parted "
+            f"company while this was recording, nothing in this file can say "
+            f"by how much.",
+            "",
+        ]
+    total = state.get("total") or 0.0
+    if not total:
+        return []
+    return [
+        f"**The host's wall clock stepped {total:+.2f}s while this was "
+        f"recorded**, over {state.get('steps')} step(s). The times below are "
+        f"`time.monotonic()`; the recording is on that wall clock, so a beat "
+        f"this table puts at `t` sits at `t` plus the steps its own capture "
+        f"recorded before it — not at `t`. `timeline.json`'s `capture_clock` "
+        f"carries every step and the capture it was measured in; "
+        f"`frames/frames.md` says whether the review frames were cut with it "
+        f"applied.",
+        "",
+    ]
+
+
 def _coverage_md(coverage: object) -> list[str]:
     """The acceptance-criteria section of timeline.md, or nothing (issue #12).
 
@@ -552,6 +720,12 @@ def render_timeline_md(doc: dict) -> str:
     # scrolls past 28 beats first has already formed the impression the
     # coverage report exists to test (issue #12).
     out += _coverage_md(doc.get("coverage"))
+    # Directly above the beat table, because it is a statement about the
+    # numbers in it: a reader who has scrolled past the table has already read
+    # the timestamps as the video's, which is the misreading this says out
+    # loud. The recorder warns about the same thing on stderr, minutes and
+    # several thousand lines before anybody opens this file (issue #229).
+    out += _capture_clock_md(capture_clock_correction(doc)[1])
     # The exit column only exists when something in this take has one — a web
     # timeline would otherwise carry an empty column on every row. A `run` beat
     # whose status could not be read shows "?" rather than blank, so the

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -70,12 +70,20 @@ from .markdown import _fmt_t, _md_cell
 #                          (issue #247). An empty `steps` with `measured` true
 #                          means the clock held still, which is a different
 #                          answer again from the field being absent.
-#                          **A beat the log puts at `t` sits at
-#                          `t + (the steps before it)` in the video** —
+#                          **An instant the log puts at `t` sits at
+#                          `t + (the steps before `t`)` in the video** —
 #                          measured against the encode over six takes and 38
 #                          caption transitions, residual under 101 ms where
 #                          the uncorrected log was out by up to 1.50 s.
-#                          reference/limits.md has the measurement.
+#                          reference/limits.md has the measurement. Note the
+#                          rule is indexed by the **instant being converted**,
+#                          not by the beat it came from: converting a beat's
+#                          midpoint sums the steps before the midpoint, and a
+#                          step inside that beat's first half belongs to it.
+#                          Reading `t_start` for every instant of a beat leaves
+#                          such a step out entirely, and the measurement above
+#                          cannot see that — caption transitions sit at beat
+#                          *starts*, the one instant where the two agree.
 #                          On a merged demo (`stitch`) every part's steps are
 #                          here, moved onto the stitched clock by that part's
 #                          `offset`, and each step also carries the `segment`
@@ -84,10 +92,12 @@ from .markdown import _fmt_t, _md_cell
 #                          sampled for as long as the capture runs, which is
 #                          longer than the video it produced, so a step's `t`
 #                          can fall past the next part's `boundaries` entry.
-#                          The correction for a beat is the steps of *its own*
-#                          segment up to its `t_start` — never `total`, and
+#                          The correction for an instant is the steps of *its
+#                          own* segment up to that instant — never `total`, and
 #                          never an earlier part's, whose loss is already in
-#                          the offsets. `boundaries` (merged demos only) is
+#                          the offsets. `capture_clock_correction` below is
+#                          this rule, and is what the recorder's own consumers
+#                          read it through. `boundaries` (merged demos only) is
 #                          where each capture starts on the stitched clock.
 #                          **Null** on a merged demo any of whose parts carried
 #                          no usable record: a partial answer here would say a
@@ -383,12 +393,23 @@ def timeline_paths(out_dir: Path | str, segment: str | None = None) -> tuple[Pat
 
 # -- reading `capture_clock` back ---------------------------------------------
 #
-# `beats` are `time.monotonic()`; `media` is on the host's *wall* clock. So a
-# beat the log puts at `t` sits at `t + (the steps its own capture recorded
+# `beats` are `time.monotonic()`; `media` is on the host's *wall* clock. So an
+# instant the log puts at `t` sits at `t + (the steps its own capture recorded
 # before it)` in the video — the rule the envelope documentation above states,
 # measured over six takes and 38 caption transitions: uncorrected the video was
 # up to 1.50 s from the log by 13.5 s in, corrected all 38 landed within 101 ms
 # (issue #229, reference/limits.md).
+#
+# **It is indexed by the instant, not by the beat**, and the difference is a
+# whole step. The envelope's "up to its `t_start`" is that rule applied to a
+# beat's *start*; a consumer converting the beat's **midpoint** — which is what
+# a review frame is cut at — has to sum the steps before the *midpoint*, or a
+# step landing in the beat's own first half is left out and that frame does not
+# move at all. That is not a corner case: across this repo's three committed
+# demos, 49.2-49.6 % of take wall time lies inside some beat's first half, so
+# roughly one recorded step in two falls there. It was missed the first time
+# because #250 validated the rule against *caption transitions*, which sit at
+# beat starts — the one instant at which the two readings cannot differ.
 #
 # **The record can give three different answers, and the third is the one that
 # is easy to lose:**
@@ -421,7 +442,14 @@ def _usable_steps(doc: dict, record: dict) -> list[dict] | None:
     listed = record.get("steps")
     if not isinstance(listed, list):
         return None
-    merged = {s.get("segment") for s in doc.get("segments") or [] if isinstance(s, dict)}
+    # Which captures a step is allowed to name, read off the document rather
+    # than assumed: the segments of a merged demo, and *no segment at all* on a
+    # take recorded in one piece, whose beats carry none either. Both
+    # directions matter — a merged step with no `segment` and a single take's
+    # step that has one both match no beat, so they would correct nothing while
+    # the sheet reported a correction.
+    named = {s.get("segment") for s in doc.get("segments") or [] if isinstance(s, dict)}
+    allowed = named or {None}
     steps = []
     for step in listed:
         if not isinstance(step, dict):
@@ -430,26 +458,32 @@ def _usable_steps(doc: dict, record: dict) -> list[dict] | None:
         for value in (at, delta):
             if not isinstance(value, (int, float)) or isinstance(value, bool):
                 return None
-        if merged and step.get("segment") not in merged:
+        if step.get("segment") not in allowed:
             return None
         steps.append(step)
     return steps
 
 
-def _no_correction(beat: dict) -> float:
+def _no_correction(beat: dict, t: float) -> float:
     """The correction for a record that cannot supply one. Zero, and stated."""
     return 0.0
 
 
-def capture_clock_correction(doc: dict) -> tuple[Callable[[dict], float], dict]:
-    """(correct, state) — how far each beat of `doc` slid under the video.
+def capture_clock_correction(
+    doc: dict,
+) -> tuple[Callable[[dict, float], float], dict]:
+    """(correct, state) — how far each instant of `doc` slid under the video.
 
-    `correct(beat)` is the seconds to add to a timestamp taken from that beat
-    to reach the same moment in `media`: the steps of that beat's **own
-    capture** up to its `t_start`, never the running total and never an earlier
-    part's, whose loss is already in the merged offsets (see
+    `correct(beat, t)` is the seconds to add to the beat-log instant `t`, taken
+    from `beat`, to reach the same moment in `media`: the steps of that beat's
+    **own capture** up to **`t` itself**, never the running total and never an
+    earlier part's, whose loss is already in the merged offsets (see
     `_merge_capture_clock`). On a take recorded in one piece neither the steps
     nor the beats name a segment, and the same rule is then the whole list.
+
+    **`t` and not the beat**, because a caller converting a beat's midpoint and
+    one converting its start are asking different questions whenever a step
+    landed between the two — see the note above this function.
 
     `state` is what the artifact says about the correction — `applied`,
     `total`, `steps` (how many the record carries) and `note` (why not, when
@@ -492,15 +526,12 @@ def capture_clock_correction(doc: dict) -> tuple[Callable[[dict], float], dict]:
             ),
         }
 
-    def correct(beat: dict) -> float:
-        t_start = beat.get("t_start")
-        if not isinstance(t_start, (int, float)) or isinstance(t_start, bool):
-            return 0.0
+    def correct(beat: dict, t: float) -> float:
         return sum(
             float(step["delta"])
             for step in steps
             if step.get("segment") == beat.get("segment")
-            and float(step["t"]) <= float(t_start)
+            and float(step["t"]) <= float(t)
         )
 
     return correct, {
@@ -532,18 +563,20 @@ def _capture_clock_md(state: dict) -> list[str]:
             f"by how much.",
             "",
         ]
-    total = state.get("total") or 0.0
-    if not total:
+    # On the **count**, never on the total: two steps that cancel total zero
+    # and still part the two clocks for everything recorded between them.
+    if not state.get("steps"):
         return []
     return [
-        f"**The host's wall clock stepped {total:+.2f}s while this was "
-        f"recorded**, over {state.get('steps')} step(s). The times below are "
-        f"`time.monotonic()`; the recording is on that wall clock, so a beat "
-        f"this table puts at `t` sits at `t` plus the steps its own capture "
-        f"recorded before it — not at `t`. `timeline.json`'s `capture_clock` "
-        f"carries every step and the capture it was measured in; "
-        f"`frames/frames.md` says whether the review frames were cut with it "
-        f"applied.",
+        f"**The host's wall clock stepped {state.get('steps')} time(s) while "
+        f"this was recorded** ({state.get('total') or 0.0:+.2f}s in total). The "
+        f"times below are `time.monotonic()`; the recording is on that wall "
+        f"clock, so an instant this table puts at `t` sits at `t` plus the "
+        f"steps its own capture recorded before `t` — not at `t`, and not at "
+        f"`t` plus the total above, which is the correction for no single row. "
+        f"`timeline.json`'s `capture_clock` carries every step and the capture "
+        f"it was measured in; `frames/frames.md` says whether the review "
+        f"frames were cut with it applied.",
         "",
     ]
 

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -133,9 +133,18 @@ rather than by widening a bar, which is why `MAX_SKEW_DRIFT_S` could be
 restored at 250 ms after being deleted in
 [#217](https://github.com/rogvid/skills/issues/217).
 
-What to do: prefer `timeline.json`'s `capture_clock`, which records every step
-with its offset and size, and correct with it — **after checking
-`capture_clock.measured`**. That flag is false when the recorder's sampler
+Two things in the recorder already apply this for you, and reading them as
+uncorrected is the way to get it wrong twice
+([#229](https://github.com/rogvid/skills/issues/229)): **the review frames
+under `frames/` are cut on the video's clock**, midpoint plus that beat's own
+capture's steps before it, and `frames/frames.md` says which of the three
+cases the take was; and `timeline.md` says above its beat table when the clock
+stepped and by how much. `timeline.json`'s beat timestamps are untouched — they
+are the log, and the log is `time.monotonic()`.
+
+What to do everywhere else: prefer `timeline.json`'s `capture_clock`, which
+records every step with its offset and size, and correct with it — **after
+checking `capture_clock.measured`**. That flag is false when the recorder's sampler
 could not keep its interval, and then `steps` is empty and `total` is `null`
 on purpose: a record that says "I did not watch this" is the one thing worth
 more than a number that might be wrong. `max_gap` and `max_gap_limit` are the

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -137,8 +137,9 @@ Two things in the recorder already apply this for you, and reading them as
 uncorrected is the way to get it wrong twice
 ([#229](https://github.com/rogvid/skills/issues/229)): **the review frames
 under `frames/` are cut on the video's clock**, midpoint plus that beat's own
-capture's steps before it, and `frames/frames.md` says which of the three
-cases the take was; and `timeline.md` says above its beat table when the clock
+capture's steps before *that midpoint* (the rule is indexed by the instant you
+are converting, not by the beat — a step inside a beat's first half moves its
+frame), and `frames/frames.md` says which of the three cases the take was; and `timeline.md` says above its beat table when the clock
 stepped and by how much. `timeline.json`'s beat timestamps are untouched — they
 are the log, and the log is `time.monotonic()`.
 

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -17,8 +17,9 @@ machine.
 
 They are aligned to **beats, not to a clock**. The old advice was
 `ffmpeg -vf fps=1/3`, which misses a short beat entirely and photographs a long
-static one twice. Each frame is taken at its beat's **midpoint** — `t_start` is
-0% into the caption bar's fade and before the verb has done anything.
+static one twice. Each frame is taken at its beat's **midpoint**, moved onto
+the video's own clock (below) — `t_start` is 0% into the caption bar's fade and
+before the verb has done anything.
 
 **How accurate that aim is, honestly.** The beat log is `time.monotonic()`;
 the video is on the host's **wall** clock, because that is what Chromium
@@ -31,11 +32,25 @@ idle time — that explanation was measured and retracted; see
 instrumented takes with a steady host clock, and by however much the host's
 wall clock moved during the take on one that does not: **1.50 s** by 13.5 s
 into a take on the WSL2 box of
-[#247](https://github.com/rogvid/skills/issues/247), with no fixed bound. The
-size is in `timeline.json`'s `capture_clock`, and nothing in the recorder
-applies it to these frames yet
-([#229](https://github.com/rogvid/skills/issues/229)). The practical
-consequence: for a beat comfortably longer
+[#247](https://github.com/rogvid/skills/issues/247), with no fixed bound.
+
+**The second of those two is corrected, and the first is not**
+([#229](https://github.com/rogvid/skills/issues/229)). Each frame is cut at
+its beat's midpoint **plus the wall-clock steps its own capture recorded
+before it**, read out of `timeline.json`'s `capture_clock`; corrected that way,
+38 caption transitions over six takes landed within 101 ms of the log where the
+uncorrected cut was out by up to 1.50 s. The timestamps in `frames.json` and
+`frames.md` are **already on the video's clock** — do not apply
+`capture_clock` to them a second time.
+
+`frames.md` says which of the three cases the take was, because a corrected
+sheet and an uncorrected one are otherwise the same document: the clock
+stepped and the frames were moved, the clock was watched and held still, or
+**nothing could be corrected** — no record, or a sampler that says it could
+not watch (`capture_clock.measured` false). In that last case the frames are
+cut on the raw beat log and the sheet says so; treat their aim as unbounded.
+
+The practical consequence, for what is left: for a beat comfortably longer
 than that, the frame is of that beat; **for a beat shorter than the drift — a
 bare `shot()`, a `wait_for()` that returned immediately — the frame can be of
 the beat after it.** `tests/smoke` measures exactly this and shows it: with the

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -37,7 +37,9 @@ into a take on the WSL2 box of
 **The second of those two is corrected, and the first is not**
 ([#229](https://github.com/rogvid/skills/issues/229)). Each frame is cut at
 its beat's midpoint **plus the wall-clock steps its own capture recorded
-before it**, read out of `timeline.json`'s `capture_clock`; corrected that way,
+before that midpoint** — the instant being converted, not the beat's start, so
+a step landing inside a beat's first half moves that beat's frame — read out of
+`timeline.json`'s `capture_clock`; corrected that way,
 38 caption transitions over six takes landed within 101 ms of the log where the
 uncorrected cut was out by up to 1.50 s. The timestamps in `frames.json` and
 `frames.md` are **already on the video's clock** — do not apply

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -14,7 +14,15 @@ next to the media, whether or not the storyboard finished. No storyboard
 changes are needed; it is a byproduct of recording.
 
 `timeline.md` is the readable version: a table of every beat, then each still
-embedded under the caption it was taken during. **Commit both.** They are
+embedded under the caption it was taken during. Directly above that table it
+says when the host's wall clock **stepped** during the take, and by how much —
+the times in the table are `time.monotonic()` and `demo.mp4` is on the wall
+clock, so a step parts the two (`timeline.json`'s `capture_clock` carries every
+step; [limits.md](limits.md) has the measurement, and
+[#229](https://github.com/rogvid/skills/issues/229) is why this is printed).
+When nothing could watch
+that clock it says *that* instead, which is a different answer from silence.
+**Commit both.** They are
 small, diffable, and unlike `demo.mp4` they survive as a record of what the
 demo showed after the video has been regenerated or thrown away — which is
 what makes them worth reviewing in a PR.

--- a/tests/README.md
+++ b/tests/README.md
@@ -183,7 +183,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~48 s)
-tests/smoke-inject                # all 48 entries, ~41 min
+tests/smoke-inject                # all 49 entries, ~41 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -661,10 +661,16 @@ recorder claims, and it deliberately claims very little:
   off-by-one name fails without a pixel being read. Every file on disk is named
   by the manifest and vice versa.
 - **Each frame is the moment it says it is.** Two halves, and only together.
-  Its timestamp must be its beat's midpoint, computed *here* from
-  `timeline.json` — not imported from the recorder, because a check that
-  re-derives its expectation from the constants it is grading moves whenever
-  they do. And the PNG must be that frame: the harness **cuts the same second
+  Its timestamp must be its beat's midpoint **moved onto the video's clock by
+  this harness's own wall-clock watcher** ([#229](https://github.com/rogvid/skills/issues/229)),
+  computed *here* from
+  `timeline.json` — not imported from the recorder, and not corrected with the
+  take's own `capture_clock`, because a check that re-derives its expectation
+  from the numbers it is grading passes on whatever they say. A beat whose
+  midpoint sits within `MAX_CLOCK_STEP_TIME_DISAGREEMENT_S` of a step is not
+  placement-graded and is counted in the arm's output: two samplers on their
+  own 20 ms grids do not both know which side of a step a beat fell on.
+  And the PNG must be that frame: the harness **cuts the same second
   out of `demo.mp4` again and compares the bytes**. 56 of 56 identical across
   the three graded takes — 23 web, 18 terminal, and 15 off the stitched
   `segments/` demo; one frame away (40 ms) is already a different file.
@@ -676,6 +682,15 @@ recorder claims, and it deliberately claims very little:
   filtered table and a refreshed one are mostly the same white page). A
   threshold loose enough to absorb the first cannot see the second — measured,
   by injecting exactly that and watching it pass.
+- **The sheet says which clock it cut them on.** On a host whose clock never
+  steps the corrected instant and the uncorrected one are the same number, so
+  nothing above can tell a recorder that applies `capture_clock` from one that
+  ignores it — but "a correction was applied" and "nobody could compute one"
+  are still two different sentences over identical timestamps. `frames.json`
+  must carry the answer, `frames.md` must say it in words, and a sheet that
+  reports no correction on a take *this harness* watched to within its own
+  interval is a failure. One `smoke-inject` entry breaks each half.
+
 - **The sheet leaks no storyboard.** `frames.md` goes to a *context-free*
   reviewer who is asked what story the pictures tell. It is searched for every
   caption in `WEB_CAPTIONS`/`TERMINAL_CAPTIONS` and every selector in the beat
@@ -1671,7 +1686,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-48 entries, 12 arms, ~41.0 min of takes
+49 entries, 12 arms, ~41.4 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -1704,7 +1719,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
-| `--segments-only` | 13 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
+| `--segments-only` | 14 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the sheet stops saying **which clock** it cut them on, so a reviewer cannot tell a corrected sheet from one cut on the raw beat log ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
@@ -1999,16 +2014,30 @@ knows is missing is worse than one that is openly absent.
 
   What is fixed: the recorder measures the same clock and writes it into
   `timeline.json` as `capture_clock`, warns on the way out, and this harness
-  measures it independently and subtracts it before grading. What is **not**
-  fixed: a real demo's `timeline.json` still carries timestamps on a clock the
-  video is not on — a consumer has to apply `capture_clock` itself, and
-  nothing in the recorder does it for them. So a frame extracted at a beat
-  timestamp can still show the wrong moment, and narration still inherits the
-  lag because audio is mixed at wall-clock offsets while pixels ride the
-  screencast — measured at +0.70 s and now correctable from `capture_clock`,
-  which is [#226](https://github.com/rogvid/skills/issues/226). What is left of
+  measures it independently and subtracts it before grading. Since
+  [#229](https://github.com/rogvid/skills/issues/229) the recorder also
+  *applies* it where it owns the consumer — the review frames are cut on the
+  video's clock, and both `frames.md` and `timeline.md` say when the clock
+  stepped — so a reader of those two artifacts is no longer on their own.
+
+  What is **not** fixed: a real demo's `timeline.json` still carries beat
+  timestamps on a clock the video is not on, because that is what the log is,
+  and anything else reading them has to apply the field itself. Narration
+  still inherits the lag, because audio is mixed at wall-clock offsets while
+  pixels ride the screencast — measured at +0.70 s and now correctable from
+  `capture_clock`, which is
+  [#226](https://github.com/rogvid/skills/issues/226). What is left of
   [#18](https://github.com/rogvid/skills/issues/18) is that boundary, and it
   matters most to [#8](https://github.com/rogvid/skills/issues/8).
+
+  **And on a host whose clock never steps, the correction is a no-op** — a
+  corrected cut and an uncorrected one are the same number, so no arm of this
+  suite can tell them apart there. The arithmetic is graded on a *scripted*
+  record by `FrameClockCorrection` in `tests/unit`, where six injections cost
+  0.2 s each; what `--segments-only` adds on any host is that the sheet states
+  which of the three cases it was, and that a step the recorder invents moves
+  the frames and is caught by a placement check reading this harness's own
+  watcher.
 
 - **~~…and the correction above rests on a premise that did not reproduce on
   2026-08-08.~~ Retracted; the premise holds and the *sampler* was broken**
@@ -2080,6 +2109,18 @@ knows is missing is worse than one that is openly absent.
   in `tests/smoke` itself and were seen failing. That is a weaker claim than
   the arm passing — it does not prove the guard is *reached* on a real take —
   and it is the strongest one this host allows.
+
+  **Re-measured on 2026-08-09 while #229 was implemented, and it was green.**
+  Same box, same arm, `--segments-only` clean: **PASSED in 37 s**, with
+  `capture_clock agrees with the harness (the host's wall clock did not step
+  during this take)` for both parts and 0 merged steps. The host's 5.5 s pulse
+  was simply not running on that reading. That does not retract the entry
+  above — the arm was red twice earlier the same day, and a box that is red
+  when its clock steps and green when it does not is exactly the bimodality
+  #215 reported — but it does mean the three coverage entries, and #229's two,
+  are runnable here when the host is quiet, and #229's two were run and caught.
+  Treat a green `--segments-only` on this box as a reading of the host as much
+  as of the recorder.
 
 - **The terminal arm loses roughly a second more than its host clock explains,
   and nothing here knows why.** The correction is exact on the web arm — six

--- a/tests/README.md
+++ b/tests/README.md
@@ -662,7 +662,8 @@ recorder claims, and it deliberately claims very little:
   by the manifest and vice versa.
 - **Each frame is the moment it says it is.** Two halves, and only together.
   Its timestamp must be its beat's midpoint **moved onto the video's clock by
-  this harness's own wall-clock watcher** ([#229](https://github.com/rogvid/skills/issues/229)),
+  this harness's own wall-clock watcher, read at the midpoint**
+  ([#229](https://github.com/rogvid/skills/issues/229)),
   computed *here* from
   `timeline.json` — not imported from the recorder, and not corrected with the
   take's own `capture_clock`, because a check that re-derives its expectation
@@ -2033,8 +2034,11 @@ knows is missing is worse than one that is openly absent.
   **And on a host whose clock never steps, the correction is a no-op** — a
   corrected cut and an uncorrected one are the same number, so no arm of this
   suite can tell them apart there. The arithmetic is graded on a *scripted*
-  record by `FrameClockCorrection` in `tests/unit`, where six injections cost
-  0.2 s each; what `--segments-only` adds on any host is that the sheet states
+  record by `FrameClockCorrection` in `tests/unit`, where ten injections cost
+  0.2 s each — including the one that reads the correction at a beat's
+  `t_start` and applies it to the midpoint, which is how #253 shipped its first
+  round and is a whole step wrong for every step landing in a beat's first
+  half (49.2-49.6 % of take wall time, across the three committed demos); what `--segments-only` adds on any host is that the sheet states
   which of the three cases it was, and that a step the recorder invents moves
   the frames and is caught by a placement check reading this harness's own
   watcher.
@@ -2121,6 +2125,45 @@ knows is missing is worse than one that is openly absent.
   are runnable here when the host is quiet, and #229's two were run and caught.
   Treat a green `--segments-only` on this box as a reading of the host as much
   as of the recorder.
+
+- **`_check_frame_captions` is the only check that compares the review sheet
+  against the world, and it has no injection.** Everything else about the
+  frames — the count, the naming, the placement, and since
+  [#229](https://github.com/rogvid/skills/issues/229) the correction the sheet
+  states — grades an artifact against a record or against this harness's own
+  watcher. Only the caption-band ranking reads pixels, and it is one of the 16
+  of 40 check functions with no `smoke-inject` entry. #229 increased what rests
+  on it: a correction applied to the wrong instant moves frames away from their
+  beats, and this is the arm that would see it. Closing it is
+  [#233](https://github.com/rogvid/skills/issues/233)'s shape, and it is not
+  closed.
+
+- **#229's frame-placement guard cannot see the defect it was assumed to
+  catch, on a short beat.** Two clean `--segments-only` runs on the WSL2 box on
+  2026-08-09 caught the host stepping (**−907 ms at 8.62 s** and **−918 ms at
+  9.094 s** on the merged clock, part2 both times), and the frames check passed
+  both with the correction applied — 14 of 15 and 12 of 15 frames placed within
+  0.02 s of where this harness's own watcher puts them. Run 2 also contains a
+  real instance of the defect review #253 blocked on: the step landed **inside**
+  beat 9's span (8.935–9.255 s), so the shipped code cut `beat-09.png` at
+  8.177 s where the pre-fix code would have cut it at 9.095 s — **0.918 s**, or
+  ~23 frames.
+
+  **And the guard would not have caught that one.** Beat 9 is 0.32 s long, so
+  its midpoint sits 1 ms from the step and
+  `MAX_CLOCK_STEP_TIME_DISAGREEMENT_S` skips it — it is one of the "3 not
+  placement-graded" the arm printed — and `_check_frame_captions` excluded it
+  too, as within 0.75 s of a caption change. The guard catches this class only
+  for a beat **longer than 0.5 s** whose step lands **more than 0.25 s before
+  the midpoint**; on a short beat the exclusion window covers exactly the
+  frames the defect hits. `FrameClockCorrection` in `tests/unit` is the real
+  gate on it, and this is why: an arm that skips the ambiguous frames cannot
+  also be the thing that grades them.
+
+  Both runs were nonetheless **red**, on `check_merge_offset`'s caption timing
+  (+540 ms and +340 ms of *log-ahead* skew, and on the second run a slide past
+  the 1.5 s search window) — the #215/#224 shape, in assertions #229 does not
+  touch.
 
 - **The terminal arm loses roughly a second more than its host clock explains,
   and nothing here knows why.** The correction is exact on the web arm — six

--- a/tests/README.md
+++ b/tests/README.md
@@ -2034,11 +2034,14 @@ knows is missing is worse than one that is openly absent.
   **And on a host whose clock never steps, the correction is a no-op** — a
   corrected cut and an uncorrected one are the same number, so no arm of this
   suite can tell them apart there. The arithmetic is graded on a *scripted*
-  record by `FrameClockCorrection` in `tests/unit`, where ten injections cost
-  0.2 s each — including the one that reads the correction at a beat's
+  record by `FrameClockCorrection` in `tests/unit`, where 15 injections cost
+  0.2 s each — the figure is checked against the manifest by
+  `StatedInjectionCount`, because it drifted once already — including the one that reads the correction at a beat's
   `t_start` and applies it to the midpoint, which is how #253 shipped its first
   round and is a whole step wrong for every step landing in a beat's first
-  half (49.2-49.6 % of take wall time, across the three committed demos); what `--segments-only` adds on any host is that the sheet states
+  half (**46.9 %, 48.0 % and 48.8 % of the take's `duration`** across the three
+  committed demos — half of the beats' own spans by construction, so the
+  denominator is the whole of the claim); what `--segments-only` adds on any host is that the sheet states
   which of the three cases it was, and that a step the recorder invents moves
   the frames and is caught by a placement check reading this harness's own
   watcher.
@@ -2159,6 +2162,15 @@ knows is missing is worse than one that is openly absent.
   frames the defect hits. `FrameClockCorrection` in `tests/unit` is the real
   gate on it, and this is why: an arm that skips the ambiguous frames cannot
   also be the thing that grades them.
+
+  **One margin from those runs is worth writing down rather than leaving in a
+  transcript**: after the fix, beat 9's frame clears the nearest caption change
+  by **0.758 s** against a `FRAME_CAPTION_GUARD_S` of 0.750 s — an 8 ms margin
+  on the guard that decides whether `_check_frame_captions` grades a frame at
+  all. Nothing rests on it in the direction of this change (the frame is
+  excluded either way on that run), and it is not resolved: whether the margin
+  is stable across takes needs a browser and a stepping host at the same time,
+  which no run here has had twice.
 
   Both runs were nonetheless **red**, on `check_merge_offset`'s caption timing
   (+540 ms and +340 ms of *log-ahead* skew, and on the second run a slide past

--- a/tests/smoke
+++ b/tests/smoke
@@ -6569,11 +6569,18 @@ def check_beat_frames(
         hand-written beat list rather than against the recorder's own idea of
         how many beats there were;
       * **each frame is the moment it says it is** — its timestamp is the
-        beat's midpoint computed here from `timeline.json`, and the PNG is
-        byte-identical to that second cut out of `demo.mp4` again. Only
+        beat's midpoint computed here from `timeline.json`, moved onto the
+        video's clock by *this harness's own* wall-clock watcher (issue #229),
+        and the PNG is byte-identical to that second cut out of `demo.mp4`
+        again. Only
         together: the first without the second passes a manifest that says the
         right time over the wrong picture, and the second without the first
         passes a frame faithfully cut from the wrong second;
+      * **the sheet says which clock it cut them on.** On a host that never
+        steps its clock the corrected instant and the uncorrected one are the
+        same number, so the bullet above cannot tell a recorder that applies
+        the record from one that ignores it. What it can tell is whether the
+        sheet *claims* a correction it could not compute;
       * **the sheet leaks no storyboard.** `frames.md` goes to a context-free
         reviewer who is asked what story the pictures tell. A caption, a verb
         or a selector printed beside a frame answers that for them, and the
@@ -6645,11 +6652,21 @@ def check_beat_frames(
             )
 
     # -- each frame is the moment it says it is ------------------------------
+    #
+    # The beat's midpoint is on the beat log's clock and the seek is on the
+    # video's, so the instant to expect is the midpoint **plus what the host's
+    # wall clock did before it** (issue #229). That correction is taken from
+    # *this harness's own* watcher, never from the take's `capture_clock`: the
+    # recorder cut the frames with its own record, and grading a record against
+    # itself passes on whatever number it wrote.
     doc = json.loads((out_dir / "timeline.json").read_text())
     beats = {b.get("index"): b for b in doc.get("beats") or []}
     mp4 = out_dir / "demo.mp4"
     duration = float(doc.get("duration") or 0.0)
+    stepped = clock.before if clock is not None else (lambda _t: 0.0)
+    step_times = [at for at, _delta in (clock.steps if clock is not None else [])]
     measured = 0
+    ungraded = 0
     for frame in listed:
         beat = beats.get(frame.get("beat"))
         png = frames_dir / str(frame.get("file"))
@@ -6657,12 +6674,26 @@ def check_beat_frames(
             continue
         middle = (float(beat["t_start"]) + float(beat["t_end"])) / 2
         at = float(frame["t"])
-        if abs(at - middle) > MAX_FRAME_PLACEMENT_S and at < duration - 0.2:
+        # A midpoint sitting on top of a step is not placement-gradeable: the
+        # two samplers are on their own 20 ms grids and do not both know which
+        # side of it the beat fell on, and a bar as wide as a step would grade
+        # nothing. Counted out loud rather than dropped silently — and the
+        # byte comparison below still runs on every frame.
+        on_a_step = any(
+            abs(middle - when) <= MAX_CLOCK_STEP_TIME_DISAGREEMENT_S
+            for when in step_times
+        )
+        want = middle + stepped(middle)
+        if on_a_step:
+            ungraded += 1
+        elif abs(at - want) > MAX_FRAME_PLACEMENT_S and at < duration - 0.2:
             failures.append(
                 f"{label}: {frame.get('file')} was taken at {at:.3f}s, but beat "
                 f"{frame.get('beat')} runs {beat['t_start']}-{beat['t_end']}s "
-                f"and its midpoint is {middle:.3f}s — the frame is not the "
-                f"moment the sheet numbers it for"
+                f"and its midpoint sits at {want:.3f}s in the video "
+                f"({middle:.3f}s on the beat log, {stepped(middle):+.3f}s of "
+                f"wall clock before it) — "
+                f"the frame is not the moment the sheet numbers it for"
             )
         if not mp4.is_file() or not duration:
             continue
@@ -6680,6 +6711,38 @@ def check_beat_frames(
             f"compared against demo.mp4 — the rest went ungraded, which is not "
             f"the same as passing"
         )
+
+    # -- and the sheet says which clock it cut them on -----------------------
+    #
+    # The one half of #229 that is gradeable on a host whose clock never steps.
+    # There the corrected instant and the uncorrected one are the same number,
+    # so nothing above can tell them apart — but "a correction was applied" and
+    # "nobody could compute one" are still two different sentences, and a sheet
+    # that let them look alike would be claiming an accuracy nobody measured.
+    stated = manifest.get("clock_correction")
+    if not isinstance(stated, dict):
+        failures.append(
+            f"{label}: frames.json says nothing about the clock its frames "
+            f"were cut on — a reviewer reading these timestamps cannot tell a "
+            f"sheet corrected for the host's wall clock from one cut on the "
+            f"raw beat log, and they are up to seconds apart"
+        )
+    elif clock is not None and clock.covered and not stated.get("applied"):
+        failures.append(
+            f"{label}: the sheet says its frames were cut uncorrected "
+            f"({stated.get('note')}) on a take this harness watched to within "
+            f"{clock.max_gap:.3f}s — the recorder had a record to cut them "
+            f"with and did not use it"
+        )
+    elif isinstance(stated, dict) and md_path.is_file():
+        said = md_path.read_text()
+        if "wall clock" not in said:
+            failures.append(
+                f"{label}: frames.md never mentions the wall clock, so the "
+                f"sheet a reviewer is handed states nothing about which clock "
+                f"its timestamps are on (frames.json says applied="
+                f"{stated.get('applied')!r})"
+            )
 
     # -- the sheet carries no storyboard -------------------------------------
     if not md_path.is_file():
@@ -6727,9 +6790,23 @@ def check_beat_frames(
     failures += _check_scene_fallback(label, out_dir, doc)
 
     if not failures:
+        cut = (
+            "on the beat log, uncorrected"
+            if not (isinstance(stated, dict) and stated.get("applied"))
+            else f"{stated.get('total'):+.2f}s of wall clock applied"
+            if stated.get("total")
+            else "on a wall clock that was watched and held still"
+        )
         print(
             f"smoke: {label} frames/ ok ({len(listed)} beat frames, each "
-            f"byte-identical to the demo.mp4 frame it claims to be)"
+            f"byte-identical to the demo.mp4 frame it claims to be; cut {cut}"
+            + (
+                f", {ungraded} not placement-graded within "
+                f"{MAX_CLOCK_STEP_TIME_DISAGREEMENT_S}s of a step"
+                if ungraded
+                else ""
+            )
+            + ")"
         )
     return failures
 
@@ -6801,9 +6878,11 @@ def _check_frame_captions(
         if not png.is_file():
             continue
         # Where the frame was cut, and where it actually sits in the story.
-        # The extractor seeks demo.mp4 at the beat's midpoint on the *log's*
-        # clock and the video is on the host's, so on a take whose host clock
-        # stepped those are two different moments (issue #215) — and a caption
+        # The extractor seeks demo.mp4 at the beat's midpoint moved onto the
+        # video's clock by the take's own record (issue #229) — and where that
+        # record could not answer, at the bare midpoint. Either way the two
+        # accounts of where the frame sits can differ by the residual between
+        # this watcher and the recorder's (issue #215) — and a caption
         # change *between* them is exactly the case where the sheet's label and
         # the picture disagree and neither is wrong. Grade a frame only when
         # the whole interval between the two accounts of where it is clears

--- a/tests/smoke
+++ b/tests/smoke
@@ -6734,9 +6734,14 @@ def check_beat_frames(
             f"{clock.max_gap:.3f}s — the recorder had a record to cut them "
             f"with and did not use it"
         )
-    elif isinstance(stated, dict) and md_path.is_file():
-        said = md_path.read_text()
-        if "wall clock" not in said:
+    elif md_path.is_file():
+        # A deliberately weak last line, and worth saying so: this only asks
+        # that the sheet mentions the clock at all — it cannot tell a sheet
+        # that stated the *wrong* one of the three cases from one that stated
+        # the right one. The weight is on the `applied` check above and on the
+        # placement check before it; this is here so a renderer that dropped
+        # the sentence entirely does not pass silently.
+        if "wall clock" not in md_path.read_text():
             failures.append(
                 f"{label}: frames.md never mentions the wall clock, so the "
                 f"sheet a reviewer is handed states nothing about which clock "

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -477,8 +477,18 @@ INJECTIONS = [
             '        self.steps.append({"t": 1.0, "delta": -0.5})\n'
         ),
         arm="--segments-only",
-        sites=("check_capture_clock",),
-        must_contain=("is not measuring the clock",),
+        # Two assertions on one break since #229: the record is checked
+        # against this harness's own watcher, and the *review sheet* is cut
+        # with that record — so a step nobody measured moves every frame after
+        # 1.0s half a second away from the beat it is named for. The second
+        # site is what proves the frame placement is graded against an
+        # independent measurement rather than against the artifact that
+        # produced it.
+        sites=("check_capture_clock", "check_beat_frames"),
+        must_contain=(
+            "is not measuring the clock",
+            "the frame is not the moment the sheet numbers it for",
+        ),
     ),
     # -- what the record says about its own coverage (issue #247) ------------
     #
@@ -642,11 +652,31 @@ INJECTIONS = [
         # instant `frames.py`'s own header says is the wrong one.
         name="every review frame is cut at the start of its beat, not its midpoint",
         module="frames.py",
-        old="        middle = min(max((float(t_start) + float(t_end)) / 2, 0.0), last)",
-        new="        middle = min(max(float(t_start), 0.0), last)",
+        old=(
+            "        middle = min(max((float(t_start) + float(t_end)) / 2 + slid, "
+            "0.0), last)"
+        ),
+        new="        middle = min(max(float(t_start) + slid, 0.0), last)",
         arm="--segments-only",
         sites=("check_beat_frames",),
-        must_contain=("moment the sheet numbers it for",),
+        must_contain=("the frame is not the moment the sheet numbers it for",),
+    ),
+    Injection(
+        # The sheet stops saying which clock its frames were cut on. Every
+        # frame is in exactly the same place and every other claim about the
+        # directory holds; what is gone is the sentence that tells a reviewer
+        # whether the timestamps were corrected for the host's wall clock or
+        # cut on the raw beat log — two documents that look identical and are
+        # up to seconds apart (issue #229). This is the half of #229 that is
+        # gradeable on a host whose clock never steps, where the corrected
+        # instant and the uncorrected one are the same number.
+        name="the review sheet stops saying which clock its frames were cut on",
+        module="frames.py",
+        old='    manifest["clock_correction"] = clock',
+        new='    manifest["clock_correction"] = None',
+        arm="--segments-only",
+        sites=("check_beat_frames",),
+        must_contain=("says nothing about the clock its frames ",),
     ),
     # -- what a beat's evidence says was on screen (issue #9), 7 s an entry ----
     Injection(

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -652,11 +652,11 @@ INJECTIONS = [
         # instant `frames.py`'s own header says is the wrong one.
         name="every review frame is cut at the start of its beat, not its midpoint",
         module="frames.py",
-        old=(
-            "        middle = min(max((float(t_start) + float(t_end)) / 2 + slid, "
-            "0.0), last)"
+        old="        middle = min(max(logged + correct(beat, logged), 0.0), last)",
+        new=(
+            "        middle = min(max(float(t_start) + correct(beat, "
+            "float(t_start)), 0.0), last)"
         ),
-        new="        middle = min(max(float(t_start) + slid, 0.0), last)",
         arm="--segments-only",
         sites=("check_beat_frames",),
         must_contain=("the frame is not the moment the sheet numbers it for",),

--- a/tests/unit
+++ b/tests/unit
@@ -6196,8 +6196,14 @@ INJECTIONS = [
         # rather than at the check, because a search string that is *also* the
         # line it replaces occurs twice in this file and the harness refuses it
         # — which is the exactly-once rule doing its job on its own suite.
+        #
+        # It has to be an entry whose **only** FrameClockCorrection name is
+        # this one: the counter asks `any(...)` per entry, so removing one of
+        # two names from the same entry changes nothing. The first version of
+        # this injection did exactly that and `--fault-inject` reported it
+        # unnoticed.
         '            "FrameClockCorrection."\n'
-        '            "test_a_scene_window_is_clipped_by_a_step_inside_its_own_beat",',
+        '            "test_a_step_inside_the_last_beat_is_not_reported_as_capture_loss",',
         '            "TimelineClockNote.test_a_watched_clock_that_held_still_adds_nothing",',
         [
             "StatedInjectionCount."

--- a/tests/unit
+++ b/tests/unit
@@ -92,6 +92,10 @@ from demo_recording.failure import (  # noqa: E402
     render_failure_marker,
     render_failure_md,
 )
+from demo_recording.frames import (  # noqa: E402
+    beat_frames,
+    render_frames_md,
+)
 from demo_recording.markdown import _fmt_t, _md_cell  # noqa: E402
 from demo_recording.narration import (  # noqa: E402
     TTS_KEY_CHARS,
@@ -147,6 +151,7 @@ sys.modules["playwright"] = _pw
 sys.modules["playwright.sync_api"] = _pw_sync
 
 import demo_recording.core as core_module  # noqa: E402
+import demo_recording.frames as frames_module  # noqa: E402
 from demo_recording.core import _beat_verb, _CaptureClock, _DemoBase  # noqa: E402
 from demo_recording.terminal import TerminalRecorder  # noqa: E402
 from demo_recording.web import _CURSOR_JS, Recorder  # noqa: E402
@@ -5106,6 +5111,264 @@ class MergedCaptureClock(unittest.TestCase):
         self.assertIsNone(mixed["capture_clock"]["sample_interval"])
 
 
+def clock_record(*steps: tuple[float, float], measured: bool = True) -> dict:
+    """One take's `capture_clock`: (seconds into the take, size of the step).
+
+    Hand-written rather than sampled, for the reason `CaptureClock` gives at
+    length: a box either steps its wall clock or it does not, and on one that
+    does not a corrected cut and an uncorrected one are the same number. An
+    assertion that only bites on a stepping host grades the host.
+    """
+    return {
+        "measured": measured,
+        "note": None if measured else "the sampler was away for up to 5.50s",
+        "steps": [{"t": t, "delta": delta} for t, delta in steps],
+        "total": round(sum(delta for _, delta in steps), 4) if measured else None,
+        "sample_interval": 0.02,
+        "min_step": 0.005,
+        "max_gap": 0.021 if measured else 5.5,
+        "max_gap_limit": 0.25,
+    }
+
+
+class FrameClockCorrection(unittest.TestCase):
+    """Where the review sheet cuts each frame, and what it says about it (#229).
+
+    The sheet **is** the review in this skill — nobody watches the video — so
+    the instant a frame is cut at is the demo as far as a reviewer is
+    concerned. The beat log is `time.monotonic()` and the video is stamped with
+    the host's wall clock, so on a host that steps that clock the beat's
+    midpoint and the frame's seek are two different moments: measured at up to
+    1.50 s apart by 13.5 s into a take, which at 25 fps is ~37 frames.
+
+    Every case here is driven by a **scripted** record and a stand-in for
+    ffmpeg, which is what makes the claim gradeable at all — see
+    `clock_record`. What no assertion in this file can say is whether the
+    record describes the world: that the video really followed the host's
+    clock was measured off the pixels of six takes (#229, #250) and belongs to
+    `tests/smoke`, not here.
+    """
+
+    def sheet(self, doc: dict) -> tuple[dict, list[float], list[tuple[float, float]]]:
+        """(manifest, the seconds ffmpeg was asked for, the scene windows).
+
+        The cuts are captured at the extractor rather than read back out of
+        the manifest: a manifest that printed the corrected time over a frame
+        cut somewhere else is exactly the failure the smoke arm's byte
+        comparison exists for, and it would satisfy an assertion that only
+        read the manifest.
+        """
+        cuts: list[float] = []
+        windows: list[tuple[float, float]] = []
+
+        def extract(mp4: Path, at: float, path: Path) -> bool:
+            cuts.append(round(float(at), 3))
+            path.write_bytes(b"a stand-in for a frame")
+            return True
+
+        def scenes(mp4: Path, start: float, end: float, *_a, **_k) -> list[float]:
+            windows.append((round(start, 3), round(end, 3)))
+            return []
+
+        out_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, out_dir, ignore_errors=True)
+        (out_dir / "demo.mp4").write_bytes(b"a stand-in for a recording")
+        was = frames_module._extract, frames_module.scene_times
+        frames_module._extract, frames_module.scene_times = extract, scenes
+        try:
+            manifest = beat_frames(out_dir, doc)
+        finally:
+            frames_module._extract, frames_module.scene_times = was
+        return manifest, cuts, windows
+
+    def take(self, clock: object, *starts: float, span: float = 0.1) -> dict:
+        beats = [beat(n, "caption", t, t_end=t + span) for n, t in enumerate(starts)]
+        return envelope(duration=20.0, capture_clock=clock, beats=beats)
+
+    def merged(self, clocks: list[object]) -> dict:
+        doc = merged_of(clocks, [7.5, 6.0])
+        # `_merged_timeline` probes a demo.mp4 that was never encoded, so it
+        # reports no duration; the frame planner would then ask ffprobe.
+        doc["duration"] = 20.0
+        return doc
+
+    # -- the cut instant ----------------------------------------------------
+
+    def test_a_frame_is_cut_where_its_beat_sits_in_the_video(self):
+        # Beat 1's midpoint is 2.05 s on the beat log, and the wall clock had
+        # already given up 0.78 s by then, so that moment is at 1.27 s of the
+        # file. Beat 0 is before the step and does not move. Both numbers are
+        # written out here rather than derived from the record.
+        _manifest, cuts, _windows = self.sheet(
+            self.take(clock_record((1.0, -0.78)), 0.5, 2.0)
+        )
+        self.assertEqual(cuts, [0.55, 1.27])
+
+    def test_the_manifest_prints_the_second_the_frame_was_really_cut_at(self):
+        manifest, cuts, _windows = self.sheet(
+            self.take(clock_record((1.0, -0.78)), 0.5, 2.0)
+        )
+        self.assertEqual([f["t"] for f in manifest["frames"]], cuts)
+
+    def test_a_step_after_a_beat_does_not_move_that_beats_frame(self):
+        # The wall clock stepping at 4.0 s moved the frames after 4.0 s. A
+        # reader that applied the take's `total` to every beat would put both
+        # of these 0.78 s from the moment they name.
+        _manifest, cuts, _windows = self.sheet(
+            self.take(clock_record((4.0, -0.78)), 0.5, 2.0)
+        )
+        self.assertEqual(cuts, [0.55, 2.05])
+
+    def test_a_step_only_moves_the_frames_of_the_capture_that_measured_it(self):
+        # Part one losing 0.78 s of wall time is already in part two's offset,
+        # because `stitch()` lays the parts out by their measured durations.
+        # Applying it again would put every frame of part two 0.78 s early —
+        # worse than not correcting at all.
+        _manifest, cuts, _windows = self.sheet(
+            self.merged([clock_record((1.5, -0.78)), clock_record()])
+        )
+        self.assertEqual(cuts, [0.55, 1.27, 8.05, 9.55])
+
+    def test_a_beat_before_its_own_captures_step_is_cut_at_its_midpoint(self):
+        # The other direction of the same rule, inside one part: part two's
+        # step at 1.5 s of its own clock is 9.0 s on the stitched one, so the
+        # beat at 8.05 s keeps its midpoint and the beat at 9.55 s moves.
+        _manifest, cuts, _windows = self.sheet(
+            self.merged([clock_record(), clock_record((1.5, -0.78))])
+        )
+        self.assertEqual(cuts, [0.55, 2.05, 8.05, 8.77])
+
+    def test_the_scene_search_window_is_the_beats_span_in_the_video(self):
+        # A beat long enough for the unscripted-transition fallback: the
+        # window ffmpeg scans has to be where that beat is in the file, or the
+        # extra frames come from a stretch the beat had already left.
+        _manifest, cuts, windows = self.sheet(
+            self.take(clock_record((1.0, -0.78)), 3.0, span=4.0)
+        )
+        self.assertEqual(cuts, [4.22])
+        self.assertEqual(windows, [(2.22, 6.22)])
+
+    # -- and what the sheet says it did -------------------------------------
+
+    def test_a_take_nobody_watched_the_clock_of_is_cut_uncorrected_and_says_so(self):
+        # The case that looks like the healthy one: `steps` is an empty list
+        # here too (#247), so a consumer reading only `steps` cannot tell
+        # "the clock held still" from "nobody was watching". Zero is still the
+        # number applied — there is no other — but the sheet must not let it
+        # read as a correction.
+        doc = self.take(clock_record((1.0, -0.78), measured=False), 0.5, 2.0)
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [0.55, 2.05])
+        self.assertIs(manifest["clock_correction"]["applied"], False)
+        self.assertIsNone(manifest["clock_correction"]["total"])
+        sheet = render_frames_md(manifest)
+        self.assertIn("cut on the beat log, uncorrected", sheet)
+        self.assertIn("the sampler was away for up to 5.50s", sheet)
+
+    def test_a_timeline_with_no_record_at_all_is_cut_uncorrected_and_says_so(self):
+        doc = self.take(None, 0.5, 2.0)
+        del doc["capture_clock"]
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [0.55, 2.05])
+        self.assertIs(manifest["clock_correction"]["applied"], False)
+        self.assertIn("no capture_clock", manifest["clock_correction"]["note"])
+        self.assertIn("cut on the beat log, uncorrected", render_frames_md(manifest))
+
+    def test_a_watched_clock_that_held_still_says_that_rather_than_nothing(self):
+        manifest, cuts, _windows = self.sheet(self.take(clock_record(), 0.5, 2.0))
+        self.assertEqual(cuts, [0.55, 2.05])
+        self.assertIs(manifest["clock_correction"]["applied"], True)
+        sheet = render_frames_md(manifest)
+        self.assertIn("did not step", sheet)
+        self.assertNotIn("uncorrected", sheet)
+
+    def test_a_stepped_take_says_on_the_sheet_that_its_frames_were_moved(self):
+        manifest, _cuts, _windows = self.sheet(
+            self.take(clock_record((1.0, -0.78)), 0.5, 2.0)
+        )
+        self.assertEqual(manifest["clock_correction"]["steps"], 1)
+        sheet = render_frames_md(manifest)
+        self.assertIn("wall clock stepped -0.78s", sheet)
+        self.assertIn("plus the steps its own capture recorded before it", sheet)
+
+    def test_a_merged_step_that_names_no_capture_corrects_nothing_and_says_so(self):
+        # The shape #250's own injection was rewritten for: on a merged
+        # record a step with no `segment` matches no beat, so a reader that
+        # accepted it would apply nothing while reporting a correction. It is
+        # refused instead, and the sheet carries the refusal.
+        doc = self.merged([clock_record((1.5, -0.78)), clock_record()])
+        for step in doc["capture_clock"]["steps"]:
+            del step["segment"]
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [0.55, 2.05, 8.05, 9.55])
+        self.assertIs(manifest["clock_correction"]["applied"], False)
+        self.assertIn("cut on the beat log, uncorrected", render_frames_md(manifest))
+
+    def test_a_step_missing_its_size_refuses_the_whole_record(self):
+        # Half a record is not a correction: the malformed step would drop
+        # silently out of every sum and leave the rest looking applied.
+        doc = self.take(clock_record((1.0, -0.78), (4.0, -0.5)), 0.5, 5.0)
+        del doc["capture_clock"]["steps"][1]["delta"]
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [0.55, 5.05])
+        self.assertIs(manifest["clock_correction"]["applied"], False)
+
+    def test_a_recorded_step_is_not_also_reported_as_capture_loss(self):
+        # The last beat ends 0.70 s after the video does, and 0.78 s of wall
+        # clock is why. Reporting that as loss too would tell a reviewer the
+        # frames may be stale by the amount they were just moved by.
+        doc = envelope(
+            duration=5.0,
+            capture_clock=clock_record((1.0, -0.78)),
+            beats=[beat(0, "caption", 0.5), beat(1, "hold", 5.6)],
+        )
+        manifest, _cuts, _windows = self.sheet(doc)
+        self.assertEqual(manifest["capture_loss_at_least"], 0.0)
+        # ...and the control: the same beats with no record to explain them.
+        doc["capture_clock"] = clock_record((1.0, -0.78), measured=False)
+        bare, _cuts, _windows = self.sheet(doc)
+        self.assertAlmostEqual(bare["capture_loss_at_least"], 0.7, places=3)
+
+    def test_a_sheet_that_wrote_no_frames_claims_no_correction(self):
+        doc = self.take(clock_record((1.0, -0.78)), 0.5)
+        doc["segment"] = "part1"
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [])
+        self.assertIsNone(manifest["clock_correction"])
+
+
+class TimelineClockNote(unittest.TestCase):
+    """What `timeline.md` says about the clock its own timestamps are not on.
+
+    The recorder warns about a stepped clock on stderr as the take ends —
+    minutes and several thousand lines before anybody opens the sheet — and
+    until #229 the committed, diffable half of the record said nothing at all.
+    """
+
+    def doc(self, clock: object) -> dict:
+        return envelope(capture_clock=clock, beats=[beat(0, "goto", 0.1)])
+
+    def test_a_stepped_clock_is_named_with_its_size_above_the_beat_table(self):
+        text = render_timeline_md(self.doc(clock_record((1.0, -0.78), (4.0, -0.72))))
+        self.assertIn("wall clock stepped -1.50s", text)
+        self.assertIn("over 2 step(s)", text)
+        # Above the table, not under it: a reader who has already read the
+        # rows has read them as the video's timestamps.
+        self.assertLess(text.index("wall clock stepped"), text.index("| # | start |"))
+
+    def test_a_clock_nobody_watched_is_reported_as_unmeasured(self):
+        text = render_timeline_md(self.doc(clock_record(measured=False)))
+        self.assertIn("was not measured", text)
+        self.assertIn("the sampler was away for up to 5.50s", text)
+
+    def test_a_watched_clock_that_held_still_adds_nothing(self):
+        # The ordinary take, and the reason the two paragraphs above are worth
+        # reading: a line on every timeline is a line nobody reads.
+        text = render_timeline_md(self.doc(clock_record()))
+        self.assertNotIn("wall clock stepped", text)
+        self.assertNotIn("was not measured", text)
+
+
 # --------------------------------------------------------------------------
 # Fault injection
 # --------------------------------------------------------------------------
@@ -5490,6 +5753,165 @@ INJECTIONS = [
         [
             "MergedCaptureClock."
             "test_a_part_that_could_not_watch_its_clock_makes_the_merged_record_null",
+        ],
+    ),
+    # -- and what the review sheet does with all of it (issue #229) ----------
+    #
+    # Six entries, and all six are breaks a steady host cannot notice: with no
+    # step in the record, a corrected cut and an uncorrected one are the same
+    # number. The scripted records in `FrameClockCorrection` are what makes
+    # them faults on any box — the hazard #250's own manifest hit, where an
+    # injection that stripped `segment` off every merged step was a no-op
+    # wherever the clock never moved.
+    (
+        # The state everything was in before this: the sheet a reviewer reads
+        # is cut on the beat log, and on a host that stepped its clock every
+        # frame after the step is of a moment ~37 frames later in the demo.
+        # The manifest, the names and the count are all untouched.
+        "every review frame is cut on the beat log rather than on the video's clock",
+        "frames.py",
+        "        middle = min(max((float(t_start) + float(t_end)) / 2 + slid, 0.0), last)",
+        "        middle = min(max((float(t_start) + float(t_end)) / 2, 0.0), last)",
+        [
+            "FrameClockCorrection.test_a_frame_is_cut_where_its_beat_sits_in_the_video",
+            "FrameClockCorrection."
+            "test_a_step_only_moves_the_frames_of_the_capture_that_measured_it",
+        ],
+    ),
+    (
+        # The beat frame moves and the unscripted-transition search does not,
+        # so the extra frames come off a stretch of video the beat had already
+        # left — and they arrive named for it.
+        "the scene search window stays on the beat log's clock",
+        "frames.py",
+        "        window = (\n"
+        "            min(max(float(t_start) + slid, 0.0), last),\n"
+        "            min(max(float(t_end) + slid, 0.0), last),\n"
+        "        )",
+        "        window = (min(float(t_start), last), min(float(t_end), last))",
+        [
+            "FrameClockCorrection.test_the_scene_search_window_is_the_beats_span_in_the_video",
+        ],
+    ),
+    (
+        # Every capture's steps applied to every beat. On a stitched demo an
+        # earlier part's loss is already in the later parts' offsets, so this
+        # over-corrects each later frame by a whole step — the direction that
+        # is worse than not correcting at all.
+        "a beat is corrected by every capture's steps rather than its own",
+        "timeline.py",
+        '            if step.get("segment") == beat.get("segment")\n'
+        '            and float(step["t"]) <= float(t_start)',
+        '            if float(step["t"]) <= float(t_start)',
+        [
+            # Only this one. A merged demo whose *later* part carries the step
+            # is unmoved by dropping the filter — every earlier beat is before
+            # that step anyway — so listing
+            # `test_a_beat_before_its_own_captures_step_is_cut_at_its_midpoint`
+            # here would have claimed a grade it does not give;
+            # `--fault-inject` reported it unnoticed and that is how it came
+            # off this list.
+            "FrameClockCorrection."
+            "test_a_step_only_moves_the_frames_of_the_capture_that_measured_it",
+        ],
+    ),
+    (
+        # The take's whole total applied to every beat, including the ones
+        # recorded before the clock moved. `total` is the one number in the
+        # record that is the correction for no beat at all.
+        "a beat is corrected by steps the clock had not taken yet",
+        "timeline.py",
+        '            and float(step["t"]) <= float(t_start)',
+        "            and True",
+        [
+            "FrameClockCorrection.test_a_step_after_a_beat_does_not_move_that_beats_frame",
+            "FrameClockCorrection.test_a_frame_is_cut_where_its_beat_sits_in_the_video",
+        ],
+    ),
+    (
+        # "Nobody watched this take" read as "the clock held still". The cut
+        # instants are identical either way — an unmeasured record carries no
+        # steps — so the whole of the fault is in what the sheet then claims:
+        # a corrected sheet, on a take where no correction was possible.
+        "a record that says it watched nothing is read as a clock that held still",
+        "timeline.py",
+        '    if record.get("measured") is not True:',
+        "    if False:",
+        [
+            "FrameClockCorrection."
+            "test_a_take_nobody_watched_the_clock_of_is_cut_uncorrected_and_says_so",
+        ],
+    ),
+    (
+        # A merged record whose steps name no capture matches no beat, so this
+        # applies nothing while reporting a correction — the same no-op the
+        # sheet would then be silent about.
+        "a merged step belonging to no capture is accepted as usable",
+        "timeline.py",
+        '        if merged and step.get("segment") not in merged:\n            return None',
+        "        if False:\n            return None",
+        [
+            "FrameClockCorrection."
+            "test_a_merged_step_that_names_no_capture_corrects_nothing_and_says_so",
+        ],
+    ),
+    (
+        # The sheet stops saying which of the two it is. The frames are cut in
+        # exactly the same places; what is gone is the one sentence telling a
+        # reviewer that nothing was corrected, on a document whose numbers look
+        # identical to a corrected one's.
+        "the review sheet stops saying its frames were cut uncorrected",
+        "frames.py",
+        '    if not clock.get("applied"):\n        return [\n            f"**These frames were cut on the beat log, uncorrected**: "',
+        '    if not clock.get("applied"):\n        return []\n    if False:\n        return [\n            f"**These frames were cut on the beat log, uncorrected**: "',
+        [
+            "FrameClockCorrection."
+            "test_a_take_nobody_watched_the_clock_of_is_cut_uncorrected_and_says_so",
+            "FrameClockCorrection."
+            "test_a_timeline_with_no_record_at_all_is_cut_uncorrected_and_says_so",
+        ],
+    ),
+    (
+        # The step is applied to the frames and reported *again* as capture
+        # loss, so the sheet moves every frame by 0.78 s and then warns that
+        # they may be stale by 0.70 s — the same wall time, counted twice, in
+        # the one line of the sheet that is about how much to distrust it.
+        "a recorded wall-clock step is also reported as lost capture time",
+        "frames.py",
+        '    over = float(tail.get("t_end") or 0.0) + correct(tail) - float(duration)',
+        '    over = float(tail.get("t_end") or 0.0) - float(duration)',
+        [
+            "FrameClockCorrection.test_a_recorded_step_is_not_also_reported_as_capture_loss",
+        ],
+    ),
+    (
+        # The other half of the same sentence: the sheet goes quiet about the
+        # correction it *did* apply. A reviewer then has a corrected sheet and
+        # an uncorrected one that read identically — the same ambiguity as the
+        # entry above, from the other side.
+        "the review sheet stops saying its frames were cut with the clock applied",
+        "frames.py",
+        '    total = clock.get("total") or 0.0\n    if not total:',
+        '    return []\n    total = clock.get("total") or 0.0\n    if not total:',
+        [
+            "FrameClockCorrection."
+            "test_a_watched_clock_that_held_still_says_that_rather_than_nothing",
+            "FrameClockCorrection."
+            "test_a_stepped_take_says_on_the_sheet_that_its_frames_were_moved",
+        ],
+    ),
+    (
+        # `timeline.md` back to saying nothing about the clock its own
+        # timestamps are not on. The recorder's stderr warning is the only
+        # other place it is said, minutes before anybody opens this file.
+        "timeline.md stops mentioning the clock its timestamps are not on",
+        "timeline.py",
+        "    out += _capture_clock_md(capture_clock_correction(doc)[1])",
+        "    out += []",
+        [
+            "TimelineClockNote."
+            "test_a_stepped_clock_is_named_with_its_size_above_the_beat_table",
+            "TimelineClockNote.test_a_clock_nobody_watched_is_reported_as_unmeasured",
         ],
     ),
     # -- and the harness's own reading of that claim (issue #247) ------------

--- a/tests/unit
+++ b/tests/unit
@@ -2120,6 +2120,12 @@ class PublicSurface(unittest.TestCase):
 
 SMOKE = Path(os.environ.get("UNIT_SMOKE", REPO / "tests" / "smoke"))
 
+# `tests/README.md`, overridable for the same reason `SMOKE` is: under
+# `--fault-inject` this file runs from a temp directory, where `REPO` points at
+# nothing. The runner passes the real path, so the figures below stay graded
+# while an injection is in place rather than going quiet exactly then.
+README = Path(os.environ.get("UNIT_README", REPO / "tests" / "README.md"))
+
 # Below this, `tests/smoke` was not parsed — an empty or truncated file makes
 # "nothing is unread" hold trivially, the catalogue's vacuous sweep. It is 271
 # today; this is a floor on "a suite was read", not a bar on its size.
@@ -5256,6 +5262,43 @@ class FrameClockCorrection(unittest.TestCase):
         _manifest, _cuts, windows = self.sheet(doc)
         self.assertEqual(windows, [(1.0, 8.22)])
 
+    def test_a_beat_the_clock_swallowed_loses_its_scene_frames_out_loud(self):
+        """A step bigger than the beat it lands in inverts the search window.
+
+        Per-instant edges are what make this reachable: the start is corrected
+        by nothing and the end by the whole step, so a step larger than the
+        beat's span puts the end before the start and there is no stretch of
+        video left to search. That is honest — the wall time the beat occupied
+        is not in the file — but `scene_times` answers an inverted window with
+        an empty list, so without this the sheet would simply have fewer frames
+        and say nothing. It needs a step over `SCENE_MIN_SPAN_S`, which is this
+        host's 10 s pulse transient.
+        """
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((2.0, -6.0)),
+            beats=[beat(0, "hold", 1.0, t_end=5.0)],
+        )
+        manifest, cuts, windows = self.sheet(doc)
+        self.assertEqual(windows, [], "no window can be searched, so none was")
+        self.assertEqual(manifest["scene_search_skipped"], [0])
+        self.assertEqual(cuts, [0.0])
+        sheet = render_frames_md(manifest)
+        self.assertIn("no extra frames were looked for", sheet)
+
+    def test_a_beat_the_clock_left_alone_reports_no_skipped_search(self):
+        # The control: the same long beat with the step outside it keeps its
+        # window, and the key stays empty rather than being absent or truthy.
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((0.5, -0.2)),
+            beats=[beat(0, "hold", 1.0, t_end=5.0)],
+        )
+        manifest, _cuts, windows = self.sheet(doc)
+        self.assertEqual(windows, [(0.8, 4.8)])
+        self.assertEqual(manifest["scene_search_skipped"], [])
+        self.assertNotIn("no extra frames were looked for", render_frames_md(manifest))
+
     def test_a_step_only_moves_the_frames_of_the_capture_that_measured_it(self):
         # Part one losing 0.78 s of wall time is already in part two's offset,
         # because `stitch()` lays the parts out by their measured durations.
@@ -5458,6 +5501,51 @@ class TimelineClockNote(unittest.TestCase):
         text = render_timeline_md(self.doc(clock_record()))
         self.assertNotIn("wall clock stepped", text)
         self.assertNotIn("was not measured", text)
+
+
+class StatedInjectionCount(unittest.TestCase):
+    """The figure `tests/README.md` prints about this file's own manifest.
+
+    It is here because it drifted: the README said "ten injections" while
+    `INJECTIONS` had grown to thirteen naming `FrameClockCorrection`, and
+    nothing anywhere compared the two. `tests/smoke-inject --self-test` grades
+    its own README figures exactly this way — the prose is the claim, the
+    manifest is the truth, and a pattern that stops matching is a failure
+    rather than a pass.
+    """
+
+    CLAIM = re.compile(
+        r"`FrameClockCorrection` in `tests/unit`, where (\d+)\s+injections"
+    )
+
+    def graded_by_frame_clock_correction(self) -> int:
+        return sum(
+            1
+            for _name, _module, _old, _new, tests in INJECTIONS
+            if any(t.startswith("FrameClockCorrection.") for t in tests)
+        )
+
+    def test_the_readme_states_the_number_this_file_actually_carries(self):
+        found = self.CLAIM.search(README.read_text(encoding="utf-8"))
+        # The pattern first: a README reworded past this regex would otherwise
+        # make the comparison below hold over nothing at all.
+        self.assertIsNotNone(
+            found,
+            f"{README} no longer states how many injections grade "
+            f"FrameClockCorrection in the shape this reads — reword the check "
+            f"with the prose, or the figure goes ungraded again",
+        )
+        self.assertEqual(
+            int(found.group(1)),
+            self.graded_by_frame_clock_correction(),
+            "tests/README.md and INJECTIONS disagree about how many "
+            "injections grade the frame-clock correction",
+        )
+
+    def test_the_count_it_grades_is_not_zero(self):
+        # The haystack. Every assertion above is satisfied by a manifest with
+        # no such entries and a README that says so.
+        self.assertGreater(self.graded_by_frame_clock_correction(), 5)
 
 
 # --------------------------------------------------------------------------
@@ -5875,15 +5963,15 @@ INJECTIONS = [
         # left — and they arrive named for it.
         "the scene search window stays on the beat log's clock",
         "frames.py",
-        "        window = (\n"
-        "            min(max(float(t_start) + correct(beat, float(t_start)), 0.0), last),\n"
-        "            min(max(float(t_end) + correct(beat, float(t_end)), 0.0), last),\n"
-        "        )",
-        "        window = (min(float(t_start), last), min(float(t_end), last))",
+        "        lo = min(max(float(t_start) + correct(beat, float(t_start)), 0.0), last)\n"
+        "        hi = min(max(float(t_end) + correct(beat, float(t_end)), 0.0), last)",
+        "        lo = min(float(t_start), last)\n        hi = min(float(t_end), last)",
         [
             "FrameClockCorrection.test_the_scene_search_window_is_the_beats_span_in_the_video",
             "FrameClockCorrection."
             "test_a_scene_window_is_clipped_by_a_step_inside_its_own_beat",
+            "FrameClockCorrection."
+            "test_a_beat_the_clock_swallowed_loses_its_scene_frames_out_loud",
         ],
     ),
     (
@@ -5892,8 +5980,9 @@ INJECTIONS = [
         # window edges and the tail. A step landing in a beat's own first half
         # is then left out, that frame does not move at all — by the whole
         # step — and the sheet says it was corrected. Roughly one recorded step
-        # in two lands there: 49.2-49.6 % of take wall time is inside some
-        # beat's first half across this repo's three committed demos.
+        # in two lands there: 46.9 %, 48.0 % and 48.8 % of the take's
+        # `duration` is inside some beat's first half across this repo's three
+        # committed demos (50.0 % of the beats' own spans, by construction).
         "the correction is read at the beat's start and applied to its midpoint",
         "frames.py",
         "        logged = (float(t_start) + float(t_end)) / 2\n"
@@ -6013,6 +6102,35 @@ INJECTIONS = [
         ],
     ),
     (
+        # The window inverts and the sheet says nothing: `scene_times` answers
+        # an inverted window with an empty list, so the review sheet simply
+        # carries fewer frames than it would on a steady host. A degradation
+        # rather than a lie, which is exactly why it has to be printed —
+        # "the sheet is quietly thinner" is the wrong failure mode for a
+        # document whose whole claim is that it does not mislead.
+        "a beat the clock swallowed loses its scene frames silently",
+        "frames.py",
+        "        if hi <= lo:\n            skipped_scenes.append(index)\n            continue",
+        "        if False:\n            skipped_scenes.append(index)\n            continue",
+        [
+            "FrameClockCorrection."
+            "test_a_beat_the_clock_swallowed_loses_its_scene_frames_out_loud",
+        ],
+    ),
+    (
+        # The drop is recorded and never reaches the reader — the manifest
+        # knows, `frames.md` does not, and `frames.md` is the document a
+        # reviewer is handed.
+        "the sheet stops naming the beat whose scene search was swallowed",
+        "frames.py",
+        '    swallowed = manifest.get("scene_search_skipped") or []',
+        "    swallowed = []",
+        [
+            "FrameClockCorrection."
+            "test_a_beat_the_clock_swallowed_loses_its_scene_frames_out_loud",
+        ],
+    ),
+    (
         # The step is applied to the frames and reported *again* as capture
         # loss, so the sheet moves every frame by 0.78 s and then warns that
         # they may be stale by 0.70 s — the same wall time, counted twice, in
@@ -6064,6 +6182,39 @@ INJECTIONS = [
         '    if not (state.get("total") or 0.0):',
         [
             "TimelineClockNote.test_steps_that_cancel_are_still_named_in_the_timeline",
+        ],
+    ),
+    (
+        # The README's figure for this file's own manifest goes stale — the
+        # exact drift `StatedInjectionCount` exists for, and the reason it
+        # exists is that it had already happened once (ten stated, thirteen
+        # real) with nothing comparing the two.
+        "the README's count of frame-clock injections stops matching the manifest",
+        "tests/unit",
+        # One entry stops naming a `FrameClockCorrection` test, so the manifest
+        # carries one fewer than the README states. Targeted at the manifest
+        # rather than at the check, because a search string that is *also* the
+        # line it replaces occurs twice in this file and the harness refuses it
+        # — which is the exactly-once rule doing its job on its own suite.
+        '            "FrameClockCorrection."\n'
+        '            "test_a_scene_window_is_clipped_by_a_step_inside_its_own_beat",',
+        '            "TimelineClockNote.test_a_watched_clock_that_held_still_adds_nothing",',
+        [
+            "StatedInjectionCount."
+            "test_the_readme_states_the_number_this_file_actually_carries",
+        ],
+    ),
+    (
+        # The claim's own pattern goes stale, so the figure is compared against
+        # nothing and a drifted README reads clean forever — the vacuous sweep,
+        # in the check that exists because a figure drifted.
+        "the README-figure pattern matches nothing, so that check goes vacuous",
+        "tests/unit",
+        'r"`FrameClockCorrection` in `tests/unit`, where (\\d+)\\s+injections"',
+        'r"`FrameClockCorrection` in `tests/unit`, where (\\d{9,})\\s+injections"',
+        [
+            "StatedInjectionCount."
+            "test_the_readme_states_the_number_this_file_actually_carries",
         ],
     ),
     (
@@ -7619,6 +7770,7 @@ def fault_inject() -> int:
                     "UNIT_HELPERS": str(root),
                     "UNIT_SKILL_DIR": str(skill),
                     "UNIT_SMOKE": str(smoke),
+                    "UNIT_README": str(REPO / "tests" / "README.md"),
                 },
             )
             noticed = {t for t in must_fail if t in done.stderr}

--- a/tests/unit
+++ b/tests/unit
@@ -5219,6 +5219,43 @@ class FrameClockCorrection(unittest.TestCase):
         )
         self.assertEqual(cuts, [0.55, 2.05])
 
+    def test_a_step_inside_a_beat_moves_the_frame_cut_after_it(self):
+        """The correction is indexed by the **instant**, not by the beat.
+
+        A frame is cut at the midpoint, so the steps that apply to it are the
+        ones before the *midpoint* — a step landing in the beat's first half
+        moved that frame and nothing about the beat's start says so. Summing
+        to `t_start` instead leaves exactly this beat uncorrected, by the whole
+        step, while the sheet claims the correction was applied; and it is not
+        a corner, because roughly half of a take's wall time is inside some
+        beat's first half.
+
+        The numbers are written out: beat 0 runs 1.0-9.0 s, its midpoint is
+        5.0 s on the log, the clock had given up 0.78 s by then, so the frame
+        is at 4.22 s of the file. Beat 1 is wholly after the step and moves by
+        the same 0.78 s.
+        """
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((2.0, -0.78)),
+            beats=[beat(0, "hold", 1.0, t_end=9.0), beat(1, "caption", 10.4)],
+        )
+        _manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [4.22, 9.67])
+
+    def test_a_scene_window_is_clipped_by_a_step_inside_its_own_beat(self):
+        # The same rule at both edges of the search window: the step at 2.0 s
+        # is inside the beat, so the window's start is uncorrected (1.0 s) and
+        # its end is 0.78 s earlier (9.0 - 0.78). Correcting both edges by one
+        # number would scan 0.78 s of the wrong video either way.
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((2.0, -0.78)),
+            beats=[beat(0, "hold", 1.0, t_end=9.0)],
+        )
+        _manifest, _cuts, windows = self.sheet(doc)
+        self.assertEqual(windows, [(1.0, 8.22)])
+
     def test_a_step_only_moves_the_frames_of_the_capture_that_measured_it(self):
         # Part one losing 0.78 s of wall time is already in part two's offset,
         # because `stitch()` lays the parts out by their measured durations.
@@ -5288,8 +5325,41 @@ class FrameClockCorrection(unittest.TestCase):
         )
         self.assertEqual(manifest["clock_correction"]["steps"], 1)
         sheet = render_frames_md(manifest)
-        self.assertIn("wall clock stepped -0.78s", sheet)
-        self.assertIn("plus the steps its own capture recorded before it", sheet)
+        self.assertIn("wall clock stepped 1 time(s)", sheet)
+        self.assertIn("(-0.78s in total)", sheet)
+        self.assertIn(
+            "plus the steps its own capture recorded before that instant", sheet
+        )
+
+    def test_steps_that_cancel_are_still_steps_on_the_sheet(self):
+        # The host this work exists for moves in *pulses* — up 0.9 s, back
+        # down 0.9 s — and a take that catches both totals zero while every
+        # frame cut between them has moved by nearly a second. A sheet that
+        # branched on the total would print "did not step" over exactly that.
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((2.0, 0.9), (8.0, -0.9)),
+            beats=[beat(0, "caption", 5.0)],
+        )
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [5.95])
+        self.assertEqual(manifest["clock_correction"]["total"], 0.0)
+        self.assertEqual(manifest["clock_correction"]["steps"], 2)
+        sheet = render_frames_md(manifest)
+        self.assertNotIn("did not step", sheet)
+        self.assertIn("stepped 2 time(s)", sheet)
+
+    def test_a_single_takes_step_that_names_a_capture_refuses_the_record(self):
+        # A take recorded in one piece has no `segments` and its beats carry
+        # no segment, so a step that names one matches nothing — the same
+        # correct-nothing-while-reporting-a-correction shape as the merged
+        # case below, from the other side of the guard.
+        doc = self.take(clock_record((1.0, -0.78)), 0.5, 2.0)
+        doc["capture_clock"]["steps"][0]["segment"] = "part1"
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [0.55, 2.05])
+        self.assertIs(manifest["clock_correction"]["applied"], False)
+        self.assertIn("cut on the beat log, uncorrected", render_frames_md(manifest))
 
     def test_a_merged_step_that_names_no_capture_corrects_nothing_and_says_so(self):
         # The shape #250's own injection was rewritten for: on a merged
@@ -5329,6 +5399,19 @@ class FrameClockCorrection(unittest.TestCase):
         bare, _cuts, _windows = self.sheet(doc)
         self.assertAlmostEqual(bare["capture_loss_at_least"], 0.7, places=3)
 
+    def test_a_step_inside_the_last_beat_is_not_reported_as_capture_loss(self):
+        # The same claim where the correction has to be read at the beat's
+        # **end**: the step at 5.2 s is inside the last beat (4.8-5.6 s), so a
+        # reader summing to the beat's *start* finds nothing and reports
+        # 0.60 s of loss that the record has already explained.
+        doc = envelope(
+            duration=5.0,
+            capture_clock=clock_record((5.2, -0.78)),
+            beats=[beat(0, "caption", 0.5), beat(1, "hold", 4.8, t_end=5.6)],
+        )
+        manifest, _cuts, _windows = self.sheet(doc)
+        self.assertEqual(manifest["capture_loss_at_least"], 0.0)
+
     def test_a_sheet_that_wrote_no_frames_claims_no_correction(self):
         doc = self.take(clock_record((1.0, -0.78)), 0.5)
         doc["segment"] = "part1"
@@ -5350,8 +5433,8 @@ class TimelineClockNote(unittest.TestCase):
 
     def test_a_stepped_clock_is_named_with_its_size_above_the_beat_table(self):
         text = render_timeline_md(self.doc(clock_record((1.0, -0.78), (4.0, -0.72))))
-        self.assertIn("wall clock stepped -1.50s", text)
-        self.assertIn("over 2 step(s)", text)
+        self.assertIn("wall clock stepped 2 time(s)", text)
+        self.assertIn("(-1.50s in total)", text)
         # Above the table, not under it: a reader who has already read the
         # rows has read them as the video's timestamps.
         self.assertLess(text.index("wall clock stepped"), text.index("| # | start |"))
@@ -5360,6 +5443,14 @@ class TimelineClockNote(unittest.TestCase):
         text = render_timeline_md(self.doc(clock_record(measured=False)))
         self.assertIn("was not measured", text)
         self.assertIn("the sampler was away for up to 5.50s", text)
+
+    def test_steps_that_cancel_are_still_named_in_the_timeline(self):
+        # Two steps that undo each other total zero and still part the beat
+        # log from the video for everything recorded between them, so the
+        # paragraph is decided on the count.
+        text = render_timeline_md(self.doc(clock_record((2.0, 0.9), (8.0, -0.9))))
+        self.assertIn("stepped 2 time(s)", text)
+        self.assertIn("(+0.00s in total)", text)
 
     def test_a_watched_clock_that_held_still_adds_nothing(self):
         # The ordinary take, and the reason the two paragraphs above are worth
@@ -5757,12 +5848,12 @@ INJECTIONS = [
     ),
     # -- and what the review sheet does with all of it (issue #229) ----------
     #
-    # Six entries, and all six are breaks a steady host cannot notice: with no
-    # step in the record, a corrected cut and an uncorrected one are the same
-    # number. The scripted records in `FrameClockCorrection` are what makes
-    # them faults on any box — the hazard #250's own manifest hit, where an
-    # injection that stripped `segment` off every merged step was a no-op
-    # wherever the clock never moved.
+    # Every entry below is a break a steady host cannot notice: with no step in
+    # the record, a corrected cut and an uncorrected one are the same number.
+    # The scripted records in `FrameClockCorrection` are what makes them faults
+    # on any box — the hazard #250's own manifest hit, where an injection that
+    # stripped `segment` off every merged step was a no-op wherever the clock
+    # never moved.
     (
         # The state everything was in before this: the sheet a reviewer reads
         # is cut on the beat log, and on a host that stepped its clock every
@@ -5770,8 +5861,8 @@ INJECTIONS = [
         # The manifest, the names and the count are all untouched.
         "every review frame is cut on the beat log rather than on the video's clock",
         "frames.py",
-        "        middle = min(max((float(t_start) + float(t_end)) / 2 + slid, 0.0), last)",
-        "        middle = min(max((float(t_start) + float(t_end)) / 2, 0.0), last)",
+        "        middle = min(max(logged + correct(beat, logged), 0.0), last)",
+        "        middle = min(max(logged, 0.0), last)",
         [
             "FrameClockCorrection.test_a_frame_is_cut_where_its_beat_sits_in_the_video",
             "FrameClockCorrection."
@@ -5785,12 +5876,46 @@ INJECTIONS = [
         "the scene search window stays on the beat log's clock",
         "frames.py",
         "        window = (\n"
-        "            min(max(float(t_start) + slid, 0.0), last),\n"
-        "            min(max(float(t_end) + slid, 0.0), last),\n"
+        "            min(max(float(t_start) + correct(beat, float(t_start)), 0.0), last),\n"
+        "            min(max(float(t_end) + correct(beat, float(t_end)), 0.0), last),\n"
         "        )",
         "        window = (min(float(t_start), last), min(float(t_end), last))",
         [
             "FrameClockCorrection.test_the_scene_search_window_is_the_beats_span_in_the_video",
+            "FrameClockCorrection."
+            "test_a_scene_window_is_clipped_by_a_step_inside_its_own_beat",
+        ],
+    ),
+    (
+        # **The defect review #253 blocked on**, as it shipped: the correction
+        # read at the beat's `t_start` and then applied to its midpoint, both
+        # window edges and the tail. A step landing in a beat's own first half
+        # is then left out, that frame does not move at all — by the whole
+        # step — and the sheet says it was corrected. Roughly one recorded step
+        # in two lands there: 49.2-49.6 % of take wall time is inside some
+        # beat's first half across this repo's three committed demos.
+        "the correction is read at the beat's start and applied to its midpoint",
+        "frames.py",
+        "        logged = (float(t_start) + float(t_end)) / 2\n"
+        "        middle = min(max(logged + correct(beat, logged), 0.0), last)",
+        "        logged = (float(t_start) + float(t_end)) / 2\n"
+        "        middle = min(max(logged + correct(beat, float(t_start)), 0.0), last)",
+        [
+            "FrameClockCorrection.test_a_step_inside_a_beat_moves_the_frame_cut_after_it",
+        ],
+    ),
+    (
+        # The same defect at the tail: the last beat's *end* corrected by the
+        # steps before its start, so a step inside that beat is counted again
+        # as capture loss the record has already explained.
+        "the capture-loss floor is corrected at the last beat's start, not its end",
+        "frames.py",
+        "    over = tail_end + correct(tail, tail_end) - float(duration)",
+        '    over = tail_end + correct(tail, float(tail.get("t_start") or 0.0)) '
+        "- float(duration)",
+        [
+            "FrameClockCorrection."
+            "test_a_step_inside_the_last_beat_is_not_reported_as_capture_loss",
         ],
     ),
     (
@@ -5801,8 +5926,8 @@ INJECTIONS = [
         "a beat is corrected by every capture's steps rather than its own",
         "timeline.py",
         '            if step.get("segment") == beat.get("segment")\n'
-        '            and float(step["t"]) <= float(t_start)',
-        '            if float(step["t"]) <= float(t_start)',
+        '            and float(step["t"]) <= float(t)',
+        '            if float(step["t"]) <= float(t)',
         [
             # Only this one. A merged demo whose *later* part carries the step
             # is unmoved by dropping the filter — every earlier beat is before
@@ -5821,7 +5946,7 @@ INJECTIONS = [
         # record that is the correction for no beat at all.
         "a beat is corrected by steps the clock had not taken yet",
         "timeline.py",
-        '            and float(step["t"]) <= float(t_start)',
+        '            and float(step["t"]) <= float(t)',
         "            and True",
         [
             "FrameClockCorrection.test_a_step_after_a_beat_does_not_move_that_beats_frame",
@@ -5846,13 +5971,29 @@ INJECTIONS = [
         # A merged record whose steps name no capture matches no beat, so this
         # applies nothing while reporting a correction — the same no-op the
         # sheet would then be silent about.
-        "a merged step belonging to no capture is accepted as usable",
+        "a step belonging to no capture of this demo is accepted as usable",
         "timeline.py",
-        '        if merged and step.get("segment") not in merged:\n            return None',
+        '        if step.get("segment") not in allowed:\n            return None',
         "        if False:\n            return None",
         [
             "FrameClockCorrection."
             "test_a_merged_step_that_names_no_capture_corrects_nothing_and_says_so",
+            "FrameClockCorrection."
+            "test_a_single_takes_step_that_names_a_capture_refuses_the_record",
+        ],
+    ),
+    (
+        # The guard as it first shipped: keyed off `doc["segments"]`, so it
+        # never ran on a take recorded in one piece. A step naming a capture
+        # that demo does not have then matches no beat, corrects nothing, and
+        # is reported as applied.
+        "a single take's steps may name a capture the demo does not have",
+        "timeline.py",
+        '        if step.get("segment") not in allowed:',
+        '        if named and step.get("segment") not in named:',
+        [
+            "FrameClockCorrection."
+            "test_a_single_takes_step_that_names_a_capture_refuses_the_record",
         ],
     ),
     (
@@ -5878,8 +6019,8 @@ INJECTIONS = [
         # the one line of the sheet that is about how much to distrust it.
         "a recorded wall-clock step is also reported as lost capture time",
         "frames.py",
-        '    over = float(tail.get("t_end") or 0.0) + correct(tail) - float(duration)',
-        '    over = float(tail.get("t_end") or 0.0) - float(duration)',
+        "    over = tail_end + correct(tail, tail_end) - float(duration)",
+        "    over = tail_end - float(duration)",
         [
             "FrameClockCorrection.test_a_recorded_step_is_not_also_reported_as_capture_loss",
         ],
@@ -5891,13 +6032,38 @@ INJECTIONS = [
         # entry above, from the other side.
         "the review sheet stops saying its frames were cut with the clock applied",
         "frames.py",
-        '    total = clock.get("total") or 0.0\n    if not total:',
-        '    return []\n    total = clock.get("total") or 0.0\n    if not total:',
+        '    if not clock.get("steps"):',
+        '    return []\n    if not clock.get("steps"):',
         [
             "FrameClockCorrection."
             "test_a_watched_clock_that_held_still_says_that_rather_than_nothing",
             "FrameClockCorrection."
             "test_a_stepped_take_says_on_the_sheet_that_its_frames_were_moved",
+        ],
+    ),
+    (
+        # The sheet decides "did it step?" on the **total** rather than on the
+        # count, so a pulse and the step that undoes it read as a clock that
+        # held still — over a sheet whose frames moved by 0.9 s. Narrow
+        # trigger, and it is the shape of the host this whole field exists for.
+        "the sheet reads a pulse and its undo as a clock that never stepped",
+        "frames.py",
+        '    if not clock.get("steps"):',
+        '    if not (clock.get("total") or 0.0):',
+        [
+            "FrameClockCorrection.test_steps_that_cancel_are_still_steps_on_the_sheet",
+        ],
+    ),
+    (
+        # The same, in the beat table: two steps that cancel take the whole
+        # paragraph off `timeline.md`, on a take whose beats and video really
+        # did part company in between.
+        "timeline.md reads a pulse and its undo as a clock that never stepped",
+        "timeline.py",
+        '    if not state.get("steps"):',
+        '    if not (state.get("total") or 0.0):',
+        [
+            "TimelineClockNote.test_steps_that_cancel_are_still_named_in_the_timeline",
         ],
     ),
     (


### PR DESCRIPTION
Fixes #229.

## Acceptance criterion

> On a take recorded while the host's clock stepped, the frame `beat-NN.png`
> shows the beat's midpoint to within the residual `tests/smoke` measures — not
> the step. And `timeline.md` says, when the total is non-zero, that the clock
> stepped and by how much, next to the timestamps it affects.

Both consumers now read `capture_clock`:

- **`write_beat_frames`** cuts every review frame at the beat's midpoint **plus
  the steps that beat's own capture recorded before that midpoint** — never
  `total`, never an earlier part's, exactly the rule the envelope in
  `timeline.py` documents and `_merge_capture_clock` attributes by `segment`.
  The scene-change search window moves with it, each edge at its own instant,
  for the same reason: it is a search through the video.
- **`render_timeline_md`** says, directly above the beat table, that the clock
  stepped and by how much — or that nobody watched it.

The reader-side rule lives in one place, `timeline.capture_clock_correction`,
which returns *(the per-beat correction, what the artifact should say about
it)*. Both documents render from that one derivation.

## The third case: a record that does not know

Since #250 a record can say `measured: false` with `steps: []` and
`total: null`. Zero is still the number applied there — there is no other — but
it is a **fallback, not a correction**, and the artifacts say which:

| record | frames cut at | `frames.md` says |
|---|---|---|
| `measured: true`, steps | midpoint + its capture's steps | the clock stepped −1.50s, frames moved |
| `measured: true`, none | midpoint | the clock was watched and held still |
| `measured: false`, or no field, or steps this reader cannot attribute | midpoint | **cut on the beat log, uncorrected** — with the record's own note |

`frames.json` carries the same three states as `clock_correction`
(`applied`/`total`/`steps`/`note`). A merged record whose steps have lost their
`segment` matches no beat, so it is **refused** rather than applied to nothing
while reporting a correction.

One related honesty fix: `capture_loss_at_least` is now measured against the
last beat's *corrected* end. Without that a stepping take moves every frame by
0.78 s and then warns the reviewer the frames may be stale by 0.70 s — the same
wall time, counted twice, in the one line of the sheet about how much to
distrust it.

## Counts

| | before | after |
|---|---|---|
| `tests/unit` | 212 | 250 (with #252's, post-rebase) |
| `tests/unit --fault-inject` | 135 | see the rebase table below |
| `tests/smoke-inject` entries | 48 | 49 |
| `tests/ci-unit` | 49 | 49 |

`tests/unit --budget`, `tests/lint`, `uvx ruff@0.16.1 format .` and CI's mypy
(1.18.2 over `skills/demo-video/helpers/`) all clean.

## Evidence: every new assertion seen failing

Ten unit injections, all caught (`tests/unit --fault-inject`):

```
PASS  break: every review frame is cut on the beat log rather than on the video's clock
      in frames.py: middle = min(max((float(t_start) + float(t_end)) / 2 + slid, 0.0), l…
      FAIL: FrameClockCorrection.test_a_frame_is_cut_where_its_beat_sits_in_the_video
      FAIL: FrameClockCorrection.test_a_step_only_moves_the_frames_of_the_capture_that_measured_it
      FAIL: FrameClockCorrection.test_a_beat_before_its_own_captures_step_is_cut_at_its_midpoint
      FAIL: FrameClockCorrection.test_the_scene_search_window_is_the_beats_span_in_the_video

PASS  break: a beat is corrected by every capture's steps rather than its own
      in timeline.py: if step.get("segment") == beat.get("segment")…
      FAIL: FrameClockCorrection.test_a_step_only_moves_the_frames_of_the_capture_that_measured_it

PASS  break: a beat is corrected by steps the clock had not taken yet
      in timeline.py: and float(step["t"]) <= float(t_start)…
      FAIL: FrameClockCorrection.test_a_step_after_a_beat_does_not_move_that_beats_frame
      FAIL: FrameClockCorrection.test_a_frame_is_cut_where_its_beat_sits_in_the_video

PASS  break: a record that says it watched nothing is read as a clock that held still
      in timeline.py: if record.get("measured") is not True:…
      FAIL: FrameClockCorrection.test_a_take_nobody_watched_the_clock_of_is_cut_uncorrected_and_says_so
      FAIL: TimelineClockNote.test_a_clock_nobody_watched_is_reported_as_unmeasured

PASS  break: a merged step belonging to no capture is accepted as usable
      in timeline.py: if merged and step.get("segment") not in merged:…
      FAIL: FrameClockCorrection.test_a_merged_step_that_names_no_capture_corrects_nothing_and_says_so

PASS  break: the review sheet stops saying its frames were cut uncorrected
      FAIL: FrameClockCorrection.test_a_take_nobody_watched_the_clock_of_is_cut_uncorrected_and_says_so
      FAIL: FrameClockCorrection.test_a_timeline_with_no_record_at_all_is_cut_uncorrected_and_says_so

PASS  break: the review sheet stops saying its frames were cut with the clock applied
      FAIL: FrameClockCorrection.test_a_stepped_take_says_on_the_sheet_that_its_frames_were_moved
      FAIL: FrameClockCorrection.test_a_watched_clock_that_held_still_says_that_rather_than_nothing

PASS  break: a recorded wall-clock step is also reported as lost capture time
      FAIL: FrameClockCorrection.test_a_recorded_step_is_not_also_reported_as_capture_loss

PASS  break: the scene search window stays on the beat log's clock
      FAIL: FrameClockCorrection.test_the_scene_search_window_is_the_beats_span_in_the_video

PASS  break: timeline.md stops mentioning the clock its timestamps are not on
      FAIL: TimelineClockNote.test_a_stepped_clock_is_named_with_its_size_above_the_beat_table
      FAIL: TimelineClockNote.test_a_clock_nobody_watched_is_reported_as_unmeasured
```

**Every one of those is driven by a scripted record.** On a host whose clock
never steps, a corrected cut and an uncorrected one are the same number — the
hazard #250's own manifest hit, where an injection that stripped `segment` off
every merged step was a no-op wherever the clock never moved. One
mis-targeted claim was found and removed this way: the injection dropping the
per-segment filter was listed as failing
`test_a_beat_before_its_own_captures_step_is_cut_at_its_midpoint`, and
`--fault-inject` reported it unnoticed — that case is unmoved by the filter,
and the entry now names only the test that does grade it.

### And on a real take: `--segments-only` was green on this box today

The box #250 measured is the box this ran on, and its `--segments-only`
baseline **passed clean in 29–37 s** this time (`capture_clock agrees with the
harness — the host's wall clock did not step during this take`, both parts).
So the arm's entries were runnable and were run:

```
PASS  break: the review sheet stops saying which clock its frames were cut on
      --segments-only, in frames.py: manifest["clock_correction"] = clock…
      caught: segments: frames.json says nothing about the clock its frames were cut on
              — a reviewer reading these timestamps cannot tell a sheet corrected for the …

PASS  break: the recorder reports a wall-clock step that never happened
      --segments-only, in core.py: def start(self, t0: float) -> None:…
      caught: segments/part1: inside the 5.7s the storyboard ran, this harness saw 0 wall-clock step(s) …
      caught: segments: beat-02.png was taken at 1.522s, but beat 2 runs 1.015-3.028s and
              its midpoint sits at 2.022s in the video (2.022s on the beat log, +0.000s …
```

That second one is the load-bearing one: an invented −0.5 s step in the
recorder's record moved every review frame half a second, and the placement
check caught it **because it corrects with this harness's own watcher rather
than with the artifact it is grading**.

## Round 2 — the blocking finding, and what it cost

Review blocked this on a real defect and it is fixed here. **The correction was
evaluated at the beat's `t_start` and then applied to the midpoint**, so a step
landing in a beat's own first half was left out and that frame did not move at
all — off by the whole step. Reproduced before the fix, one beat 1.0–9.0 s and
one step of −0.78 s at 2.0 s:

```
cuts:   [5.0, 9.67]     # beat 0 wanted 4.22, got 5.00 — uncorrected
```

Not a corner: 49.2–49.6 % of take wall time lies inside some beat's first half
across the three committed demos, so roughly one recorded step in two lands
there. It survived round 1 because **#250 validated the rule against caption
transitions, which sit at beat *starts*** — the one instant at which the two
readings cannot differ — and because every `FrameClockCorrection` case used a
0.1 s beat, so no step fell inside a beat's span.

The correction is now a function of the instant: `correct(beat, t)`, called
with the midpoint, each window edge, and the last beat's end. That is what
`check_beat_frames` already computed (`middle + stepped(middle)`), so harness
and recorder no longer disagree. The envelope's own wording in `timeline.py`
said "up to its `t_start`", which is the rule for a beat's *start*; it now says
the rule is indexed by the instant being converted, and why the measurement
could not see the difference.

Three narrower fixes in the same pass, each with its own injection:

- **Steps that cancel are still steps.** `+0.9 @ 2.0s` with `−0.9 @ 8.0s`
  totals zero and still moved a beat at 5.0 s to 5.95 s, while the sheet said
  the clock "did not step". Both renderers now branch on the step **count**.
  This is the pulse shape of the host the work exists for.
- **`capture_loss_at_least`** inherited the same defect at the tail; the
  instant-indexed fix resolves it, confirmed by a case with the step *inside*
  the last beat rather than assumed.
- **A single take's step that names a capture** now refuses the record. The
  guard was keyed off `doc["segments"]` and so never ran on an unsegmented
  take, which is the exact shape it exists to refuse.

Five more injections, all caught (`tests/unit --fault-inject`, 150/150):

```
PASS  break: the correction is read at the beat's start and applied to its midpoint
      FAIL: FrameClockCorrection.test_a_step_inside_a_beat_moves_the_frame_cut_after_it
PASS  break: the capture-loss floor is corrected at the last beat's start, not its end
      FAIL: FrameClockCorrection.test_a_step_inside_the_last_beat_is_not_reported_as_capture_loss
PASS  break: a single take's steps may name a capture the demo does not have
      FAIL: FrameClockCorrection.test_a_single_takes_step_that_names_a_capture_refuses_the_record
PASS  break: the sheet reads a pulse and its undo as a clock that never stepped
      FAIL: FrameClockCorrection.test_steps_that_cancel_are_still_steps_on_the_sheet
PASS  break: timeline.md reads a pulse and its undo as a clock that never stepped
      FAIL: TimelineClockNote.test_steps_that_cancel_are_still_named_in_the_timeline
```

The manifest also refused a stale entry on the way through — `ABORT: injection
'a recorded wall-clock step is also reported as lost capture time' matched 0
times in frames.py, expected exactly 1` — because the refactor moved the line
it targeted. That is the exactly-once rule doing its job.

**Stated as limits rather than chased**, per review: `"wall clock" not in said`
is a deliberately weak last line and cannot tell *which* case the sheet stated
— the weight is on the `applied` check and the placement check, and the code
says so; the dominated `isinstance` in that `elif` is gone;
`_check_frame_captions` is still one of 16 of 40 smoke checks with no
injection, and this PR increases what rests on it, now written up under Known
gaps.

### The host stepped this time, and it corrected two of my claims

Two clean `--segments-only` runs after the fix, and on both the host really
stepped: **−907 ms at 8.62 s** and **−918 ms at 9.094 s** (merged clock,
part2). The frames check passed both **with the correction applied**:

```
smoke: segments/part2 capture_clock agrees with the harness (the host's wall clock stepped -907 ms at 2.0s)
smoke: segments frames/ ok (15 beat frames, each byte-identical to the demo.mp4 frame
       it claims to be; cut -0.91s of wall clock applied, 1 not placement-graded within 0.25s of a step)
```

14 of 15 and 12 of 15 frames placed within 0.02 s of where this harness's
**independent** watcher puts them, on a take that genuinely slid ~0.9 s. That
is the observation round 1 could not make.

**Claim corrected #1 — the defect was real on this hardware.** Run 2's step
landed *inside* beat 9's span (8.935–9.255 s): the shipped code cut
`beat-09.png` at **8.177 s**, the pre-fix code would have cut it at **9.095 s**
— 0.918 s, ~23 frames. Not a constructed case; a recorded one.

**Claim corrected #2 — and the harness would *not* have caught that instance.**
Beat 9 is 0.32 s long, so its midpoint is 1 ms from the step and
`MAX_CLOCK_STEP_TIME_DISAGREEMENT_S` skips it (one of the "3 not
placement-graded"); `_check_frame_captions` excluded it too, as within 0.75 s
of a caption change. So "`--segments-only` would have gone red" is **true only
for a beat longer than 0.5 s whose step lands more than 0.25 s before the
midpoint**. On a short beat the exclusion window covers exactly the frames the
defect hits. `FrameClockCorrection` is the real gate, and I would rather say
that than leave a stronger claim standing.

**Both runs were still red**, on `check_merge_offset`'s caption timing (+540 ms
and +340 ms of *log-ahead* skew, and a slide past the 1.5 s search window on
run 2) — the #215/#224 shape, in assertions this PR does not touch. So
`tests/smoke-inject --arm segments` could not be re-run after the fix: the
harness refuses a red baseline, correctly. Its 14 entries were run and caught
**before** the fix, on the steady-host run earlier the same day; the five new
unit injections carry the fix itself.

## Round 3 — three corrections, all of them numbers or silence

Re-review passed the fix and asked for three things. All three were real.

**The README's own figure was wrong and ungraded.** It said "ten injections"
grade `FrameClockCorrection` where the manifest had more. `StatedInjectionCount`
now compares the prose against `INJECTIONS`, the way `smoke-inject --self-test`
grades its own README figures — and it caught the hand-written replacement
immediately (`AssertionError: 13 != 15`). Two injections keep it honest: one
drops a `FrameClockCorrection` name from an entry, one makes the claim's regex
match nothing. The first had to be re-aimed — the counter asks `any(...)` per
entry, so removing one of two names from the *same* entry changes nothing, and
`--fault-inject` reported it unnoticed. It now targets an entry whose only such
name is the one it removes.

**The 49.2–49.6 % figure did not reproduce, and I have replaced it with the
measurement and its denominator.** Over the three committed demos the time
inside some beat's first half is **46.9 %, 48.0 % and 48.8 % of each take's
`duration`** — and 50.0 % of the beats' own spans, by construction, which is
exactly why the denominator has to be stated. The substance is unchanged and it
is the only part that mattered: roughly one recorded step in two lands in a
beat's first half. Corrected in `timeline.py`, `tests/unit`, `tests/README.md`
and here.

**Per-instant window edges introduced one silent behaviour, and it is now
loud.** A step larger than the beat it lands in inverts the scene-search
window; `scene_times` answers an inverted window with an empty list, so the
sheet quietly carried fewer frames. It needs a step over
`SCENE_MIN_SPAN_S = 3.0 s` — this host's pulse transient. I chose *record*
rather than clamp, because there genuinely is no video left to search: the drop
is per beat in `frames.json` as `scene_search_skipped` and named in
`frames.md` ("no extra frames were looked for"), with a control test for the
untouched case and two injections — one for the recording, one for the
sentence reaching the reader.

**Stated, not chased:** `_usable_steps` is inexact for a single *segment*'s own
timeline (beats carry a segment, steps do not); unreachable because
`beat_frames` returns `skipped` for a segment document before it asks for a
correction, and pre-existing. Written into the comment.

**Recorded as unresolved:** after the fix, beat 9's frame clears the nearest
caption change by **0.758 s** against a `FRAME_CAPTION_GUARD_S` of 0.750 s — an
8 ms margin. Nothing here rests on it, and settling whether it is stable needs
a browser and a stepping host at once. In `tests/README.md`'s Known gaps.

### Rebased onto `540c3f5` (#252)

`git rebase --onto origin/main ac8e7d6` — clean, no conflicts in the two files
that overlap (`tests/unit`, `tests/README.md`). The post-rebase manifest run
also caught the re-aimed README injection described above, which is the only
thing that changed between the two runs. Post-rebase local numbers:

| | |
|---|---|
| `tests/unit` | **250** |
| `tests/unit --fault-inject` | **166, all caught** (150 mine, 16 from #252) |
| `tests/ci-unit` | 54, 18 injections all caught |
| `tests/lint`, `--self-test`, `smoke-inject --self-test`, `ruff format .` | clean |
| mypy 1.18.2 | clean, 13 source files |

## What this does not verify

- **That the video follows the host's wall clock.** That is #250's pixel
  measurement (38 caption transitions over six takes, residual under 101 ms
  corrected against up to −1.50 s uncorrected), and nothing here re-runs it.
  Every assertion added here grades the *transformation* against a record; the
  only check in the repo that compares the sheet against the world is
  `_check_frame_captions`, which reads pixels and still runs.
- **That the frame-placement guard catches the blocking defect.** It does not,
  on a short beat — see the section above; the unit test is the gate.
- **The correction itself, on a real take.** It is a no-op on a steady host,
  and this host was steady for every clean run. The arithmetic is graded on
  scripted records at the unit level; the arm adds that the sheet *states*
  which case it was, and that an invented step is caught.
- **`MAX_GAP_S = 0.25` under contention on a 2-core runner**, unchanged and
  still unmeasured (#247).
- **The terminal arm's extra ~1 s of loss (#224) and narration (#226)** are out
  of scope per the issue, and untouched.

`tests/README.md` carries all four as Known gaps, plus a note that a green
`--segments-only` on that WSL2 box is a reading of the host as much as of the
recorder.
