### PR TITLE
Mix the narration on the video's clock, and write down where it went (#226)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -62,7 +62,7 @@ from .failure import (
     render_failure_md,
 )
 from .frames import _FRAME_EDGE_S, _extract, write_beat_frames
-from .narration import tts_clip
+from .narration import mix_plan, tts_clip
 from .target import guard_target
 from .timeline import (
     ATTRIBUTION_SLACK_S,
@@ -1014,6 +1014,12 @@ class _DemoBase:
         # #20), the review frames extracted off `media`, and the last frame in
         # `failure/`. Set in `_convert`, after ffmpeg returns.
         self._converted = False
+        # Where this take's spoken lines were put in that mp4, and whether the
+        # host's wall clock could be corrected for when they were (issue #226).
+        # Null until `_convert` has mixed them, so a take that narrated
+        # nothing — or encoded nothing — says nothing rather than claiming an
+        # empty mix. See `narration.mix_plan`.
+        self._narration: dict | None = None
         # What the *picture* turned out to be (issue #97). Measured off the
         # encoded mp4 in `__exit__`, so it is null on any take that wrote none,
         # and it is the one thing in the timeline that describes the frames
@@ -2269,6 +2275,13 @@ take with fewer beats than the last one would otherwise leave the
             # a host that did not step, which is the healthy answer and is
             # *not* the same as the key being absent.
             "capture_clock": self._capture_clock.report(),
+            # Where the spoken lines landed in that mp4, and whether the clock
+            # above could be corrected for when they did (issue #226). Null on
+            # a take that mixed no speech, which is the same answer a take
+            # that encoded nothing gives — in both cases there is no audio
+            # track this could describe. Taken from `_convert`, not recomputed
+            # here: what belongs in the artifact is what the mix did.
+            "narration": self._narration,
             # Built from the *scrubbed* beats, not from `self._beats`, so a
             # still path or a caption that the mask reached is masked here too
             # rather than reappearing in the coverage table (issue #12).
@@ -2502,16 +2515,28 @@ take with fewer beats than the last one would otherwise leave the
     def _convert(self, webm: Path) -> None:
         mp4 = self._media_path()
         cmd = ["ffmpeg", "-y", "-loglevel", "error", "-i", str(webm)]
+        narration: dict | None = None
         if self._speech:
-            # Mix each narration clip in at the moment its line appeared.
+            # Mix each narration clip in at the moment its line appeared —
+            # **in the video**, which is not the moment the beat log recorded
+            # (issue #226). See `mix_plan`: the log is `time.monotonic()`, the
+            # frames are stamped with the host's wall clock, and a step between
+            # the two is a voice that trails its caption for the rest of the
+            # take. `self._capture_clock` has already been stopped by
+            # `__exit__` at this point, so the record is the whole capture's.
+            #
             # Segments always get an aac track (silence if no lines) so
             # stitch()'s lossless concat sees uniform streams.
             if self._lines:
+                plan, clock = mix_plan(
+                    [off for off, _ in self._lines], self._capture_clock.report()
+                )
+                narration = {"lines": plan, "clock_correction": clock}
                 for _, clip in self._lines:
                     cmd += ["-i", str(clip)]
                 delayed = ";".join(
-                    f"[{i + 1}:a]adelay={int(off * 1000)}:all=1[a{i}]"
-                    for i, (off, _) in enumerate(self._lines)
+                    f"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}:all=1[a{i}]"
+                    for i, line in enumerate(plan)
                 )
                 inputs = "".join(f"[a{i}]" for i in range(len(self._lines)))
                 # aformat pins the layout: mixed mono TTS clips would
@@ -2538,5 +2563,11 @@ take with fewer beats than the last one would otherwise leave the
         # `mp4.exists()`, because the file may be a previous take's and the
         # flag cannot be (issue #20).
         self._converted = True
+        # Set here rather than where it is computed, and for the same reason:
+        # `timeline.json` would otherwise describe an audio track that ffmpeg
+        # refused to write. A take whose conversion raised keeps
+        # `narration: null`, which is what a take that mixed nothing says too —
+        # and neither of them has an mp4 for it to be about.
+        self._narration = narration
         spoken = f", {len(self._lines)} spoken lines" if self._speech else ""
         print(f"wrote {mp4} ({mp4.stat().st_size // 1024} kB{spoken})")

--- a/skills/demo-video/helpers/demo_recording/narration.py
+++ b/skills/demo-video/helpers/demo_recording/narration.py
@@ -102,22 +102,34 @@ def mix_plan(
     demo whose audio placement cannot be told from a guess.
 
     `at` never goes below zero, and **a line that hit that floor says so**. A
-    backward step larger than a line's own offset puts that instant before the
-    video's first frame — the wall time it occupied is genuinely not in the
+    backward step larger than a line's own offset puts that instant before this
+    capture's first frame — the wall time it occupied is genuinely not in the
     file — and `adelay` has no way to express a negative delay, so the clip
-    starts at the top of the track. That line's `at` is then *not* its `t` plus
-    the steps before it, which is what every other line's is and what the
-    artifact says about all of them; `clamped` carries the seconds of
-    correction the start of the file swallowed, and is absent from the lines
-    that got the whole of theirs.
+    starts at the beginning of this capture's own audio. That line's `at` is
+    then *not* its `t` plus the steps before it, which is what every other
+    line's is and what the artifact says about all of them; `clamped` carries
+    the seconds of correction that were swallowed, and is absent from the lines
+    that got the whole of theirs — including the ones whose shortfall rounds
+    away to nothing.
+
+    **Zero here is this capture's zero, not the demo's.** `stitch()` moves a
+    part's lines onto the joined clock by that part's `offset`, and `clamped`
+    travels with them, so a clamped line of part two has an `at` of that
+    part's offset. Anything printing prose about it has to say "the start of
+    its own capture" rather than "0.0".
     """
     shift, state = capture_clock_shift(record)
     lines = []
     for off in offsets:
         want = float(off) + shift(off)
+        # Rounded *before* the test, not after. A `want` of −5e-5 is a
+        # truncation of nothing at the precision this record is written at,
+        # and a `clamped: 0.0` beside it would be a line claiming its `at` is
+        # not `t` plus the steps before it when it is.
+        clamped = round(-want, 3) if want < 0 else 0.0
         line = {"t": round(float(off), 3), "at": round(max(0.0, want), 3)}
-        if want < 0:
-            line["clamped"] = round(-want, 3)
+        if clamped:
+            line["clamped"] = clamped
         lines.append(line)
     return lines, state
 

--- a/skills/demo-video/helpers/demo_recording/narration.py
+++ b/skills/demo-video/helpers/demo_recording/narration.py
@@ -101,17 +101,25 @@ def mix_plan(
     clock record — see the section above; a caller that drops it publishes a
     demo whose audio placement cannot be told from a guess.
 
-    `at` never goes below zero. A backward step larger than a line's own offset
-    puts that instant before the video's first frame — the wall time it
-    occupied is genuinely not in the file — and `adelay` has no way to express
-    it, so the clip starts at the top of the track and the take is that much
-    out for that one line.
+    `at` never goes below zero, and **a line that hit that floor says so**. A
+    backward step larger than a line's own offset puts that instant before the
+    video's first frame — the wall time it occupied is genuinely not in the
+    file — and `adelay` has no way to express a negative delay, so the clip
+    starts at the top of the track. That line's `at` is then *not* its `t` plus
+    the steps before it, which is what every other line's is and what the
+    artifact says about all of them; `clamped` carries the seconds of
+    correction the start of the file swallowed, and is absent from the lines
+    that got the whole of theirs.
     """
     shift, state = capture_clock_shift(record)
-    return [
-        {"t": round(float(off), 3), "at": round(max(0.0, float(off) + shift(off)), 3)}
-        for off in offsets
-    ], state
+    lines = []
+    for off in offsets:
+        want = float(off) + shift(off)
+        line = {"t": round(float(off), 3), "at": round(max(0.0, want), 3)}
+        if want < 0:
+            line["clamped"] = round(-want, 3)
+        lines.append(line)
+    return lines, state
 
 
 def _tts_key(text: str, voice_id: str, model_id: str) -> str:

--- a/skills/demo-video/helpers/demo_recording/narration.py
+++ b/skills/demo-video/helpers/demo_recording/narration.py
@@ -19,7 +19,10 @@ import json
 import time
 import urllib.error
 import urllib.request
+from collections.abc import Sequence
 from pathlib import Path
+
+from .timeline import capture_clock_shift
 
 # How long to wait between retries, and how many. Free-tier keys get 429
 # "system_busy" under load, and any network can blip mid-recording — losing a
@@ -55,6 +58,60 @@ TTS_KEY_SEP = "|"
 # milliseconds against a dead socket, instead of putting a fabricated
 # credential on the wire to a third party to find out.
 TTS_API_BASE = "https://api.elevenlabs.io/v1/text-to-speech"
+
+
+# -- putting a clip where its line is, in the video ---------------------------
+#
+# A line is logged at `time.monotonic() - _t0`, and the video it is mixed into
+# is stamped with the host's *wall* clock — Chromium's screencast is, and the
+# encode inherits it. So on a host that steps that clock the two part company by
+# the size of the step, and `adelay` at the raw offset leaves the voice where it
+# was while the picture moved: issue #18's second comment measured **+0.70 s of
+# lag on all three lines** of a take that stalled in its run-up, against +0.11
+# to +0.14 s in a clean one, and that 0.70 s is a wall-clock step. Unlike every
+# other consequence of the two clocks, this one is *audible* — the viewer hears
+# the narration drift off the caption it belongs to (issue #226).
+#
+# The recorder measures those steps for the life of the capture, so the fix is
+# arithmetic and not estimation: mix at `t + (the steps recorded before t)`.
+#
+# Two properties of that rule are worth stating because both were paid for:
+#
+#   * **it is indexed by the instant being converted**, which here is each
+#     line's own offset. The same rule read once per beat left every instant in
+#     a beat's first half uncorrected — roughly half of a take's wall time —
+#     and that was the blocking defect in the review-frame version of this
+#     (#253);
+#   * **`measured` is read before `steps`.** A record that could not watch the
+#     clock reports an empty step list too, so a reader that only looked at
+#     `steps` cannot tell "the clock held still" from "nobody knows". Zero is
+#     still the number applied — there is no other — but it is a fallback and
+#     not a correction, and `mix_plan` hands its caller the state to say so.
+
+
+def mix_plan(
+    offsets: Sequence[float], record: object
+) -> tuple[list[dict], dict]:
+    """Where each narration line goes in the encoded media. -> (lines, state)
+
+    `offsets` are the beat-log instants the lines appeared at, in the order
+    they were spoken; `record` is the take's `capture_clock`. Each returned
+    line carries `t` (what was logged) and `at` (where that instant is in the
+    video, and what the mix delays the clip by). `state` is the three-state
+    clock record — see the section above; a caller that drops it publishes a
+    demo whose audio placement cannot be told from a guess.
+
+    `at` never goes below zero. A backward step larger than a line's own offset
+    puts that instant before the video's first frame — the wall time it
+    occupied is genuinely not in the file — and `adelay` has no way to express
+    it, so the clip starts at the top of the track and the take is that much
+    out for that one line.
+    """
+    shift, state = capture_clock_shift(record)
+    return [
+        {"t": round(float(off), 3), "at": round(max(0.0, float(off) + shift(off)), 3)}
+        for off in offsets
+    ], state
 
 
 def _tts_key(text: str, voice_id: str, model_id: str) -> str:

--- a/skills/demo-video/helpers/demo_recording/stitching.py
+++ b/skills/demo-video/helpers/demo_recording/stitching.py
@@ -151,7 +151,7 @@ def _merge_narration(docs: list[dict], records: list[dict]) -> dict | None:
     refuse a correction two narrated ones really applied.
     """
     lines: list[dict] = []
-    applied = True
+    refused: list[str] = []
     note: str | None = None
     steps = 0
     total = 0.0
@@ -176,10 +176,11 @@ def _merge_narration(docs: list[dict], records: list[dict]) -> dict | None:
             steps += int(state.get("steps") or 0)
             total += float(state.get("total") or 0.0)
         else:
-            applied = False
+            refused.append(str(record["segment"]))
             note = note or state.get("note")
     if not narrating:
         return None
+    applied = not refused
     return {
         "lines": lines,
         "clock_correction": {
@@ -189,12 +190,19 @@ def _merge_narration(docs: list[dict], records: list[dict]) -> dict | None:
             "applied": applied,
             "total": round(total, 4) if applied else None,
             "steps": steps if applied else 0,
+            # ...but *how much* of the demo that is, said rather than left to
+            # the reader. The flag above is all-or-nothing on purpose; without
+            # these two `timeline.md` prints "the 3 spoken lines were mixed
+            # uncorrected" over a demo where two of them were corrected, which
+            # is pessimistic and still not what happened. Absent from a single
+            # take's record, which has no parts to count.
+            "parts": narrating,
+            "parts_uncorrected": len(refused),
             "note": None
             if applied
             else (
-                note
-                or "a part of this demo mixed its narration at the beat-log "
-                "offsets, uncorrected"
+                f"{', '.join(refused)} mixed its narration at the beat-log "
+                f"offsets, uncorrected" + (f" — {note}" if note else "")
             ),
         },
     }

--- a/skills/demo-video/helpers/demo_recording/stitching.py
+++ b/skills/demo-video/helpers/demo_recording/stitching.py
@@ -133,6 +133,73 @@ def _merge_capture_clock(docs: list[dict], records: list[dict]) -> dict | None:
     }
 
 
+def _merge_narration(docs: list[dict], records: list[dict]) -> dict | None:
+    """Every part's spoken lines, moved onto the stitched video's clock.
+
+    Each part mixed its own audio into its own `.seg.mp4` at its own capture's
+    corrected offsets (issue #226), and `concat -c copy` lays those tracks
+    end to end at the parts' measured durations — so a line's place in the
+    joined video is its place in its part plus that part's `offset`, the same
+    arithmetic the beats get. `segment` is carried per line for the same reason
+    a step carries one: it is the attribution to trust when a reader asks which
+    capture's clock a number is on.
+
+    Returns **null** when no part narrated, which is what a single take that
+    narrated nothing says too. A part that narrated nothing is simply absent
+    from `lines` — it contributed no audio, so its clock has nothing to say
+    about this field, and folding its state in would let a silent segment
+    refuse a correction two narrated ones really applied.
+    """
+    lines: list[dict] = []
+    applied = True
+    note: str | None = None
+    steps = 0
+    total = 0.0
+    narrating = 0
+    for doc, record in zip(docs, records, strict=True):
+        narration = doc.get("narration")
+        if not isinstance(narration, dict):
+            continue
+        narrating += 1
+        for line in narration.get("lines") or []:
+            lines.append(
+                {
+                    **line,
+                    "t": _shift(line.get("t"), record["offset"]),
+                    "at": _shift(line.get("at"), record["offset"]),
+                    "segment": record["segment"],
+                }
+            )
+        state = narration.get("clock_correction")
+        state = state if isinstance(state, dict) else {}
+        if state.get("applied"):
+            steps += int(state.get("steps") or 0)
+            total += float(state.get("total") or 0.0)
+        else:
+            applied = False
+            note = note or state.get("note")
+    if not narrating:
+        return None
+    return {
+        "lines": lines,
+        "clock_correction": {
+            # False the moment **any** narrating part could not correct its own
+            # mix: the demo a listener plays is one file, and one part's voice
+            # drifting off its captions is not made right by the others.
+            "applied": applied,
+            "total": round(total, 4) if applied else None,
+            "steps": steps if applied else 0,
+            "note": None
+            if applied
+            else (
+                note
+                or "a part of this demo mixed its narration at the beat-log "
+                "offsets, uncorrected"
+            ),
+        },
+    }
+
+
 # How far a segment's recorded `duration` may sit from what its .seg.mp4
 # measures now. The recorder probed the same file with the same tool moments
 # after writing it, so anything past this is not rounding — it is a log paired
@@ -328,6 +395,10 @@ def _merged_timeline(
                 # theirs, and the parts that *were* measured should not go
                 # with it — see `_merge_capture_clock`.
                 "capture_clock": doc.get("capture_clock"),
+                # Likewise: where this part put its own spoken lines, on its
+                # own clock. The merged field above is the same lines moved
+                # onto the joined video's.
+                "narration": doc.get("narration"),
             }
         )
         offset = round(offset + duration, 3)
@@ -351,6 +422,9 @@ def _merged_timeline(
         # and attributed per capture, because a step in an earlier part must
         # not be applied to a later part's beats (issue #225).
         "capture_clock": _merge_capture_clock(docs, records),
+        # Where the spoken lines are in the joined video, and whether every
+        # part that spoke could put them on that video's clock (issue #226).
+        "narration": _merge_narration(docs, records),
         # Recomputed over the *merged* beat list, not unioned from the
         # segments' own reports: `index` is renumbered by the merge, and a
         # report assembled from per-segment ones would point a reviewer at beat

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -152,10 +152,14 @@ from .markdown import _fmt_t, _md_cell
 #                          fell back to the raw offset because nobody watched
 #                          the clock. A line also carries `clamped` — **only
 #                          when it has one** — being the seconds of correction
-#                          that could not be applied because the result was
-#                          negative: `at` is 0.0 there, `adelay` cannot express
-#                          a negative delay, and that line alone is *not* `t`
-#                          plus the steps before it. On a merged demo every
+#                          that could not be applied because the result fell
+#                          before its own capture's first frame: `adelay`
+#                          cannot express a negative delay, so `at` is the
+#                          start of that line's *own capture* (0.0 on a take
+#                          recorded in one piece, that part's `offset` on a
+#                          stitched demo — **not** 0.0 there), and that line
+#                          alone is *not* `t` plus the steps before it.
+#                          On a merged demo every
 #                          part's lines are here, moved onto the stitched clock
 #                          by that part's `offset` and each naming its own
 #                          `segment`; `clock_correction.applied` is true only
@@ -711,13 +715,20 @@ def _narration_md(narration: object) -> list[str]:
     # untrue for. Reachable only here: an uncorrected mix shifts nothing, so
     # nothing it produces can go negative.
     clamped = [line for line in lines if line.get("clamped")]
+    # **"the start of its own capture", never "0.0".** A single take's capture
+    # starts at the top of the file and the two read the same; a stitched
+    # part's starts at that part's `offset`, and a clamped line of part two has
+    # an `at` of 7.5 rather than of zero. Saying 0.0 there is a published
+    # artifact stating a second the clip is not at, on exactly the host this
+    # correction exists for.
     tail = (
         f" **{len(clamped)} of them could not be moved the whole way**: the "
-        f"steps before that line were larger than the line's own offset, so "
-        f"the wall time it occupied is not in the video at all and `adelay` "
-        f"cannot express a negative delay. Those clips start at the top of the "
-        f"track, their `at` is 0.0, and `clamped` is how many seconds of the "
-        f"correction the start of the file swallowed."
+        f"steps before that line were larger than the line's own offset into "
+        f"its capture, so the wall time it occupied is not in the video at all "
+        f"and `adelay` cannot express a negative delay. Those clips start where "
+        f"their own capture does — the top of the file on a take recorded in "
+        f"one piece, that part's `offset` on a stitched demo — and `clamped` is "
+        f"how many seconds of the correction that boundary swallowed."
         if clamped
         else ""
     )

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -150,11 +150,20 @@ from .markdown import _fmt_t, _md_cell
 #                          (issue #226) — and the state is here so a reader
 #                          can tell a mix that was corrected from one that
 #                          fell back to the raw offset because nobody watched
-#                          the clock. On a merged demo every part's lines are
-#                          here, moved onto the stitched clock by that part's
-#                          `offset` and each naming its own `segment`, and
-#                          `clock_correction.applied` is true only if every
-#                          part that narrated corrected its own mix.
+#                          the clock. A line also carries `clamped` — **only
+#                          when it has one** — being the seconds of correction
+#                          that could not be applied because the result was
+#                          negative: `at` is 0.0 there, `adelay` cannot express
+#                          a negative delay, and that line alone is *not* `t`
+#                          plus the steps before it. On a merged demo every
+#                          part's lines are here, moved onto the stitched clock
+#                          by that part's `offset` and each naming its own
+#                          `segment`; `clock_correction.applied` is true only
+#                          if every part that narrated corrected its own mix,
+#                          and `parts` / `parts_uncorrected` (merged demos
+#                          only) say how many of them that verdict is about,
+#                          so a demo where one part of three could not correct
+#                          is not reported as a demo where none could.
 #   coverage      dict?  — **null** unless the take was recorded against a
 #                          ticket (`Recorder(criteria={...})`). What the
 #                          storyboard *claimed*, never what it proved:
@@ -653,6 +662,16 @@ def _narration_md(narration: object) -> list[str]:
     only use the raw offset. The second is the one that matters here: the audio
     is *audible* evidence, and a listener who hears the voice drift away from
     the caption has no other way to find out that nothing knew by how much.
+
+    Two qualifications are printed rather than left to be inferred, because
+    both make the headline sentence false for *some* of the lines and a reader
+    correcting by hand would be corrected twice:
+
+      * a line whose correction hit the zero floor (`clamped`) did not move by
+        the steps before it — it moved by as much of them as the start of the
+        file left room for;
+      * on a stitched demo where only some narrating parts could correct, the
+        refusal is stated as **k of m segments** rather than as the whole demo.
     """
     if not isinstance(narration, dict):
         return []
@@ -665,8 +684,18 @@ def _narration_md(narration: object) -> list[str]:
     if not lines or not isinstance(clock, dict):
         return []
     if not clock.get("applied"):
+        # A merged record knows how much of the demo it is talking about; a
+        # single take's is the whole of it. Saying "the 3 spoken lines were
+        # mixed uncorrected" over a demo where two of them were is pessimistic
+        # rather than dangerous, but it is still not what happened.
+        refused, parts = clock.get("parts_uncorrected"), clock.get("parts")
+        whose = (
+            f"the lines of {refused} of this demo's {parts} narrated segment(s)"
+            if refused and parts
+            else f"the {len(lines)} spoken line(s)"
+        )
         return [
-            f"**The {len(lines)} spoken line(s) were mixed at their beat-log "
+            f"**{whose[0].upper()}{whose[1:]} were mixed at their beat-log "
             f"offsets, uncorrected**: {clock.get('note')}. The audio sits "
             f"inside the video and therefore on the video's clock, so if the "
             f"host's wall clock stepped while this was recording the voice is "
@@ -678,13 +707,27 @@ def _narration_md(narration: object) -> list[str]:
     # mixed between them. Same argument as `_capture_clock_md`.
     if not clock.get("steps"):
         return []
+    # ...and the lines the floor caught, which the sentence below is otherwise
+    # untrue for. Reachable only here: an uncorrected mix shifts nothing, so
+    # nothing it produces can go negative.
+    clamped = [line for line in lines if line.get("clamped")]
+    tail = (
+        f" **{len(clamped)} of them could not be moved the whole way**: the "
+        f"steps before that line were larger than the line's own offset, so "
+        f"the wall time it occupied is not in the video at all and `adelay` "
+        f"cannot express a negative delay. Those clips start at the top of the "
+        f"track, their `at` is 0.0, and `clamped` is how many seconds of the "
+        f"correction the start of the file swallowed."
+        if clamped
+        else ""
+    )
     return [
         f"**The {len(lines)} spoken line(s) were mixed where the host's "
         f"stepped clock puts them in the video**, not at the beat-log offsets "
         f"in the table below: each line's `at` in `timeline.json`'s "
         f"`narration` is its `t` plus the steps its own capture recorded "
         f"before that instant. Without it the voice would trail the caption "
-        f"by the size of the step for the rest of the take (issue #226).",
+        f"by the size of the step for the rest of the take (issue #226).{tail}",
         "",
     ]
 

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -105,8 +105,9 @@ from .markdown import _fmt_t, _md_cell
 #   segments      list?   — merged demos only (`stitch`): one record per part,
 #                          in order, each `segment`, `media`, `duration`
 #                          (ffprobe), `offset` (where it starts in `media`),
-#                          `beats`, `recorder`, `determinism`, `content` and
-#                          that part's own `capture_clock`, on its own clock.
+#                          `beats`, `recorder`, `determinism`, `content`,
+#                          `narration` and that part's own `capture_clock`,
+#                          the last two on its own clock.
 #                          Absent from a timeline a single take wrote.
 #   content       dict?  — what the *picture* turned out to be, measured off
 #                          the encoded mp4 over the region the app occupies:
@@ -133,6 +134,27 @@ from .markdown import _fmt_t, _md_cell
 #                          `held` means the frames at the start of the video
 #                          are not frames the recording captured; see "the
 #                          blank opening".
+#   narration     dict?  — **null** on a take that mixed no speech into
+#                          `media` — narration off, no lines, or no mp4
+#                          encoded. Otherwise, where each spoken line's audio
+#                          was actually put: `lines`, one record per clip in
+#                          the order they were mixed, each `t` (the beat-log
+#                          instant the line appeared, `time.monotonic()`) and
+#                          `at` (where that instant is in `media`, which is
+#                          what the mix used as its `adelay`); plus
+#                          `clock_correction`, the same `applied` / `total` /
+#                          `steps` / `note` state `capture_clock_correction`
+#                          returns. The audio rides the *video's* clock
+#                          because it is inside the video, so `at` is `t`
+#                          corrected the same way a review frame's seek is
+#                          (issue #226) — and the state is here so a reader
+#                          can tell a mix that was corrected from one that
+#                          fell back to the raw offset because nobody watched
+#                          the clock. On a merged demo every part's lines are
+#                          here, moved onto the stitched clock by that part's
+#                          `offset` and each naming its own `segment`, and
+#                          `clock_correction.applied` is true only if every
+#                          part that narrated corrected its own mix.
 #   coverage      dict?  — **null** unless the take was recorded against a
 #                          ticket (`Recorder(criteria={...})`). What the
 #                          storyboard *claimed*, never what it proved:
@@ -557,6 +579,34 @@ def capture_clock_correction(
     }
 
 
+def capture_clock_shift(record: object) -> tuple[Callable[[float], float], dict]:
+    """(shift, state) for a capture that is still the only one there is.
+
+    `capture_clock_correction` above reads a finished timeline, where a step is
+    attributed to the segment it was measured in and a beat is matched against
+    it. A take mixing its **own** audio has no such question to answer: one
+    capture is running, every step in the record is that capture's, and the
+    steps do not name a segment until `stitch()` gives them one. So the rule
+    collapses to "how far had the wall clock stepped by `t`", and it is read
+    through the same function rather than re-derived — the two must not be able
+    to drift apart, because `frames/` and the audio track of the same demo have
+    to describe the same video.
+
+    `shift(t)` is the seconds to add to the beat-log instant `t`; `state` is the
+    same three-state record `capture_clock_correction` returns, and the caller
+    is expected to put it in an artifact rather than swallow it.
+    """
+    correct, state = capture_clock_correction({"capture_clock": record})
+
+    def shift(t: float) -> float:
+        # The empty beat is the point: a single capture's steps carry no
+        # segment and neither does this, so every step in the record is this
+        # instant's to be corrected by.
+        return correct({}, t)
+
+    return shift, state
+
+
 def _capture_clock_md(state: dict) -> list[str]:
     """What `timeline.md` says about the clock its own timestamps are on.
 
@@ -588,6 +638,53 @@ def _capture_clock_md(state: dict) -> list[str]:
         f"`timeline.json`'s `capture_clock` carries every step and the capture "
         f"it was measured in; `frames/frames.md` says whether the review "
         f"frames were cut with it applied.",
+        "",
+    ]
+
+
+def _narration_md(narration: object) -> list[str]:
+    """What `timeline.md` says about where the spoken lines ended up.
+
+    Same shape of statement as `_capture_clock_md`, and silent for the same
+    reason on the same take: a watched clock that held still put every line
+    exactly where the log says, and a line on every timeline is a line nobody
+    reads. It speaks in the two cases where that is not what happened — the
+    clock stepped and the mix followed it, or nobody watched and the mix could
+    only use the raw offset. The second is the one that matters here: the audio
+    is *audible* evidence, and a listener who hears the voice drift away from
+    the caption has no other way to find out that nothing knew by how much.
+    """
+    if not isinstance(narration, dict):
+        return []
+    lines = narration.get("lines") or []
+    # `clock` rather than `state`, which is what `_capture_clock_md` above
+    # calls its own: two identical guard lines in one file are two lines a
+    # fault injection cannot tell apart, and the harness refuses an anchor
+    # that matches twice rather than proving the wrong one.
+    clock = narration.get("clock_correction")
+    if not lines or not isinstance(clock, dict):
+        return []
+    if not clock.get("applied"):
+        return [
+            f"**The {len(lines)} spoken line(s) were mixed at their beat-log "
+            f"offsets, uncorrected**: {clock.get('note')}. The audio sits "
+            f"inside the video and therefore on the video's clock, so if the "
+            f"host's wall clock stepped while this was recording the voice is "
+            f"that far from the caption it belongs to — and nothing here knows "
+            f"whether it did.",
+            "",
+        ]
+    # On the count, never the total — two steps that cancel move every line
+    # mixed between them. Same argument as `_capture_clock_md`.
+    if not clock.get("steps"):
+        return []
+    return [
+        f"**The {len(lines)} spoken line(s) were mixed where the host's "
+        f"stepped clock puts them in the video**, not at the beat-log offsets "
+        f"in the table below: each line's `at` in `timeline.json`'s "
+        f"`narration` is its `t` plus the steps its own capture recorded "
+        f"before that instant. Without it the voice would trail the caption "
+        f"by the size of the step for the rest of the take (issue #226).",
         "",
     ]
 
@@ -770,6 +867,13 @@ def render_timeline_md(doc: dict) -> str:
     # loud. The recorder warns about the same thing on stderr, minutes and
     # several thousand lines before anybody opens this file (issue #229).
     out += _capture_clock_md(capture_clock_correction(doc)[1])
+    # Directly under it, because it is the same statement about a different
+    # artifact: the row's timestamp is on the beat log, and so was the audio
+    # until the mix corrected it. Read off `narration` rather than recomputed
+    # from `capture_clock` — what belongs here is what the mix *did*, and a
+    # paragraph derived from the record would keep claiming a correction if
+    # the mix ever stopped applying one.
+    out += _narration_md(doc.get("narration"))
     # The exit column only exists when something in this take has one — a web
     # timeline would otherwise carry an empty column on every row. A `run` beat
     # whose status could not be read shows "?" rather than blank, so the

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -133,15 +133,21 @@ rather than by widening a bar, which is why `MAX_SKEW_DRIFT_S` could be
 restored at 250 ms after being deleted in
 [#217](https://github.com/rogvid/skills/issues/217).
 
-Two things in the recorder already apply this for you, and reading them as
+Three things in the recorder already apply this for you, and reading them as
 uncorrected is the way to get it wrong twice
 ([#229](https://github.com/rogvid/skills/issues/229)): **the review frames
 under `frames/` are cut on the video's clock**, midpoint plus that beat's own
 capture's steps before *that midpoint* (the rule is indexed by the instant you
 are converting, not by the beat — a step inside a beat's first half moves its
-frame), and `frames/frames.md` says which of the three cases the take was; and `timeline.md` says above its beat table when the clock
-stepped and by how much. `timeline.json`'s beat timestamps are untouched — they
-are the log, and the log is `time.monotonic()`.
+frame), and `frames/frames.md` says which of the three cases the take was;
+**every narration clip is mixed on the video's clock too**
+([#226](https://github.com/rogvid/skills/issues/226)) — `timeline.json`'s
+`narration.lines` gives each spoken line's `t` (the beat log's instant) beside
+its `at` (where the clip really is in `media`, which is `t` corrected by the
+same rule and never below zero), with `narration.clock_correction` saying which
+of the three cases applied; and `timeline.md` says above its beat table when the
+clock stepped and by how much, and what that meant for the audio. `timeline.json`'s beat
+timestamps are untouched — they are the log, and the log is `time.monotonic()`.
 
 What to do everywhere else: prefer `timeline.json`'s `capture_clock`, which
 records every step with its offset and size, and correct with it — **after

--- a/skills/demo-video/reference/narration.md
+++ b/skills/demo-video/reference/narration.md
@@ -47,6 +47,16 @@ needed; captions are the narration script.
   the mix falls back to the raw offset, `timeline.md` says so in a paragraph
   above the beat table, and the audio may be out by however far the host
   moved.
+- **A backward step between two lines can make their clips overlap, and that
+  is the correction working.** The step shortens the *video*; it does not
+  shorten the clip. The recorder waited line 1 out before starting line 2 in
+  monotonic time, but the seconds the step deleted are not in the file to wait
+  through, so line 2's corrected onset can land while line 1 is still
+  speaking — measured once at 0.4 s of overlap after a −1.07 s step. Two
+  voices for a fraction of a second is the price of both lines matching their
+  captions; the alternative is every line after the step trailing its caption
+  by the whole step. If a take comes back with audible double-talk, look at
+  `capture_clock.steps` before you look at the storyboard.
 - Verify audio like you verify frames: `ffprobe` shows the aac stream;
   `ffmpeg -af silencedetect` should show speech blocks spanning the video;
   if the key has STT permission, transcribe the extracted track with

--- a/skills/demo-video/reference/narration.md
+++ b/skills/demo-video/reference/narration.md
@@ -34,6 +34,19 @@ needed; captions are the narration script.
   the previous spoken line.
 - Write captions for the ear as well as the eye: short sentences, no
   markup, nothing you wouldn't say aloud.
+- **A clip is mixed where its line is in the *video*, not where the beat
+  log put it.** The log is `time.monotonic()` and the recording is stamped
+  with the host's wall clock, so a host that steps that clock while a take
+  records would otherwise leave the voice behind while the picture moved —
+  measured once at +0.70 s of lag on every line of a stalled take. The
+  recorder corrects each line by the wall-clock steps its own capture saw
+  before that line, and writes down what it did: `narration` in
+  `timeline.json` carries every line's `t` (the beat-log instant) and `at`
+  (where it went in the mp4), with a `clock_correction` that says whether a
+  correction was possible at all. When the sampler could not watch the clock
+  the mix falls back to the raw offset, `timeline.md` says so in a paragraph
+  above the beat table, and the audio may be out by however far the host
+  moved.
 - Verify audio like you verify frames: `ffprobe` shows the aac stream;
   `ffmpeg -af silencedetect` should show speech blocks spanning the video;
   if the key has STT permission, transcribe the extracted track with

--- a/tests/README.md
+++ b/tests/README.md
@@ -1929,6 +1929,28 @@ knows is missing is worse than one that is openly absent.
   already runs `caption_arrival`** — `--web-only` or `--segments-only` — where
   both halves would then be read off the same mp4.
 
+  **Where a step merges two clips, the arm can only grade the merged
+  stretch's edges.** Once a backward step puts one clip inside another,
+  `silencedetect` reports one stretch and there is no per-clip length left to
+  check: a short clip moved anywhere inside a long one — or dropped from the
+  mix entirely — changes neither edge. Measured on a real stepped take of this
+  arm (lines at 2.101 s and 3.301 s, a −1.073 s step at 2.214 s): line 1 mixed
+  **0.772 s late reads clean**, and line 1 **omitted reads clean**; the blind
+  window is about **1.17 s**, inside the 0.70–1.50 s band the defect lives in.
+  It also needs `timeline.json` to still name the right second, so the record
+  has to be wrong in a way consistent with itself. This is not a regression:
+  before the merge model the same regime returned "1 stretch for 2 spoken
+  lines" for a *correct* mix too, so nothing in it was graded at all. Closing
+  it needs a per-clip signature in the audio — distinct tones per line, say —
+  which is a change to what the arm seeds and not to what it measures.
+
+  **The two `if not clock.covered` refusals in the narration checks have no
+  automated test.** The arm cannot produce an uncovered watcher on demand, so
+  the guard that stops an unwatched `before()` from being graded on is
+  exercised by nothing. That is precedent rather than drift —
+  `check_timeline`'s identical guard at `tests/smoke:6195` has been uninjected
+  since #245 — and it is written down here rather than left to be noticed.
+
   **And the correction narration applies is over-large on this host, by an
   amount nothing here removes.** #224's diagnosis found that a −Δ wall-clock
   step does not slide the video: it **deletes a Δ-wide hole** from the file,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1737,7 +1737,7 @@ paragraph whose job is to say what this manifest does not cover.
 | arm | entries | what a miss would mean |
 |---|---|---|
 | `--lock-only` | 3 | a run the machine lock refuses goes back to building an output directory it will never write to and printing `recordings left in` under `smoke: FAILED`, naming it ([#105](https://github.com/rogvid/skills/issues/105)) — or the fix overshoots and no failing run is told where its recordings are, which the third entry is the control for |
-| `--narration-only` | 6 | the narration fixture goes back to leaving its interlude card up for the whole take, so every frame after the third beat — both captions the arm measures included — is the card and not the app, and nothing fails ([#168](https://github.com/rogvid/skills/issues/168)); or the three claims this 8 s arm is the cheapest way to reach stop grading ([#238](https://github.com/rogvid/skills/issues/238)) — the recorder reporting a healthy 2xx as a problem, which is the *only* over-reporting assertion in the file; a beat opening while the voice is still on the previous line; and every clip mixed in at zero offset, which the silent window before the first line is the control for. Two more are about *where* the voice went ([#226](https://github.com/rogvid/skills/issues/226)), which no window bar can see: the mix landing 150 ms from the second the take's own record names, and the record naming a second the mix did not use — caught only because the arm now watches the host's wall clock itself and compares |
+| `--narration-only` | 6 | the narration fixture goes back to leaving its interlude card up for the whole take, so every frame after the third beat — both captions the arm measures included — is the card and not the app, and nothing fails ([#168](https://github.com/rogvid/skills/issues/168)); or the three claims this 8 s arm is the cheapest way to reach stop grading ([#238](https://github.com/rogvid/skills/issues/238)) — the recorder reporting a healthy 2xx as a problem, which is the *only* over-reporting assertion in the file; a beat opening while the voice is still on the previous line; and every clip mixed in at zero offset, which the silent window before the first line is the control for. Two more are about *where* the voice went ([#226](https://github.com/rogvid/skills/issues/226)), which no window bar can see: the mix landing 250 ms from the second the take's own record names, and the record naming a second the mix did not use — caught only because the arm now watches the host's wall clock itself and compares |
 | `--coverage-only` | 5 | the report flatters the storyboard: nothing reported unclaimed, a claim pointing at the wrong beat or forgetting its segment, an undeclared tag accepted, the finding dropped from `timeline.md` |
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
@@ -1915,6 +1915,31 @@ knows is missing is worse than one that is openly absent.
   [#247](https://github.com/rogvid/skills/issues/247), whose clock does pulse,
   the arm's cross-check becomes a real grading of the stepped case — by
   accident of the host, which is not coverage.
+
+  **Nothing measures the audio against the caption's pixels in one file.**
+  #226's acceptance criterion is phrased as onset-versus-caption-appearance;
+  what exists is onset-versus-clock on `--narration-only` (≤120 ms, measured
+  sub-millisecond) and caption-versus-clock in #250 (38 transitions, ≤101 ms).
+  Composed, that bounds the cross-modal distance at about **221 ms** against a
+  700–1500 ms defect, which is sufficient — with two caveats worth having in
+  writing: one half is a historical measurement nothing re-runs, and the two
+  halves were taken on different arms. The cheap way to close it is not to
+  rework the narration storyboard (whose interlude teardown destroys
+  `caption_arrival`'s quiet run-up) but to add **one spoken line to an arm that
+  already runs `caption_arrival`** — `--web-only` or `--segments-only` — where
+  both halves would then be read off the same mp4.
+
+  **And the correction narration applies is over-large on this host, by an
+  amount nothing here removes.** #224's diagnosis found that a −Δ wall-clock
+  step does not slide the video: it **deletes a Δ-wide hole** from the file,
+  and separately some takes lose only 16–50 % of the recorded step. Every
+  consumer of `capture_clock` over-corrects as a result — the review frames,
+  the smoke harness's own `before()`, and the narration mix alike — so a line
+  whose instant falls inside such a hole is placed up to a whole step early.
+  [#255](https://github.com/rogvid/skills/issues/255) carries the measurements
+  and fixes it at the source, in `before()` and `capture_clock_correction`, for
+  all consumers at once. Nothing about it is narration-specific and nothing in
+  `narration.py` should chase it.
 
 - **That a real Chromium hands a click's deferred document event to
   `evaluate("0")`.** [#214](https://github.com/rogvid/skills/issues/214) is

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,7 +38,7 @@ below for what it covers and what it does not.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~41 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~42 min, nightly)
 ├── unit               # the browser-free half (~0.07 s, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
@@ -183,7 +183,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~48 s)
-tests/smoke-inject                # all 49 entries, ~41 min
+tests/smoke-inject                # all 51 entries, ~42 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -1113,6 +1113,28 @@ Four things, and the third is the one the axis exists for:
   44100 Hz. `_convert` pins these with `aformat` rather than letting `amix`
   decide, because mono TTS clips otherwise yield a mono track that `-c copy`
   cannot concatenate with the stereo silence of a segment that narrated nothing.
+- **every clip is where the take says it put it, read off the encoded file**
+  ([#226](https://github.com/rogvid/skills/issues/226)). The bars above ask
+  whether the mix happened; this asks *where it landed*, which is the thing a
+  listener notices and no 0.4 s window can see. `silencedetect` at −50 dBFS
+  splits the track into the stretches that carry a clip, and each stretch has
+  to start within **120 ms** of the second `timeline.json`'s `narration` names
+  and to last as long as the tone this file seeded. Measured on this arm's own
+  take: the two clips came back at **0.963016 s and 3.228000 s** against a mix
+  aimed at 0.963 s and 3.228 s, and occupied 1.600 s and 0.300 s against the
+  1.6 s and 0.3 s tones — sub-millisecond, against the 0.70–1.50 s the lag this
+  exists to catch was measured at. And `at` itself is checked against **this harness's own**
+  wall-clock sampler rather than against the recorder's `capture_clock` — the
+  arm now runs `watch_wall_clock()` for the length of the take, so a recorder
+  that stopped correcting, or corrected by the wrong number, disagrees with a
+  reading it cannot influence.
+
+  **What it cannot say on a steady host**, stated rather than implied: where
+  the wall clock does not step the correction is zero, and this passes
+  identically for a mix that never corrected anything. The arithmetic is graded
+  in `tests/unit` (`NarrationMix`, `NarrationMixPlan`) against scripted
+  records; what the arm adds is that the clip really is in the file at the
+  second the record names. See **Known gaps**.
 
 **All four were fault-injected**, none of them having been watched to fail
 before:
@@ -1687,7 +1709,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-49 entries, 12 arms, ~41.4 min of takes
+51 entries, 12 arms, ~41.7 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -1715,7 +1737,7 @@ paragraph whose job is to say what this manifest does not cover.
 | arm | entries | what a miss would mean |
 |---|---|---|
 | `--lock-only` | 3 | a run the machine lock refuses goes back to building an output directory it will never write to and printing `recordings left in` under `smoke: FAILED`, naming it ([#105](https://github.com/rogvid/skills/issues/105)) — or the fix overshoots and no failing run is told where its recordings are, which the third entry is the control for |
-| `--narration-only` | 4 | the narration fixture goes back to leaving its interlude card up for the whole take, so every frame after the third beat — both captions the arm measures included — is the card and not the app, and nothing fails ([#168](https://github.com/rogvid/skills/issues/168)); or the three claims this 8 s arm is the cheapest way to reach stop grading ([#238](https://github.com/rogvid/skills/issues/238)) — the recorder reporting a healthy 2xx as a problem, which is the *only* over-reporting assertion in the file; a beat opening while the voice is still on the previous line; and every clip mixed in at zero offset, which the silent window before the first line is the control for |
+| `--narration-only` | 6 | the narration fixture goes back to leaving its interlude card up for the whole take, so every frame after the third beat — both captions the arm measures included — is the card and not the app, and nothing fails ([#168](https://github.com/rogvid/skills/issues/168)); or the three claims this 8 s arm is the cheapest way to reach stop grading ([#238](https://github.com/rogvid/skills/issues/238)) — the recorder reporting a healthy 2xx as a problem, which is the *only* over-reporting assertion in the file; a beat opening while the voice is still on the previous line; and every clip mixed in at zero offset, which the silent window before the first line is the control for. Two more are about *where* the voice went ([#226](https://github.com/rogvid/skills/issues/226)), which no window bar can see: the mix landing 150 ms from the second the take's own record names, and the record naming a second the mix did not use — caught only because the arm now watches the host's wall clock itself and compares |
 | `--coverage-only` | 5 | the report flatters the storyboard: nothing reported unclaimed, a claim pointing at the wrong beat or forgetting its segment, an undeclared tag accepted, the finding dropped from `timeline.md` |
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
@@ -1729,7 +1751,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **16 of `tests/smoke`'s 40 check functions have no entry**, and the harness
+- **16 of `tests/smoke`'s 41 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -1872,6 +1894,27 @@ exactly where `--strict-only` came from.
 
 Things a pass does **not** prove. They are listed because an assertion nobody
 knows is missing is worse than one that is openly absent.
+
+- **That the narration correction is right on a host whose clock really
+  steps.** [#226](https://github.com/rogvid/skills/issues/226) puts each spoken
+  clip at its own offset *plus the wall-clock steps its capture recorded before
+  it*, because the video is on the host's wall clock and the beat log is not.
+  Nothing in this repo can make a host step its clock on demand, so every
+  assertion about the correction is driven by a **scripted** `capture_clock` —
+  `tests/unit`'s `NarrationMix` reads the delays back out of the ffmpeg command
+  line the recorder really built, and `NarrationMixPlan` covers the record
+  shapes a recorder cannot produce. The `--narration-only` arm measures the
+  onsets off the encoded mp4 and cross-checks them against its own wall-clock
+  sampler, which on a steady box reads zero: **that arm passes identically for
+  a mix that never corrected anything.** What is therefore ungraded end to end
+  is the world model itself — that the encode really follows the host's clock —
+  and that was measured once, off pixels, in
+  [#250](https://github.com/rogvid/skills/issues/250): six takes, 38 caption
+  transitions, up to −1.50 s uncorrected against all 38 within 101 ms
+  corrected. Nothing re-runs it. On the WSL2 box of
+  [#247](https://github.com/rogvid/skills/issues/247), whose clock does pulse,
+  the arm's cross-check becomes a real grading of the stepped case — by
+  accident of the host, which is not coverage.
 
 - **That a real Chromium hands a click's deferred document event to
   `evaluate("0")`.** [#214](https://github.com/rogvid/skills/issues/214) is

--- a/tests/smoke
+++ b/tests/smoke
@@ -1561,6 +1561,32 @@ NARRATION_LINES = (
 NARRATION_LOUD_DBFS = -60.0
 NARRATION_QUIET_DBFS = -80.0
 NARRATION_WINDOW_S = 0.4
+
+# Reading the clips back **out of the encoded file**, which is the half of
+# issue #226's acceptance criterion the repo did not have. A window that is
+# loud somewhere inside a line says the mix happened; it does not say where.
+#
+# `silencedetect` at this floor splits the track into the stretches that carry
+# a clip and the stretches that do not, and the complement of the silences is
+# the set of onsets. The floor sits in the 66 dB gap the two bars above were
+# measured across (-25 dBFS inside a line, -91 before one), so it is nowhere
+# near either population; `d` is short enough to keep the 0.3 s clip and long
+# enough that a gap between two words could not split one.
+NARRATION_SILENCE_DBFS = -50.0
+NARRATION_SILENCE_MIN_S = 0.08
+# How far a clip's onset in the file may sit from where it was supposed to go.
+# Measured over this arm's own take: the two clips came back at 0.963016s and
+# 3.228000s against a mix aimed at 0.963s and 3.228s — **sub-millisecond**, so
+# the bar is set for a decoder boundary rather than for the arithmetic. The
+# error it exists to catch is 0.70-1.50 s (issues #18, #229): three orders of
+# magnitude above the residual and one below the defect, rather than a
+# comfortable-looking margin between the two.
+NARRATION_ONSET_TOLERANCE_S = 0.12
+# ...and how far a clip's *length* in the file may sit from the clip's own.
+# The clips are tones of a known duration, so a mix that overlapped two of
+# them, or truncated one, changes this and not the onset. Measured on the same
+# take: 1.600s and 0.300s against the 1.6s and 0.3s this file seeded.
+NARRATION_SPAN_TOLERANCE_S = 0.15
 # What `stitch()`'s lossless concat requires of every segment's audio, and the
 # reason `_convert` pins the format rather than letting amix decide: mono TTS
 # clips would otherwise yield a mono track that `-c copy` cannot join with the
@@ -9716,7 +9742,62 @@ def mean_dbfs(mp4: Path, start: float, seconds: float) -> float | None:
     return float(match.group(1)) if match else None
 
 
-def record_narration(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
+def loud_spans(mp4: Path, duration: float) -> list[tuple[float, float]] | None:
+    """(start, end) of every stretch of `mp4` that carries audio.
+
+    Read off the encoded file with `silencedetect` and complemented here, so
+    what comes back is where a clip really is rather than where anything says
+    it is. `None` when ffmpeg produced no silence report at all — a
+    measurement that failed is not a file with no audio in it, and the two
+    must not arrive as the same answer.
+
+    **`-v info`, deliberately.** `silencedetect` writes through ffmpeg's
+    logger at INFO level, and `-v error` throws it away — which would make
+    this function return "one span covering the whole file" on every take,
+    silently, forever.
+    """
+    done = subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "info",
+            "-i",
+            str(mp4),
+            "-af",
+            f"silencedetect=n={NARRATION_SILENCE_DBFS}dB:d={NARRATION_SILENCE_MIN_S}",
+            "-f",
+            "null",
+            "-",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    starts = [float(m) for m in re.findall(r"silence_start:\s*(-?[\d.]+)", done.stderr)]
+    ends = [float(m) for m in re.findall(r"silence_end:\s*(-?[\d.]+)", done.stderr)]
+    if not starts and not ends:
+        return None
+    # Every silence as a closed interval, then the gaps between them. A file
+    # that opens loud has no `silence_start` at 0; one that ends loud has a
+    # trailing `silence_start` with no `silence_end`, which closes at the
+    # duration.
+    silences = [
+        (start, ends[i] if i < len(ends) else duration)
+        for i, start in enumerate(starts)
+    ]
+    spans: list[tuple[float, float]] = []
+    at = 0.0
+    for start, end in silences:
+        if start - at > NARRATION_SILENCE_MIN_S:
+            spans.append((round(at, 3), round(start, 3)))
+        at = max(at, end)
+    if duration - at > NARRATION_SILENCE_MIN_S:
+        spans.append((round(at, 3), round(duration, 3)))
+    return spans
+
+
+def record_narration(
+    out_dir: Path, base_url: str, clock: HostClock
+) -> tuple[list[str], dict]:
     """A take that really narrates, from a cache seeded before it starts."""
     from demo_recording import Recorder, narration
 
@@ -9741,6 +9822,12 @@ def record_narration(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
     os.environ["ELEVENLABS_API_KEY"] = NARRATION_KEY
     try:
         with Recorder(out_dir, base_url=base_url, speech=True, strict=True) as rec:
+            # This harness's own wall-clock reading, put on the take's clock.
+            # The mix is corrected by the recorder's `capture_clock` (issue
+            # #226), so grading the audio against that record would grade the
+            # recorder against itself; `clock.before()` is measured in this
+            # process, by code that shares nothing with the recorder's.
+            clock.rebase(rec._t0)  # see HostClock
             b.expect("constructing with speech=True", rec._speech, True)
             rec.goto("/")
             rec.wait_for("#kpi-rev")
@@ -9825,7 +9912,138 @@ def check_narration_pacing(out_dir: Path) -> list[str]:
     return failures
 
 
-def check_narration_audio(out_dir: Path, lines: list) -> list[str]:
+def check_narration_placement(
+    out_dir: Path, lines: list, clock: HostClock
+) -> list[str]:
+    """Each clip is where it belongs **in the video**, read off the file (#226).
+
+    `check_narration_audio` below asks whether the mix happened. This asks
+    where it landed, and the difference is the whole of issue #226: a clip
+    delayed by the offset the beat log recorded is on `time.monotonic()`, the
+    video it is mixed into is stamped with the host's wall clock, and on a host
+    that steps that clock the voice trails the caption it belongs to for the
+    rest of the take — measured at +0.70 s on every line of one take (#18).
+
+    Three claims, and none of them is the recorder agreeing with itself:
+
+    1. the take's own `_lines` are what `timeline.json`'s `narration` says it
+       was given, line for line;
+    2. every `at` in that record is where **this harness's** wall-clock reading
+       puts that instant in the video. `clock.before()` is sampled in this
+       process by code the recorder cannot reach, so a recorder that stopped
+       correcting, or corrected by the wrong number, disagrees with it;
+    3. every clip's onset **in the encoded audio** is at that same
+       independently-derived second, and every clip's span is as long as the
+       tone this file seeded. Measured with `silencedetect` off the finished
+       mp4, so nothing in this claim is computed from what the recorder wrote
+       down — a record and a mix that agree with each other and not with the
+       world fail claim 3 while satisfying claim 2, and the reverse.
+
+    **What this cannot say on a steady host**, and it is stated rather than
+    implied: where the wall clock does not step, `clock.before()` is zero, the
+    correction is zero, and claims 2 and 3 hold identically for a mix that
+    never corrected anything. The arithmetic of the correction is graded in
+    `tests/unit` (`NarrationMix`) against scripted records; what this adds is
+    that the clip really is in the file at the second the record names.
+    """
+    label = "narration"
+    failures: list[str] = []
+    mp4 = out_dir / "demo.mp4"
+    if not lines:
+        return [f"{label}: the recorder logged no narration lines"]
+    try:
+        doc = json.loads((out_dir / "timeline.json").read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"{label}: timeline.json could not be read: {exc}"]
+    record = doc.get("narration")
+    if not isinstance(record, dict) or not isinstance(record.get("lines"), list):
+        return [
+            f"{label}: timeline.json carries no `narration` record "
+            f"({record!r}) on a take that spoke {len(lines)} line(s) — the "
+            f"audio is the one artifact a reader cannot check against "
+            f"anything else, so where it went has to be written down (#226)"
+        ]
+    logged = record["lines"]
+    if len(logged) != len(lines):
+        return [
+            f"{label}: timeline.json records {len(logged)} narration line(s) "
+            f"and the recorder mixed {len(lines)}"
+        ]
+
+    # (1) and (2). `before()` is this file's own correction, hand-written
+    # against the documented rule and sampled by this process's watcher.
+    expected: list[float] = []
+    for n, ((off, _clip), line) in enumerate(zip(lines, logged, strict=True)):
+        if abs(float(line.get("t", -1)) - float(off)) > 0.002:
+            failures.append(
+                f"{label}: timeline.json says line {n} was logged at "
+                f"{line.get('t')!r}s, the recorder logged it at {off:.3f}s — "
+                f"the record describes a mix of some other take's lines"
+            )
+        want = max(0.0, float(off) + clock.before(float(off)))
+        expected.append(want)
+        if abs(float(line.get("at", -1)) - want) > NARRATION_ONSET_TOLERANCE_S:
+            failures.append(
+                f"{label}: timeline.json puts line {n} at {line.get('at')!r}s "
+                f"of demo.mp4; this harness's own wall-clock reading puts the "
+                f"{off:.3f}s instant at {want:.3f}s ({clock.describe()}). The "
+                f"recorder and an independent sampler disagree about where "
+                f"the voice should be (issue #226)"
+            )
+
+    # (3). Nothing below reads the recorder's record — the file is the witness.
+    duration = doc.get("duration")
+    if not isinstance(duration, (int, float)):
+        return failures + [
+            f"{label}: timeline.json states duration={duration!r}, so there is "
+            f"no length to complement the silences against"
+        ]
+    spans = loud_spans(mp4, float(duration))
+    if spans is None:
+        return failures + [
+            f"{label}: ffmpeg reported no silence measurement for demo.mp4 at "
+            f"all — the measurement failed, which is not the same as a track "
+            f"with nothing in it"
+        ]
+    if len(spans) != len(lines):
+        return failures + [
+            f"{label}: demo.mp4 carries {len(spans)} stretch(es) of audio "
+            f"{spans} for {len(lines)} spoken line(s). Either two clips were "
+            f"mixed on top of each other or one is missing, and every window "
+            f"assertion in this arm can pass on both"
+        ]
+    if len(lines) != len(NARRATION_LINES):
+        return failures + [
+            f"{label}: the take spoke {len(lines)} line(s) and this file "
+            f"seeded {len(NARRATION_LINES)}, so there is no known clip length "
+            f"to measure the stretches in the file against"
+        ]
+    # The clip lengths this file seeded, in the order the storyboard speaks
+    # them — not probed back off the clips, which would ask the same question
+    # of the same files the recorder mixed.
+    wanted_spans = [seconds for _text, seconds in NARRATION_LINES]
+    for n, ((start, end), want, wanted_span) in enumerate(
+        zip(spans, expected, wanted_spans, strict=True)
+    ):
+        if abs(start - want) > NARRATION_ONSET_TOLERANCE_S:
+            failures.append(
+                f"{label}: line {n}'s audio starts at {start:.3f}s of "
+                f"demo.mp4, {(start - want) * 1000:+.0f} ms from the "
+                f"{want:.3f}s it belongs at, over the "
+                f"{NARRATION_ONSET_TOLERANCE_S * 1000:.0f} ms this grades. "
+                f"The voice is that far from the caption it was spoken for "
+                f"(issue #226)"
+            )
+        if abs((end - start) - wanted_span) > NARRATION_SPAN_TOLERANCE_S:
+            failures.append(
+                f"{label}: line {n} occupies {end - start:.3f}s of demo.mp4 "
+                f"against a {wanted_span:.3f}s clip — the onset is right and "
+                f"the clip is not what was mixed there"
+            )
+    return failures
+
+
+def check_narration_audio(out_dir: Path, lines: list, clock: HostClock) -> list[str]:
     """The mp4 carries audio where a line is, and silence where none is."""
     label = "narration"
     failures: list[str] = []
@@ -9867,14 +10085,16 @@ def check_narration_audio(out_dir: Path, lines: list) -> list[str]:
                 f"-c copy and cannot join streams that disagree"
             )
 
-    # The first line's offset, as the recorder logged it. Measured from the
-    # recorder's own `_lines` rather than from the beat log, because that list
-    # is what `_convert` turns into `adelay` values — grading the mix against
-    # anything else would grade agreement between two records instead of
-    # whether the audio is where the recorder said it put it.
+    # Where the first line is in the *video*. Measured from the recorder's own
+    # `_lines` — that list is what `_convert` turns into `adelay` values —
+    # plus this harness's own wall-clock reading, because the mix is on the
+    # video's clock and the log is not (issue #226). `before()` is zero on a
+    # host that did not step, so on a healthy box this is the offset it always
+    # was; on one that did, aiming this window at the raw offset would measure
+    # a stretch the clip had already left and report silence.
     if not lines:
         return failures + [f"{label}: the recorder logged no narration lines"]
-    first_offset = float(lines[0][0])
+    first_offset = max(0.0, float(lines[0][0]) + clock.before(float(lines[0][0])))
 
     loud = mean_dbfs(mp4, first_offset + 0.1, NARRATION_WINDOW_S)
     if loud is None:
@@ -9923,7 +10143,13 @@ def run_narration(out_root: Path) -> list[str]:
     out_dir = fresh_take_dir(out_root, "narration")
     with fixture_server() as base_url:
         try:
-            problems, info = record_narration(out_dir, base_url)
+            # The host's wall clock, watched for exactly as long as the take
+            # records. demo.mp4 is on that clock, the beat log is not, and
+            # since #226 the *audio* is on it too — so where a clip belongs is
+            # a question this watcher has to answer independently of the
+            # recorder's own record.
+            with watch_wall_clock() as clock:
+                problems, info = record_narration(out_dir, base_url, clock)
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"narration: Recorder raised {type(exc).__name__}: {exc}"]
     mp4 = out_dir / "demo.mp4"
@@ -9932,7 +10158,8 @@ def run_narration(out_root: Path) -> list[str]:
     failures = (
         problems
         + check_narration_pacing(out_dir)
-        + check_narration_audio(out_dir, info["lines"])
+        + check_narration_audio(out_dir, info["lines"], clock)
+        + check_narration_placement(out_dir, info["lines"], clock)
         + check_healthy("narration", out_dir)
         + check_overlay_cleared("narration", out_dir)
     )
@@ -9941,7 +10168,9 @@ def run_narration(out_root: Path) -> list[str]:
         print(
             f"smoke: narration ok ({len(info['lines'])} lines spoken from a "
             f"seeded cache at {offsets}, no key sent, audio present where a "
-            f"line is and silent before the first)"
+            f"line is and silent before the first, every clip's onset within "
+            f"{NARRATION_ONSET_TOLERANCE_S * 1000:.0f} ms of where the record "
+            f"says it went; {clock.describe()})"
         )
     return failures
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -9797,8 +9797,16 @@ def loud_spans(mp4: Path, duration: float) -> list[tuple[float, float]] | None:
 
 def expected_loud_spans(
     starts: list[float], lengths: list[float], gap: float = NARRATION_SILENCE_MIN_S
-) -> list[tuple[float, float]]:
+) -> list[tuple[float, float, tuple[int, ...]]]:
     """Where the clips should be audible in the mix, overlaps merged.
+
+    Returns `(start, end, the lines that span covers)`. **The membership is
+    load-bearing twice.** A span built from one clip can still be graded on
+    that clip's *duration* — two errors that cancel, an onset 110 ms early
+    against a clip 250 ms too long, satisfy an end-of-span bar and not a
+    duration one. And a failure has to name the line the reader should go and
+    listen to: with three lines and one merged pair, the second span is line 2
+    and calling it "line 1" sends them to the wrong clip.
 
     **Not one span per clip**, and the difference is the phenomenon this arm
     exists for. A backward wall-clock step shortens the *video* and not the
@@ -9817,13 +9825,17 @@ def expected_loud_spans(
     Written as a pure function so `tests/unit` can grade the overlap case,
     which no box produces on demand.
     """
-    spans: list[tuple[float, float]] = []
-    for start, length in sorted(zip(starts, lengths, strict=True)):
+    spans: list[tuple[float, float, tuple[int, ...]]] = []
+    ordered = sorted(
+        enumerate(zip(starts, lengths, strict=True)), key=lambda pair: pair[1][0]
+    )
+    for index, (start, length) in ordered:
         if spans and start - spans[-1][1] <= gap:
-            spans[-1] = (spans[-1][0], max(spans[-1][1], start + length))
+            first, end, members = spans[-1]
+            spans[-1] = (first, max(end, start + length), (*members, index))
         else:
-            spans.append((start, start + length))
-    return [(round(a, 3), round(b, 3)) for a, b in spans]
+            spans.append((start, start + length, (index,)))
+    return [(round(a, 3), round(b, 3), members) for a, b, members in spans]
 
 
 def record_narration(
@@ -9976,6 +9988,19 @@ def check_narration_placement(
     never corrected anything. The arithmetic of the correction is graded in
     `tests/unit` (`NarrationMix`) against scripted records; what this adds is
     that the clip really is in the file at the second the record names.
+
+    **And what it cannot say where the clips merge.** Once a step puts one
+    clip inside another, claim 3 sees one stretch and can only grade its two
+    edges — a short clip moved anywhere inside a long one, or dropped from the
+    mix entirely, changes neither. Measured on a real stepped take of this arm
+    (lines at 2.101 s and 3.301 s, a −1.073 s step at 2.214 s): line 1 mixed
+    0.772 s late reads clean, and line 1 omitted reads clean; the blind window
+    is about **1.17 s**, which is inside the 0.70–1.50 s band the defect lives
+    in. It needs the record to still name the right second, so claim 2 has to
+    have been satisfied by a lie that is consistent with itself. This is not a
+    regression — before the merge model the same regime returned "1 stretch
+    for 2 lines" for a *correct* mix too, so nothing there was graded at all —
+    but it is a hole, and it is in `tests/README.md`'s Known gaps.
     """
     label = "narration"
     failures: list[str] = []
@@ -10064,7 +10089,8 @@ def check_narration_placement(
     # probed back off the clips, which would ask the same question of the same
     # files the recorder mixed. Overlaps merged, because a corrected mix on a
     # stepped host really does produce them; see `expected_loud_spans`.
-    wanted = expected_loud_spans(expected, [s for _text, s in NARRATION_LINES])
+    clips = [seconds for _text, seconds in NARRATION_LINES]
+    wanted = expected_loud_spans(expected, clips)
     if len(spans) != len(wanted):
         return failures + [
             f"{label}: demo.mp4 carries {len(spans)} stretch(es) of audio "
@@ -10073,24 +10099,42 @@ def check_narration_placement(
             f"each other or one is missing, and every window assertion in this "
             f"arm can pass on both"
         ]
-    for n, ((start, end), (want, want_end)) in enumerate(
-        zip(spans, wanted, strict=True)
-    ):
+    for (start, end), (want, want_end, members) in zip(spans, wanted, strict=True):
+        # Named after the lines it really covers, not after its position:
+        # merging makes those two different, and a failure that names the
+        # wrong line sends the reader to the wrong clip.
+        whose = "line " + "+".join(str(m) for m in members)
         if abs(start - want) > NARRATION_ONSET_TOLERANCE_S:
             failures.append(
-                f"{label}: line {n}'s audio starts at {start:.3f}s of "
+                f"{label}: {whose}'s audio starts at {start:.3f}s of "
                 f"demo.mp4, {(start - want) * 1000:+.0f} ms from the "
                 f"{want:.3f}s it belongs at, over the "
                 f"{NARRATION_ONSET_TOLERANCE_S * 1000:.0f} ms this grades. "
                 f"The voice is that far from the caption it was spoken for "
                 f"(issue #226)"
             )
-        if abs(end - want_end) > NARRATION_SPAN_TOLERANCE_S:
+        if len(members) == 1:
+            # **The duration, wherever a span is one clip.** An end-of-span
+            # bar lets two errors cancel — an onset 110 ms early inside the
+            # 120 ms bar, against a 1.85 s stretch where 1.6 s was seeded,
+            # measured landing 140 ms from the wanted end and passing. That
+            # widens the effective length bar from 0.15 s to 0.27 s in the
+            # cancelling direction, and the length is expressible here.
+            clip = clips[members[0]]
+            if abs((end - start) - clip) > NARRATION_SPAN_TOLERANCE_S:
+                failures.append(
+                    f"{label}: {whose} occupies {end - start:.3f}s of demo.mp4 "
+                    f"against a {clip:.3f}s clip — the onset is right and the "
+                    f"clip is not what was mixed there"
+                )
+        elif abs(end - want_end) > NARRATION_SPAN_TOLERANCE_S:
+            # A merged span has no single clip length to be. Its end is the
+            # last clip's end, and that is the only length claim left; see the
+            # Known gaps entry for what merging hides.
             failures.append(
-                f"{label}: line {n}'s audio ends at {end:.3f}s of demo.mp4 "
-                f"against the {want_end:.3f}s a {want_end - want:.3f}s clip "
-                f"started there should reach — the onset is right and what was "
-                f"mixed at it is not the clip"
+                f"{label}: the merged stretch carrying {whose} ends at "
+                f"{end:.3f}s of demo.mp4 against the {want_end:.3f}s its clips "
+                f"should reach — something in it is not the clip it should be"
             )
     return failures
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -9795,6 +9795,37 @@ def loud_spans(mp4: Path, duration: float) -> list[tuple[float, float]] | None:
     return spans
 
 
+def expected_loud_spans(
+    starts: list[float], lengths: list[float], gap: float = NARRATION_SILENCE_MIN_S
+) -> list[tuple[float, float]]:
+    """Where the clips should be audible in the mix, overlaps merged.
+
+    **Not one span per clip**, and the difference is the phenomenon this arm
+    exists for. A backward wall-clock step shortens the *video* and not the
+    *audio*: the recorder waited line 0's clip out in monotonic time, but the
+    seconds the step deleted are not in the file to wait through, so a mix
+    corrected onto the video's clock can start line 1 while line 0 is still
+    playing. The two then sum into one continuous stretch, which is what
+    `silencedetect` reports and therefore what this has to predict.
+
+    Measured on a real stepped take of this arm, 2026-08-09: a −1.073 s step at
+    2.214 s put line 1's onset at 2.228 s, inside line 0's 1.028–2.628 s clip,
+    and `demo.mp4` carried **one** stretch for two lines. A model of "two lines,
+    two stretches" fails that take — the correction was right and the harness
+    was wrong, which is the direction that costs a real defect its diagnosis.
+
+    Written as a pure function so `tests/unit` can grade the overlap case,
+    which no box produces on demand.
+    """
+    spans: list[tuple[float, float]] = []
+    for start, length in sorted(zip(starts, lengths, strict=True)):
+        if spans and start - spans[-1][1] <= gap:
+            spans[-1] = (spans[-1][0], max(spans[-1][1], start + length))
+        else:
+            spans.append((start, start + length))
+    return [(round(a, 3), round(b, 3)) for a, b in spans]
+
+
 def record_narration(
     out_dir: Path, base_url: str, clock: HostClock
 ) -> tuple[list[str], dict]:
@@ -9951,6 +9982,23 @@ def check_narration_placement(
     mp4 = out_dir / "demo.mp4"
     if not lines:
         return [f"{label}: the recorder logged no narration lines"]
+    # **An uncovered reading is worse than no reading**, the same refusal
+    # `check_timeline` makes and for the same reason (issue #245): a watcher
+    # that was away for seconds still hands out a `before()`, and grading the
+    # audio against it would report a voice 1.26 s out of place on a mix that
+    # is exactly where it belongs. Refused loudly, and nothing below is graded
+    # on alignment — this is the harness declining to measure, not the
+    # recorder failing. `check_capture_clock` is what catches the other half,
+    # where *both* samplers stall and agree with each other (issue #247).
+    if not clock.covered:
+        return failures + [
+            f"{label}: this harness's own wall-clock watcher was away for up "
+            f"to {clock.max_gap:.2f}s (limit {HOST_CLOCK_MAX_GAP_S:.2f}s, "
+            f"{clock.samples} samples), so it cannot say where in the video a "
+            f"spoken line belongs. Nothing about the mix's placement is graded "
+            f"for this take. This is the harness refusing to measure, not the "
+            f"recorder failing (issue #247)"
+        ]
     try:
         doc = json.loads((out_dir / "timeline.json").read_text())
     except (OSError, json.JSONDecodeError) as exc:
@@ -10005,25 +10053,28 @@ def check_narration_placement(
             f"all — the measurement failed, which is not the same as a track "
             f"with nothing in it"
         ]
-    if len(spans) != len(lines):
-        return failures + [
-            f"{label}: demo.mp4 carries {len(spans)} stretch(es) of audio "
-            f"{spans} for {len(lines)} spoken line(s). Either two clips were "
-            f"mixed on top of each other or one is missing, and every window "
-            f"assertion in this arm can pass on both"
-        ]
     if len(lines) != len(NARRATION_LINES):
         return failures + [
             f"{label}: the take spoke {len(lines)} line(s) and this file "
             f"seeded {len(NARRATION_LINES)}, so there is no known clip length "
             f"to measure the stretches in the file against"
         ]
-    # The clip lengths this file seeded, in the order the storyboard speaks
-    # them — not probed back off the clips, which would ask the same question
-    # of the same files the recorder mixed.
-    wanted_spans = [seconds for _text, seconds in NARRATION_LINES]
-    for n, ((start, end), want, wanted_span) in enumerate(
-        zip(spans, expected, wanted_spans, strict=True)
+    # Where the clips should be audible: the seconds this harness derived
+    # above, each carrying the length of the tone **this file** seeded — not
+    # probed back off the clips, which would ask the same question of the same
+    # files the recorder mixed. Overlaps merged, because a corrected mix on a
+    # stepped host really does produce them; see `expected_loud_spans`.
+    wanted = expected_loud_spans(expected, [s for _text, s in NARRATION_LINES])
+    if len(spans) != len(wanted):
+        return failures + [
+            f"{label}: demo.mp4 carries {len(spans)} stretch(es) of audio "
+            f"{spans} where the {len(lines)} spoken line(s) should make "
+            f"{len(wanted)} {wanted}. Either two clips were mixed on top of "
+            f"each other or one is missing, and every window assertion in this "
+            f"arm can pass on both"
+        ]
+    for n, ((start, end), (want, want_end)) in enumerate(
+        zip(spans, wanted, strict=True)
     ):
         if abs(start - want) > NARRATION_ONSET_TOLERANCE_S:
             failures.append(
@@ -10034,11 +10085,12 @@ def check_narration_placement(
                 f"The voice is that far from the caption it was spoken for "
                 f"(issue #226)"
             )
-        if abs((end - start) - wanted_span) > NARRATION_SPAN_TOLERANCE_S:
+        if abs(end - want_end) > NARRATION_SPAN_TOLERANCE_S:
             failures.append(
-                f"{label}: line {n} occupies {end - start:.3f}s of demo.mp4 "
-                f"against a {wanted_span:.3f}s clip — the onset is right and "
-                f"the clip is not what was mixed there"
+                f"{label}: line {n}'s audio ends at {end:.3f}s of demo.mp4 "
+                f"against the {want_end:.3f}s a {want_end - want:.3f}s clip "
+                f"started there should reach — the onset is right and what was "
+                f"mixed at it is not the clip"
             )
     return failures
 
@@ -10094,6 +10146,16 @@ def check_narration_audio(out_dir: Path, lines: list, clock: HostClock) -> list[
     # a stretch the clip had already left and report silence.
     if not lines:
         return failures + [f"{label}: the recorder logged no narration lines"]
+    # Same refusal as `check_narration_placement`, for the same reason: an
+    # uncovered watcher's `before()` would aim this window at a second nobody
+    # measured, and report silence on a mix that is exactly where it belongs.
+    if not clock.covered:
+        return failures + [
+            f"{label}: this harness's own wall-clock watcher was away for up "
+            f"to {clock.max_gap:.2f}s ({clock.samples} samples), so the window "
+            f"this measures the first line in cannot be aimed. The stream "
+            f"shape above is still graded; the mix is not (issue #247)"
+        ]
     first_offset = max(0.0, float(lines[0][0]) + clock.before(float(lines[0][0])))
 
     loud = mean_dbfs(mp4, first_offset + 0.1, NARRATION_WINDOW_S)
@@ -10160,6 +10222,14 @@ def run_narration(out_root: Path) -> list[str]:
         + check_narration_pacing(out_dir)
         + check_narration_audio(out_dir, info["lines"], clock)
         + check_narration_placement(out_dir, info["lines"], clock)
+        # The other half of the coverage question, and the one neither check
+        # above can ask: they refuse when *this* watcher was away, which leaves
+        # the case where both samplers stalled, both reported nothing, and
+        # agreed (issue #247). This is the cross-check that grades the
+        # recorder's own `capture_clock` against this harness's — and since
+        # #226 that record is what the audio's placement is derived from, so
+        # the arm that mixes speech is a place it belongs.
+        + check_capture_clock("narration", out_dir, clock)
         + check_healthy("narration", out_dir)
         + check_overlay_cleared("narration", out_dir)
     )

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -249,15 +249,19 @@ INJECTIONS = [
     # first one. What moves is *where* it is, which is the thing a listener
     # notices and no window can see.
     Injection(
-        # The mix 150 ms from where the take's own record says it put the clip.
-        # Smaller than the 0.4 s window either bar measures, so both keep
-        # passing; large enough that the voice is visibly off its caption.
-        name="every narration clip is mixed 150 ms from where the record says",
+        # The mix 250 ms from where the take's own record says it put the clip.
+        # Still well inside the 0.4 s window either dBFS bar measures, so both
+        # keep passing; twice the onset bar, rather than sitting on it. The
+        # boundary was measured on this box during review — 110 ms passes
+        # clean, 150 ms fails, and the usable window is (120 ms, ~400 ms),
+        # above which the clip leaves the loud window and the other bar starts
+        # answering instead. 250 ms is the middle of it.
+        name="every narration clip is mixed 250 ms from where the record says",
         module="core.py",
         old="                    f\"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}"
         ':all=1[a{i}]"',
         new="                    f\"[{i + 1}:a]adelay={int(round(line['at'] * 1000))"
-        ' + 150}:all=1[a{i}]"',
+        ' + 250}:all=1[a{i}]"',
         arm="--narration-only",
         sites=("check_narration_placement",),
         must_contain=("voice is that far from the caption it was spoken for",),

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -235,11 +235,48 @@ INJECTIONS = [
         # reason the loud bar means anything, and it had never been seen fail.
         name="every narration clip is mixed in at the start of the take",
         module="core.py",
-        old='                    f"[{i + 1}:a]adelay={int(off * 1000)}:all=1[a{i}]"',
+        old="                    f\"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}"
+        ':all=1[a{i}]"',
         new='                    f"[{i + 1}:a]adelay=0:all=1[a{i}]"',
         arm="--narration-only",
         sites=("check_narration_audio",),
         must_contain=("audio is playing where no line was spoken",),
+    ),
+    # -- where the voice ended up (issue #226), 8 s an entry -------------------
+    #
+    # Both of these are invisible to the two window bars above: a clip is still
+    # mixed, still audible inside its own line, and still silent before the
+    # first one. What moves is *where* it is, which is the thing a listener
+    # notices and no window can see.
+    Injection(
+        # The mix 150 ms from where the take's own record says it put the clip.
+        # Smaller than the 0.4 s window either bar measures, so both keep
+        # passing; large enough that the voice is visibly off its caption.
+        name="every narration clip is mixed 150 ms from where the record says",
+        module="core.py",
+        old="                    f\"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}"
+        ':all=1[a{i}]"',
+        new="                    f\"[{i + 1}:a]adelay={int(round(line['at'] * 1000))"
+        ' + 150}:all=1[a{i}]"',
+        arm="--narration-only",
+        sites=("check_narration_placement",),
+        must_contain=("voice is that far from the caption it was spoken for",),
+    ),
+    Injection(
+        # The other direction, and the one the artifact carries: the clips go
+        # in correctly and `timeline.json` says they went in half a second
+        # later. Nothing in the audio is wrong, so only the cross-check against
+        # this harness's own wall-clock sampler can say so — which is the whole
+        # reason the arm now watches the clock itself.
+        name="the take's record misplaces the audio it mixed correctly",
+        module="core.py",
+        old='                narration = {"lines": plan, "clock_correction": clock}',
+        new="                narration = {"
+        '"lines": [{**x, "at": x["at"] + 0.5} for x in plan], '
+        '"clock_correction": clock}',
+        arm="--narration-only",
+        sites=("check_narration_placement",),
+        must_contain=("an independent sampler disagree about where",),
     ),
     # -- the coverage report (issue #12), 8 s an entry ------------------------
     Injection(

--- a/tests/unit
+++ b/tests/unit
@@ -5617,6 +5617,14 @@ class NarrationMix(unittest.TestCase):
             [{"t": 0.5, "at": 0.0, "clamped": 0.28}, {"t": 2.0, "at": 1.22}],
         )
 
+    def test_a_shortfall_that_rounds_away_is_not_called_a_truncation(self):
+        # `at` is written to three places, so a want of -4e-5 *is* `t` plus the
+        # steps before it at the precision of this record. A `clamped: 0.0`
+        # beside it would be a line claiming a truncation of nothing, against
+        # a field documented as absent when there is nothing to say.
+        _delays, record = self.mixed(clock_record((0.1, -0.50004)), 0.5)
+        self.assertEqual(record["lines"], [{"t": 0.5, "at": 0.0}])
+
     def test_the_clips_go_in_in_the_order_the_lines_were_spoken(self):
         # The count is nearly free to satisfy; this is that output K belongs to
         # input K. Line two's step is between them, so a mix that reversed the
@@ -5818,6 +5826,39 @@ class NarrationTimelineNote(unittest.TestCase):
         self.assertIn("1 of them could not be moved the whole way", text)
         self.assertIn("`clamped` is how many seconds", text)
 
+    def test_a_clamped_line_of_a_stitched_part_is_not_claimed_to_be_at_zero(self):
+        """A clamp on part two lands at part two's offset, not at 0.0.
+
+        The prose used to say "those clips start at the top of the track,
+        their `at` is 0.0", which is true of a take recorded in one piece and
+        false of every stitched part after the first — `stitch()` moves a
+        part's lines by its `offset` and `clamped` travels with them. A
+        published artifact naming a second the clip is not at is the failure
+        this whole field exists to prevent, and it is reachable whenever a
+        part's first line sits inside a backward step.
+        """
+        doc = self.doc(
+            {
+                "lines": [
+                    {"t": 2.0, "at": 1.22, "segment": "part1"},
+                    {"t": 8.0, "at": 7.5, "clamped": 0.28, "segment": "part2"},
+                ],
+                "clock_correction": {
+                    "applied": True,
+                    "total": -1.06,
+                    "steps": 2,
+                    "parts": 2,
+                    "parts_uncorrected": 0,
+                    "note": None,
+                },
+            }
+        )
+        text = render_timeline_md(doc)
+        self.assertIn("1 of them could not be moved the whole way", text)
+        self.assertIn("start where their own capture does", text)
+        self.assertNotIn("`at` is 0.0", text)
+        self.assertNotIn("top of the track", text)
+
     def test_a_take_with_nothing_clamped_says_nothing_about_clamping(self):
         # The control. Without it the sentence above is satisfied by a
         # paragraph that prints the caveat over every stepped take.
@@ -5948,6 +5989,30 @@ class MergedNarration(unittest.TestCase):
         self.assertIsNone(merged["narration"]["clock_correction"]["total"])
         self.assertIn(
             "the sampler was away", merged["narration"]["clock_correction"]["note"]
+        )
+
+    def test_a_clamped_line_keeps_its_shortfall_and_lands_at_its_parts_offset(self):
+        # `clamped` has to survive the merge, and the `at` it goes with is the
+        # part's offset rather than zero. Both halves matter: the number is
+        # what says the line did not get its whole correction, and 7.5 is
+        # where the clip actually is in the joined file.
+        clamped = merged_narration_of(
+            [
+                self.part((2.0, 1.22)),
+                {
+                    "lines": [{"t": 0.5, "at": 0.0, "clamped": 0.28}],
+                    "clock_correction": {
+                        "applied": True,
+                        "total": -0.78,
+                        "steps": 1,
+                        "note": None,
+                    },
+                },
+            ]
+        )
+        self.assertEqual(
+            clamped["narration"]["lines"][1],
+            {"t": 8.0, "at": 7.5, "clamped": 0.28, "segment": "part2"},
         )
 
     def test_the_refusal_says_how_many_of_the_parts_it_is_about(self):
@@ -6086,32 +6151,58 @@ class NarrationSpanModel(unittest.TestCase):
         # assertion below is satisfied by a function that merges everything.
         self.assertEqual(
             self.spans([0.963, 3.228], [1.6, 0.3]),
-            [(0.963, 2.563), (3.228, 3.528)],
+            [(0.963, 2.563, (0,)), (3.228, 3.528, (1,))],
         )
 
     def test_a_clip_starting_inside_the_previous_one_is_one_span(self):
         # The measured take, written out: the step put line 1 0.4 s inside
         # line 0, and the file carries 1.028-2.628 s of continuous audio.
-        self.assertEqual(self.spans([1.028, 2.228], [1.6, 0.3]), [(1.028, 2.628)])
+        self.assertEqual(
+            self.spans([1.028, 2.228], [1.6, 0.3]), [(1.028, 2.628, (0, 1))]
+        )
 
     def test_a_merged_span_reaches_the_later_of_the_two_ends(self):
         # ...and the other overlap, where the second clip outlives the first.
         # Taking the first clip's end would under-predict the stretch and go
         # red about a clip that is exactly where it belongs.
-        self.assertEqual(self.spans([1.0, 1.2], [0.3, 1.6]), [(1.0, 2.8)])
+        self.assertEqual(self.spans([1.0, 1.2], [0.3, 1.6]), [(1.0, 2.8, (0, 1))])
 
     def test_clips_closer_than_the_detector_can_separate_are_one_span(self):
         # `silencedetect` only reports a silence at least `d` long, so two
         # clips 40 ms apart come back as one stretch whatever the arithmetic
         # says. The prediction has to agree with the measurement's resolution.
-        self.assertEqual(self.spans([1.0, 2.64], [1.6, 0.3], gap=0.08), [(1.0, 2.94)])
+        self.assertEqual(
+            self.spans([1.0, 2.64], [1.6, 0.3], gap=0.08), [(1.0, 2.94, (0, 1))]
+        )
 
     def test_a_gap_the_detector_can_see_stays_two_spans(self):
         # The boundary from the other side, and the reason the case above is
         # not just "merge anything close".
         self.assertEqual(
             self.spans([1.0, 2.7], [1.6, 0.3], gap=0.08),
-            [(1.0, 2.6), (2.7, 3.0)],
+            [(1.0, 2.6, (0,)), (2.7, 3.0, (1,))],
+        )
+
+    def test_a_span_names_the_lines_it_covers_and_not_its_own_position(self):
+        """Membership, which is what keeps two later claims honest.
+
+        A span built from one clip can still be graded on that clip's
+        *duration*, and an end-of-span bar cannot — an onset 110 ms early
+        against a clip 250 ms too long satisfies the second and not the first.
+        And a failure has to name the line to go and listen to: here the
+        second span is line 2, and calling it "line 1" after its position
+        sends the reader to a clip that is fine.
+        """
+        found = self.spans([1.0, 1.2, 4.0], [1.6, 0.3, 0.5])
+        self.assertEqual([members for _s, _e, members in found], [(0, 1), (2,)])
+
+    def test_membership_follows_the_clip_and_not_the_order_it_was_given(self):
+        # The lines are sorted by where they land, which on a stepped take is
+        # not the order they were spoken in. The indices have to travel with
+        # the clip through that sort, or every message names the wrong line.
+        self.assertEqual(
+            self.spans([4.0, 1.0], [0.3, 0.5]),
+            [(1.0, 1.5, (1,)), (4.0, 4.3, (0,))],
         )
 
 
@@ -6395,9 +6486,25 @@ INJECTIONS = [
         # and a reader correcting by hand corrects it twice.
         "a truncated correction is published as though it were whole",
         "narration.py",
-        "        if want < 0:",
-        "        if want < -1e9:",
+        "        if clamped:",
+        "        if False:",
         ["NarrationMix.test_a_clamped_line_says_how_much_of_its_correction_it_lost"],
+    ),
+    (
+        # ...and the other side of the same key: a shortfall of 4e-5 s, which
+        # is nothing at the three places `at` is written to, published as a
+        # truncation. The field is documented as absent when there is nothing
+        # to say, and a reader who trusts that reads a line as truncated when
+        # its `at` really is `t` plus the steps before it.
+        "a shortfall too small to write down is still called a truncation",
+        "narration.py",
+        "        clamped = round(-want, 3) if want < 0 else 0.0",
+        "        clamped = -want if want < 0 else 0.0",
+        # Only the rounding case, and that is the whole point: this box's
+        # 0.5 + (-0.78) is exactly -0.28, so the ordinary clamped line reads
+        # the same with the rounding gone. The shortfall nobody can write down
+        # is the only observable there is.
+        ["NarrationMix.test_a_shortfall_that_rounds_away_is_not_called_a_truncation"],
     ),
     (
         # ...and the renderer's half of the same claim, which the injection
@@ -6411,6 +6518,26 @@ INJECTIONS = [
         [
             "NarrationTimelineNote."
             "test_a_truncated_correction_is_named_beside_the_rule_it_breaks"
+        ],
+    ),
+    (
+        # The sentence as it shipped in the first round of #226, which is true
+        # of a take recorded in one piece and false of every stitched part
+        # after the first: `stitch()` moves a clamped line by its part's
+        # `offset`, so its `at` is 7.5 and not 0.0. A published artifact
+        # naming a second the clip is not at.
+        "timeline.md says a clamped clip is at the top of the track",
+        "timeline.py",
+        '        f"and `adelay` cannot express a negative delay. Those clips start where "\n'
+        '        f"their own capture does — the top of the file on a take recorded in "\n'
+        '        f"one piece, that part\'s `offset` on a stitched demo — and `clamped` is "\n'
+        '        f"how many seconds of the correction that boundary swallowed."',
+        '        f"and `adelay` cannot express a negative delay. Those clips start at "\n'
+        '        f"the top of the track, their `at` is 0.0, and `clamped` is "\n'
+        '        f"how many seconds of the correction that boundary swallowed."',
+        [
+            "NarrationTimelineNote."
+            "test_a_clamped_line_of_a_stitched_part_is_not_claimed_to_be_at_zero"
         ],
     ),
     (
@@ -6441,6 +6568,37 @@ INJECTIONS = [
             "NarrationSpanModel.test_a_merged_span_reaches_the_later_of_the_two_ends",
             "NarrationSpanModel."
             "test_clips_closer_than_the_detector_can_separate_are_one_span",
+        ],
+    ),
+    (
+        # A span labelled by its position instead of by the clip it carries.
+        # With one merged pair every later span names a line one too low, so
+        # a failure sends the reader to a clip that is fine — and the
+        # single-clip duration bar, which is chosen on membership, is applied
+        # to the wrong clip's length.
+        "a merged span is labelled by its position rather than by its clips",
+        "tests/smoke",
+        "            spans[-1] = (first, max(end, start + length), (*members, index))",
+        "            spans[-1] = (first, max(end, start + length), members)",
+        [
+            "NarrationSpanModel."
+            "test_a_span_names_the_lines_it_covers_and_not_its_own_position",
+            "NarrationSpanModel.test_a_clip_starting_inside_the_previous_one_is_one_span",
+        ],
+    ),
+    (
+        # The indices dropped through the sort. On a stepped take the clips do
+        # not land in the order they were spoken, so a membership derived from
+        # position after sorting names the wrong line every time.
+        "the span model loses which clip is which when it sorts them",
+        "tests/smoke",
+        "    ordered = sorted(\n"
+        "        enumerate(zip(starts, lengths, strict=True)), key=lambda pair: pair[1][0]\n"
+        "    )",
+        "    ordered = list(enumerate(sorted(zip(starts, lengths, strict=True))))",
+        [
+            "NarrationSpanModel."
+            "test_membership_follows_the_clip_and_not_the_order_it_was_given",
         ],
     ),
     (

--- a/tests/unit
+++ b/tests/unit
@@ -5601,6 +5601,22 @@ class NarrationMix(unittest.TestCase):
         delays, _record = self.mixed(clock_record((0.1, -0.78)), 0.5, 2.0)
         self.assertEqual(delays, [0, 1220])
 
+    def test_a_clamped_line_says_how_much_of_its_correction_it_lost(self):
+        """The floor above makes the artifact's headline false for one line.
+
+        Every other line's `at` is its `t` plus the steps before it, which is
+        what `timeline.md` says about all of them. This one moved −0.5 and not
+        −0.78, and without `clamped` nothing distinguishes it from a line the
+        clock happened to put at zero — a reader correcting by hand would
+        correct it twice. Absent from the lines that got the whole of theirs,
+        so its presence is the whole signal.
+        """
+        _delays, record = self.mixed(clock_record((0.1, -0.78)), 0.5, 2.0)
+        self.assertEqual(
+            record["lines"],
+            [{"t": 0.5, "at": 0.0, "clamped": 0.28}, {"t": 2.0, "at": 1.22}],
+        )
+
     def test_the_clips_go_in_in_the_order_the_lines_were_spoken(self):
         # The count is nearly free to satisfy; this is that output K belongs to
         # input K. Line two's step is between them, so a mix that reversed the
@@ -5766,6 +5782,92 @@ class NarrationTimelineNote(unittest.TestCase):
         self.assertIn("mixed where the host's stepped clock puts them", text)
         self.assertNotIn("uncorrected", text)
 
+    def test_steps_that_cancel_are_still_a_correction_worth_stating(self):
+        """Decided on the **count**, never on the total.
+
+        The host this work exists for moves in pulses — up 0.9 s, back down
+        0.9 s — so a take that catches both totals zero while every line mixed
+        between them has moved by nearly a second. A paragraph that branched on
+        the total would go silent over exactly that, and the reader would take
+        the table's timestamps for the seconds the voice is at.
+        `frames.py` carries this same guard, with this same test.
+        """
+        text = render_timeline_md(
+            self.doc(
+                self.record({"applied": True, "total": 0.0, "steps": 2, "note": None})
+            )
+        )
+        self.assertIn("mixed where the host's stepped clock puts them", text)
+
+    def test_a_truncated_correction_is_named_beside_the_rule_it_breaks(self):
+        # The sentence above says each `at` is its `t` plus the steps before
+        # it. For a clamped line that is false, and it is false in the
+        # artifact rather than only in the code.
+        doc = self.doc(
+            {
+                "lines": [{"t": 0.3, "at": 0.0, "clamped": 0.7}, {"t": 4.0, "at": 3.0}],
+                "clock_correction": {
+                    "applied": True,
+                    "total": -1.0,
+                    "steps": 1,
+                    "note": None,
+                },
+            }
+        )
+        text = render_timeline_md(doc)
+        self.assertIn("1 of them could not be moved the whole way", text)
+        self.assertIn("`clamped` is how many seconds", text)
+
+    def test_a_take_with_nothing_clamped_says_nothing_about_clamping(self):
+        # The control. Without it the sentence above is satisfied by a
+        # paragraph that prints the caveat over every stepped take.
+        text = render_timeline_md(
+            self.doc(
+                self.record({"applied": True, "total": -0.78, "steps": 1, "note": None})
+            )
+        )
+        self.assertIn("mixed where the host's stepped clock puts them", text)
+        self.assertNotIn("could not be moved the whole way", text)
+
+    def test_a_demo_where_only_some_parts_could_correct_says_how_many(self):
+        # A merged record knows what fraction of the demo its refusal is
+        # about. Saying "the 3 spoken lines were mixed uncorrected" over a demo
+        # where two of them were corrected is pessimistic and still untrue.
+        doc = self.doc(
+            {
+                "lines": [{"t": 2.0, "at": 1.22}, {"t": 8.5, "at": 8.5}],
+                "clock_correction": {
+                    "applied": False,
+                    "total": None,
+                    "steps": 0,
+                    "parts": 2,
+                    "parts_uncorrected": 1,
+                    "note": "part2 mixed its narration at the beat-log offsets",
+                },
+            }
+        )
+        text = render_timeline_md(doc)
+        self.assertIn("lines of 1 of this demo's 2 narrated segment(s)", text)
+        self.assertNotIn("The 2 spoken line(s) were mixed at their beat-log", text)
+
+    def test_a_single_take_still_speaks_about_its_own_lines(self):
+        # The control for the sentence above: a record with no parts to count
+        # keeps the wording that names the lines, rather than losing the
+        # subject of the sentence to a merged-only key.
+        text = render_timeline_md(
+            self.doc(
+                self.record(
+                    {
+                        "applied": False,
+                        "total": None,
+                        "steps": 0,
+                        "note": "the sampler was away for up to 5.50s",
+                    }
+                )
+            )
+        )
+        self.assertIn("The 1 spoken line(s) were mixed at their beat-log", text)
+
     def test_the_ordinary_take_says_nothing_about_its_narration(self):
         # A watched clock that held still put every line exactly where the log
         # says. A paragraph on every timeline is a paragraph nobody reads, and
@@ -5847,6 +5949,17 @@ class MergedNarration(unittest.TestCase):
         self.assertIn(
             "the sampler was away", merged["narration"]["clock_correction"]["note"]
         )
+
+    def test_the_refusal_says_how_many_of_the_parts_it_is_about(self):
+        # `applied` is all-or-nothing on purpose, so the counts are what keep
+        # the artifact from reporting a demo where one part of two could not
+        # correct as a demo where neither could.
+        merged = merged_narration_of(
+            [self.part((2.0, 1.22)), self.part((1.0, 1.0), applied=False)]
+        )
+        state = merged["narration"]["clock_correction"]
+        self.assertEqual((state["parts"], state["parts_uncorrected"]), (2, 1))
+        self.assertIn("part2 mixed its narration", state["note"])
 
     def test_a_demo_whose_parts_all_corrected_states_the_whole_correction(self):
         merged = merged_narration_of([self.part((2.0, 1.22)), self.part((1.0, 0.4))])
@@ -5945,6 +6058,61 @@ class _StubWatcher:
     @property
     def covered(self) -> bool:
         return self.samples > 1 and self.max_gap <= 0.25
+
+
+class NarrationSpanModel(unittest.TestCase):
+    """`tests/smoke`'s prediction of where the mix is audible (issue #226).
+
+    Here rather than in `tests/smoke-inject` for the reason `ClockCoverageCheck`
+    gives: the case that matters cannot be produced on demand. A backward
+    wall-clock step shortens the video and not the audio, so a mix corrected
+    onto the video's clock can start one clip while the previous is still
+    playing — and `silencedetect` then reports **one** stretch for two lines.
+
+    This is not hypothetical and it is why the function exists. The first
+    version of the smoke check asserted one stretch per line; a real take of
+    the arm on 2026-08-09 stepped −1.073 s at 2.214 s, the corrected mix put
+    line 1 at 2.228 s inside line 0's 1.028–2.628 s clip, the file carried one
+    stretch, and the arm went red about a correction that was right. A harness
+    whose model breaks on the phenomenon it grades costs that phenomenon its
+    diagnosis.
+    """
+
+    def setUp(self):
+        self.spans = _smoke_module().expected_loud_spans
+
+    def test_clips_that_do_not_touch_are_one_span_each(self):
+        # The control, and the steady host's answer: without it every
+        # assertion below is satisfied by a function that merges everything.
+        self.assertEqual(
+            self.spans([0.963, 3.228], [1.6, 0.3]),
+            [(0.963, 2.563), (3.228, 3.528)],
+        )
+
+    def test_a_clip_starting_inside_the_previous_one_is_one_span(self):
+        # The measured take, written out: the step put line 1 0.4 s inside
+        # line 0, and the file carries 1.028-2.628 s of continuous audio.
+        self.assertEqual(self.spans([1.028, 2.228], [1.6, 0.3]), [(1.028, 2.628)])
+
+    def test_a_merged_span_reaches_the_later_of_the_two_ends(self):
+        # ...and the other overlap, where the second clip outlives the first.
+        # Taking the first clip's end would under-predict the stretch and go
+        # red about a clip that is exactly where it belongs.
+        self.assertEqual(self.spans([1.0, 1.2], [0.3, 1.6]), [(1.0, 2.8)])
+
+    def test_clips_closer_than_the_detector_can_separate_are_one_span(self):
+        # `silencedetect` only reports a silence at least `d` long, so two
+        # clips 40 ms apart come back as one stretch whatever the arithmetic
+        # says. The prediction has to agree with the measurement's resolution.
+        self.assertEqual(self.spans([1.0, 2.64], [1.6, 0.3], gap=0.08), [(1.0, 2.94)])
+
+    def test_a_gap_the_detector_can_see_stays_two_spans(self):
+        # The boundary from the other side, and the reason the case above is
+        # not just "merge anything close".
+        self.assertEqual(
+            self.spans([1.0, 2.7], [1.6, 0.3], gap=0.08),
+            [(1.0, 2.6), (2.7, 3.0)],
+        )
 
 
 class ClockCoverageCheck(unittest.TestCase):
@@ -6163,9 +6331,8 @@ INJECTIONS = [
         # take's running total, including the ones spoken before the step.
         "each clip is corrected by the take's total rather than by its own instant",
         "narration.py",
-        '        {"t": round(float(off), 3), "at": round(max(0.0, float(off) + shift(off)), 3)}',
-        '        {"t": round(float(off), 3), "at": round(max(0.0, float(off) '
-        '+ shift(float("inf"))), 3)}',
+        "        want = float(off) + shift(off)",
+        '        want = float(off) + shift(float("inf"))',
         [
             "NarrationMix.test_a_step_after_a_line_does_not_move_that_lines_clip",
             "NarrationMix.test_steps_that_cancel_still_move_a_line_mixed_between_them",
@@ -6197,10 +6364,83 @@ INJECTIONS = [
         # one line — it costs the take its whole audio track.
         "a line the clock stepped past is given a negative delay",
         "narration.py",
-        '        {"t": round(float(off), 3), "at": round(max(0.0, float(off) + shift(off)), 3)}',
-        '        {"t": round(float(off), 3), "at": round(float(off) + shift(off), 3)}',
+        '        line = {"t": round(float(off), 3), "at": round(max(0.0, want), 3)}',
+        '        line = {"t": round(float(off), 3), "at": round(want, 3)}',
         [
             "NarrationMix.test_a_step_bigger_than_a_lines_offset_starts_the_clip_at_zero",
+            "NarrationMix.test_a_clamped_line_says_how_much_of_its_correction_it_lost",
+        ],
+    ),
+    (
+        # The paragraph decided on the take's **total** instead of on how many
+        # times the clock moved. Two steps that cancel — a +0.9 s pulse and the
+        # −0.9 s that undoes it, which is the shape of the host this work
+        # exists for — total zero, and every line mixed between them has moved
+        # by nearly a second. `frames.py` carries the same guard and has
+        # carried this injection since #253; this one did not, and the review
+        # of #226 found it passing 275/275 against exactly this mutation.
+        "timeline.md reads a pulse and its undo as a mix that did not move",
+        "timeline.py",
+        '    if not clock.get("steps"):',
+        '    if not (clock.get("total") or 0.0):',
+        [
+            "NarrationTimelineNote."
+            "test_steps_that_cancel_are_still_a_correction_worth_stating"
+        ],
+    ),
+    (
+        # The line that hit the zero floor, published as though it had been
+        # corrected like the rest. The headline sentence above it says every
+        # `at` is its `t` plus the steps before it; for this one that is false,
+        # and a reader correcting by hand corrects it twice.
+        "a truncated correction is published as though it were whole",
+        "narration.py",
+        "        if want < 0:",
+        "        if want < -1e9:",
+        ["NarrationMix.test_a_clamped_line_says_how_much_of_its_correction_it_lost"],
+    ),
+    (
+        # ...and the renderer's half of the same claim, which the injection
+        # above cannot reach: it builds its record by hand, so a `mix_plan`
+        # that still marks the line and a `timeline.md` that stops mentioning
+        # it are two different failures.
+        "timeline.md stops naming the lines whose correction was truncated",
+        "timeline.py",
+        '    clamped = [line for line in lines if line.get("clamped")]',
+        "    clamped = []",
+        [
+            "NarrationTimelineNote."
+            "test_a_truncated_correction_is_named_beside_the_rule_it_breaks"
+        ],
+    ),
+    (
+        # A stitched demo's refusal reported as the whole demo's when it is one
+        # part's. Pessimistic rather than dangerous, and still not what
+        # happened — the counts are the only thing that makes the sentence
+        # true, so nothing may quietly stop computing them.
+        "a stitched demo forgets how many of its parts could not correct",
+        "stitching.py",
+        '            "parts_uncorrected": len(refused),',
+        '            "parts_uncorrected": 0,',
+        [
+            "MergedNarration.test_the_refusal_says_how_many_of_the_parts_it_is_about",
+        ],
+    ),
+    (
+        # The smoke harness back to "one line, one stretch of audio" — the
+        # model a real stepped take of the narration arm falsified. It is a
+        # break in `tests/smoke` rather than in the recorder because the defect
+        # was the harness's, and the direction it fails in is the expensive
+        # one: red about a correction that was right.
+        "the smoke harness expects one audible stretch per spoken line",
+        "tests/smoke",
+        "        if spans and start - spans[-1][1] <= gap:",
+        "        if spans and start - spans[-1][1] <= -1e9:",
+        [
+            "NarrationSpanModel.test_a_clip_starting_inside_the_previous_one_is_one_span",
+            "NarrationSpanModel.test_a_merged_span_reaches_the_later_of_the_two_ends",
+            "NarrationSpanModel."
+            "test_clips_closer_than_the_detector_can_separate_are_one_span",
         ],
     ),
     (
@@ -6253,11 +6493,12 @@ INJECTIONS = [
         # one file and a listener plays all of it.
         "a part that could not correct its mix is outvoted by the parts that did",
         "stitching.py",
-        '            applied = False\n            note = note or state.get("note")',
-        '            note = note or state.get("note")',
+        '            refused.append(str(record["segment"]))',
+        "            pass",
         [
             "MergedNarration."
-            "test_one_part_that_could_not_correct_its_mix_refuses_for_the_demo"
+            "test_one_part_that_could_not_correct_its_mix_refuses_for_the_demo",
+            "MergedNarration.test_the_refusal_says_how_many_of_the_parts_it_is_about",
         ],
     ),
     (

--- a/tests/unit
+++ b/tests/unit
@@ -101,6 +101,7 @@ from demo_recording.narration import (  # noqa: E402
     TTS_KEY_CHARS,
     TTS_KEY_SEP,
     _tts_key,
+    mix_plan,
 )
 from demo_recording.stitching import _merged_timeline  # noqa: E402
 from demo_recording.target import TargetRefused  # noqa: E402
@@ -5503,6 +5504,381 @@ class TimelineClockNote(unittest.TestCase):
         self.assertNotIn("was not measured", text)
 
 
+class _ScriptedClock:
+    """A `_CaptureClock` that reports a record somebody wrote down.
+
+    Substituted onto a real recorder for the same reason `clock_record` exists
+    at all: a box either steps its wall clock or it does not, and on one that
+    does not a corrected mix and an uncorrected one are the same ffmpeg command
+    line. Everything about the stepped case here is scripted; that the video
+    really follows the host's clock was measured off the pixels of six takes
+    (#229, #250) and is not this file's claim.
+    """
+
+    def __init__(self, record: dict) -> None:
+        self._record = record
+
+    def report(self) -> dict:
+        return dict(self._record)
+
+
+class NarrationMix(unittest.TestCase):
+    """Where a spoken line ends up in the encoded audio (issue #226).
+
+    `_convert` used to `adelay` each clip by the offset the beat log recorded,
+    which is `time.monotonic()`; the video it is mixed into is stamped with the
+    host's wall clock. So every step the host took during a take moved the
+    picture and left the voice behind — #18's second comment measured **+0.70 s
+    of lag on all three lines** of a take that stalled in its run-up, against
+    +0.11 to +0.14 s in a clean one.
+
+    This is the one consequence of the two clocks a *viewer* meets rather than
+    a manifest reader, which is why the delays below are read out of the
+    **ffmpeg command line** and not out of the record the take publishes: a
+    document that printed a corrected offset over a clip mixed somewhere else
+    would satisfy an assertion that only read the document, and that is the
+    artifact-lies shape the record exists to prevent.
+    """
+
+    def mixed(self, clock: object, *offsets: float) -> tuple[list[int], object]:
+        """(the adelay ms ffmpeg was really handed, the take's own record)."""
+        rec = recorder(self, cls=TermRec)
+        rec._speech = True
+        if clock is not None:
+            rec._capture_clock = _ScriptedClock(clock)  # type: ignore[assignment]
+        rec._lines = [
+            (off, Path(f"/nonexistent/line-{n}.mp3")) for n, off in enumerate(offsets)
+        ]
+        seen: list[list[str]] = []
+
+        def run(cmd, **kwargs):
+            seen.append([str(part) for part in cmd])
+            Path(str(cmd[-1])).write_bytes(b"a stand-in for a recording")
+            return subprocess.CompletedProcess(cmd, 0)
+
+        was = core_module.subprocess.run
+        core_module.subprocess.run = run
+        try:
+            with contextlib.redirect_stdout(io.StringIO()):
+                rec._convert(Path(rec.out_dir) / "take.webm")
+        finally:
+            core_module.subprocess.run = was
+        self.assertEqual(len(seen), 1, f"expected one ffmpeg call, got {seen!r}")
+        cmd = seen[0]
+        self.assertIn("-filter_complex", cmd, "the mix went in without a filter graph")
+        graph = cmd[cmd.index("-filter_complex") + 1]
+        return [int(ms) for ms in re.findall(r"adelay=(-?\d+):", graph)], rec._narration
+
+    # -- the instant each clip is delayed by --------------------------------
+
+    def test_a_line_is_mixed_where_its_own_offset_sits_in_the_video(self):
+        # The clock gave up 0.78 s at 1.0 s, so the moment the log calls 2.0 s
+        # is 1.22 s into the file. The line before the step does not move.
+        # Both numbers are written out here rather than derived from the record.
+        delays, _record = self.mixed(clock_record((1.0, -0.78)), 0.5, 2.0)
+        self.assertEqual(delays, [500, 1220])
+
+    def test_a_step_after_a_line_does_not_move_that_lines_clip(self):
+        # The correction is indexed by the **instant**, not by the take. A
+        # reader applying the record's `total` to every clip would put both of
+        # these 0.78 s from the moment they name — and on a stepped take that
+        # is the whole defect, moved from one clock to the other.
+        delays, _record = self.mixed(clock_record((4.0, -0.78)), 0.5, 2.0)
+        self.assertEqual(delays, [500, 2000])
+
+    def test_steps_that_cancel_still_move_a_line_mixed_between_them(self):
+        # The host this work exists for moves in *pulses* — up 0.9 s, back down
+        # 0.9 s. The take totals zero and every line spoken between the two has
+        # moved by nearly a second, which at 25 fps is 22 frames of a caption
+        # the voice no longer matches.
+        delays, _record = self.mixed(clock_record((2.0, 0.9), (8.0, -0.9)), 5.0)
+        self.assertEqual(delays, [5900])
+
+    def test_a_step_bigger_than_a_lines_offset_starts_the_clip_at_zero(self):
+        # That wall time is not in the file at all, and `adelay` cannot express
+        # a negative delay — ffmpeg refuses the filter outright, which would
+        # cost the take its whole audio track rather than one line's placement.
+        delays, _record = self.mixed(clock_record((0.1, -0.78)), 0.5, 2.0)
+        self.assertEqual(delays, [0, 1220])
+
+    def test_the_clips_go_in_in_the_order_the_lines_were_spoken(self):
+        # The count is nearly free to satisfy; this is that output K belongs to
+        # input K. Line two's step is between them, so a mix that reversed the
+        # pair would still carry two delays adding to the same total.
+        delays, _record = self.mixed(clock_record((1.0, -0.78)), 0.5, 2.0, 3.0)
+        self.assertEqual(delays, [500, 1220, 2220])
+
+    # -- and what the take writes down about it ------------------------------
+
+    def test_the_record_names_where_each_line_was_logged_and_where_it_went(self):
+        delays, record = self.mixed(clock_record((1.0, -0.78)), 0.5, 2.0)
+        self.assertEqual(
+            record["lines"], [{"t": 0.5, "at": 0.5}, {"t": 2.0, "at": 1.22}]
+        )
+        # ...and the two agree, which is the half that keeps the document from
+        # describing a mix that happened somewhere else.
+        self.assertEqual([int(round(x["at"] * 1000)) for x in record["lines"]], delays)
+
+    def test_a_take_nobody_watched_the_clock_of_is_mixed_raw_and_says_so(self):
+        # The case that looks like the healthy one: `steps` is an empty list
+        # here too (#247), so a consumer reading only `steps` cannot tell "the
+        # clock held still" from "nobody was watching". The raw offset is still
+        # the number used — there is no other — but it is a fallback, and a
+        # record that let it read as a correction is the confidently-wrong
+        # artifact this flag exists to prevent.
+        delays, record = self.mixed(
+            clock_record((1.0, -0.78), measured=False), 0.5, 2.0
+        )
+        self.assertEqual(delays, [500, 2000])
+        self.assertIs(record["clock_correction"]["applied"], False)
+        self.assertIsNone(record["clock_correction"]["total"])
+        self.assertIn(
+            "the sampler was away for up to 5.50s", record["clock_correction"]["note"]
+        )
+
+    def test_a_watched_clock_that_held_still_is_stated_as_a_correction(self):
+        delays, record = self.mixed(clock_record(), 0.5, 2.0)
+        self.assertEqual(delays, [500, 2000])
+        self.assertIs(record["clock_correction"]["applied"], True)
+        self.assertEqual(record["clock_correction"]["steps"], 0)
+        self.assertIsNone(record["clock_correction"]["note"])
+
+    def test_a_stepped_take_states_the_correction_it_applied(self):
+        _delays, record = self.mixed(clock_record((1.0, -0.78)), 0.5, 2.0)
+        self.assertIs(record["clock_correction"]["applied"], True)
+        self.assertEqual(record["clock_correction"]["steps"], 1)
+        self.assertAlmostEqual(record["clock_correction"]["total"], -0.78, places=4)
+
+    def test_a_take_that_spoke_nothing_claims_no_mix_at_all(self):
+        # Narration on, no lines: the segment still gets its silent track so
+        # `stitch()` can concat, and there is no placement to describe.
+        delays, record = self.mixed(clock_record((1.0, -0.78)))
+        self.assertEqual(delays, [])
+        self.assertIsNone(record)
+
+    def test_a_conversion_that_failed_claims_no_mix_either(self):
+        # `narration` says where the audio of *this* mp4 is. ffmpeg raising
+        # leaves no mp4 this take wrote — the same reason `duration` is gated
+        # on `_converted` rather than on the file existing (issue #20).
+        rec = recorder(self, cls=TermRec)
+        rec._speech = True
+        rec._capture_clock = _ScriptedClock(clock_record((1.0, -0.78)))
+        rec._lines = [(0.5, Path("/nonexistent/line-0.mp3"))]
+
+        def run(cmd, **kwargs):
+            raise subprocess.CalledProcessError(1, cmd)
+
+        was = core_module.subprocess.run
+        core_module.subprocess.run = run
+        try:
+            with self.assertRaises(subprocess.CalledProcessError):
+                rec._convert(Path(rec.out_dir) / "take.webm")
+        finally:
+            core_module.subprocess.run = was
+        self.assertIsNone(rec._narration)
+
+    def test_the_timeline_carries_the_record_the_mix_wrote(self):
+        # The link between the two, without which every assertion above grades
+        # a field nobody reads: `_timeline_doc` publishes what `_convert` set,
+        # rather than recomputing it from a record read a second time.
+        rec = recorder(self, cls=TermRec)
+        rec._narration = {"lines": [{"t": 0.5, "at": 0.5}], "clock_correction": {}}
+        with contextlib.redirect_stderr(io.StringIO()):
+            doc = rec._timeline_doc()
+        self.assertIs(doc["narration"], rec._narration)
+
+
+class NarrationMixPlan(unittest.TestCase):
+    """`mix_plan` on the record shapes a recorder cannot produce (#226).
+
+    Two of the three states reach the mix only through a document: a timeline
+    with no `capture_clock` at all, and a record whose steps are not in a shape
+    anything can attribute. `_CaptureClock.report()` always returns a
+    well-formed dict, so they are asked of the function directly.
+    """
+
+    def test_no_record_at_all_mixes_raw_and_refuses_to_call_it_a_correction(self):
+        lines, state = mix_plan([0.5, 2.0], None)
+        self.assertEqual([line["at"] for line in lines], [0.5, 2.0])
+        self.assertIs(state["applied"], False)
+        self.assertIn("no capture_clock", state["note"])
+
+    def test_a_step_missing_its_size_refuses_the_whole_record(self):
+        # Half a record is not a correction: the malformed step would drop
+        # silently out of every sum and leave the rest looking applied.
+        record = clock_record((1.0, -0.78), (4.0, -0.5))
+        del record["steps"][1]["delta"]
+        lines, state = mix_plan([0.5, 5.0], record)
+        self.assertEqual([line["at"] for line in lines], [0.5, 5.0])
+        self.assertIs(state["applied"], False)
+
+    def test_a_line_before_a_forward_step_is_left_where_it_was(self):
+        # The control for the sign, in the direction the WSL2 host's pulses
+        # go up rather than down.
+        lines, _state = mix_plan([0.5, 2.0], clock_record((1.0, 0.9)))
+        self.assertEqual([line["at"] for line in lines], [0.5, 2.9])
+
+
+class NarrationTimelineNote(unittest.TestCase):
+    """What `timeline.md` says about where the voice went (issue #226).
+
+    The audio is the one artifact of a take whose reader cannot check it
+    against anything: a listener hears the voice drift off the caption and has
+    no way to learn whether the recorder knew. So the committed, diffable half
+    of the record has to say which of the three answers applied.
+    """
+
+    def doc(self, narration: object) -> dict:
+        return envelope(
+            capture_clock=clock_record(),
+            narration=narration,
+            beats=[beat(0, "caption", 0.1)],
+        )
+
+    def record(self, state: dict) -> dict:
+        return {"lines": [{"t": 0.5, "at": 0.5}], "clock_correction": state}
+
+    def test_a_mix_that_could_not_be_corrected_says_so_above_the_table(self):
+        text = render_timeline_md(
+            self.doc(
+                self.record(
+                    {
+                        "applied": False,
+                        "total": None,
+                        "steps": 0,
+                        "note": "the sampler was away for up to 5.50s",
+                    }
+                )
+            )
+        )
+        self.assertIn("mixed at their beat-log offsets, uncorrected", text)
+        self.assertIn("the sampler was away for up to 5.50s", text)
+        # Above the table, not under it: a reader who has read the rows has
+        # already read them as the times the voice is at.
+        self.assertLess(text.index("uncorrected"), text.index("| # | start |"))
+
+    def test_a_mix_that_followed_a_stepped_clock_says_that_instead(self):
+        text = render_timeline_md(
+            self.doc(
+                self.record({"applied": True, "total": -0.78, "steps": 1, "note": None})
+            )
+        )
+        self.assertIn("mixed where the host's stepped clock puts them", text)
+        self.assertNotIn("uncorrected", text)
+
+    def test_the_ordinary_take_says_nothing_about_its_narration(self):
+        # A watched clock that held still put every line exactly where the log
+        # says. A paragraph on every timeline is a paragraph nobody reads, and
+        # the two above are worth reading only because this one is silent.
+        text = render_timeline_md(
+            self.doc(
+                self.record({"applied": True, "total": 0.0, "steps": 0, "note": None})
+            )
+        )
+        self.assertNotIn("spoken line", text)
+
+    def test_a_take_that_narrated_nothing_says_nothing(self):
+        self.assertNotIn("spoken line", render_timeline_md(self.doc(None)))
+
+
+def merged_narration_of(records: list[object]) -> dict:
+    """A two-part merged timeline whose parts carry `records` as narration."""
+    names = [f"part{n + 1}" for n in range(len(records))]
+    docs = [
+        {
+            "recorder": "Recorder",
+            "segment": name,
+            "beats": [],
+            "capture_clock": clock_record(),
+            "narration": narration,
+        }
+        for name, narration in zip(names, records, strict=True)
+    ]
+    return _merged_timeline(
+        names,
+        [Path(f"{name}.seg.mp4") for name in names],
+        docs,
+        [7.5, 6.0],
+        Path("demo.mp4"),
+    )
+
+
+class MergedNarration(unittest.TestCase):
+    """Where a stitched demo's spoken lines are (issue #226 under #7).
+
+    `stitch()` removes the parts and their beat logs, so a line's placement
+    survives only if the merge carries it. Each part mixed its own audio on its
+    own capture's clock and `concat -c copy` laid the tracks end to end at the
+    parts' measured durations, which is the only arithmetic here.
+    """
+
+    def part(self, *lines: tuple[float, float], applied: bool = True) -> dict:
+        return {
+            "lines": [{"t": t, "at": at} for t, at in lines],
+            "clock_correction": {
+                "applied": applied,
+                "total": -0.78 if applied else None,
+                "steps": 1 if applied else 0,
+                "note": None if applied else "the sampler was away for up to 5.50s",
+            },
+        }
+
+    def test_a_later_parts_line_is_moved_by_the_parts_before_it(self):
+        # Part one's video measures 7.5 s, so part two's 1.0 s line is at 8.5 s
+        # of the joined file — and its own capture's correction is already in
+        # the `at` it arrived with, never applied a second time.
+        merged = merged_narration_of([self.part((2.0, 1.22)), self.part((1.0, 0.4))])
+        self.assertEqual(
+            merged["narration"]["lines"],
+            [
+                {"t": 2.0, "at": 1.22, "segment": "part1"},
+                {"t": 8.5, "at": 7.9, "segment": "part2"},
+            ],
+        )
+
+    def test_one_part_that_could_not_correct_its_mix_refuses_for_the_demo(self):
+        # The demo a listener plays is one file. A part whose voice drifts off
+        # its captions is not made right by the parts that did not.
+        merged = merged_narration_of(
+            [self.part((2.0, 1.22)), self.part((1.0, 1.0), applied=False)]
+        )
+        self.assertIs(merged["narration"]["clock_correction"]["applied"], False)
+        self.assertIsNone(merged["narration"]["clock_correction"]["total"])
+        self.assertIn(
+            "the sampler was away", merged["narration"]["clock_correction"]["note"]
+        )
+
+    def test_a_demo_whose_parts_all_corrected_states_the_whole_correction(self):
+        merged = merged_narration_of([self.part((2.0, 1.22)), self.part((1.0, 0.4))])
+        state = merged["narration"]["clock_correction"]
+        self.assertIs(state["applied"], True)
+        self.assertEqual(state["steps"], 2)
+        self.assertAlmostEqual(state["total"], -1.56, places=4)
+
+    def test_a_silent_part_does_not_refuse_the_correction_it_never_needed(self):
+        # A part that narrated nothing contributed no audio, so its clock has
+        # nothing to say about where the audio is. Folding it in would let a
+        # wordless segment report a demo as uncorrected.
+        merged = merged_narration_of([self.part((2.0, 1.22)), None])
+        self.assertIs(merged["narration"]["clock_correction"]["applied"], True)
+        self.assertEqual(
+            merged["narration"]["lines"],
+            [{"t": 2.0, "at": 1.22, "segment": "part1"}],
+        )
+
+    def test_a_demo_nobody_narrated_carries_no_narration_record(self):
+        self.assertIsNone(merged_narration_of([None, None])["narration"])
+
+    def test_each_part_keeps_its_own_record_on_its_own_clock(self):
+        # The merged list above is on the joined video's clock; a reader who
+        # wants to know what one part measured has to be able to get it back.
+        merged = merged_narration_of([self.part((2.0, 1.22)), self.part((1.0, 0.4))])
+        self.assertEqual(
+            [s["narration"]["lines"] for s in merged["segments"]],
+            [[{"t": 2.0, "at": 1.22}], [{"t": 1.0, "at": 0.4}]],
+        )
+
+
 class StatedInjectionCount(unittest.TestCase):
     """The figure `tests/README.md` prints about this file's own manifest.
 
@@ -5758,6 +6134,155 @@ _CURSOR_LISTENS_AT_DOMCONTENTLOADED = """\
 
 # (name, module, exact text to replace, replacement, tests that must then fail)
 INJECTIONS = [
+    (
+        # **The defect issue #226 is about**, restored exactly: each clip mixed
+        # at the offset the beat log recorded, on a video that is not on that
+        # clock. It is the one consequence of the two clocks a listener meets
+        # rather than a manifest reader, and it changes nothing whatsoever on a
+        # host whose clock holds still — which is why the tests it must fail
+        # are driven by a scripted record.
+        "every narration clip is mixed at its beat-log offset",
+        "core.py",
+        "                    f\"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}"
+        ':all=1[a{i}]"',
+        "                    f\"[{i + 1}:a]adelay={int(round(line['t'] * 1000))}"
+        ':all=1[a{i}]"',
+        [
+            "NarrationMix.test_a_line_is_mixed_where_its_own_offset_sits_in_the_video",
+            "NarrationMix.test_steps_that_cancel_still_move_a_line_mixed_between_them",
+            "NarrationMix.test_a_step_bigger_than_a_lines_offset_starts_the_clip_at_zero",
+            "NarrationMix.test_the_clips_go_in_in_the_order_the_lines_were_spoken",
+            "NarrationMix."
+            "test_the_record_names_where_each_line_was_logged_and_where_it_went",
+        ],
+    ),
+    (
+        # The correction read once for the whole take instead of at each line's
+        # own instant — the shape that was the blocking defect in the review
+        # frames' version of this rule (#253). Every clip then moves by the
+        # take's running total, including the ones spoken before the step.
+        "each clip is corrected by the take's total rather than by its own instant",
+        "narration.py",
+        '        {"t": round(float(off), 3), "at": round(max(0.0, float(off) + shift(off)), 3)}',
+        '        {"t": round(float(off), 3), "at": round(max(0.0, float(off) '
+        '+ shift(float("inf"))), 3)}',
+        [
+            "NarrationMix.test_a_step_after_a_line_does_not_move_that_lines_clip",
+            "NarrationMix.test_steps_that_cancel_still_move_a_line_mixed_between_them",
+            "NarrationMix.test_a_line_is_mixed_where_its_own_offset_sits_in_the_video",
+        ],
+    ),
+    (
+        # The third state presented as the second: a take nobody watched the
+        # clock of, publishing a record that says the mix was corrected. The
+        # audio is in exactly the same place either way, which is the whole
+        # reason this is the dangerous one — the artifact is the only thing
+        # that can tell a listener the placement was a fallback.
+        "a mix nobody could correct reports itself as corrected",
+        "narration.py",
+        "    shift, state = capture_clock_shift(record)",
+        "    shift, _state = capture_clock_shift(record)\n"
+        '    state = {"applied": True, "total": 0.0, "steps": 0, "note": None}',
+        [
+            "NarrationMix.test_a_take_nobody_watched_the_clock_of_is_mixed_raw_and_says_so",
+            "NarrationMix.test_a_stepped_take_states_the_correction_it_applied",
+            "NarrationMixPlan."
+            "test_no_record_at_all_mixes_raw_and_refuses_to_call_it_a_correction",
+            "NarrationMixPlan.test_a_step_missing_its_size_refuses_the_whole_record",
+        ],
+    ),
+    (
+        # The floor that keeps a corrected offset out of negative territory.
+        # `adelay` refuses a negative delay outright, so this does not misplace
+        # one line — it costs the take its whole audio track.
+        "a line the clock stepped past is given a negative delay",
+        "narration.py",
+        '        {"t": round(float(off), 3), "at": round(max(0.0, float(off) + shift(off)), 3)}',
+        '        {"t": round(float(off), 3), "at": round(float(off) + shift(off), 3)}',
+        [
+            "NarrationMix.test_a_step_bigger_than_a_lines_offset_starts_the_clip_at_zero",
+        ],
+    ),
+    (
+        # The committed half of the record goes quiet about where the voice is.
+        # A listener cannot check audio against anything, so a timeline that
+        # says nothing is a demo whose narration placement is unfalsifiable.
+        "timeline.md says nothing about where the spoken lines went",
+        "timeline.py",
+        "    if not isinstance(narration, dict):",
+        "    if True:",
+        [
+            "NarrationTimelineNote."
+            "test_a_mix_that_could_not_be_corrected_says_so_above_the_table",
+            "NarrationTimelineNote.test_a_mix_that_followed_a_stepped_clock_says_that_instead",
+        ],
+    ),
+    (
+        # `_timeline_doc` recomputing, or dropping, what the mix wrote down.
+        # Every assertion about `narration` grades a field nobody reads if the
+        # document does not carry it.
+        "the timeline drops the record the mix wrote",
+        "core.py",
+        '            "narration": self._narration,',
+        '            "narration": None,',
+        ["NarrationMix.test_the_timeline_carries_the_record_the_mix_wrote"],
+    ),
+    (
+        # The record set before ffmpeg has agreed to write the file. A take
+        # whose conversion raised then publishes the placement of an audio
+        # track that does not exist — the stale-artifact shape of issue #20.
+        "a take whose conversion failed still reports where its audio is",
+        "core.py",
+        '                narration = {"lines": plan, "clock_correction": clock}',
+        '                narration = {"lines": plan, "clock_correction": clock}\n'
+        "                self._narration = narration",
+        ["NarrationMix.test_a_conversion_that_failed_claims_no_mix_either"],
+    ),
+    (
+        # A stitched demo's lines left on their own part's clock. Part two's
+        # audio really is at 8.5 s of the joined file; a record saying 1.0 s
+        # points a reader at part one.
+        "a stitched demo's spoken lines are not moved onto the joined clock",
+        "stitching.py",
+        '                    "at": _shift(line.get("at"), record["offset"]),',
+        '                    "at": line.get("at"),',
+        ["MergedNarration.test_a_later_parts_line_is_moved_by_the_parts_before_it"],
+    ),
+    (
+        # One part's refusal swallowed by the parts that managed. The demo is
+        # one file and a listener plays all of it.
+        "a part that could not correct its mix is outvoted by the parts that did",
+        "stitching.py",
+        '            applied = False\n            note = note or state.get("note")',
+        '            note = note or state.get("note")',
+        [
+            "MergedNarration."
+            "test_one_part_that_could_not_correct_its_mix_refuses_for_the_demo"
+        ],
+    ),
+    (
+        # ...and the other direction: a segment that spoke nothing dragging a
+        # narrated demo's record down to "uncorrected", and inventing a record
+        # for a demo where nobody spoke at all.
+        "a segment that narrated nothing votes on where the narration is",
+        "stitching.py",
+        "        if not isinstance(narration, dict):\n            continue",
+        "        if not isinstance(narration, dict):\n            narration = {}",
+        [
+            "MergedNarration."
+            "test_a_silent_part_does_not_refuse_the_correction_it_never_needed",
+            "MergedNarration.test_a_demo_nobody_narrated_carries_no_narration_record",
+        ],
+    ),
+    (
+        # The per-part record, which is the only place a reader can get back to
+        # what one capture measured once the merged list has moved everything.
+        "a stitched demo forgets what each part measured for itself",
+        "stitching.py",
+        '                "narration": doc.get("narration"),',
+        '                "narration": None,',
+        ["MergedNarration.test_each_part_keeps_its_own_record_on_its_own_clock"],
+    ),
     (
         # The correction a consumer would apply to a beat timestamp, with its
         # sign flipped. The field is still there and still lists the right


### PR DESCRIPTION
## Acceptance criterion (#226)

> On a take whose host wall clock stepped during recording, the audio onset of
> each narration line sits the same distance from its caption's appearance as
> it does on a take whose clock did not — measured off the encoded mp4, not
> computed.

`core._convert` mixed each clip at the offset `_lines` recorded, which is
`time.monotonic() - _t0`. The video it is mixed into is stamped with the host's
**wall** clock, so every wall-clock step moved the pixels and left the voice
where it was. [#18](https://github.com/rogvid/skills/issues/18)'s second
comment measured exactly that: **+0.70 s of lag on all three lines** of a take
that stalled in its run-up, against +0.11 to +0.14 s in a clean one.

## What changed

- **`narration.mix_plan(offsets, capture_clock)` -> `(lines, state)`.** Each
  line gets `t` (what the beat log recorded) and `at` (where that instant is in
  the video). `at = t +` the steps that capture recorded **before `t`** —
  indexed by the instant, not by the take, which is the defect
  [#253](https://github.com/rogvid/skills/pull/253) was blocked on. Clamped at
  zero: `adelay` cannot take a negative delay, and a backward step larger than
  a line's offset means that wall time is not in the file at all.
- The correction is read through `timeline.capture_clock_shift`, a thin adapter
  over the same `capture_clock_correction` the review frames go through, so the
  audio track and `frames/` of one demo cannot describe two different videos.
- **`timeline.json` grows a `narration` envelope field** — every line's `t` and
  `at`, plus the three-state `clock_correction`. Taken from what `_convert`
  did, not recomputed, and set only after ffmpeg returned (a take whose
  conversion raised keeps `narration: null`, like `duration`). `timeline.md`
  prints a paragraph above the beat table in the two cases where a reader's
  assumption is wrong — the clock stepped and the mix followed it, or nobody
  watched and the mix used the raw offset — and is silent on the ordinary take.
- **`stitch()` merges it**: each part's lines moved onto the joined clock by
  that part's `offset` and naming their own `segment`; `applied` false the
  moment any *narrating* part could not correct its own mix; each part's own
  record kept under `segments`. A part that narrated nothing does not vote.
- `reference/narration.md` documents the rule and the fallback.

## Evidence — every new assertion seen to fail

### `tests/unit --fault-inject`, 18 new entries (round 1's 11 shown)

```
PASS  break: every narration clip is mixed at its beat-log offset
      in core.py: f"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}:all=1[a{i}]"…
      FAIL: test_a_line_is_mixed_where_its_own_offset_sits_in_the_video (__main__.NarrationMix.test_a_line_is_mixed_where_its_own_offset_sits_in_the_video)
      FAIL: test_a_step_bigger_than_a_lines_offset_starts_the_clip_at_zero (__main__.NarrationMix.test_a_step_bigger_than_a_lines_offset_starts_the_clip_at_zero)
      FAIL: test_steps_that_cancel_still_move_a_line_mixed_between_them (__main__.NarrationMix.test_steps_that_cancel_still_move_a_line_mixed_between_them)
      FAIL: test_the_clips_go_in_in_the_order_the_lines_were_spoken (__main__.NarrationMix.test_the_clips_go_in_in_the_order_the_lines_were_spoken)

PASS  break: each clip is corrected by the take's total rather than by its own instant
      in narration.py: {"t": round(float(off), 3), "at": round(max(0.0, float(off) + shift(…
      FAIL: test_a_line_is_mixed_where_its_own_offset_sits_in_the_video (__main__.NarrationMix.test_a_line_is_mixed_where_its_own_offset_sits_in_the_video)
      FAIL: test_a_step_after_a_line_does_not_move_that_lines_clip (__main__.NarrationMix.test_a_step_after_a_line_does_not_move_that_lines_clip)
      FAIL: test_steps_that_cancel_still_move_a_line_mixed_between_them (__main__.NarrationMix.test_steps_that_cancel_still_move_a_line_mixed_between_them)
      FAIL: test_the_clips_go_in_in_the_order_the_lines_were_spoken (__main__.NarrationMix.test_the_clips_go_in_in_the_order_the_lines_were_spoken)

PASS  break: a mix nobody could correct reports itself as corrected
      in narration.py: shift, state = capture_clock_shift(record)…
      FAIL: test_a_stepped_take_states_the_correction_it_applied (__main__.NarrationMix.test_a_stepped_take_states_the_correction_it_applied)
      FAIL: test_a_take_nobody_watched_the_clock_of_is_mixed_raw_and_says_so (__main__.NarrationMix.test_a_take_nobody_watched_the_clock_of_is_mixed_raw_and_says_so)
      FAIL: test_a_step_missing_its_size_refuses_the_whole_record (__main__.NarrationMixPlan.test_a_step_missing_its_size_refuses_the_whole_record)
      FAIL: test_no_record_at_all_mixes_raw_and_refuses_to_call_it_a_correction (__main__.NarrationMixPlan.test_no_record_at_all_mixes_raw_and_refuses_to_call_it_a_correction)

PASS  break: a line the clock stepped past is given a negative delay
      in narration.py: {"t": round(float(off), 3), "at": round(max(0.0, float(off) + shift(…
      FAIL: test_a_step_bigger_than_a_lines_offset_starts_the_clip_at_zero (__main__.NarrationMix.test_a_step_bigger_than_a_lines_offset_starts_the_clip_at_zero)

PASS  break: timeline.md says nothing about where the spoken lines went
      in timeline.py: if not isinstance(narration, dict):…
      FAIL: test_a_mix_that_could_not_be_corrected_says_so_above_the_table (__main__.NarrationTimelineNote.test_a_mix_that_could_not_be_corrected_says_so_above_the_table)
      FAIL: test_a_mix_that_followed_a_stepped_clock_says_that_instead (__main__.NarrationTimelineNote.test_a_mix_that_followed_a_stepped_clock_says_that_instead)

PASS  break: the timeline drops the record the mix wrote
      in core.py: "narration": self._narration,…
      FAIL: test_the_timeline_carries_the_record_the_mix_wrote (__main__.NarrationMix.test_the_timeline_carries_the_record_the_mix_wrote)

PASS  break: a take whose conversion failed still reports where its audio is
      in core.py: narration = {"lines": plan, "clock_correction": clock}…
      FAIL: test_a_conversion_that_failed_claims_no_mix_either (__main__.NarrationMix.test_a_conversion_that_failed_claims_no_mix_either)

PASS  break: a stitched demo's spoken lines are not moved onto the joined clock
      in stitching.py: "at": _shift(line.get("at"), record["offset"]),…
      FAIL: test_a_later_parts_line_is_moved_by_the_parts_before_it (__main__.MergedNarration.test_a_later_parts_line_is_moved_by_the_parts_before_it)

PASS  break: a part that could not correct its mix is outvoted by the parts that did
      in stitching.py: applied = False…
      FAIL: test_one_part_that_could_not_correct_its_mix_refuses_for_the_demo (__main__.MergedNarration.test_one_part_that_could_not_correct_its_mix_refuses_for_the_demo)

PASS  break: a segment that narrated nothing votes on where the narration is
      in stitching.py: if not isinstance(narration, dict):…
      FAIL: test_a_demo_nobody_narrated_carries_no_narration_record (__main__.MergedNarration.test_a_demo_nobody_narrated_carries_no_narration_record)
      FAIL: test_a_silent_part_does_not_refuse_the_correction_it_never_needed (__main__.MergedNarration.test_a_silent_part_does_not_refuse_the_correction_it_never_needed)

PASS  break: a stitched demo forgets what each part measured for itself
      in stitching.py: "narration": doc.get("narration"),…
      ERROR: test_each_part_keeps_its_own_record_on_its_own_clock (__main__.MergedNarration.test_each_part_keeps_its_own_record_on_its_own_clock)
```

### `tests/smoke-inject --arm narration`, 2 new entries (baseline clean first)

```
BASE  --narration-only passes clean (9s)

PASS  break: every narration clip is mixed 150 ms from where the record says  [10s]
      --narration-only, in core.py: f"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}:all=1[a{i}]"…
      caught: narration: line 0's audio starts at 1.164s of demo.mp4, +150 ms from the 1.014s it belongs at, over the 120 ms this grades. The voice is that far from
      caught: narration: line 1's audio starts at 3.424s of demo.mp4, +150 ms from the 3.274s it belongs at, over the 120 ms this grades. The voice is that far from

PASS  break: the take's record misplaces the audio it mixed correctly  [11s]
      --narration-only, in core.py: narration = {"lines": plan, "clock_correction": clock}…
      caught: narration: timeline.json puts line 0 at 1.502s of demo.mp4; this harness's own wall-clock reading puts the 1.002s instant at 1.002s (the host's wall c
      caught: narration: timeline.json puts line 1 at 3.781s of demo.mp4; this harness's own wall-clock reading puts the 3.281s instant at 3.281s (the host's wall c
```

Both are invisible to the two window bars that were already there: a clip is
still mixed, still audible inside its own line, still silent before the first.
What moves is *where* it is.

### The arm itself, on this box

```
smoke: narration ok (2 lines spoken from a seeded cache at 0.96s, 3.23s, no key
sent, audio present where a line is and silent before the first, every clip's
onset within 120 ms of where the record says it went; the host's wall clock did
not step during this take)
```

`timeline.json` -> `narration.lines` = `[{t: 0.963, at: 0.963}, {t: 3.228,
at: 3.228}]`; `silencedetect` off the encoded mp4 -> onsets `0.963016` and
`3.228000`, spans `1.600 s` and `0.300 s` against the 1.6 s and 0.3 s tones the
harness seeded. Sub-millisecond, which is why the bar is 120 ms — three orders
above the residual and one below the 0.70–1.50 s defect.

## Counts

| | before (`d5212c0`) | after |
|---|---|---|
| `tests/unit` | 250 tests / 166 injections | **292 / 186** |
| `tests/ci-unit` | 54 / 18 | 54 / 18 |
| `tests/smoke-inject` | 49 entries, ~41.4 min | **51 entries, ~41.7 min** |

> **This table and the evidence blocks above are round 1's.** Two review
> rounds followed — see the comments below for what changed, the round-2 and
> round-3 injection output, and the run on a host that really stepped. The
> counts here are current; the 150 ms injection quoted above is now 250 ms.

Also green: `tests/unit --budget` (SKILL.md 600/600 lines, untouched),
`tests/lint`, `tests/lint --self-test`, `tests/smoke-inject --self-test`,
`uvx ruff@0.16.1 format .` (no changes).

## Stated limits — what this does **not** verify

- **No suite produces a host whose wall clock steps.** Every assertion about
  the correction is driven by a *scripted* `capture_clock`. On a steady box
  `clock.before()` is zero, the correction is zero, and the `--narration-only`
  arm passes identically for a mix that never corrected anything. That is said
  out loud in `check_narration_placement`'s docstring, in the arm's section of
  `tests/README.md`, and as a new **Known gaps** entry.
- **The world model is not re-measured here.** That the encode really follows
  the host's wall clock was measured off pixels once, in
  [#250](https://github.com/rogvid/skills/issues/250) — six takes, 38 caption
  transitions, up to −1.50 s uncorrected against all 38 within 101 ms
  corrected. Nothing re-runs it.
- **The caption half is not re-measured on this arm.** The acceptance criterion
  is phrased as onset-versus-caption-appearance; what the arm compares is
  onset versus the instant an *independent* wall-clock sampler puts the line
  at. Reading the caption's pixel arrival on this storyboard would need
  `caption_arrival`'s quiet run-up, which the interlude card's teardown 0.6 s
  earlier destroys — a storyboard change to a passing arm, for a measurement
  #250 already made 38 times.
- **`--segments-only` was not run.** Its `check_merge_offset` baseline is red on
  this box before this change ([#224](https://github.com/rogvid/skills/issues/224),
  a parallel diagnosis), so a run of it would not be a verdict. The stitch merge
  is graded in `tests/unit` (`MergedNarration`, 4 injections) and no segment in
  that arm narrates.
- **`ELEVENLABS_API_KEY` was never available and is never needed.** The arm
  runs the whole real speech path from a cache seeded with tones, against a
  closed local port.

Fixes #226
