### PR TITLE
A step's hole is published, and all three consumers refuse to correct into it (#256)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -296,7 +296,14 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         # **Only when there is one**, like narration's `clamped`: a key on
         # every frame is a key nobody reads, and `0.0` beside a frame that is
         # exactly where its beat is would be a hole nobody found.
-        if placed.lost:
+        #
+        # Rounded *before* the test, exactly as `mix_plan` does it and for the
+        # same reason: a midpoint 0.2 ms short of where the video resumes is
+        # inside a hole by less than this record can write down, and
+        # `"no_video": 0.0` beside it says "there is no frame of this beat"
+        # about a frame that is where its beat is. Testing the raw float was
+        # this file's own version of the bug the rounding exists to stop.
+        if round(placed.lost, 3):
             entry["no_video"] = round(placed.lost, 3)
         planned.append(entry)
         # Only for beats long enough to hide an unscripted transition. Beat
@@ -409,7 +416,7 @@ def write_beat_frames(out_dir: Path | str, doc: dict, where: str) -> dict | None
     return manifest
 
 
-def _clock_md(clock: object) -> list[str]:
+def _clock_md(clock: object, holed: bool = False) -> list[str]:
     """What the sheet says about the clock its frames were cut on.
 
     Three sentences for three states, and the reason all three are printed
@@ -419,6 +426,14 @@ def _clock_md(clock: object) -> list[str]:
     a corrected one — which is the confidently-wrong artifact this whole field
     exists to avoid, and it is why "the clock was watched and held still" is
     also stated out loud instead of being inferred from silence.
+
+    `holed` is whether any frame on this sheet is of a beat the clock deleted
+    from the file, and it is a parameter rather than something the paragraph
+    below leaves to `_no_video_md` to correct afterwards: the stepped sentence
+    says flatly that every frame is its midpoint plus the steps before it, and
+    for those frames that is false. A reader who stops at the first paragraph
+    — which is what a headline paragraph is for — would carry away the wrong
+    rule and never reach the correction.
     """
     if not isinstance(clock, dict):
         return []
@@ -445,12 +460,18 @@ def _clock_md(clock: object) -> list[str]:
     return [
         f"**The host's wall clock stepped {clock.get('steps')} time(s) while "
         f"this was recorded** ({clock.get('total') or 0.0:+.2f}s in total), and "
-        f"the video is on that clock. Each frame below was therefore cut at "
-        f"its beat's midpoint **plus the steps its own capture recorded before "
-        f"that instant**, not at the midpoint itself — the timestamps in the "
-        f"table are where the frames came out of the video, and the total "
-        f"above is the correction for none of them individually. "
-        f"`timeline.json`'s `capture_clock` has the steps.",
+        f"the video is on that clock. "
+        + (
+            "Each frame below was therefore cut at "
+            if not holed
+            else "Except for the frames named in the next paragraph, whose "
+            "beats are not in the file at all, each frame below was cut at "
+        )
+        + "its beat's midpoint **plus the steps its own capture recorded "
+        "before that instant**, not at the midpoint itself — the timestamps "
+        "in the table are where the frames came out of the video, and the "
+        "total above is the correction for none of them individually. "
+        "`timeline.json`'s `capture_clock` has the steps.",
         "",
     ]
 
@@ -538,8 +559,9 @@ def render_frames_md(manifest: dict) -> str:
     ]
     if manifest.get("skipped"):
         return "\n".join(out + [f"No frames were written: {manifest['skipped']}.", ""])
-    out += _clock_md(manifest.get("clock_correction"))
-    out += _no_video_md(frames)
+    holed = _no_video_md(frames)
+    out += _clock_md(manifest.get("clock_correction"), bool(holed))
+    out += holed
     swallowed = manifest.get("scene_search_skipped") or []
     if swallowed:
         # Named, not counted: the reader's question is which beat is thinner

--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -76,6 +76,18 @@ from .timeline import capture_clock_correction, timeline_paths
 # manifest and the sheet say so in as many words. Zero is the only number
 # available there, but it is a fallback and not a correction, and a sheet that
 # let the two look alike would be claiming an accuracy nobody measured.
+#
+# **And a beat can have no frame to be cut at all.** A backward step of Δ does
+# not slide the video, it deletes a Δ-wide window of wall time from the file
+# (issue #256, and the note over `capture_clock_correction`), so a midpoint
+# inside that window is of a moment `demo.mp4` does not contain. `Placed.lost`
+# is how the correction says so, and this is the one case where the sheet's
+# timestamp is *not* where the beat is: the frame is cut at the last instant
+# before the gap, and both manifest and sheet name the beat as one whose own
+# wall time is missing. The alternative — cutting at the midpoint plus the
+# steps, as everything here did until #256 — puts the frame up to a whole step
+# early, in content that predates the step, and it was found by eye:
+# `seg-run1`'s `beat-05.png` was cut at 4.58 s and shows the previous caption.
 FRAMES_DIRNAME = "frames"
 FRAMES_SCHEMA = 1
 
@@ -185,9 +197,10 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
     Reads the timeline the take just wrote (or `doc`), extracts
     `frames/beat-NN.png` at each beat's midpoint **on the video's clock** — the
     midpoint plus that beat's own capture's recorded wall-clock steps, or the
-    bare midpoint with the reason stated when the record cannot say (see the
-    section header) — and writes `frames/frames.md` for a reviewer and
-    `frames/frames.json` for a tool. Neither says anything
+    bare midpoint with the reason stated when the record cannot say, or the
+    last instant before the gap for a beat a backward step deleted from the
+    file (see the section header) — and writes `frames/frames.md` for a
+    reviewer and `frames/frames.json` for a tool. Neither says anything
     about what is *in* a frame — see the section header.
 
     Returns the manifest. Safe to re-run: it is a pure function of the mp4 and
@@ -247,7 +260,7 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
             duration = float(beats[-1].get("t_end") or 0.0)
     last = max(0.0, float(duration) - _FRAME_EDGE_S)
 
-    correct, clock = capture_clock_correction(doc)
+    place, clock = capture_clock_correction(doc)
     manifest["clock_correction"] = clock
 
     planned: list[dict] = []
@@ -264,23 +277,28 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         # what puts the beat where the frames are, and clamping first would
         # aim at the end of a file the beat does not reach.
         #
-        # Every instant is corrected **by the steps before that instant** —
-        # `correct(beat, t)`, not one number per beat. A step landing inside a
+        # Every instant is placed **by the steps before that instant** —
+        # `place(beat, t)`, not one number per beat. A step landing inside a
         # beat's own first half moved this frame and did not move the beat's
         # start, and half of a take's wall time is inside some beat's first
         # half, so a per-beat number leaves roughly one step in two applied to
         # the wrong instants.
         logged = (float(t_start) + float(t_end)) / 2
-        middle = min(max(logged + correct(beat, logged), 0.0), last)
+        placed = place(beat, logged)
+        middle = min(max(placed.at, 0.0), last)
         index = int(beat.get("index", len(planned)))
-        planned.append(
-            {
-                "file": f"beat-{index:02d}.png",
-                "kind": "beat",
-                "beat": index,
-                "t": round(middle, 3),
-            }
-        )
+        entry = {
+            "file": f"beat-{index:02d}.png",
+            "kind": "beat",
+            "beat": index,
+            "t": round(middle, 3),
+        }
+        # **Only when there is one**, like narration's `clamped`: a key on
+        # every frame is a key nobody reads, and `0.0` beside a frame that is
+        # exactly where its beat is would be a hole nobody found.
+        if placed.lost:
+            entry["no_video"] = round(placed.lost, 3)
+        planned.append(entry)
         # Only for beats long enough to hide an unscripted transition. Beat
         # alignment sees what the storyboard wrote down; a redirect, a toast or
         # a load finishing inside a long hold is invisible to it.
@@ -291,15 +309,17 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         # the log's clock it would scan a stretch the beat had already left —
         # and each edge is corrected at its own instant, because a step inside
         # the beat moves its end and not its start.
-        lo = min(max(float(t_start) + correct(beat, float(t_start)), 0.0), last)
-        hi = min(max(float(t_end) + correct(beat, float(t_end)), 0.0), last)
-        # Correcting each edge at its own instant can put the end *before* the
-        # start: a step larger than the beat's span leaves none of that beat's
-        # wall time in the file, and a beat clamped past the end of the video
-        # collapses the same way. There is genuinely nothing to search, and
-        # `scene_times` answers an inverted window with an empty list — so the
-        # only wrong move is to let the sheet quietly carry fewer frames.
-        # Recorded here, printed in frames.md, and named by beat.
+        lo = min(max(place(beat, float(t_start)).at, 0.0), last)
+        hi = min(max(place(beat, float(t_end)).at, 0.0), last)
+        # Placing each edge at its own instant can leave no window at all: a
+        # beat that begins and ends inside one backward step's hole has none of
+        # its wall time in the file, so both edges clamp to the same instant,
+        # and a beat clamped past the end of the video collapses the same way.
+        # There is genuinely nothing to search, and `scene_times` answers an
+        # empty window with an empty list — so the only wrong move is to let the
+        # sheet quietly carry fewer frames. Recorded here, printed in frames.md,
+        # and named by beat. A beat the step lands *inside* keeps the part of
+        # its span the file still has, which is `lo` up to the hole's edge.
         if hi <= lo:
             skipped_scenes.append(index)
             continue
@@ -350,7 +370,7 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
     # amount they were just moved by.
     tail = beats[-1]
     tail_end = float(tail.get("t_end") or 0.0)
-    over = tail_end + correct(tail, tail_end) - float(duration)
+    over = place(tail, tail_end).at - float(duration)
     manifest["capture_loss_at_least"] = round(max(0.0, over), 3)
     json_path.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n")
     md_path.write_text(render_frames_md(manifest))
@@ -435,6 +455,48 @@ def _clock_md(clock: object) -> list[str]:
     ]
 
 
+def _no_video_md(frames: list[dict]) -> list[str]:
+    """The frames whose beat the host's clock deleted from the file (#256).
+
+    Named, never counted, and never silent: the sheet's whole contract is that
+    a frame is the moment its heading says it is, and for these it is not —
+    there is no such moment in `demo.mp4` to be. A backward step of Δ deletes
+    a Δ-wide window of wall time outright rather than sliding the video, so a
+    beat inside that window was never encoded. The frame is the last one before
+    the gap, which is as close as the file goes.
+
+    Saying nothing here is the failure this exists to stop, and it is not
+    hypothetical: it is what shipped. `seg-run1`'s `beat-05.png` was cut a
+    whole step early, into content that predates the step, and arrived on a
+    sheet that presented it as the beat's midpoint — a frame of the previous
+    caption, confidently numbered for the beat after it.
+    """
+    holed = [f for f in frames if f.get("no_video")]
+    if not holed:
+        return []
+    named = ", ".join(f"`{_md_cell(f.get('file'))}`" for f in holed)
+    return [
+        f"**{named} {'is' if len(holed) == 1 else 'are'} not at the beat "
+        f"{'it is' if len(holed) == 1 else 'they are'} named for: the host's "
+        f"wall clock stepped backwards over that moment, and a backward step "
+        f"takes its own width of wall time *out of the file* rather than "
+        f"moving it.** There is no frame of "
+        f"{'that beat' if len(holed) == 1 else 'those beats'} in this "
+        f"recording. What is printed is the last frame before the gap — the "
+        f"video resumes "
+        + ", ".join(
+            f"{float(f['no_video']) * 1000:.0f} ms after `{_md_cell(f.get('file'))}`'s "
+            f"own moment"
+            for f in holed
+        )
+        + ". Read "
+        + ("it" if len(holed) == 1 else "them")
+        + " as the moment the demo reached before the clock moved, not as the "
+        "beat. `timeline.json`'s `capture_clock` has the steps.",
+        "",
+    ]
+
+
 def render_frames_md(manifest: dict) -> str:
     """The review sheet: the frames, in order, and nothing else.
 
@@ -477,6 +539,7 @@ def render_frames_md(manifest: dict) -> str:
     if manifest.get("skipped"):
         return "\n".join(out + [f"No frames were written: {manifest['skipped']}.", ""])
     out += _clock_md(manifest.get("clock_correction"))
+    out += _no_video_md(frames)
     swallowed = manifest.get("scene_search_skipped") or []
     if swallowed:
         # Named, not counted: the reader's question is which beat is thinner
@@ -512,5 +575,10 @@ def render_frames_md(manifest: dict) -> str:
         title = f"{name.removesuffix('.png')} — {_fmt_t(frame.get('t'))}s"
         if frame.get("kind") == "scene":
             title += " (an extra frame: the picture changed here)"
+        # Beside the picture as well as above the table: a reviewer scrolling
+        # the frames reads the headings and never the preamble, and this is the
+        # one heading whose timestamp is not where its beat is.
+        if frame.get("no_video"):
+            title += " (no video of this beat — the last frame before the gap)"
         out += [f"## {title}", "", f"![{name}]({name})", ""]
     return "\n".join(out).rstrip() + "\n"

--- a/skills/demo-video/helpers/demo_recording/narration.py
+++ b/skills/demo-video/helpers/demo_recording/narration.py
@@ -87,6 +87,18 @@ TTS_API_BASE = "https://api.elevenlabs.io/v1/text-to-speech"
 #     `steps` cannot tell "the clock held still" from "nobody knows". Zero is
 #     still the number applied — there is no other — but it is a fallback and
 #     not a correction, and `mix_plan` hands its caller the state to say so.
+#
+# And one property of the *step* that the arithmetic above got wrong until
+# issue #256: a backward step of Δ does not slide the video, it deletes a
+# Δ-wide window of wall time from the file. A line spoken inside that window
+# was spoken over a moment `media` does not contain, and `t + (the steps before
+# t)` puts its clip up to a whole step early — over content that predates the
+# step, which for a narration line means the caption before the one it is
+# about. `capture_clock_shift` clamps such an instant to the last moment the
+# file has and says how much it swallowed; `no_video` carries that onto the
+# line, for the same reason `clamped` does, and `timeline.md` states it. The
+# clip is still mixed, because the alternative is dropping a spoken line out
+# of the audio over a defect of the host's clock.
 
 
 def mix_plan(
@@ -117,19 +129,30 @@ def mix_plan(
     travels with them, so a clamped line of part two has an `at` of that
     part's offset. Anything printing prose about it has to say "the start of
     its own capture" rather than "0.0".
+
+    A line whose instant a backward step deleted from the file carries
+    `no_video` instead — also **only when it has one** — being the seconds
+    between where the clip was put and where the video starts again. Its `at`
+    is the last moment the file has before the gap rather than `t` plus the
+    steps before it, for the reason the section above gives: there is no such
+    moment in the video, and the placement every other line gets would put
+    this clip a whole step early (issue #256).
     """
-    shift, state = capture_clock_shift(record)
+    place, state = capture_clock_shift(record)
     lines = []
     for off in offsets:
-        want = float(off) + shift(off)
+        placed = place(off)
+        want = placed.at
         # Rounded *before* the test, not after. A `want` of −5e-5 is a
         # truncation of nothing at the precision this record is written at,
         # and a `clamped: 0.0` beside it would be a line claiming its `at` is
-        # not `t` plus the steps before it when it is.
+        # not `t` plus the steps before it when it is. Same for `no_video`.
         clamped = round(-want, 3) if want < 0 else 0.0
         line = {"t": round(float(off), 3), "at": round(max(0.0, want), 3)}
         if clamped:
             line["clamped"] = clamped
+        if round(placed.lost, 3):
+            line["no_video"] = round(placed.lost, 3)
         lines.append(line)
     return lines, state
 

--- a/skills/demo-video/helpers/demo_recording/narration.py
+++ b/skills/demo-video/helpers/demo_recording/narration.py
@@ -113,7 +113,13 @@ def mix_plan(
     clock record — see the section above; a caller that drops it publishes a
     demo whose audio placement cannot be told from a guess.
 
-    `at` never goes below zero, and **a line that hit that floor says so**. A
+    `at` never goes below zero, and **a line that hit that floor says so** —
+    though since #256 nothing this recorder writes can hit it: a step's own
+    hole clamps every instant inside it to a moment no earlier than the step,
+    and the sampler's first reading is at frame zero, so only a record from
+    somewhere else (a step timestamped before the capture began) can drive
+    `at` negative. The floor stays for that record, because `adelay` refuses a
+    negative delay and takes the whole audio track with it. A
     backward step larger than a line's own offset puts that instant before this
     capture's first frame — the wall time it occupied is genuinely not in the
     file — and `adelay` has no way to express a negative delay, so the clip

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -183,6 +183,14 @@ from .markdown import _fmt_t, _md_cell
 #                          recorded in one piece, that part's `offset` on a
 #                          stitched demo — **not** 0.0 there), and that line
 #                          alone is *not* `t` plus the steps before it.
+#                          **No record this recorder emits produces a
+#                          `clamped` line any more** (issue #256): an instant
+#                          is never placed earlier than the step that moved
+#                          it, and the sampler starts at frame zero, so `at`
+#                          cannot come out negative. The field and its floor
+#                          stay for a record from somewhere else, because
+#                          `adelay` refuses a negative delay and that costs a
+#                          take its whole audio track rather than one clip.
 #                          A line carries `no_video` — again **only when it
 #                          has one** — when the instant it was spoken at falls
 #                          inside a hole a backward step deleted from the file
@@ -790,7 +798,8 @@ def _narration_md(narration: object) -> list[str]:
 
       * a line whose correction hit the zero floor (`clamped`) did not move by
         the steps before it — it moved by as much of them as the start of the
-        file left room for;
+        file left room for. Unreachable from a record this recorder writes
+        since #256, and kept for one that came from elsewhere;
       * a line the clock stepped *over* (`no_video`) was spoken during wall
         time the file does not contain, so its clip sits at the last moment
         before the gap and not where the steps put it (issue #256);

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -13,8 +13,10 @@ checkable without recording anything.
 from __future__ import annotations
 
 import json
+import math
 from collections.abc import Callable
 from pathlib import Path
+from typing import NamedTuple
 
 from .failure import FAILURE_DIR, FAILURE_MARKER
 from .markdown import _fmt_t, _md_cell
@@ -84,6 +86,28 @@ from .markdown import _fmt_t, _md_cell
 #                          such a step out entirely, and the measurement above
 #                          cannot see that — caption transitions sit at beat
 #                          *starts*, the one instant where the two agree.
+#                          **A backward step also leaves a hole, and the rule
+#                          above is wrong inside it** (issue #256). A step of
+#                          −Δ at `T` does not slide the video: it *deletes*
+#                          the monotonic window `(T, T+Δ)` from the file,
+#                          because the encoder stamps frames with the wall
+#                          clock and will not write a stamp it has already
+#                          written. Measured one video frame wide — `video
+#                          31.560 → 31.600 shows mono 31.644 → 32.644`. An
+#                          instant inside that window has **no video at all**,
+#                          and `t + (the steps before t)` lands it up to a
+#                          whole step early, in content that predates the
+#                          step. The rule that holds everywhere is that the
+#                          video's clock is the *high-water mark* of the wall
+#                          clock: an instant sits at the greatest of `t + (the
+#                          steps before t)` and every `T + (the steps before
+#                          T)` for a step at `T ≤ t`. Outside a hole the two
+#                          agree exactly and this is the same arithmetic;
+#                          inside one it clamps to the last instant the file
+#                          has. `capture_clock_correction` below answers both
+#                          — where the instant sits, and how many seconds of
+#                          the correction the hole swallowed — and the
+#                          recorder's own consumers say which they got.
 #                          On a merged demo (`stitch`) every part's steps are
 #                          here, moved onto the stitched clock by that part's
 #                          `offset`, and each step also carries the `segment`
@@ -159,6 +183,14 @@ from .markdown import _fmt_t, _md_cell
 #                          recorded in one piece, that part's `offset` on a
 #                          stitched demo — **not** 0.0 there), and that line
 #                          alone is *not* `t` plus the steps before it.
+#                          A line carries `no_video` — again **only when it
+#                          has one** — when the instant it was spoken at falls
+#                          inside a hole a backward step deleted from the file
+#                          (issue #256): its `at` is the last moment before
+#                          that gap and `no_video` is how many seconds later
+#                          the video resumes. There is no moment in `media`
+#                          for such a line to be at, and the rule above is
+#                          false for it in the other direction.
 #                          On a merged demo every
 #                          part's lines are here, moved onto the stitched clock
 #                          by that part's `offset` and each naming its own
@@ -465,6 +497,76 @@ def timeline_paths(out_dir: Path | str, segment: str | None = None) -> tuple[Pat
 # `state` below is what an artifact prints so its reader can tell the three
 # apart, and it is deliberately part of the return value rather than something
 # a caller re-derives.
+#
+# **And there is a fourth thing an *instant* can be, which no state describes:
+# inside a hole, with no video at all** (issue #256). That is a property of the
+# instant and not of the record — the same well-measured record answers it for
+# one beat and not for the next — so it rides on the answer instead, as
+# `Placed.lost`. A −Δ step deletes the monotonic window `(T, T+Δ)` from the
+# file, and until #256 every consumer here returned a shift for every `t > T`,
+# so an instant inside that window was corrected up to a whole step early, into
+# content that predates the step. Measured in the shipped path: `seg-run1`'s
+# `beat-05` had its midpoint at 5.633 s, inside the hole (5.151, 6.202); its
+# frame was cut at video 4.58 s and **shows the previous caption**.
+#
+# The arithmetic is `_placed` below, and it is the wall clock's *high-water
+# mark* rather than a running sum with a special case bolted on. Two properties
+# of writing it that way are worth stating, because both are what make it safe
+# to apply everywhere:
+#
+#   * **on a host that never steps it is the identity**, and on a host that
+#     steps it is the old sum digit for digit everywhere outside a hole.
+#     Nothing about an ordinary take changes — which is also why nothing about
+#     an ordinary take can grade it, and why every case for it is synthetic.
+#   * **it composes.** Overlapping holes — a second step landing inside the
+#     first one's window — fall out of the maximum with no rule of their own,
+#     which a per-step special case would have had to get right by hand.
+#
+# What it deliberately does **not** do is second-guess the size of the step:
+# the hole is Δ wide because the record says the step was Δ. Three of six
+# stepping takes in #255 showed the video moving by less than the recorded
+# amount, and that is issue #259 — a question about whether the record
+# describes the world, which no arithmetic here can answer.
+
+
+class Placed(NamedTuple):
+    """Where a beat-log instant is in the video, and whether it is there at all.
+
+    `at` is the instant in `media`, already clamped to the last instant the
+    file has if this one falls inside a hole. `lost` is how many seconds of
+    the correction that clamp swallowed: **zero for an instant with video**,
+    and for one without, the distance from here to where the file starts
+    again — which is also how far too early the uncorrected rule would have
+    put it. A consumer that publishes `at` without saying `lost` is back to
+    presenting a beat with no video as a frame at its midpoint.
+    """
+
+    at: float
+    lost: float
+
+
+def _placed(steps: list[tuple[float, float]], t: float) -> Placed:
+    """`t` on the video's clock, given one capture's steps. See above.
+
+    The video's clock is the high-water mark of the host's wall clock, because
+    the encoder will not write a frame stamp it has already written: the file
+    stalls for the width of a backward step instead of rewinding.
+    """
+    running = 0.0
+    # The furthest the file had got before any step at or before `t` — the
+    # edge a hole clamps to. `-inf` rather than 0.0 so that a capture with no
+    # steps is the identity rather than a floor at its own start.
+    edge = -math.inf
+    for at, delta in sorted(steps):
+        if at > t:
+            break
+        edge = max(edge, at + running)
+        running += delta
+    shifted = t + running
+    # `max`, so an instant with video returns `shifted` *itself* and `lost` is
+    # exactly 0.0 rather than a rounding of it.
+    reached = max(shifted, edge)
+    return Placed(reached, reached - shifted)
 
 
 def _usable_steps(doc: dict, record: dict) -> list[dict] | None:
@@ -510,26 +612,39 @@ def _usable_steps(doc: dict, record: dict) -> list[dict] | None:
     return steps
 
 
-def _no_correction(beat: dict, t: float) -> float:
-    """The correction for a record that cannot supply one. Zero, and stated."""
-    return 0.0
+def _no_correction(beat: dict, t: float) -> Placed:
+    """The placement for a record that cannot supply one. `t`, and stated.
+
+    `lost` is 0.0 rather than null, and that is not a claim that this instant
+    has video: a record nobody could read says nothing about holes either.
+    `state.applied` is what carries "nothing here knows", and every consumer
+    prints it — a second null to mean the same thing would be a second thing
+    to forget.
+    """
+    return Placed(float(t), 0.0)
 
 
 def capture_clock_correction(
     doc: dict,
-) -> tuple[Callable[[dict, float], float], dict]:
-    """(correct, state) — how far each instant of `doc` slid under the video.
+) -> tuple[Callable[[dict, float], Placed], dict]:
+    """(place, state) — where each instant of `doc` is in the video.
 
-    `correct(beat, t)` is the seconds to add to the beat-log instant `t`, taken
-    from `beat`, to reach the same moment in `media`: the steps of that beat's
-    **own capture** up to **`t` itself**, never the running total and never an
-    earlier part's, whose loss is already in the merged offsets (see
-    `_merge_capture_clock`). On a take recorded in one piece neither the steps
-    nor the beats name a segment, and the same rule is then the whole list.
+    `place(beat, t)` puts the beat-log instant `t`, taken from `beat`, at the
+    same moment in `media`, using the steps of that beat's **own capture** up
+    to **`t` itself** — never the running total and never an earlier part's,
+    whose loss is already in the merged offsets (see `_merge_capture_clock`).
+    On a take recorded in one piece neither the steps nor the beats name a
+    segment, and the same rule is then the whole list.
 
     **`t` and not the beat**, because a caller converting a beat's midpoint and
     one converting its start are asking different questions whenever a step
     landed between the two — see the note above this function.
+
+    It returns a `Placed`, not a number of seconds, because an instant a
+    backward step deleted from the file has no honest number: `at` is then the
+    last instant the file has and `lost` says how much of the correction that
+    clamp swallowed. A caller that reads `at` alone is publishing a frame at a
+    moment the video does not contain (issue #256).
 
     `state` is what the artifact says about the correction — `applied`,
     `total`, `steps` (how many the record carries) and `note` (why not, when
@@ -572,15 +687,17 @@ def capture_clock_correction(
             ),
         }
 
-    def correct(beat: dict, t: float) -> float:
-        return sum(
-            float(step["delta"])
-            for step in steps
-            if step.get("segment") == beat.get("segment")
-            and float(step["t"]) <= float(t)
+    def place(beat: dict, t: float) -> Placed:
+        return _placed(
+            [
+                (float(step["t"]), float(step["delta"]))
+                for step in steps
+                if step.get("segment") == beat.get("segment")
+            ],
+            float(t),
         )
 
-    return correct, {
+    return place, {
         "applied": True,
         # Totalled from the steps that were **used**, not copied out of the
         # record's own `total`. The two can disagree — `tests/smoke` has an
@@ -592,8 +709,8 @@ def capture_clock_correction(
     }
 
 
-def capture_clock_shift(record: object) -> tuple[Callable[[float], float], dict]:
-    """(shift, state) for a capture that is still the only one there is.
+def capture_clock_shift(record: object) -> tuple[Callable[[float], Placed], dict]:
+    """(place, state) for a capture that is still the only one there is.
 
     `capture_clock_correction` above reads a finished timeline, where a step is
     attributed to the segment it was measured in and a beat is matched against
@@ -605,19 +722,19 @@ def capture_clock_shift(record: object) -> tuple[Callable[[float], float], dict]
     to drift apart, because `frames/` and the audio track of the same demo have
     to describe the same video.
 
-    `shift(t)` is the seconds to add to the beat-log instant `t`; `state` is the
-    same three-state record `capture_clock_correction` returns, and the caller
-    is expected to put it in an artifact rather than swallow it.
+    `place(t)` puts the beat-log instant `t` in the video, as a `Placed`;
+    `state` is the same three-state record `capture_clock_correction` returns,
+    and the caller is expected to put it in an artifact rather than swallow it.
     """
     correct, state = capture_clock_correction({"capture_clock": record})
 
-    def shift(t: float) -> float:
+    def place(t: float) -> Placed:
         # The empty beat is the point: a single capture's steps carry no
         # segment and neither does this, so every step in the record is this
         # instant's to be corrected by.
         return correct({}, t)
 
-    return shift, state
+    return place, state
 
 
 def _capture_clock_md(state: dict) -> list[str]:
@@ -674,6 +791,9 @@ def _narration_md(narration: object) -> list[str]:
       * a line whose correction hit the zero floor (`clamped`) did not move by
         the steps before it — it moved by as much of them as the start of the
         file left room for;
+      * a line the clock stepped *over* (`no_video`) was spoken during wall
+        time the file does not contain, so its clip sits at the last moment
+        before the gap and not where the steps put it (issue #256);
       * on a stitched demo where only some narrating parts could correct, the
         refusal is stated as **k of m segments** rather than as the whole demo.
     """
@@ -730,6 +850,24 @@ def _narration_md(narration: object) -> list[str]:
         f"one piece, that part's `offset` on a stitched demo — and `clamped` is "
         f"how many seconds of the correction that boundary swallowed."
         if clamped
+        else ""
+    )
+    # ...and the lines that were spoken over wall time the file does not have.
+    # A different sentence from `clamped` and never folded into it: that one is
+    # a line the *start of the file* caught, this one is a line the host's
+    # clock deleted the moment of. Both make the headline sentence false, for
+    # different reasons a listener would chase differently.
+    holed = [line for line in lines if line.get("no_video")]
+    tail += (
+        f" **{len(holed)} of them {'was' if len(holed) == 1 else 'were'} spoken "
+        f"over wall time that is not in the video at all**: a backward step "
+        f"takes its own width out of the file rather than moving it, so there "
+        f"is no moment in `media` for "
+        f"{'that line' if len(holed) == 1 else 'those lines'} to be at. "
+        f"{'Its' if len(holed) == 1 else 'Their'} clip starts at the last "
+        f"moment before the gap, and `no_video` is how many seconds later the "
+        f"video resumes (issue #256)."
+        if holed
         else ""
     )
     return [

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -147,7 +147,15 @@ instant before the gap and marked `no_video`, see below), and
 `narration.lines` gives each spoken line's `t` (the beat log's instant) beside
 its `at` (where the clip really is in `media`, which is `t` corrected by the
 same rule and never below zero), with `narration.clock_correction` saying which
-of the three cases applied; and `timeline.md` says above its beat table when the
+of the three cases applied — a line may also carry `clamped`, the seconds a
+correction lost to the start of the file, but **no record the recorder can
+emit produces one any more**: since
+[#256](https://github.com/rogvid/skills/issues/256) an instant is never placed
+earlier than the step that moved it, and the recorder's sampler starts at frame
+zero, so `at` cannot come out negative. The floor and the field stay because
+`adelay` refuses a negative delay outright and would cost the take its whole
+audio track; read `clamped` as a guard against a malformed record, not as
+something to expect; and `timeline.md` says above its beat table when the
 clock stepped and by how much, and what that meant for the audio. `timeline.json`'s beat
 timestamps are untouched — they are the log, and the log is `time.monotonic()`.
 

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -139,7 +139,9 @@ uncorrected is the way to get it wrong twice
 under `frames/` are cut on the video's clock**, midpoint plus that beat's own
 capture's steps before *that midpoint* (the rule is indexed by the instant you
 are converting, not by the beat — a step inside a beat's first half moves its
-frame), and `frames/frames.md` says which of the three cases the take was;
+frame; and a beat a backward step deleted from the file is cut at the last
+instant before the gap and marked `no_video`, see below), and
+`frames/frames.md` says which of the three cases the take was;
 **every narration clip is mixed on the video's clock too**
 ([#226](https://github.com/rogvid/skills/issues/226)) — `timeline.json`'s
 `narration.lines` gives each spoken line's `t` (the beat log's instant) beside
@@ -148,6 +150,25 @@ same rule and never below zero), with `narration.clock_correction` saying which
 of the three cases applied; and `timeline.md` says above its beat table when the
 clock stepped and by how much, and what that meant for the audio. `timeline.json`'s beat
 timestamps are untouched — they are the log, and the log is `time.monotonic()`.
+
+**A backward step is not a slide, and correcting one as though it were puts an
+instant up to a whole step early.** A step of −Δ at `T` deletes the monotonic
+window `(T, T+Δ)` from the file outright: the encoder stamps frames with the
+wall clock and will not write a stamp it has already written, so the file
+stalls for the width of the step instead of rewinding. Measured one video
+frame wide — `video 31.560 → 31.600 shows mono 31.644 → 32.644`. An instant
+inside that window has **no video at all**, and `t + (the steps before t)`
+lands it in content that predates the step; that is how a review frame came
+out showing the previous caption
+([#256](https://github.com/rogvid/skills/issues/256)). The rule that holds
+everywhere is that the video's clock is the wall clock's **high-water mark**:
+an instant sits at the greatest of `t + (the steps before t)` and every
+`T + (the steps before T)` for a step at `T ≤ t`. Outside a hole that is the
+same sum; inside one it is the last instant the file has, and whatever you
+build on it has to be able to say *this beat has no frame* rather than print a
+timestamp as though it did. The recorder's own consumers do: a `no_video` on a
+review frame and on a narration line, and a paragraph in `frames.md` and
+`timeline.md` naming them.
 
 What to do everywhere else: prefer `timeline.json`'s `capture_clock`, which
 records every step with its offset and size, and correct with it — **after

--- a/skills/demo-video/reference/narration.md
+++ b/skills/demo-video/reference/narration.md
@@ -47,6 +47,14 @@ needed; captions are the narration script.
   the mix falls back to the raw offset, `timeline.md` says so in a paragraph
   above the beat table, and the audio may be out by however far the host
   moved.
+- **A line spoken while the clock was stepping back has no moment in the
+  video, and its record says so.** A backward step of Δ deletes Δ of wall time
+  from the file rather than moving it, so there is nothing in the mp4 for such
+  a line to be at: its clip starts at the last moment before the gap and
+  carries `no_video`, the seconds until the video resumes
+  ([#256](https://github.com/rogvid/skills/issues/256)). `timeline.md` names
+  those lines. Correcting them like the rest puts the voice a whole step
+  early, over the caption before the one it is about.
 - **A backward step between two lines can make their clips overlap, and that
   is the correction working.** The step shortens the *video*; it does not
   shorten the clip. The recorder waited line 1 out before starting line 2 in

--- a/skills/demo-video/reference/narration.md
+++ b/skills/demo-video/reference/narration.md
@@ -54,7 +54,12 @@ needed; captions are the narration script.
   carries `no_video`, the seconds until the video resumes
   ([#256](https://github.com/rogvid/skills/issues/256)). `timeline.md` names
   those lines. Correcting them like the rest puts the voice a whole step
-  early, over the caption before the one it is about.
+  early, over the caption before the one it is about. This **replaced** the
+  older case where such a line was pushed to the very start of the track and
+  marked `clamped`: no record the recorder can emit produces a `clamped` line
+  any more, because an instant is never placed earlier than the step that
+  moved it. The floor stays only because `adelay` cannot express a negative
+  delay for a malformed record.
 - **A backward step between two lines can make their clips overlap, and that
   is the correction working.** The step shortens the *video*; it does not
   shorten the clip. The recorder waited line 1 out before starting line 2 in

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -45,6 +45,18 @@ uncorrected cut was out by up to 1.50 s. The timestamps in `frames.json` and
 `frames.md` are **already on the video's clock** — do not apply
 `capture_clock` to them a second time.
 
+**A beat can have no frame at all, and the sheet says which**
+([#256](https://github.com/rogvid/skills/issues/256)). A backward step of Δ
+does not slide the video: it takes a Δ-wide window of wall time *out of the
+file*, because the encoder will not write a frame stamp it has already
+written. A beat inside that window was never encoded, so its frame is the last
+one before the gap — `frames.json` gives it a `no_video` (how many seconds
+later the video resumes) and `frames.md` names it, above the table and beside
+the picture. Read such a frame as the moment the demo had reached when the
+clock moved, not as the beat. Without the clamp the cut lands up to a whole
+step early, which is how `seg-run1`'s `beat-05.png` came out showing the
+previous caption.
+
 `frames.md` says which of the three cases the take was, because a corrected
 sheet and an uncorrected one are otherwise the same document: the clock
 stepped and the frames were moved, the clock was watched and held still, or

--- a/tests/README.md
+++ b/tests/README.md
@@ -1751,7 +1751,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **16 of `tests/smoke`'s 41 check functions have no entry**, and the harness
+- **17 of `tests/smoke`'s 42 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -1786,6 +1786,7 @@ paragraph whose job is to say what this manifest does not cover.
   | `_check_stale_frames` | genuinely ungraded. `FailureCleanup` is the same shape for the failure dump, not for `frames/` |
   | `_check_segment_refusal` | genuinely ungraded — an unmerged segment's document, graded against the frames a recorder did not write |
   | `_check_scene_fallback` | genuinely ungraded — measured straight off `demo.mp4`, because no beat in either storyboard is long enough to provoke it |
+  | `_check_unstated_holes` | `HostClockHole` — the whole of it, on a scripted `HostClock`: the complaint, the marker that silences it, the steady-host control and both edge guards (#256). Genuinely ungraded *as a check that runs*: a host that does not step its wall clock produces no hole for it to find, so no arm has ever reached its failure |
 
   **Three rows above are worse off than the rest, and #61 is why.**
   `check_opening`, `check_opening_gap` and `check_verb_classification` are
@@ -2128,7 +2129,7 @@ knows is missing is worse than one that is openly absent.
   **And on a host whose clock never steps, the correction is a no-op** — a
   corrected cut and an uncorrected one are the same number, so no arm of this
   suite can tell them apart there. The arithmetic is graded on a *scripted*
-  record by `FrameClockCorrection` in `tests/unit`, where 21 injections cost
+  record by `FrameClockCorrection` in `tests/unit`, where 22 injections cost
   0.2 s each — the figure is checked against the manifest by
   `StatedInjectionCount`, because it drifted once already — including the one that reads the correction at a beat's
   `t_start` and applies it to the midpoint, which is how #253 shipped its first
@@ -2161,6 +2162,19 @@ knows is missing is worse than one that is openly absent.
   which is why all of it is synthetic; what #256 deliberately did not do is
   question whether the recorded Δ is the width of the hole, which is
   [#259](https://github.com/rogvid/skills/issues/259).
+
+  **And none of #256's harness half has ever been executed against a real
+  take.** `_check_unstated_holes`, the `hole_clause` both placement failures
+  append, and the re-pointed `--segments-only` entry for the frame-cut instant
+  are all **text-verified and unit-verified only**: `--segments-only` is red
+  on this box whenever its clock steps ([#258](https://github.com/rogvid/skills/issues/258)),
+  and `smoke-inject` — rightly — refuses to grade an injection whose clean
+  baseline already fails. "Every entry still matches the tree" says the search
+  strings are current; it does not say the arm ran. What did run is
+  `HostClockHole`, against a scripted `HostClock`, in 0.1 s. That is a weaker
+  claim than the arm passing — it does not prove the check is *reached* on a
+  real take — and it is the strongest one this host allows, which is the same
+  position `ClockCoverageCheck` has been in since #247.
 
 - **~~…and the correction above rests on a premise that did not reproduce on
   2026-08-08.~~ Retracted; the premise holds and the *sampler* was broken**

--- a/tests/README.md
+++ b/tests/README.md
@@ -1951,17 +1951,21 @@ knows is missing is worse than one that is openly absent.
   `check_timeline`'s identical guard at `tests/smoke:6195` has been uninjected
   since #245 — and it is written down here rather than left to be noticed.
 
-  **And the correction narration applies is over-large on this host, by an
-  amount nothing here removes.** #224's diagnosis found that a −Δ wall-clock
-  step does not slide the video: it **deletes a Δ-wide hole** from the file,
-  and separately some takes lose only 16–50 % of the recorded step. Every
-  consumer of `capture_clock` over-corrects as a result — the review frames,
-  the smoke harness's own `before()`, and the narration mix alike — so a line
-  whose instant falls inside such a hole is placed up to a whole step early.
-  [#255](https://github.com/rogvid/skills/issues/255) carries the measurements
-  and fixes it at the source, in `before()` and `capture_clock_correction`, for
-  all consumers at once. Nothing about it is narration-specific and nothing in
-  `narration.py` should chase it.
+  **And the correction narration applies can still be over-large on this
+  host, by an amount nothing here measures.** #224's diagnosis found two
+  things. The first — that a −Δ wall-clock step **deletes a Δ-wide hole** from
+  the file rather than sliding it, so a line spoken inside that hole was
+  placed up to a whole step early — is fixed at the source in
+  [#256](https://github.com/rogvid/skills/issues/256), for the review frames,
+  the smoke harness's own `before()` and the narration mix at once; a line in
+  a hole now carries `no_video` and `timeline.md` names it. The second is
+  open: some takes lose only **16–50 %** of the recorded step, so subtracting
+  all of it aims a clip Δ−loss too early even outside a hole. Nothing in this
+  repo checks the recorded step against the pixels, which is
+  [#259](https://github.com/rogvid/skills/issues/259).
+  [#255](https://github.com/rogvid/skills/issues/255) carries both
+  measurements. Nothing about either is narration-specific and nothing in
+  `narration.py` should chase them.
 
 - **That a real Chromium hands a click's deferred document event to
   `evaluate("0")`.** [#214](https://github.com/rogvid/skills/issues/214) is
@@ -2124,7 +2128,7 @@ knows is missing is worse than one that is openly absent.
   **And on a host whose clock never steps, the correction is a no-op** — a
   corrected cut and an uncorrected one are the same number, so no arm of this
   suite can tell them apart there. The arithmetic is graded on a *scripted*
-  record by `FrameClockCorrection` in `tests/unit`, where 15 injections cost
+  record by `FrameClockCorrection` in `tests/unit`, where 21 injections cost
   0.2 s each — the figure is checked against the manifest by
   `StatedInjectionCount`, because it drifted once already — including the one that reads the correction at a beat's
   `t_start` and applies it to the midpoint, which is how #253 shipped its first
@@ -2135,6 +2139,28 @@ knows is missing is worse than one that is openly absent.
   which of the three cases it was, and that a step the recorder invents moves
   the frames and is caught by a placement check reading this harness's own
   watcher.
+
+  **A backward step is not a slide, and until
+  [#256](https://github.com/rogvid/skills/issues/256) every consumer read it
+  as one.** A step of −Δ deletes the monotonic window `(T, T+Δ)` from the file
+  outright — the encoder stamps frames with the wall clock and will not write
+  a stamp it has already written, so the file stalls instead of rewinding,
+  measured one video frame wide (`video 31.560 → 31.600 shows mono 31.644 →
+  32.644`). An instant inside that window has no frame at all, and `t + (the
+  steps before t)` puts it up to a whole step early, in content that predates
+  the step: `seg-run1`'s `beat-05.png`, cut at 4.58 s, **showing the previous
+  caption**. All three consumers now place an instant at the wall clock's
+  *high-water mark* — the recorder's `timeline._placed`, and this harness's
+  own `video_instant`, hand-written apart from it — which is the same sum
+  digit for digit outside a hole and clamps to the file's last instant inside
+  one, and each says so in its own artifact: `no_video` on a frame and on a
+  narration line, a named paragraph in `frames.md` and in `timeline.md`, and
+  the hole in the harness's own failure text. `HostClockHole` in `tests/unit`
+  grades the harness's half on a scripted clock, `FrameClockCorrection` and
+  `NarrationMix` the recorder's. **None of it is reachable on a steady host**,
+  which is why all of it is synthetic; what #256 deliberately did not do is
+  question whether the recorded Δ is the width of the hole, which is
+  [#259](https://github.com/rogvid/skills/issues/259).
 
 - **~~…and the correction above rests on a premise that did not reproduce on
   2026-08-08.~~ Retracted; the premise holds and the *sampler* was broken**

--- a/tests/smoke
+++ b/tests/smoke
@@ -2097,12 +2097,8 @@ class HostClock:
     def total(self) -> float:
         return sum(delta for _, delta in self.steps)
 
-    def before(self, t: float) -> float:
-        """How much the wall clock had stepped by `t` seconds into the video.
-
-        Negative when the clock went backwards, which is the direction that
-        takes wall time out of the video. A beat the log puts at `t` is at
-        `t + before(t)` in demo.mp4.
+    def in_video(self, t: float) -> tuple[float, float]:
+        """(where `t` is in demo.mp4, how much of it has no video) — see below.
 
         **Only the steps inside `t`'s own capture count.** A capture's first
         frame is where its clock starts, so a step during an earlier part
@@ -2118,7 +2114,35 @@ class HostClock:
         to be able to disagree, or `capture_clock` is not being graded.
         """
         start = max((b for b in self.boundaries if b <= t), default=0.0)
-        return sum(delta for at, delta in self.steps if start <= at <= t)
+        return video_instant(
+            [(at, delta) for at, delta in self.steps if start <= at <= t], t
+        )
+
+    def before(self, t: float) -> float:
+        """How much the wall clock had stepped by `t` seconds into the video.
+
+        Negative when the clock went backwards, which is the direction that
+        takes wall time out of the video. A beat the log puts at `t` is at
+        `t + before(t)` in demo.mp4.
+
+        **Not simply the sum of the steps before `t`**, and the difference is a
+        whole step: a backward step deletes its own width of wall time from the
+        file rather than sliding it, so an instant inside that hole has no
+        frame and `before()` returns what it takes to reach the last one there
+        is (issue #256). `hole()` is how a caller tells that case from an
+        instant the file really contains — this number alone cannot, which is
+        the defect #256 is about, on the harness's side of it.
+        """
+        return self.in_video(t)[0] - t
+
+    def hole(self, t: float) -> float:
+        """Seconds of wall time at `t` that never reached the file, or 0.0.
+
+        Non-zero only inside a backward step's hole, where it is the distance
+        from `t` to the moment the video starts again — which is also how far
+        too early `t + (the steps before t)` would have put it.
+        """
+        return self.in_video(t)[1]
 
     def describe(self) -> str:
         if not self.steps:
@@ -2126,6 +2150,44 @@ class HostClock:
         return "the host's wall clock stepped " + ", ".join(
             f"{delta * 1000:+.0f} ms at {at:.1f}s" for at, delta in self.steps
         )
+
+
+def video_instant(steps: list[tuple[float, float]], t: float) -> tuple[float, float]:
+    """(where `t` is in the video, how many seconds of it have no video at all).
+
+    The one piece of clock arithmetic this file shares between its own watcher
+    and its reading of a published record, because it is not a claim about the
+    recorder — it is what a wall clock does to a file. `HostClock.before` and
+    `merged_clock_correction` are both hand-written *from this*, and both stay
+    hand-written away from the recorder's own `timeline._placed`, which is the
+    independence that matters: a correction taken from the code under test
+    agrees with that code whatever it says.
+
+    **A backward step of Δ does not slide the video. It deletes the monotonic
+    window `(T, T+Δ)` from the file** (issue #256): the encoder stamps frames
+    with the host's wall clock and will not write a stamp it has already
+    written, so the file stalls for the width of the step instead of rewinding.
+    Measured one video frame wide — `video 31.560 → 31.600 shows mono 31.644 →
+    32.644`. So the video's clock is the *high-water mark* of the wall clock,
+    and an instant inside a hole has no frame of its own at all: it clamps to
+    the last one the file has, and the second return value says how far short
+    of the naive `t + (the steps before t)` that left it.
+
+    Everywhere outside a hole this is that sum, digit for digit, and on a host
+    whose clock never steps it is the identity. Which is to say: **on a healthy
+    box every line of this is dead**, and nothing an arm of this suite prints
+    grades it. `HostClockHole` in `tests/unit` does, on a scripted clock.
+    """
+    running = 0.0
+    edge = -math.inf
+    for at, delta in sorted(steps):
+        if at > t:
+            break
+        edge = max(edge, at + running)
+        running += delta
+    shifted = t + running
+    reached = max(shifted, edge)
+    return reached, reached - shifted
 
 
 def joined_clock(parts: list[tuple[HostClock, float]]) -> HostClock:
@@ -2378,23 +2440,31 @@ def merged_clock_correction(record: object, beat: dict) -> float:
     "check that shares the bug's blind spot". The documented rule is the steps
     of *this beat's own capture*, up to this beat — not the running total, and
     not an earlier part's, whose lost wall time is already in the offsets the
-    merge laid the parts out by.
+    merge laid the parts out by — clamped to the last instant the file has
+    where a backward step deleted this one (`video_instant`, issue #256).
+
+    **The hole arithmetic is shared with `HostClock.before`, and that narrows
+    what the comparison in `check_merged_capture_clock` grades**: a bug in
+    `video_instant` cancels on both sides of it. What is left there is what
+    that check is for — whether the *record* attributes its steps to the right
+    capture — and the arithmetic itself is graded against hand-written numbers
+    by `HostClockHole` in `tests/unit`.
     """
     if not isinstance(record, dict):
         return 0.0
     t_start = beat.get("t_start")
     if not isinstance(t_start, (int, float)):
         return 0.0
-    total = 0.0
+    steps = []
     for step in record.get("steps") or []:
         if not isinstance(step, dict):
             continue
         at, delta = step.get("t"), step.get("delta")
         if not isinstance(at, (int, float)) or not isinstance(delta, (int, float)):
             continue
-        if step.get("segment") == beat.get("segment") and at <= float(t_start):
-            total += float(delta)
-    return total
+        if step.get("segment") == beat.get("segment"):
+            steps.append((float(at), float(delta)))
+    return video_instant(steps, float(t_start))[0] - float(t_start)
 
 
 def check_merged_capture_clock(
@@ -6577,6 +6647,60 @@ def check_form_pacing(label: str, out_dir: Path) -> list[str]:
     return failures
 
 
+def unstated_holes(label: str, clock, listed: list[dict], beats: dict) -> list[str]:
+    """Frames of a beat the host's clock deleted, that the sheet calls ordinary.
+
+    A backward step of Δ takes a Δ-wide window of wall time out of the file
+    (issue #256), and a beat whose midpoint falls inside one has no frame in
+    `demo.mp4` at all. The recorder cuts the last frame before the gap, which
+    is the only honest thing it can cut — and the sheet then has to *say* that,
+    or the reviewer reads a picture of the moment before the step as a picture
+    of the beat. That is what shipped: `seg-run1`'s `beat-05.png`, cut a whole
+    step early, showing the previous caption, numbered for the next one.
+
+    Only the missing direction is graded. A frame the recorder marks that this
+    watcher did not find a hole for is *not* failed here: the two samplers are
+    on their own 20 ms grids, and whether they agree about the steps at all is
+    `check_capture_clock`'s claim, made against the record rather than against
+    a derived consequence of it. For the same reason a midpoint within
+    `MAX_CLOCK_STEP_TIME_DISAGREEMENT_S` of either edge of the hole is left
+    alone: neither watcher knows which side of the edge it fell on.
+
+    Pure in its inputs, and that is deliberate — a host that does not step its
+    clock produces no holes and can never reach the failure below, so the only
+    way anyone sees this fail is `HostClockHole` in `tests/unit` handing it a
+    scripted clock.
+    """
+    if clock is None:
+        return []
+    failures = []
+    for frame in listed:
+        beat = beats.get(frame.get("beat"))
+        if beat is None or not isinstance(beat.get("t_start"), (int, float)):
+            continue
+        middle = (float(beat["t_start"]) + float(beat["t_end"])) / 2
+        gap = clock.hole(middle)
+        near_edge = any(
+            abs(middle - at) <= MAX_CLOCK_STEP_TIME_DISAGREEMENT_S
+            for at, _delta in clock.steps
+        )
+        if gap <= MAX_CLOCK_STEP_TIME_DISAGREEMENT_S or near_edge:
+            continue
+        if not frame.get("no_video"):
+            failures.append(
+                f"{label}: beat {frame.get('beat')} runs "
+                f"{beat['t_start']}-{beat['t_end']}s and this harness watched "
+                f"the host's wall clock step backwards over its midpoint "
+                f"({middle:.3f}s) — the video resumes {gap * 1000:.0f} ms after "
+                f"it, so there is no frame of that beat in demo.mp4 at all. "
+                f"{frame.get('file')} is at {frame.get('t')}s with nothing in "
+                f"frames.json saying so, and a sheet that presents the last "
+                f"frame before the gap as the beat's own hands the reviewer a "
+                f"picture of the moment before the step (issue #256)"
+            )
+    return failures
+
+
 def check_beat_frames(
     label: str,
     out_dir: Path,
@@ -6602,6 +6726,9 @@ def check_beat_frames(
         together: the first without the second passes a manifest that says the
         right time over the wrong picture, and the second without the first
         passes a frame faithfully cut from the wrong second;
+      * **a beat the clock deleted is not presented as a frame of itself** —
+        `unstated_holes()`, which fires only where this harness's own watcher
+        saw the wall clock step backwards over a beat's midpoint (issue #256);
       * **the sheet says which clock it cut them on.** On a host that never
         steps its clock the corrected instant and the uncorrected one are the
         same number, so the bullet above cannot tell a recorder that applies
@@ -6710,6 +6837,23 @@ def check_beat_frames(
             for when in step_times
         )
         want = middle + stepped(middle)
+        # ...and where that instant has no video at all, `want` is the last
+        # frame before the gap rather than the midpoint's own moment, so the
+        # message has to say which of the two it is comparing against. A
+        # reader sent to look for the beat at `want` would otherwise go
+        # looking for a frame the file does not contain (issue #256).
+        gap = clock.hole(middle) if clock is not None else 0.0
+        because = (
+            f"({middle:.3f}s on the beat log, {stepped(middle):+.3f}s of "
+            f"wall clock before it)"
+            if not gap
+            else (
+                f"({middle:.3f}s on the beat log, which the host's wall clock "
+                f"stepped backwards over: there is no video of that moment, and "
+                f"{want:.3f}s is the last instant before the gap — the file "
+                f"resumes {gap * 1000:.0f} ms past the beat's midpoint)"
+            )
+        )
         if on_a_step:
             ungraded += 1
         elif abs(at - want) > MAX_FRAME_PLACEMENT_S and at < duration - 0.2:
@@ -6717,8 +6861,7 @@ def check_beat_frames(
                 f"{label}: {frame.get('file')} was taken at {at:.3f}s, but beat "
                 f"{frame.get('beat')} runs {beat['t_start']}-{beat['t_end']}s "
                 f"and its midpoint sits at {want:.3f}s in the video "
-                f"({middle:.3f}s on the beat log, {stepped(middle):+.3f}s of "
-                f"wall clock before it) — "
+                f"{because} — "
                 f"the frame is not the moment the sheet numbers it for"
             )
         if not mp4.is_file() or not duration:
@@ -6807,6 +6950,7 @@ def check_beat_frames(
                 f"the storyboard into it is how it ends up back on the sheet"
             )
 
+    failures += unstated_holes(label, clock, listed, beats)
     failures += _check_frame_captions(
         label,
         out_dir,
@@ -10056,12 +10200,28 @@ def check_narration_placement(
         want = max(0.0, float(off) + clock.before(float(off)))
         expected.append(want)
         if abs(float(line.get("at", -1)) - want) > NARRATION_ONSET_TOLERANCE_S:
+            # Where the instant has no video, say so rather than reporting a
+            # second as though the file had one: `want` is then the last
+            # moment before the gap, and the recorder is expected to have
+            # clamped a line spoken during a backward step to the same place
+            # (issue #256).
+            gap = clock.hole(float(off))
             failures.append(
                 f"{label}: timeline.json puts line {n} at {line.get('at')!r}s "
                 f"of demo.mp4; this harness's own wall-clock reading puts the "
-                f"{off:.3f}s instant at {want:.3f}s ({clock.describe()}). The "
-                f"recorder and an independent sampler disagree about where "
-                f"the voice should be (issue #226)"
+                f"{off:.3f}s instant at {want:.3f}s ({clock.describe()})"
+                + (
+                    ""
+                    if not gap
+                    else (
+                        f" — and that instant is one the host's wall clock "
+                        f"stepped backwards over, so {want:.3f}s is the last "
+                        f"moment before a gap the video only resumes from "
+                        f"{gap * 1000:.0f} ms later"
+                    )
+                )
+                + ". The recorder and an independent sampler disagree about "
+                "where the voice should be (issue #226)"
             )
 
     # (3). Nothing below reads the recorder's record — the file is the witness.

--- a/tests/smoke
+++ b/tests/smoke
@@ -2190,6 +2190,31 @@ def video_instant(steps: list[tuple[float, float]], t: float) -> tuple[float, fl
     return reached, reached - shifted
 
 
+def hole_clause(clock, t: float, at: float) -> str:
+    """What a failure adds when the instant it is about has no video. Or "".
+
+    Both places this harness prints "the instant `t` is at `at` in the video"
+    are wrong about `at` inside a hole — it is not where that instant is, it is
+    the last moment the file has before the instant's own wall time was deleted
+    (issue #256). Sent to `at` without this, a reader goes looking for a frame
+    that is not there and concludes the harness is confused.
+
+    One function for both messages, appended as a whole sentence rather than
+    spliced into either, so the two cannot drift and so this is gradeable on
+    its own: neither call site is reachable on a host whose clock holds still,
+    and `HostClockHole` in `tests/unit` is the only thing that runs it.
+    """
+    gap = clock.hole(t) if clock is not None else 0.0
+    if not gap:
+        return ""
+    return (
+        f" There is no video of that instant at all: the host's wall clock "
+        f"stepped backwards over it, so {at:.3f}s is the last moment before a "
+        f"gap the video only resumes from {gap * 1000:.0f} ms later, and the "
+        f"recorder is expected to have clamped to the same place (issue #256)."
+    )
+
+
 def joined_clock(parts: list[tuple[HostClock, float]]) -> HostClock:
     """The clock of a video stitched from several captures.
 
@@ -6647,7 +6672,9 @@ def check_form_pacing(label: str, out_dir: Path) -> list[str]:
     return failures
 
 
-def unstated_holes(label: str, clock, listed: list[dict], beats: dict) -> list[str]:
+def _check_unstated_holes(
+    label: str, clock, listed: list[dict], beats: dict
+) -> list[str]:
     """Frames of a beat the host's clock deleted, that the sheet calls ordinary.
 
     A backward step of Δ takes a Δ-wide window of wall time out of the file
@@ -6669,7 +6696,9 @@ def unstated_holes(label: str, clock, listed: list[dict], beats: dict) -> list[s
     Pure in its inputs, and that is deliberate — a host that does not step its
     clock produces no holes and can never reach the failure below, so the only
     way anyone sees this fail is `HostClockHole` in `tests/unit` handing it a
-    scripted clock.
+    scripted clock. Named `_check_…` so `smoke-inject`'s roster counts it: an
+    assertion site the coverage report cannot see makes that report understate
+    what exists, which is the one direction a coverage claim must never fail in.
     """
     if clock is None:
         return []
@@ -6677,6 +6706,13 @@ def unstated_holes(label: str, clock, listed: list[dict], beats: dict) -> list[s
     for frame in listed:
         beat = beats.get(frame.get("beat"))
         if beat is None or not isinstance(beat.get("t_start"), (int, float)):
+            continue
+        # `t_end` guarded as well as `t_start`, because a beat can reach here
+        # without one — `check_beat_frames` builds `beats` straight from
+        # `timeline.json` — and a harness check that raises instead of
+        # reporting takes the whole arm down over a beat it had nothing to say
+        # about.
+        if not isinstance(beat.get("t_end"), (int, float)):
             continue
         middle = (float(beat["t_start"]) + float(beat["t_end"])) / 2
         gap = clock.hole(middle)
@@ -6727,8 +6763,9 @@ def check_beat_frames(
         right time over the wrong picture, and the second without the first
         passes a frame faithfully cut from the wrong second;
       * **a beat the clock deleted is not presented as a frame of itself** —
-        `unstated_holes()`, which fires only where this harness's own watcher
-        saw the wall clock step backwards over a beat's midpoint (issue #256);
+        `_check_unstated_holes()`, which fires only where this harness's own
+        watcher saw the wall clock step backwards over a beat's midpoint
+        (issue #256);
       * **the sheet says which clock it cut them on.** On a host that never
         steps its clock the corrected instant and the uncorrected one are the
         same number, so the bullet above cannot tell a recorder that applies
@@ -6837,23 +6874,6 @@ def check_beat_frames(
             for when in step_times
         )
         want = middle + stepped(middle)
-        # ...and where that instant has no video at all, `want` is the last
-        # frame before the gap rather than the midpoint's own moment, so the
-        # message has to say which of the two it is comparing against. A
-        # reader sent to look for the beat at `want` would otherwise go
-        # looking for a frame the file does not contain (issue #256).
-        gap = clock.hole(middle) if clock is not None else 0.0
-        because = (
-            f"({middle:.3f}s on the beat log, {stepped(middle):+.3f}s of "
-            f"wall clock before it)"
-            if not gap
-            else (
-                f"({middle:.3f}s on the beat log, which the host's wall clock "
-                f"stepped backwards over: there is no video of that moment, and "
-                f"{want:.3f}s is the last instant before the gap — the file "
-                f"resumes {gap * 1000:.0f} ms past the beat's midpoint)"
-            )
-        )
         if on_a_step:
             ungraded += 1
         elif abs(at - want) > MAX_FRAME_PLACEMENT_S and at < duration - 0.2:
@@ -6861,8 +6881,14 @@ def check_beat_frames(
                 f"{label}: {frame.get('file')} was taken at {at:.3f}s, but beat "
                 f"{frame.get('beat')} runs {beat['t_start']}-{beat['t_end']}s "
                 f"and its midpoint sits at {want:.3f}s in the video "
-                f"{because} — "
-                f"the frame is not the moment the sheet numbers it for"
+                f"({middle:.3f}s on the beat log, {stepped(middle):+.3f}s of "
+                f"wall clock before it) — "
+                f"the frame is not the moment the sheet numbers it for."
+                # ...and where that instant has no video at all, `want` is the
+                # last frame before the gap and not the midpoint's own moment.
+                # A reader sent to look for the beat at `want` would otherwise
+                # go looking for a frame the file does not contain (#256).
+                + hole_clause(clock, middle, want)
             )
         if not mp4.is_file() or not duration:
             continue
@@ -6950,7 +6976,7 @@ def check_beat_frames(
                 f"the storyboard into it is how it ends up back on the sheet"
             )
 
-    failures += unstated_holes(label, clock, listed, beats)
+    failures += _check_unstated_holes(label, clock, listed, beats)
     failures += _check_frame_captions(
         label,
         out_dir,
@@ -10200,28 +10226,18 @@ def check_narration_placement(
         want = max(0.0, float(off) + clock.before(float(off)))
         expected.append(want)
         if abs(float(line.get("at", -1)) - want) > NARRATION_ONSET_TOLERANCE_S:
-            # Where the instant has no video, say so rather than reporting a
-            # second as though the file had one: `want` is then the last
-            # moment before the gap, and the recorder is expected to have
-            # clamped a line spoken during a backward step to the same place
-            # (issue #256).
-            gap = clock.hole(float(off))
             failures.append(
                 f"{label}: timeline.json puts line {n} at {line.get('at')!r}s "
                 f"of demo.mp4; this harness's own wall-clock reading puts the "
-                f"{off:.3f}s instant at {want:.3f}s ({clock.describe()})"
-                + (
-                    ""
-                    if not gap
-                    else (
-                        f" — and that instant is one the host's wall clock "
-                        f"stepped backwards over, so {want:.3f}s is the last "
-                        f"moment before a gap the video only resumes from "
-                        f"{gap * 1000:.0f} ms later"
-                    )
-                )
-                + ". The recorder and an independent sampler disagree about "
-                "where the voice should be (issue #226)"
+                f"{off:.3f}s instant at {want:.3f}s ({clock.describe()}). The "
+                f"recorder and an independent sampler disagree about where "
+                f"the voice should be (issue #226)."
+                # Where the instant has no video, say so rather than reporting
+                # a second as though the file had one: `want` is then the last
+                # moment before the gap, and the recorder is expected to have
+                # clamped a line spoken during a backward step to the same
+                # place (issue #256).
+                + hole_clause(clock, float(off), want)
             )
 
     # (3). Nothing below reads the recorder's record — the file is the witness.

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -693,11 +693,8 @@ INJECTIONS = [
         # instant `frames.py`'s own header says is the wrong one.
         name="every review frame is cut at the start of its beat, not its midpoint",
         module="frames.py",
-        old="        middle = min(max(logged + correct(beat, logged), 0.0), last)",
-        new=(
-            "        middle = min(max(float(t_start) + correct(beat, "
-            "float(t_start)), 0.0), last)"
-        ),
+        old="        middle = min(max(placed.at, 0.0), last)",
+        new="        middle = min(max(place(beat, float(t_start)).at, 0.0), last)",
         arm="--segments-only",
         sites=("check_beat_frames",),
         must_contain=("the frame is not the moment the sheet numbers it for",),

--- a/tests/unit
+++ b/tests/unit
@@ -5264,16 +5264,38 @@ class FrameClockCorrection(unittest.TestCase):
         self.assertEqual(windows, [(1.0, 8.22)])
 
     def test_a_beat_the_clock_swallowed_loses_its_scene_frames_out_loud(self):
-        """A step bigger than the beat it lands in inverts the search window.
+        """A beat wholly inside a hole has no stretch of video to search.
 
-        Per-instant edges are what make this reachable: the start is corrected
-        by nothing and the end by the whole step, so a step larger than the
-        beat's span puts the end before the start and there is no stretch of
-        video left to search. That is honest — the wall time the beat occupied
-        is not in the file — but `scene_times` answers an inverted window with
-        an empty list, so without this the sheet would simply have fewer frames
-        and say nothing. It needs a step over `SCENE_MIN_SPAN_S`, which is this
-        host's 10 s pulse transient.
+        The step at 0.5 s deletes 0.5-6.5 s of wall time from the file (#256),
+        and the beat runs 1.0-5.0 s: both of its edges are inside that window,
+        so both clamp to the same instant and there is nothing between them.
+        That is honest — the wall time the beat occupied is not in the file —
+        but `scene_times` answers an empty window with an empty list, so
+        without this the sheet would simply have fewer frames and say nothing.
+        It needs a step over `SCENE_MIN_SPAN_S`, which is this host's 10 s
+        pulse transient.
+        """
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((0.5, -6.0)),
+            beats=[beat(0, "hold", 1.0, t_end=5.0)],
+        )
+        manifest, cuts, windows = self.sheet(doc)
+        self.assertEqual(windows, [], "no window can be searched, so none was")
+        self.assertEqual(manifest["scene_search_skipped"], [0])
+        self.assertEqual(cuts, [0.5], "the last instant the file has, not 0.0")
+        sheet = render_frames_md(manifest)
+        self.assertIn("no extra frames were looked for", sheet)
+
+    def test_a_step_inside_a_beat_leaves_the_part_of_it_the_file_still_has(self):
+        """The near miss of the case above, and the control for it.
+
+        The step at 2.0 s lands *inside* the same beat, so its first second is
+        in the file and its last three are not. The window is that first
+        second — 1.0 s up to the hole's edge — and nothing is reported as
+        skipped. Before #256 this scenario produced an *inverted* window
+        (1.0, -1.0) and was the one the case above was written from: the end
+        was corrected by the whole 6 s step as though the video had slid.
         """
         doc = envelope(
             duration=20.0,
@@ -5281,11 +5303,9 @@ class FrameClockCorrection(unittest.TestCase):
             beats=[beat(0, "hold", 1.0, t_end=5.0)],
         )
         manifest, cuts, windows = self.sheet(doc)
-        self.assertEqual(windows, [], "no window can be searched, so none was")
-        self.assertEqual(manifest["scene_search_skipped"], [0])
-        self.assertEqual(cuts, [0.0])
-        sheet = render_frames_md(manifest)
-        self.assertIn("no extra frames were looked for", sheet)
+        self.assertEqual(windows, [(1.0, 2.0)])
+        self.assertEqual(manifest["scene_search_skipped"], [])
+        self.assertEqual(cuts, [2.0])
 
     def test_a_beat_the_clock_left_alone_reports_no_skipped_search(self):
         # The control: the same long beat with the step outside it keeps its
@@ -5305,17 +5325,24 @@ class FrameClockCorrection(unittest.TestCase):
         # because `stitch()` lays the parts out by their measured durations.
         # Applying it again would put every frame of part two 0.78 s early —
         # worse than not correcting at all.
+        #
+        # The step is at 1.0 s so that its hole — the 0.78 s of wall time it
+        # takes out of the file (#256) — ends before the beat at 2.05 s. This
+        # test is about which capture a step belongs to, and a beat inside a
+        # hole answers a different question, one test below.
         _manifest, cuts, _windows = self.sheet(
-            self.merged([clock_record((1.5, -0.78)), clock_record()])
+            self.merged([clock_record((1.0, -0.78)), clock_record()])
         )
         self.assertEqual(cuts, [0.55, 1.27, 8.05, 9.55])
 
     def test_a_beat_before_its_own_captures_step_is_cut_at_its_midpoint(self):
         # The other direction of the same rule, inside one part: part two's
-        # step at 1.5 s of its own clock is 9.0 s on the stitched one, so the
-        # beat at 8.05 s keeps its midpoint and the beat at 9.55 s moves.
+        # step at 1.0 s of its own clock is 8.5 s on the stitched one, so the
+        # beat at 8.05 s keeps its midpoint and the beat at 9.55 s moves. Same
+        # reason as above for 1.0 rather than 1.5: 9.55 has to be past the end
+        # of the step's hole for this to be a test about attribution.
         _manifest, cuts, _windows = self.sheet(
-            self.merged([clock_record(), clock_record((1.5, -0.78))])
+            self.merged([clock_record(), clock_record((1.0, -0.78))])
         )
         self.assertEqual(cuts, [0.55, 2.05, 8.05, 8.77])
 
@@ -5328,6 +5355,121 @@ class FrameClockCorrection(unittest.TestCase):
         )
         self.assertEqual(cuts, [4.22])
         self.assertEqual(windows, [(2.22, 6.22)])
+
+    # -- the hole a backward step leaves (issue #256) ------------------------
+    #
+    # The numbers in the first three are the measured ones, off the take that
+    # found this: a −1.051 s step at 5.151 s of `seg-run1`, and `beat-05` with
+    # its midpoint at 5.633 s, inside the hole (5.151, 6.202). The frame that
+    # shipped was cut at **4.58 s** and shows the previous caption.
+
+    def test_a_beat_the_step_deleted_is_cut_at_the_last_frame_before_the_gap(self):
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((5.151, -1.051)),
+            beats=[beat(0, "caption", 5.133, t_end=6.133)],
+        )
+        _manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [5.151], "the hole's edge, not 4.582")
+
+    def test_that_frame_is_marked_as_one_with_no_video_of_its_beat(self):
+        # The cut alone is not the fix: 5.151 s is a real second of the file
+        # and reads exactly like a frame of the beat unless the manifest says
+        # otherwise. 0.569 s is how much longer the hole runs past the
+        # midpoint, which is also how far too early the old rule put it.
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((5.151, -1.051)),
+            beats=[beat(0, "caption", 5.133, t_end=6.133)],
+        )
+        manifest, _cuts, _windows = self.sheet(doc)
+        self.assertEqual(manifest["frames"][0]["no_video"], 0.569)
+
+    def test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat(self):
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((5.151, -1.051)),
+            beats=[beat(0, "caption", 5.133, t_end=6.133)],
+        )
+        manifest, _cuts, _windows = self.sheet(doc)
+        sheet = render_frames_md(manifest)
+        self.assertIn("`beat-00.png` is not at the beat it is named for", sheet)
+        self.assertIn("569 ms after `beat-00.png`", sheet)
+        # Beside the picture too, not only in the preamble a scrolling
+        # reviewer never reaches.
+        self.assertIn("## beat-00 — 5.15s (no video of this beat", sheet)
+
+    def test_a_beat_past_the_hole_still_gets_the_whole_step(self):
+        """The control, and the one that stops the fix from being a rollback.
+
+        A correction that clamped everything after a backward step — or that
+        stopped correcting at all — passes every assertion above. This beat's
+        midpoint is 0.1 s past the end of the same hole, so it moves by the
+        full −1.051 s and carries no marker at all.
+        """
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((5.151, -1.051)),
+            beats=[beat(0, "caption", 6.252, t_end=6.352)],
+        )
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [5.251])
+        self.assertNotIn("no_video", manifest["frames"][0])
+        self.assertNotIn("no video of this beat", render_frames_md(manifest))
+
+    def test_a_forward_step_leaves_no_hole_at_all(self):
+        """The other control, and the direction this host's pulses go *up*.
+
+        A forward step does not delete wall time from the file — the encoder
+        keeps writing, the stamps just jump — so an instant after one is at
+        `t + Δ` with nothing withheld. A clamp that fired on any step, rather
+        than on the window a *backward* one deletes, would put this frame
+        0.9 s early and call it honest.
+        """
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((2.0, 0.9)),
+            beats=[beat(0, "caption", 2.5, t_end=2.7)],
+        )
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [3.5])
+        self.assertNotIn("no_video", manifest["frames"][0])
+
+    def test_two_holes_that_overlap_clamp_to_the_first_of_them(self):
+        """Chained pulses, which is the shape of the host this exists for.
+
+        The step at 2.0 s stalls the file at 2.0 s, and the second one at
+        2.5 s — while it is still stalled — takes the wall clock another
+        second further back, so it has 2.0 s to climb rather than 1.0 s and
+        the file resumes at mono 4.0 s, not 3.0 s. The midpoint at 3.0 s is
+        inside all of that: the frame is the file's last instant, 2.0 s, and
+        the video only comes back 1.0 s after the beat. A per-step rule that
+        clamped to the *nearest* step would answer 1.5 s here — the second
+        step's own edge, which is video that does not exist either.
+        """
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((2.0, -1.0), (2.5, -1.0)),
+            beats=[beat(0, "caption", 2.9, t_end=3.1)],
+        )
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [2.0])
+        self.assertEqual(manifest["frames"][0]["no_video"], 1.0)
+
+    def test_a_hole_the_next_beat_outlives_leaves_that_beat_alone(self):
+        # Two beats, one record: the fourth state is a property of the
+        # *instant*, so the same well-measured record answers it differently
+        # for two beats 1 s apart. A manifest that marked the take rather than
+        # the frame would mark both.
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((2.0, -1.0)),
+            beats=[beat(0, "caption", 2.4, t_end=2.6), beat(1, "caption", 3.4)],
+        )
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [2.0, 2.45])
+        self.assertEqual(manifest["frames"][0]["no_video"], 0.5)
+        self.assertNotIn("no_video", manifest["frames"][1])
 
     # -- and what the sheet says it did -------------------------------------
 
@@ -5445,12 +5587,12 @@ class FrameClockCorrection(unittest.TestCase):
 
     def test_a_step_inside_the_last_beat_is_not_reported_as_capture_loss(self):
         # The same claim where the correction has to be read at the beat's
-        # **end**: the step at 5.2 s is inside the last beat (4.8-5.6 s), so a
+        # **end**: the step at 4.9 s is inside the last beat (4.8-5.6 s), so a
         # reader summing to the beat's *start* finds nothing and reports
         # 0.60 s of loss that the record has already explained.
         doc = envelope(
             duration=5.0,
-            capture_clock=clock_record((5.2, -0.78)),
+            capture_clock=clock_record((4.9, -0.78)),
             beats=[beat(0, "caption", 0.5), beat(1, "hold", 4.8, t_end=5.6)],
         )
         manifest, _cuts, _windows = self.sheet(doc)
@@ -5594,11 +5736,43 @@ class NarrationMix(unittest.TestCase):
         delays, _record = self.mixed(clock_record((2.0, 0.9), (8.0, -0.9)), 5.0)
         self.assertEqual(delays, [5900])
 
+    def test_a_line_the_step_deleted_the_moment_of_starts_before_the_gap(self):
+        """The measured hole, on the audio side of it (issue #256).
+
+        A −1.051 s step at 5.151 s takes 5.151-6.202 s of wall time out of the
+        file outright rather than sliding it, so the 5.633 s the log gives this
+        line is a moment `demo.mp4` does not contain. Mixing at `t` plus the
+        steps before it — 4.582 s — starts the clip a whole step early, over
+        the caption *before* the one it is about. It goes at the last moment
+        the file has instead, and the record says why.
+        """
+        delays, record = self.mixed(clock_record((5.151, -1.051)), 5.633)
+        self.assertEqual(delays, [5151], "the hole's edge, not 4582")
+        self.assertEqual(
+            record["lines"], [{"t": 5.633, "at": 5.151, "no_video": 0.569}]
+        )
+
+    def test_a_line_past_the_hole_still_moves_by_the_whole_step(self):
+        # The control. A mix that clamped everything after a backward step, or
+        # stopped correcting, passes the test above and puts this line 1.05 s
+        # late — the defect #226 exists for, restored by the fix to #256.
+        delays, record = self.mixed(clock_record((5.151, -1.051)), 6.3)
+        self.assertEqual(delays, [5249])
+        self.assertNotIn("no_video", record["lines"][0])
+
     def test_a_step_bigger_than_a_lines_offset_starts_the_clip_at_zero(self):
         # That wall time is not in the file at all, and `adelay` cannot express
         # a negative delay — ffmpeg refuses the filter outright, which would
         # cost the take its whole audio track rather than one line's placement.
-        delays, _record = self.mixed(clock_record((0.1, -0.78)), 0.5, 2.0)
+        #
+        # **The step is at -0.5 s, before this capture's frame zero**, and it
+        # has to be: since #256 a step's own hole clamps every instant inside
+        # it to the last moment the file has, which is never below the step's
+        # time. What is left below zero is a step the sampler saw before the
+        # first frame — the recorder's own sampler starts at `_t0` and does not
+        # produce one, so this is a record shape only a reader has to survive,
+        # and `adelay` losing the whole audio track is why it still does.
+        delays, _record = self.mixed(clock_record((-0.5, -0.78)), 0.5, 2.0)
         self.assertEqual(delays, [0, 1220])
 
     def test_a_clamped_line_says_how_much_of_its_correction_it_lost(self):
@@ -5611,7 +5785,7 @@ class NarrationMix(unittest.TestCase):
         correct it twice. Absent from the lines that got the whole of theirs,
         so its presence is the whole signal.
         """
-        _delays, record = self.mixed(clock_record((0.1, -0.78)), 0.5, 2.0)
+        _delays, record = self.mixed(clock_record((-0.5, -0.78)), 0.5, 2.0)
         self.assertEqual(
             record["lines"],
             [{"t": 0.5, "at": 0.0, "clamped": 0.28}, {"t": 2.0, "at": 1.22}],
@@ -5622,7 +5796,7 @@ class NarrationMix(unittest.TestCase):
         # steps before it at the precision of this record. A `clamped: 0.0`
         # beside it would be a line claiming a truncation of nothing, against
         # a field documented as absent when there is nothing to say.
-        _delays, record = self.mixed(clock_record((0.1, -0.50004)), 0.5)
+        _delays, record = self.mixed(clock_record((-0.5, -0.50004)), 0.5)
         self.assertEqual(record["lines"], [{"t": 0.5, "at": 0.0}])
 
     def test_the_clips_go_in_in_the_order_the_lines_were_spoken(self):
@@ -5735,6 +5909,14 @@ class NarrationMixPlan(unittest.TestCase):
         lines, state = mix_plan([0.5, 5.0], record)
         self.assertEqual([line["at"] for line in lines], [0.5, 5.0])
         self.assertIs(state["applied"], False)
+
+    def test_a_forward_step_deletes_nothing_so_no_line_is_marked(self):
+        # A forward step moves the stamps and keeps writing; only a backward
+        # one takes wall time out of the file. A `no_video` here would be the
+        # clamp firing on the sign of nothing (#256).
+        lines, _state = mix_plan([0.5, 2.0], clock_record((1.0, 0.9)))
+        self.assertEqual([line["at"] for line in lines], [0.5, 2.9])
+        self.assertEqual([line for line in lines if "no_video" in line], [])
 
     def test_a_line_before_a_forward_step_is_left_where_it_was(self):
         # The control for the sign, in the direction the WSL2 host's pulses
@@ -5868,6 +6050,37 @@ class NarrationTimelineNote(unittest.TestCase):
             )
         )
         self.assertIn("mixed where the host's stepped clock puts them", text)
+        self.assertNotIn("could not be moved the whole way", text)
+        self.assertNotIn("spoken over wall time", text)
+
+    def test_a_line_the_clock_stepped_over_is_named_as_having_no_moment(self):
+        """The other way the headline sentence is false, and a different one.
+
+        `clamped` is a line the *start of the file* caught. This is a line
+        whose moment the host's clock deleted from the middle of the file
+        (issue #256): there is nothing in `media` for it to be at, its clip
+        starts at the last instant before the gap, and a listener who hears it
+        against the caption before the one it belongs to has no other way to
+        find out why. Folding the two into one sentence would send that
+        listener to the top of the track to look for a clip that is 5 s in.
+        """
+        doc = self.doc(
+            {
+                "lines": [
+                    {"t": 5.633, "at": 5.151, "no_video": 0.569},
+                    {"t": 8.0, "at": 6.949},
+                ],
+                "clock_correction": {
+                    "applied": True,
+                    "total": -1.051,
+                    "steps": 1,
+                    "note": None,
+                },
+            }
+        )
+        text = render_timeline_md(doc)
+        self.assertIn("1 of them was spoken over wall time", text)
+        self.assertIn("`no_video` is how many seconds later", text)
         self.assertNotIn("could not be moved the whole way", text)
 
     def test_a_demo_where_only_some_parts_could_correct_says_how_many(self):
@@ -6322,6 +6535,170 @@ class ClockCoverageCheck(unittest.TestCase):
         )
 
 
+class HostClockHole(unittest.TestCase):
+    """`tests/smoke`'s own reader of a stepped clock, on a scripted one (#256).
+
+    Here for the reason `ClockCoverageCheck` gives, doubled. The harness's
+    watcher and its reading of a merged record are the third consumer #256 is
+    about, and **the case that matters cannot be produced on demand**: a
+    backward step's hole exists only on a host that steps its wall clock, and
+    on one that does not every line of `video_instant` is dead and every
+    assertion below is satisfied by the arithmetic it replaced. The host this
+    was written on stepped twice on 2026-08-09 and not at all for the six days
+    before that; grading this on the arm would be grading the host.
+
+    The numbers are the measured ones: a −1.051 s step at 5.151 s, which takes
+    5.151-6.202 s of wall time out of the file, and a beat whose midpoint is at
+    5.633 s inside it. Written out here rather than derived, so an arithmetic
+    that changed has to disagree with a person rather than with itself.
+    """
+
+    def setUp(self):
+        self.smoke = _smoke_module()
+
+    def clock(self, *steps: tuple[float, float], boundaries: list | None = None):
+        """A `HostClock` that never sampled anything, holding `steps`.
+
+        The thread is never started: `raw` is what `_run` would have appended
+        and `_t0` is what `rebase` would have set, so everything below is the
+        real class answering about a clock that behaved exactly this way.
+        """
+        clock = self.smoke.HostClock()
+        clock._t0 = 0.0
+        clock.raw = list(steps)
+        clock.boundaries = boundaries or []
+        return clock
+
+    # -- what the watcher answers -------------------------------------------
+
+    def test_an_instant_the_step_deleted_reaches_only_the_last_frame_before_it(self):
+        clock = self.clock((5.151, -1.051))
+        self.assertAlmostEqual(5.633 + clock.before(5.633), 5.151, places=6)
+
+    def test_that_instant_is_reported_as_having_no_video_of_its_own(self):
+        # `before()` alone cannot say it: −0.482 s is a perfectly ordinary
+        # correction to look at, and the whole defect is that it reads like
+        # one. 0.569 s is how much longer the hole runs past the instant.
+        clock = self.clock((5.151, -1.051))
+        self.assertAlmostEqual(clock.hole(5.633), 0.569, places=6)
+
+    def test_an_instant_past_the_hole_gets_the_whole_step_and_no_hole(self):
+        # The control. A watcher that clamped everything after a backward step
+        # passes both assertions above and puts every later beat a full step
+        # from where it is — which is #229's defect, restored.
+        clock = self.clock((5.151, -1.051))
+        self.assertAlmostEqual(clock.before(6.3), -1.051, places=6)
+        self.assertEqual(clock.hole(6.3), 0.0)
+
+    def test_an_instant_before_the_step_is_untouched(self):
+        clock = self.clock((5.151, -1.051))
+        self.assertEqual(clock.before(5.0), 0.0)
+        self.assertEqual(clock.hole(5.0), 0.0)
+
+    def test_a_forward_step_deletes_nothing(self):
+        # The direction this host's pulses go *up*. A clamp keyed on "a step
+        # happened" rather than on the window a backward one deletes would
+        # withhold this correction and read the file 0.9 s off.
+        clock = self.clock((2.0, 0.9))
+        self.assertAlmostEqual(clock.before(2.5), 0.9, places=6)
+        self.assertEqual(clock.hole(2.5), 0.0)
+
+    def test_a_hole_belongs_to_its_own_capture_and_not_to_the_next(self):
+        # `before()` reads only the steps of `t`'s own capture, and the hole
+        # has to be read the same way: part one's lost wall time is already in
+        # the offset `stitch()` laid part two out by, so a beat 0.2 s into
+        # part two is not inside part one's hole no matter how wide it was.
+        clock = self.clock((5.151, -1.051), boundaries=[0.0, 5.5])
+        self.assertEqual(clock.before(5.7), 0.0)
+        self.assertEqual(clock.hole(5.7), 0.0)
+
+    # -- and what a reader of the published record answers -------------------
+
+    def merged(self, *steps: tuple[float, float]) -> dict:
+        return {
+            "measured": True,
+            "steps": [{"t": t, "delta": d, "segment": "part1"} for t, d in steps],
+            "total": round(sum(d for _t, d in steps), 4),
+        }
+
+    def test_a_reader_of_the_record_clamps_a_beat_inside_the_hole_too(self):
+        # The same claim on the other side of `check_merged_capture_clock`'s
+        # comparison. Both sides have to move together or a stepping take goes
+        # red about a recorder that was right — which is how #255 measured
+        # 4 of 6 stepping runs failing.
+        read = self.smoke.merged_clock_correction(
+            self.merged((5.151, -1.051)),
+            {"t_start": 5.633, "segment": "part1"},
+        )
+        self.assertAlmostEqual(5.633 + read, 5.151, places=6)
+
+    def test_a_reader_still_applies_the_whole_step_past_the_hole(self):
+        read = self.smoke.merged_clock_correction(
+            self.merged((5.151, -1.051)),
+            {"t_start": 6.3, "segment": "part1"},
+        )
+        self.assertAlmostEqual(read, -1.051, places=6)
+
+    def test_a_reader_ignores_a_hole_measured_in_another_capture(self):
+        # The attribution rule, restated for the hole: part two's beats are
+        # not inside part one's hole, whatever its timestamps say.
+        read = self.smoke.merged_clock_correction(
+            self.merged((5.151, -1.051)),
+            {"t_start": 5.633, "segment": "part2"},
+        )
+        self.assertEqual(read, 0.0)
+
+    # -- and what it refuses to let the sheet get away with ------------------
+
+    def sheet(self, *, marked: bool, middle: float = 5.633):
+        """One frame of one beat, with and without the recorder's marker."""
+        frame = {"file": "beat-00.png", "kind": "beat", "beat": 0, "t": 5.151}
+        if marked:
+            frame["no_video"] = 0.569
+        beats = {0: {"index": 0, "t_start": middle - 0.5, "t_end": middle + 0.5}}
+        return [frame], beats
+
+    def test_a_frame_of_a_deleted_beat_that_says_nothing_is_a_failure(self):
+        listed, beats = self.sheet(marked=False)
+        problems = self.smoke.unstated_holes(
+            "web", self.clock((5.151, -1.051)), listed, beats
+        )
+        self.assertEqual(len(problems), 1, f"expected one complaint, got {problems!r}")
+        self.assertIn("no frame of that beat in demo.mp4 at all", problems[0])
+        self.assertIn("569 ms", problems[0])
+
+    def test_the_same_frame_with_the_marker_passes(self):
+        listed, beats = self.sheet(marked=True)
+        self.assertEqual(
+            self.smoke.unstated_holes(
+                "web", self.clock((5.151, -1.051)), listed, beats
+            ),
+            [],
+        )
+
+    def test_a_frame_of_a_beat_with_video_is_not_asked_to_claim_a_hole(self):
+        # The control, and the one a steady host runs: no step, no hole, no
+        # complaint. Without it the check is satisfied by one that demands
+        # `no_video` on every frame of every take.
+        listed, beats = self.sheet(marked=False)
+        self.assertEqual(
+            self.smoke.unstated_holes("web", self.clock(), listed, beats), []
+        )
+
+    def test_a_midpoint_on_the_edge_of_a_hole_is_left_alone(self):
+        # Two samplers on their own 20 ms grids do not both know which side of
+        # an edge an instant fell on, and this check is not the place to find
+        # out: this midpoint is 22 ms short of where the video resumes, well
+        # under `MAX_CLOCK_STEP_TIME_DISAGREEMENT_S`, and is not graded.
+        listed, beats = self.sheet(marked=False, middle=6.18)
+        self.assertEqual(
+            self.smoke.unstated_holes(
+                "web", self.clock((5.151, -1.051)), listed, beats
+            ),
+            [],
+        )
+
+
 # --------------------------------------------------------------------------
 
 # Issue #203, as the overlay shipped before it was fixed and after it was.
@@ -6420,10 +6797,12 @@ INJECTIONS = [
         # own instant — the shape that was the blocking defect in the review
         # frames' version of this rule (#253). Every clip then moves by the
         # take's running total, including the ones spoken before the step.
+        # `place(1e9)` is that total: no record puts a step out there, so the
+        # instant is past every hole and its shift is the whole sum.
         "each clip is corrected by the take's total rather than by its own instant",
         "narration.py",
-        "        want = float(off) + shift(off)",
-        '        want = float(off) + shift(float("inf"))',
+        "        want = placed.at",
+        "        want = float(off) + place(1e9).at - 1e9",
         [
             "NarrationMix.test_a_step_after_a_line_does_not_move_that_lines_clip",
             "NarrationMix.test_steps_that_cancel_still_move_a_line_mixed_between_them",
@@ -6438,8 +6817,8 @@ INJECTIONS = [
         # that can tell a listener the placement was a fallback.
         "a mix nobody could correct reports itself as corrected",
         "narration.py",
-        "    shift, state = capture_clock_shift(record)",
-        "    shift, _state = capture_clock_shift(record)\n"
+        "    place, state = capture_clock_shift(record)",
+        "    place, _state = capture_clock_shift(record)\n"
         '    state = {"applied": True, "total": 0.0, "steps": 0, "note": None}',
         [
             "NarrationMix.test_a_take_nobody_watched_the_clock_of_is_mixed_raw_and_says_so",
@@ -6552,6 +6931,174 @@ INJECTIONS = [
         [
             "MergedNarration.test_the_refusal_says_how_many_of_the_parts_it_is_about",
         ],
+    ),
+    # -- the hole a backward step leaves (issue #256) ------------------------
+    #
+    # Every one of these is a no-op on a host whose wall clock holds still, and
+    # so is the code they break. That is not a reason to skip them, it is the
+    # reason they exist here rather than in an arm: `tests/smoke` cannot make a
+    # host step, and the box this was written on stepped twice in a week.
+    (
+        # **The defect issue #256 is about**, restored exactly: a −Δ step read
+        # as a slide rather than as a Δ-wide window deleted from the file, so
+        # every instant inside that window is corrected up to a whole step
+        # early into content that predates the step. This is what shipped in
+        # `d5212c0` and `5b00786`, and it was found by eye — `beat-05.png` cut
+        # at 4.58 s, showing the previous caption.
+        "a backward step is read as a slide, so an instant with no video is moved",
+        "timeline.py",
+        "    reached = max(shifted, edge)",
+        "    reached = shifted",
+        [
+            "FrameClockCorrection."
+            "test_a_beat_the_step_deleted_is_cut_at_the_last_frame_before_the_gap",
+            "FrameClockCorrection."
+            "test_that_frame_is_marked_as_one_with_no_video_of_its_beat",
+            "FrameClockCorrection."
+            "test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat",
+            "FrameClockCorrection.test_two_holes_that_overlap_clamp_to_the_first_of_them",
+            "FrameClockCorrection.test_a_hole_the_next_beat_outlives_leaves_that_beat_alone",
+            "FrameClockCorrection."
+            "test_a_beat_the_clock_swallowed_loses_its_scene_frames_out_loud",
+            "NarrationMix.test_a_line_the_step_deleted_the_moment_of_starts_before_the_gap",
+        ],
+    ),
+    (
+        # ...and the over-correction in the other direction, which is what an
+        # author reaching for the smallest fix writes: clamp everything after a
+        # step to the last instant before it. Every beat of the rest of the
+        # take then sits a whole step from where it is, which is #229 undone —
+        # and it satisfies every assertion about the hole itself.
+        "every instant after a step is clamped, not only the ones with no video",
+        "timeline.py",
+        "    reached = max(shifted, edge)",
+        "    reached = edge if edge > -math.inf else shifted",
+        [
+            "FrameClockCorrection.test_a_beat_past_the_hole_still_gets_the_whole_step",
+            "FrameClockCorrection.test_a_forward_step_leaves_no_hole_at_all",
+            "FrameClockCorrection.test_a_frame_is_cut_where_its_beat_sits_in_the_video",
+            "NarrationMix.test_a_line_past_the_hole_still_moves_by_the_whole_step",
+            "NarrationMixPlan.test_a_forward_step_deletes_nothing_so_no_line_is_marked",
+        ],
+    ),
+    (
+        # The step's own delta counted into the edge it is the edge *of* — the
+        # off-by-one an author writing this loop by hand makes, and the one
+        # that leaves the arithmetic looking like a high-water mark while
+        # answering the naive sum for every backward step.
+        "the hole's edge is measured after its own step instead of before it",
+        "timeline.py",
+        "        edge = max(edge, at + running)\n        running += delta",
+        "        running += delta\n        edge = max(edge, at + running)",
+        [
+            "FrameClockCorrection."
+            "test_a_beat_the_step_deleted_is_cut_at_the_last_frame_before_the_gap",
+            "FrameClockCorrection.test_two_holes_that_overlap_clamp_to_the_first_of_them",
+            "NarrationMix.test_a_line_the_step_deleted_the_moment_of_starts_before_the_gap",
+        ],
+    ),
+    (
+        # The clamp applied and not published. The frame is in the right place
+        # and the sheet reads exactly like a sheet of frames that are where
+        # their beats are — which is the whole failure, because a reviewer
+        # cannot tell by looking that this one is a picture of the moment
+        # before the step rather than of the beat.
+        "a frame of a beat with no video is published as an ordinary frame",
+        "frames.py",
+        "        if placed.lost:",
+        "        if False:",
+        [
+            "FrameClockCorrection."
+            "test_that_frame_is_marked_as_one_with_no_video_of_its_beat",
+            "FrameClockCorrection."
+            "test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat",
+            "FrameClockCorrection.test_two_holes_that_overlap_clamp_to_the_first_of_them",
+            "FrameClockCorrection.test_a_hole_the_next_beat_outlives_leaves_that_beat_alone",
+        ],
+    ),
+    (
+        # ...the manifest keeping the marker and the sheet dropping the
+        # paragraph. `frames.md` is what a reviewer is handed; `frames.json` is
+        # what a tool reads, and nobody reviewing a demo through this skill
+        # opens the JSON.
+        "frames.md stops naming the beats the clock deleted",
+        "frames.py",
+        "    out += _no_video_md(frames)",
+        "    out += []",
+        [
+            "FrameClockCorrection."
+            "test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat"
+        ],
+    ),
+    (
+        # ...and the same sentence beside the picture, which is the one a
+        # reviewer scrolling the frames actually reads. The preamble is above
+        # a table they may never scroll back to.
+        "the frame's own heading stops saying there is no video of its beat",
+        "frames.py",
+        '        if frame.get("no_video"):',
+        "        if False:",
+        [
+            "FrameClockCorrection."
+            "test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat"
+        ],
+    ),
+    (
+        # The audible half of the same silence: the clip goes to the last
+        # moment before the gap, correctly, and the record says it is where
+        # every other line is. A listener who hears it against the wrong
+        # caption has nothing to read that explains it.
+        "a narration line spoken over deleted wall time is recorded as ordinary",
+        "narration.py",
+        "        if round(placed.lost, 3):",
+        "        if False:",
+        [
+            "NarrationMix.test_a_line_the_step_deleted_the_moment_of_starts_before_the_gap"
+        ],
+    ),
+    (
+        # ...and the renderer's half, which the injection above cannot reach:
+        # `NarrationTimelineNote` builds its record by hand, so a `mix_plan`
+        # that still marks the line and a `timeline.md` that stops mentioning
+        # it are two different failures.
+        "timeline.md stops naming the lines whose moment is not in the video",
+        "timeline.py",
+        '    holed = [line for line in lines if line.get("no_video")]',
+        "    holed = []",
+        [
+            "NarrationTimelineNote."
+            "test_a_line_the_clock_stepped_over_is_named_as_having_no_moment"
+        ],
+    ),
+    (
+        # The harness's own reader, broken the same way the recorder's was.
+        # This is the direction that costs a diagnosis: `check_beat_frames` and
+        # `check_merged_capture_clock` would go red on a stepping take about a
+        # recorder that placed every frame correctly, which is 4 of 6 of the
+        # runs #255 measured.
+        "the harness's own watcher reads a backward step as a slide",
+        "tests/smoke",
+        "    reached = max(shifted, edge)",
+        "    reached = shifted",
+        [
+            "HostClockHole."
+            "test_an_instant_the_step_deleted_reaches_only_the_last_frame_before_it",
+            "HostClockHole.test_that_instant_is_reported_as_having_no_video_of_its_own",
+            "HostClockHole.test_a_reader_of_the_record_clamps_a_beat_inside_the_hole_too",
+            "HostClockHole.test_a_frame_of_a_deleted_beat_that_says_nothing_is_a_failure",
+        ],
+    ),
+    (
+        # ...and the harness accepting a sheet that says nothing. Its own
+        # placement check passes either way — the frame really is at the hole's
+        # edge — so without this the one artifact a reviewer reads can go back
+        # to presenting a beat with no video as a frame at its midpoint, with
+        # the arm green.
+        "the harness lets a sheet present a deleted beat as an ordinary frame",
+        "tests/smoke",
+        '        if not frame.get("no_video"):',
+        "        if False:",
+        ["HostClockHole.test_a_frame_of_a_deleted_beat_that_says_nothing_is_a_failure"],
     ),
     (
         # The smoke harness back to "one line, one stretch of audio" — the
@@ -6873,7 +7420,9 @@ INJECTIONS = [
         # The manifest, the names and the count are all untouched.
         "every review frame is cut on the beat log rather than on the video's clock",
         "frames.py",
-        "        middle = min(max(logged + correct(beat, logged), 0.0), last)",
+        "        placed = place(beat, logged)\n"
+        "        middle = min(max(placed.at, 0.0), last)",
+        "        placed = place(beat, logged)\n"
         "        middle = min(max(logged, 0.0), last)",
         [
             "FrameClockCorrection.test_a_frame_is_cut_where_its_beat_sits_in_the_video",
@@ -6887,8 +7436,8 @@ INJECTIONS = [
         # left — and they arrive named for it.
         "the scene search window stays on the beat log's clock",
         "frames.py",
-        "        lo = min(max(float(t_start) + correct(beat, float(t_start)), 0.0), last)\n"
-        "        hi = min(max(float(t_end) + correct(beat, float(t_end)), 0.0), last)",
+        "        lo = min(max(place(beat, float(t_start)).at, 0.0), last)\n"
+        "        hi = min(max(place(beat, float(t_end)).at, 0.0), last)",
         "        lo = min(float(t_start), last)\n        hi = min(float(t_end), last)",
         [
             "FrameClockCorrection.test_the_scene_search_window_is_the_beats_span_in_the_video",
@@ -6910,9 +7459,11 @@ INJECTIONS = [
         "the correction is read at the beat's start and applied to its midpoint",
         "frames.py",
         "        logged = (float(t_start) + float(t_end)) / 2\n"
-        "        middle = min(max(logged + correct(beat, logged), 0.0), last)",
+        "        placed = place(beat, logged)",
         "        logged = (float(t_start) + float(t_end)) / 2\n"
-        "        middle = min(max(logged + correct(beat, float(t_start)), 0.0), last)",
+        "        placed = place(beat, float(t_start))._replace(\n"
+        "            at=logged + place(beat, float(t_start)).at - float(t_start)\n"
+        "        )",
         [
             "FrameClockCorrection.test_a_step_inside_a_beat_moves_the_frame_cut_after_it",
         ],
@@ -6923,9 +7474,9 @@ INJECTIONS = [
         # as capture loss the record has already explained.
         "the capture-loss floor is corrected at the last beat's start, not its end",
         "frames.py",
-        "    over = tail_end + correct(tail, tail_end) - float(duration)",
-        '    over = tail_end + correct(tail, float(tail.get("t_start") or 0.0)) '
-        "- float(duration)",
+        "    over = place(tail, tail_end).at - float(duration)",
+        '    _start = float(tail.get("t_start") or 0.0)\n'
+        "    over = tail_end + place(tail, _start).at - _start - float(duration)",
         [
             "FrameClockCorrection."
             "test_a_step_inside_the_last_beat_is_not_reported_as_capture_loss",
@@ -6938,9 +7489,8 @@ INJECTIONS = [
         # is worse than not correcting at all.
         "a beat is corrected by every capture's steps rather than its own",
         "timeline.py",
-        '            if step.get("segment") == beat.get("segment")\n'
-        '            and float(step["t"]) <= float(t)',
-        '            if float(step["t"]) <= float(t)',
+        '                if step.get("segment") == beat.get("segment")',
+        "                if True",
         [
             # Only this one. A merged demo whose *later* part carries the step
             # is unmoved by dropping the filter — every earlier beat is before
@@ -6956,11 +7506,13 @@ INJECTIONS = [
     (
         # The take's whole total applied to every beat, including the ones
         # recorded before the clock moved. `total` is the one number in the
-        # record that is the correction for no beat at all.
+        # record that is the correction for no beat at all. Since #256 the
+        # "before `t`" half of the rule lives in `_placed`'s loop, so that is
+        # where it is broken: a bound no step can exceed lets every step in.
         "a beat is corrected by steps the clock had not taken yet",
         "timeline.py",
-        '            and float(step["t"]) <= float(t)',
-        "            and True",
+        "        if at > t:",
+        "        if at > t + 1e9:",
         [
             "FrameClockCorrection.test_a_step_after_a_beat_does_not_move_that_beats_frame",
             "FrameClockCorrection.test_a_frame_is_cut_where_its_beat_sits_in_the_video",
@@ -7061,7 +7613,7 @@ INJECTIONS = [
         # the one line of the sheet that is about how much to distrust it.
         "a recorded wall-clock step is also reported as lost capture time",
         "frames.py",
-        "    over = tail_end + correct(tail, tail_end) - float(duration)",
+        "    over = place(tail, tail_end).at - float(duration)",
         "    over = tail_end - float(duration)",
         [
             "FrameClockCorrection.test_a_recorded_step_is_not_also_reported_as_capture_loss",

--- a/tests/unit
+++ b/tests/unit
@@ -5399,6 +5399,26 @@ class FrameClockCorrection(unittest.TestCase):
         # reviewer never reaches.
         self.assertIn("## beat-00 — 5.15s (no video of this beat", sheet)
 
+    def test_a_shortfall_too_small_to_write_down_is_not_called_a_hole(self):
+        """The other side of `no_video`'s key, and `mix_plan` already had it.
+
+        This midpoint is 0.2 ms short of where the video resumes, which is
+        nothing at the three places the manifest writes a second to. Testing
+        the raw float instead of the rounded one publishes
+        `"no_video": 0.0` — a frame documented as being of no moment in the
+        file, over a frame that is exactly where its beat is, in the one key
+        that is supposed to mean the sheet's timestamp cannot be trusted.
+        """
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record((5.151, -1.051)),
+            beats=[beat(0, "caption", 6.1518, t_end=6.2518)],
+        )
+        manifest, cuts, _windows = self.sheet(doc)
+        self.assertEqual(cuts, [5.151])
+        self.assertNotIn("no_video", manifest["frames"][0])
+        self.assertNotIn("no video of this beat", render_frames_md(manifest))
+
     def test_a_beat_past_the_hole_still_gets_the_whole_step(self):
         """The control, and the one that stops the fix from being a rollback.
 
@@ -6660,7 +6680,7 @@ class HostClockHole(unittest.TestCase):
 
     def test_a_frame_of_a_deleted_beat_that_says_nothing_is_a_failure(self):
         listed, beats = self.sheet(marked=False)
-        problems = self.smoke.unstated_holes(
+        problems = self.smoke._check_unstated_holes(
             "web", self.clock((5.151, -1.051)), listed, beats
         )
         self.assertEqual(len(problems), 1, f"expected one complaint, got {problems!r}")
@@ -6670,7 +6690,7 @@ class HostClockHole(unittest.TestCase):
     def test_the_same_frame_with_the_marker_passes(self):
         listed, beats = self.sheet(marked=True)
         self.assertEqual(
-            self.smoke.unstated_holes(
+            self.smoke._check_unstated_holes(
                 "web", self.clock((5.151, -1.051)), listed, beats
             ),
             [],
@@ -6682,21 +6702,79 @@ class HostClockHole(unittest.TestCase):
         # `no_video` on every frame of every take.
         listed, beats = self.sheet(marked=False)
         self.assertEqual(
-            self.smoke.unstated_holes("web", self.clock(), listed, beats), []
+            self.smoke._check_unstated_holes("web", self.clock(), listed, beats), []
         )
 
-    def test_a_midpoint_on_the_edge_of_a_hole_is_left_alone(self):
+    def test_a_midpoint_near_the_far_edge_of_a_hole_is_left_alone(self):
         # Two samplers on their own 20 ms grids do not both know which side of
         # an edge an instant fell on, and this check is not the place to find
         # out: this midpoint is 22 ms short of where the video resumes, well
         # under `MAX_CLOCK_STEP_TIME_DISAGREEMENT_S`, and is not graded.
         listed, beats = self.sheet(marked=False, middle=6.18)
         self.assertEqual(
-            self.smoke.unstated_holes(
+            self.smoke._check_unstated_holes(
                 "web", self.clock((5.151, -1.051)), listed, beats
             ),
             [],
         )
+
+    def test_a_midpoint_near_the_step_itself_is_left_alone(self):
+        """The *other* edge, which is a separate branch and was ungraded.
+
+        A midpoint 149 ms after the step is deep inside the hole by the far
+        edge's reckoning — 902 ms of it left to run — so the gap test alone
+        lets it through to a complaint. The two watchers do not agree to
+        within 149 ms about *when* a step landed, which is what
+        `MAX_CLOCK_STEP_TIME_DISAGREEMENT_S` is for everywhere else in this
+        file, so this beat may not have been inside the hole at all.
+        """
+        listed, beats = self.sheet(marked=False, middle=5.3)
+        clock = self.clock((5.151, -1.051))
+        # The guard this is about is the only thing between here and a
+        # complaint: the far-edge test does not fire on this midpoint.
+        self.assertGreater(clock.hole(5.3), 0.25)
+        self.assertEqual(
+            self.smoke._check_unstated_holes("web", clock, listed, beats), []
+        )
+
+    def test_a_beat_with_no_end_is_skipped_rather_than_raising(self):
+        # `beats` comes straight out of `timeline.json`, and a listed frame
+        # whose beat lost its `t_end` reaches here. A harness check that
+        # raises takes the whole arm down over a beat it had nothing to say
+        # about — which is worse than the silence it replaces.
+        listed, beats = self.sheet(marked=False)
+        del beats[0]["t_end"]
+        self.assertEqual(
+            self.smoke._check_unstated_holes(
+                "web", self.clock((5.151, -1.051)), listed, beats
+            ),
+            [],
+        )
+
+    # -- and what its failure text says --------------------------------------
+
+    def test_a_failure_about_an_instant_with_no_video_says_that_much(self):
+        """`hole_clause`, which both placement failures append (issue #256).
+
+        The two messages state "the instant `t` is at `at` in the video", and
+        inside a hole that is false of `at` — it is the last moment the file
+        has. Without this clause a reader is sent to a second `demo.mp4` does
+        not contain and concludes the harness is confused.
+        """
+        clause = self.smoke.hole_clause(self.clock((5.151, -1.051)), 5.633, 5.151)
+        self.assertIn("There is no video of that instant at all", clause)
+        self.assertIn("5.151s is the last moment before a gap", clause)
+        self.assertIn("569 ms later", clause)
+
+    def test_a_failure_about_an_ordinary_instant_adds_nothing(self):
+        # The control. A clause on every placement failure is a clause that
+        # says "there is no video of that instant" about takes on a steady
+        # host, which is the artifact-lies direction of the same fix.
+        self.assertEqual(
+            self.smoke.hole_clause(self.clock((5.151, -1.051)), 6.3, 5.249), ""
+        )
+        self.assertEqual(self.smoke.hole_clause(self.clock(), 6.3, 6.3), "")
+        self.assertEqual(self.smoke.hole_clause(None, 6.3, 6.3), "")
 
 
 # --------------------------------------------------------------------------
@@ -7005,7 +7083,7 @@ INJECTIONS = [
         # before the step rather than of the beat.
         "a frame of a beat with no video is published as an ordinary frame",
         "frames.py",
-        "        if placed.lost:",
+        "        if round(placed.lost, 3):",
         "        if False:",
         [
             "FrameClockCorrection."
@@ -7017,14 +7095,31 @@ INJECTIONS = [
         ],
     ),
     (
+        # ...and the other side of the same key, which `narration.py` has
+        # carried since #226 and this file did not until review: a shortfall
+        # of 0.2 ms, which is nothing at the three places the manifest writes
+        # a second to, published as a beat with no video. The field is
+        # documented as absent when there is nothing to say, and a reader who
+        # trusts that reads a frame as untrustworthy when it is exactly where
+        # its beat is.
+        "a shortfall too small to write down is still called a hole",
+        "frames.py",
+        "        if round(placed.lost, 3):",
+        "        if placed.lost:",
+        [
+            "FrameClockCorrection."
+            "test_a_shortfall_too_small_to_write_down_is_not_called_a_hole"
+        ],
+    ),
+    (
         # ...the manifest keeping the marker and the sheet dropping the
         # paragraph. `frames.md` is what a reviewer is handed; `frames.json` is
         # what a tool reads, and nobody reviewing a demo through this skill
         # opens the JSON.
         "frames.md stops naming the beats the clock deleted",
         "frames.py",
-        "    out += _no_video_md(frames)",
-        "    out += []",
+        "    holed = _no_video_md(frames)",
+        "    holed = []",
         [
             "FrameClockCorrection."
             "test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat"
@@ -7099,6 +7194,40 @@ INJECTIONS = [
         '        if not frame.get("no_video"):',
         "        if False:",
         ["HostClockHole.test_a_frame_of_a_deleted_beat_that_says_nothing_is_a_failure"],
+    ),
+    (
+        # ...and the leniency half of the same check, which review found
+        # ungraded: the guard that leaves a midpoint alone when the two
+        # samplers cannot agree which side of the *step* it fell on. It can
+        # only ever mask a complaint, never invent one, which is exactly why
+        # nothing noticed it was doing nothing.
+        # ...and the guard that keeps it from raising on a beat with no end.
+        # `beats` comes straight out of `timeline.json`, so this is reachable,
+        # and the failure mode is the whole arm dying inside a check that had
+        # nothing to say about that beat.
+        "the harness raises on a beat whose log lost its end",
+        "tests/smoke",
+        '        if not isinstance(beat.get("t_end"), (int, float)):\n            continue',
+        "        if False:\n            continue",
+        ["HostClockHole.test_a_beat_with_no_end_is_skipped_rather_than_raising"],
+    ),
+    (
+        "the harness complains about a midpoint sitting on the step itself",
+        "tests/smoke",
+        "        if gap <= MAX_CLOCK_STEP_TIME_DISAGREEMENT_S or near_edge:",
+        "        if gap <= MAX_CLOCK_STEP_TIME_DISAGREEMENT_S:",
+        ["HostClockHole.test_a_midpoint_near_the_step_itself_is_left_alone"],
+    ),
+    (
+        # The failure text going back to naming a second the file does not
+        # contain. Both placement checks still fail on the same takes and for
+        # the same reason — what is gone is the sentence that tells the reader
+        # why the second they are being sent to has no frame at it.
+        "a placement failure stops saying the instant has no video",
+        "tests/smoke",
+        "    gap = clock.hole(t) if clock is not None else 0.0",
+        "    gap = 0.0",
+        ["HostClockHole.test_a_failure_about_an_instant_with_no_video_says_that_much"],
     ),
     (
         # The smoke harness back to "one line, one stretch of audio" — the


### PR DESCRIPTION
Fixes #256. Slice of #255; repairs behaviour already shipped in `d5212c0` (#229) and `5b00786` (#226).

## Acceptance criterion

> An instant with no video is never silently corrected into content that predates the step, in any of the three consumers — review frames, narration, and the smoke harness's own reader.
>
> - `before(t)` (and the correction functions built on it) distinguish *no video here* from *shift by Δ* — return `None`, or clamp to the hole edge **and say which**.
> - Each consumer states what it did: the review sheet, the narration envelope, and the harness's failure text. A beat with no video must not be presented as a frame at its midpoint.
> - Graded by a unit case built synthetically — the host cannot be relied on to step to order.

**The choice made, stated out loud:** *clamp to the hole's leading edge* — the last instant the file has before the deleted window — never `None`. A frame is still written for every beat and a clip is still mixed for every line, because dropping either over a defect of the host's clock costs more than it saves; what changes is that the artifact says the frame is not of its beat. The withheld seconds ride on the answer as `lost` / `no_video`, so *no video here* is a different value from *shift by Δ* at every call site.

## The mechanism, and why it is one change and not three

A −Δ step deletes the monotonic window `(T, T+Δ)` from the file — the encoder stamps frames with the wall clock and will not write a stamp it has already written, so the file stalls rather than rewinding. The rule that holds everywhere is that the video's clock is the wall clock's **high-water mark**:

```
at(t) = max( t + s(t),  max over steps at T ≤ t of ( T + s(T⁻) ) )
lost  = at(t) − (t + s(t))
```

Outside a hole the two terms agree and this is the old sum digit for digit; inside one it is the file's last instant. Overlapping holes fall out of the maximum with no rule of their own — two −1.0 s steps 0.5 s apart delete 2.0 s, not 1.5 s, and the formula gets that right without knowing it is a special case.

It is written **twice, deliberately**: `timeline._placed` for the recorder's two consumers, and `tests/smoke.video_instant` hand-written apart from it for the harness's, because a correction taken from the code under test agrees with that code whatever it says.

| consumer | what it does | what it says |
|---|---|---|
| review frames | cut at the hole's edge; both scene-window edges and the capture-loss floor read the same placement | `no_video` on the frame in `frames.json`; a named paragraph above the table in `frames.md`, and the marker in the frame's own heading |
| narration | clip mixed at the hole's edge | `no_video` on the line in `timeline.json`; a sentence of its own in `timeline.md`, separate from `clamped` |
| smoke harness | `HostClock.before` and `merged_clock_correction` clamp; `HostClock.hole(t)` is the new distinguisher | `unstated_holes()` fails a sheet that presents a deleted beat as ordinary; the frame-placement and narration-placement failure texts name the gap instead of printing a second the file does not have |

## Evidence — every new assertion seen failing

`tests/unit --fault-inject`, which aborts unless each injection's search string matches **exactly once**. All ten new ones caught; the driver requires *every* named test to fail, not any.

```
PASS  break: a backward step is read as a slide, so an instant with no video is moved
      in timeline.py: reached = max(shifted, edge)…
      FAIL: test_a_beat_the_step_deleted_is_cut_at_the_last_frame_before_the_gap
      ERROR: test_that_frame_is_marked_as_one_with_no_video_of_its_beat
      FAIL: test_a_hole_the_next_beat_outlives_leaves_that_beat_alone
      FAIL: test_a_beat_the_clock_swallowed_loses_its_scene_frames_out_loud
      (also NarrationMix.test_a_line_the_step_deleted_the_moment_of_starts_before_the_gap,
       FrameClockCorrection.test_two_holes_that_overlap_clamp_to_the_first_of_them,
       FrameClockCorrection.test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat)

PASS  break: every instant after a step is clamped, not only the ones with no video
      in timeline.py: reached = max(shifted, edge)…
      FAIL: test_a_beat_past_the_hole_still_gets_the_whole_step
      FAIL: test_a_forward_step_leaves_no_hole_at_all
      FAIL: test_a_frame_is_cut_where_its_beat_sits_in_the_video
      FAIL: test_a_beat_before_its_own_captures_step_is_cut_at_its_midpoint

PASS  break: the hole's edge is measured after its own step instead of before it
      in timeline.py: edge = max(edge, at + running)…
      FAIL: test_a_beat_the_step_deleted_is_cut_at_the_last_frame_before_the_gap
      FAIL: test_two_holes_that_overlap_clamp_to_the_first_of_them
      FAIL: NarrationMix.test_a_line_the_step_deleted_the_moment_of_starts_before_the_gap

PASS  break: a frame of a beat with no video is published as an ordinary frame
      in frames.py: if placed.lost:…
      ERROR: test_that_frame_is_marked_as_one_with_no_video_of_its_beat
      FAIL: test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat

PASS  break: frames.md stops naming the beats the clock deleted
      in frames.py: out += _no_video_md(frames)…
      FAIL: test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat

PASS  break: the frame's own heading stops saying there is no video of its beat
      in frames.py: if frame.get("no_video"):…
      FAIL: test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat

PASS  break: a narration line spoken over deleted wall time is recorded as ordinary
      in narration.py: if round(placed.lost, 3):…
      FAIL: test_a_line_the_step_deleted_the_moment_of_starts_before_the_gap

PASS  break: timeline.md stops naming the lines whose moment is not in the video
      in timeline.py: holed = [line for line in lines if line.get("no_video")]…
      FAIL: test_a_line_the_clock_stepped_over_is_named_as_having_no_moment

PASS  break: the harness's own watcher reads a backward step as a slide
      in tests/smoke: reached = max(shifted, edge)…
      FAIL: test_an_instant_the_step_deleted_reaches_only_the_last_frame_before_it
      FAIL: test_that_instant_is_reported_as_having_no_video_of_its_own
      FAIL: test_a_reader_of_the_record_clamps_a_beat_inside_the_hole_too
      FAIL: test_a_frame_of_a_deleted_beat_that_says_nothing_is_a_failure

PASS  break: the harness lets a sheet present a deleted beat as an ordinary frame
      in tests/smoke: if not frame.get("no_video"):…
      FAIL: test_a_frame_of_a_deleted_beat_that_says_nothing_is_a_failure
```

**The two injections that share one test isolate.** `frames.md stops naming…` fails on the paragraph assertion; `the frame's own heading…` leaves the paragraph intact and fails on the third assertion — run by hand to be sure rather than inferred:

```
FAIL: test_the_sheet_tells_a_reviewer_that_frame_is_not_of_its_beat
    self.assertIn("## beat-00 — 5.15s (no video of this beat", sheet)
AssertionError: '## beat-00 — 5.15s (no video of this beat' not found in
"… **`beat-00.png` is not at the beat it is named for: …** …
 | frame | at |  |---|---:|  | `beat-00.png` | 5.15 |
 ## beat-00 — 5.15s   ![beat-00.png](beat-00.png)"
```

**Two controls carry the weight of the whole fix**, because the cheapest wrong version of it passes everything else: `test_a_beat_past_the_hole_still_gets_the_whole_step` (a clamp that fired after every backward step is #229 undone) and `test_a_forward_step_leaves_no_hole_at_all` (a forward step deletes nothing; this host's pulses go *up* first). Both are in the second injection's must-fail list.

**What each assertion says if the input is noise, or if the host never steps.** On a steady host every new path is dead and every new check passes for free — which is why not one of them is on an arm. All are driven by hand-written numbers (the measured `−1.051 s at 5.151 s`, midpoint `5.633 s`) rather than derived from the record, so an arithmetic that changed has to disagree with a person. What none of them can say is whether the record describes the world; that was measured once off pixels in #250 and is #259's question now.

## Counts

| | before | after |
|---|---|---|
| `tests/unit` | 292 tests | **322** (30 new cases) |
| `tests/unit --fault-inject` | 186 injections, all caught | **200**, all caught |
| `tests/ci-unit` | 54 tests / 18 injections | unchanged, all caught |
| `tests/smoke-inject --self-test` | 51 entries | 51 entries, all still match |
| `tests/smoke-inject --list` roster | 16 of 41 check functions ungraded | **17 of 42** — `_check_unstated_holes` counted and rostered |

Also green: `tests/lint`, `tests/lint --self-test`, `tests/unit --budget` (600/600 lines), `uvx ruff@0.16.1 format .` clean.

## Stated limits — what this does not cover

- **`tests/smoke` was not run, and no part of the harness half has ever been *executed* against a real take.** `--segments-only` is red on this host whenever the clock steps (#258, pre-existing), and `smoke-inject` rightly refuses an injection whose clean baseline already fails. `_check_unstated_holes()`, `hole_clause()` and the **re-pointed `--segments-only` entry** for the frame-cut instant are therefore text-verified and unit-verified only: "every entry still matches the tree" says the search strings are current, not that the arm ran. What did run is `HostClockHole` against a scripted `HostClock`. Same weaker claim `ClockCoverageCheck` has made since #247, and now written into `tests/README.md`'s Known gaps in those words. No new `smoke-inject` entry was added for the same reason.
- **No new smoke check grades the recorder's marker against the world.** `unstated_holes` grades only the missing direction: a frame the recorder marks that this harness's watcher found no hole for is not failed, because whether the two samplers agree about the steps at all is `check_capture_clock`'s claim.
- **The hole arithmetic is shared between `HostClock.before` and `merged_clock_correction`**, so a bug in `video_instant` cancels on both sides of `check_merged_capture_clock`'s comparison. That comparison is about attribution, not arithmetic; the arithmetic is graded against hand-written numbers in `HostClockHole`. Said in the docstring too.
- **This slice assumes the recorded Δ is the hole's width.** #259 owns checking the step against the pixels; nothing here would have to be undone when it lands — the width enters `_placed` only through the record's own `delta`.
- **`_check_frame_captions` still inverts the placement with `at - stepped(at)`** to guess where a frame sits in the story. Inside a hole that inversion is approximate; it widens the interval, so the guard skips *more* frames rather than grading the wrong ones. Untouched, and pre-existing.

## Behaviour changes a reviewer should look at deliberately

- **Three existing narration tests changed their scripted record, not their expectations.** `clock_record((0.1, -0.78))` with a line at 0.5 s *was* a hole case — the zero floor was clamping to `0.0` what should have clamped to `0.1`. The step moved to `-0.5 s` (before frame zero) so those tests still grade the `adelay` floor, which is now reachable only for a step the sampler saw before the first frame. Their asserted delays and `clamped` values are byte-identical to before.
- **Two merged-clock tests moved their step from 1.5 s to 1.0 s** so their beats stay out of the hole. Expectations unchanged; they are about which capture a step belongs to, and a beat inside a hole answers a different question.
- **`test_a_beat_the_clock_swallowed_loses_its_scene_frames_out_loud` changed scenario and expectation.** With per-instant edges a −6 s step *inside* a 1.0–5.0 s beat used to invert the window; now the beat's first second is correctly still in the file, so the window is `(1.0, 2.0)` and the cut is the hole's edge rather than `0.0`. The "no window to search" claim moved to a step at 0.5 s, which swallows the beat whole, and the partially-swallowed case became a test of its own.
- **`test_a_step_inside_the_last_beat_is_not_reported_as_capture_loss` moved its step from 5.2 s to 4.9 s.** With a 5.0 s file, an instant clamped to 5.2 s is genuinely past the end, so the old scenario now reports 0.2 s of loss — correctly. The test still distinguishes reading the correction at the beat's start (0.6 s) from at its end (0.0 s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round two — the seven review findings, closed

| # | finding | what changed |
|---|---|---|
| 1 | `clamped` described as live in shipped docs, and it is now unreachable | `limits.md`, `narration.md`, the envelope schema and `mix_plan`'s docstring say it is unreachable from any record the recorder emits (step times `T ≥ 0` ⟹ `at ≥ 0`) and why the floor stays: `adelay` refuses a negative delay for a record from elsewhere, and that costs a take its whole audio track |
| 2 | `frames.py` could write `"no_video": 0.0` | rounds before the test, exactly as `mix_plan` does. New case `test_a_shortfall_too_small_to_write_down_is_not_called_a_hole` (midpoint 0.2 ms short of the resumption) and its own injection |
| 3 | `KeyError` on a beat with no `t_end` | guarded, with `test_a_beat_with_no_end_is_skipped_rather_than_raising` and an injection that puts the raise back |
| 4 | `or near_edge` ungraded | `test_a_midpoint_near_the_step_itself_is_left_alone` — a midpoint 149 ms after the step with 902 ms of hole left, so the far-edge test alone would let it reach a complaint — plus the injection that drops the branch |
| 5 | invisible to the coverage roster | renamed `unstated_holes` → `_check_unstated_holes`; roster now reports **17 of 42** and carries a row saying `HostClockHole` grades all of it but no arm has reached it |
| 6 | PR body overstated what was exercised | both failure texts now append one shared `hole_clause()`, graded by a case, a control (steady clock, no clock, instant past the hole → `""`) and an injection. The sentence in **Stated limits** above is corrected too |
| 7 | "24 new unit cases" | it was 25 then and 30 now; the counts table above is corrected |
| nit | `_clock_md`'s preamble stated flatly that every frame is its midpoint plus the steps | it names the exception first when any frame is marked, instead of relying on the next paragraph to correct it |

Four new injections, all seen failing:

```
PASS  break: a shortfall too small to write down is still called a hole
      in frames.py: if round(placed.lost, 3):…
      FAIL: test_a_shortfall_too_small_to_write_down_is_not_called_a_hole

PASS  break: the harness raises on a beat whose log lost its end
      in tests/smoke: if not isinstance(beat.get("t_end"), (int, float)):…
      ERROR: test_a_beat_with_no_end_is_skipped_rather_than_raising

PASS  break: the harness complains about a midpoint sitting on the step itself
      in tests/smoke: if gap <= MAX_CLOCK_STEP_TIME_DISAGREEMENT_S or near_edge:…
      FAIL: test_a_midpoint_near_the_step_itself_is_left_alone

PASS  break: a placement failure stops saying the instant has no video
      in tests/smoke: gap = clock.hole(t) if clock is not None else 0.0…
      FAIL: test_a_failure_about_an_instant_with_no_video_says_that_much
```

Re-run after round two: `tests/unit` **322 OK**, `--fault-inject` **200/200 caught**, `tests/ci-unit` 54 OK + 18/18 caught, `tests/lint` and `--self-test` green, `tests/smoke-inject --self-test` every guard refused, `--budget` 600/600, `ruff@0.16.1 format .` clean.
