### PR TITLE
A red baseline the host's clock walked over is re-recorded, out loud (#258)

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1864,6 +1864,32 @@ paragraph whose job is to say what this manifest does not cover.
   injection for the wrong reason. What protects against that is the *named*
   message rather than the exit code, which is the same protection #135 asked
   for.
+- **…and that clean run is recorded up to `BASELINE_ATTEMPTS` (3) times, but
+  only when the host's wall clock stepped underneath it**
+  ([#258](https://github.com/rogvid/skills/issues/258)). Measured on the WSL2
+  box: `--segments-only` was red in **0 of 7** step-free runs and **4 of 6**
+  stepping ones, so the arm's 14 entries were unrunnable here at three separate
+  points — most recently for #260, which shipped with unit grading alone.
+
+  The trigger is a conjunction and nothing else: the arm went red **and** the
+  takes it left behind list a step under `capture_clock.steps`. A red baseline
+  with a steady clock still refuses on its **first** take, exactly as before —
+  that is the genuinely broken recorder, and a retry that outlasted it would
+  certify fourteen entries against a recorder nobody had shown works.
+  Exhausting the three attempts is a refusal that names each attempt's reason
+  *and* the failures the arm reported, because on this host a real fault and a
+  clock step arrive together. Every discarded attempt prints its own failure
+  list, `BASE` says which attempt passed, and the run's last line carries
+  `NOTE: not a first-take baseline` so the line a reviewer quotes cannot read
+  as a first-take green.
+
+  It does **not** make a stepping take pass, and it is not a fix for one —
+  [#255](https://github.com/rogvid/skills/issues/255) and
+  [#259](https://github.com/rogvid/skills/issues/259) own that. On a steady
+  host every line of it is dead, which is why it is graded by
+  `BaselineRerecord` in `tests/unit` against hand-written takes and a scripted
+  loop rather than by running an arm, and why 14 `tests/unit` injections break
+  `tests/smoke-inject` itself.
 
 ### When it runs
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1872,23 +1872,44 @@ paragraph whose job is to say what this manifest does not cover.
   points — most recently for #260, which shipped with unit grading alone.
 
   The trigger is a conjunction and nothing else: the arm went red **and** the
-  takes it left behind list a step under `capture_clock.steps`. A red baseline
-  with a steady clock still refuses on its **first** take, exactly as before —
-  that is the genuinely broken recorder, and a retry that outlasted it would
-  certify fourteen entries against a recorder nobody had shown works.
-  Exhausting the three attempts is a refusal that names each attempt's reason
-  *and* the failures the arm reported, because on this host a real fault and a
-  clock step arrive together. Every discarded attempt prints its own failure
-  list, `BASE` says which attempt passed, and the run's last line carries
-  `NOTE: not a first-take baseline` so the line a reviewer quotes cannot read
-  as a first-take green.
+  takes it left behind list a step of at least `MIN_GATING_STEP_S` under
+  `capture_clock.steps`. That bar is the recorder's own `_CaptureClock.WARN_S`
+  (40 ms, one frame of the encode) and **not** its sampler's floor
+  `MIN_STEP_S` (5 ms) — under `WARN_S` the video and the log still agree about
+  which frame a beat is on, so a blip there is not a reason an arm went red,
+  and gating on it would buy a broken recorder three takes eight times as
+  often as the recorder itself thinks anything happened. #255's real steps are
+  1.0–1.4 s.
+
+  A red baseline with a steady clock still refuses on its **first** take,
+  exactly as before — that is the genuinely broken recorder, and a retry that
+  outlasted it would certify fourteen entries against a recorder nobody had
+  shown works. Exhausting the three attempts is a refusal that names each
+  attempt's reason *and* the failures the arm reported, because on this host a
+  real fault and a clock step arrive together. Every discarded attempt prints
+  its own failure list live **and** keeps it, so the end-of-run block reprints
+  it 40 minutes later; `BASE` says which attempt passed; and the run's last
+  line carries `NOTE: not a first-take baseline` so the line a reviewer quotes
+  cannot read as a first-take green.
+
+  **The one absorption it cannot rule out** is a *genuinely flaky* failure that
+  arrived alongside a step and then did not recur. A deterministic red is never
+  absorbed — it comes back on every attempt and exhausts the bound — but a
+  one-in-three one is greened by attempt 2 and survives only as the failure
+  lines in the end-of-run block. That is why those lines are kept rather than
+  only printed, and the block says so itself.
+
+  **It multiplies the worst case too.** An arm that hangs after writing a
+  stepping `timeline.json` costs `ARM_TIMEOUT_S` (20 min) three times over
+  before the refusal, where it used to cost 20 minutes once. Cost only; the
+  verdict is unchanged.
 
   It does **not** make a stepping take pass, and it is not a fix for one —
   [#255](https://github.com/rogvid/skills/issues/255) and
   [#259](https://github.com/rogvid/skills/issues/259) own that. On a steady
   host every line of it is dead, which is why it is graded by
   `BaselineRerecord` in `tests/unit` against hand-written takes and a scripted
-  loop rather than by running an arm, and why 14 `tests/unit` injections break
+  loop rather than by running an arm, and why 20 `tests/unit` injections break
   `tests/smoke-inject` itself.
 
 ### When it runs

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -97,6 +97,10 @@ ARM_TIMEOUT_S = 1_200
 # else — an arm that cannot record three steady takes in a row is not a host
 # anything here should be certified on, and the exhausted message says exactly
 # that instead of retrying into a pass.
+#
+# It multiplies the worst case as well as the normal one: an arm that hangs
+# after writing a stepping `timeline.json` costs `ARM_TIMEOUT_S` (20 min) three
+# times over before the refusal, where it used to cost 20 minutes once.
 BASELINE_ATTEMPTS = 3
 
 # Measured on this box, clean, one arm at a time (see tests/README.md).
@@ -1284,23 +1288,60 @@ def _clock_records(node: object, path: str) -> Iterator[tuple[str, object]]:
             yield from _clock_records(item, f"{path}[{index}]")
 
 
-def _step_text(step: object) -> str:
-    """One `capture_clock.steps` entry, in the wording `HostClock` prints."""
-    if isinstance(step, dict):
-        at, delta = step.get("t"), step.get("delta")
-        numbers = (int, float)
-        if isinstance(at, numbers) and isinstance(delta, numbers):
-            if not isinstance(at, bool) and not isinstance(delta, bool):
-                return f"{delta * 1000:+.0f} ms at {at:.1f}s"
-    return repr(step)
+def _step_seen(step: object) -> tuple[float, float, object] | None:
+    """(t, delta, segment) of one `capture_clock.steps` entry, or `None`.
+
+    `None` for anything this cannot read as a number, and that is the safe
+    direction: a malformed record is a broken recorder, and a broken recorder
+    must not buy itself another take.
+    """
+    if not isinstance(step, dict):
+        return None
+    at, delta = step.get("t"), step.get("delta")
+    if isinstance(at, bool) or isinstance(delta, bool):
+        return None
+    if not isinstance(at, (int, float)) or not isinstance(delta, (int, float)):
+        return None
+    return float(at), float(delta), step.get("segment")
+
+
+def _step_text(at: float, delta: float, segment: object) -> str:
+    """One step, in the wording `HostClock.describe` prints.
+
+    A merged record's steps carry the `segment` they were measured in and a `t`
+    that `_merge_capture_clock` has already shifted onto the *stitched* clock,
+    while the part's own record keeps its own zero. So one step in part 2 is
+    honestly two different times in two records, and without saying which clock
+    each is on a reader looks at the pair and sees a disagreement.
+    """
+    said = f"{delta * 1000:+.0f} ms at {at:.1f}s"
+    if isinstance(segment, str):
+        return f"{said} of the stitched demo, measured in {segment}"
+    return said
+
+
+# The smallest step this gates on, and it is the **recorder's own** bar for
+# saying something out loud rather than the smallest thing its sampler can see.
+# `_CaptureClock.MIN_STEP_S` is 0.005 — five milliseconds, which by that class's
+# own comment leaves "the video and the log still agree about which frame a beat
+# is on". Gating there would let a 5 ms blip buy a broken recorder three takes.
+# `WARN_S` is one frame of the encode, it is where the recorder starts warning
+# its author, and #255's real steps are 1.0-1.4 s — two orders above it.
+#
+# Hand-written here rather than imported from `demo_recording.core`, like every
+# other constant this harness holds against the recorder: a bar taken from the
+# code under test moves whenever that code does. `BaselineRerecord` grades the
+# two against each other so the drift is a failure rather than a discovery.
+MIN_GATING_STEP_S = 0.04
 
 
 def recorded_steps(out_dir: Path) -> list[str]:
     """What the takes under `out_dir` wrote down about the host's wall clock.
 
-    One string per `capture_clock` record that lists a step, naming the file
-    and the field it came out of. Empty on a steady host, on a run that got far
-    enough to write nothing, and on a document this cannot parse.
+    One string per `capture_clock` record carrying a step of at least
+    `MIN_GATING_STEP_S`, naming the file and the field it came out of. Empty on
+    a steady host, on a run that got far enough to write nothing, and on a
+    document this cannot parse.
 
     **The recorder's own published record, deliberately.** This harness has a
     watcher of its own — `HostClock` in `tests/smoke` — but it lives and dies
@@ -1321,9 +1362,17 @@ def recorded_steps(out_dir: Path) -> list[str]:
             if not isinstance(record, dict):
                 continue
             steps = record.get("steps")
-            if not isinstance(steps, list) or not steps:
+            if not isinstance(steps, list):
                 continue
-            said = ", ".join(_step_text(step) for step in steps)
+            seen = [_step_seen(step) for step in steps]
+            big = [
+                step
+                for step in seen
+                if step is not None and abs(step[1]) >= MIN_GATING_STEP_S
+            ]
+            if not big:
+                continue
+            said = ", ".join(_step_text(*step) for step in big)
             found.append(f"{path.relative_to(out_dir)} {where}: {said}")
     return found
 
@@ -1342,13 +1391,27 @@ def rerecord_reason(code: int, steps: list[str]) -> str | None:
     return "the host's wall clock stepped during it — " + "; ".join(steps)
 
 
+class Discarded(NamedTuple):
+    """A baseline take that was thrown away, and **what it had said**.
+
+    The failures travel with the reason because the end-of-run block is the
+    only place a reader of a 42-minute run will see this. A summary that
+    printed the clock step alone would describe a genuinely flaky failure —
+    one red on attempt 1, green on attempt 2 — as nothing but the host's
+    clock, hundreds of lines below the `BASE` line that said otherwise.
+    """
+
+    reason: str
+    failures: tuple[str, ...]
+
+
 class Baseline(NamedTuple):
     """One arm's clean run, and what it cost to get one."""
 
     arm: str
     attempts: int
     seconds: float
-    discarded: tuple[str, ...]  # the reason each earlier attempt was re-recorded
+    discarded: tuple[Discarded, ...]
 
     def summary(self) -> str:
         if not self.discarded:
@@ -1389,13 +1452,24 @@ def rerecord_report(baselines: list[Baseline]) -> list[str]:
     ]
     for base in again:
         out.append(f"  {base.arm}: {base.attempts} attempt(s)")
-        for number, why in enumerate(base.discarded, 1):
-            out.append(f"    attempt {number} discarded, {why}")
+        for number, gone in enumerate(base.discarded, 1):
+            out.append(f"    attempt {number} discarded, {gone.reason}")
+            out.append(f"      and it had reported {len(gone.failures)} failure(s):")
+            for line in gone.failures:
+                out.append(f"      | {line[:160]}")
     out.append(
         "\nA re-record happens only when the arm went red *and* the takes it "
         "left recorded a wall-clock step. It does not make a stepping take "
         "pass and it is not a fix for one — #255/#259 own that — so an entry "
-        "below rests on a baseline this host had to be asked for twice.\n"
+        "below rests on a baseline this host had to be asked for twice."
+    )
+    out.append(
+        "Read those failures. The one thing this cannot tell apart is a "
+        "**genuinely flaky** failure that happened to arrive with a step and "
+        "then happened not to recur — a deterministic red is never absorbed, "
+        "because it comes back on every attempt and exhausts the bound, but a "
+        "one-in-three one is greened by attempt 2 and lives only in the lines "
+        "above.\n"
     )
     return out
 
@@ -1407,7 +1481,7 @@ def baseline(arm: str) -> Baseline:
     `rerecord_reason` names — see the section comment above.
     """
     started = time.monotonic()
-    discarded: list[str] = []
+    discarded: list[Discarded] = []
     for attempt in range(1, BASELINE_ATTEMPTS + 1):
         with tempfile.TemporaryDirectory(prefix="smoke-inject-") as tmp:
             root = stage(Path(tmp))
@@ -1435,7 +1509,7 @@ def baseline(arm: str) -> Baseline:
                 + "\n".join(f"       - {ln}" for ln in lines[:6])
                 + ("\n       " + err[-600:] if not lines else "")
             )
-        discarded.append(reason)
+        discarded.append(Discarded(reason, tuple(lines[:6])))
         # Printed in full, every time. A re-recorded baseline has to be harder
         # to overlook than a first-take green one, because the reader who is
         # about to trust fourteen PASS lines is the one who needs to know that
@@ -1453,7 +1527,9 @@ def baseline(arm: str) -> Baseline:
         f"a wall-clock step, so this is the host, the recorder, or both — "
         f"which of those it is, this cannot say, and it is not going to record "
         f"again until it likes the answer.\n"
-        + "\n".join(f"       attempt {n}: {why}" for n, why in enumerate(discarded, 1))
+        + "\n".join(
+            f"       attempt {n}: {gone.reason}" for n, gone in enumerate(discarded, 1)
+        )
         + "\n"
         + "\n".join(f"       - {ln}" for ln in lines[:6])
         + ("\n       " + err[-600:] if not lines else "")

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -65,6 +65,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import json
 import os
 import re
 import shutil
@@ -72,6 +73,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Iterator
 from pathlib import Path
 from typing import NamedTuple
 
@@ -83,6 +85,19 @@ HELPERS = REPO / "skills" / "demo-video" / "helpers" / "demo_recording"
 # that makes a take hang, and a timeout is reported as a failure of that entry
 # rather than of the run.
 ARM_TIMEOUT_S = 1_200
+
+# How many times one arm's clean baseline may be recorded before it is reported
+# red (issue #258). More than one only ever happens on the narrow signature
+# `rerecord_reason` describes; a baseline that fails for any other reason still
+# costs exactly one take, as it did before this existed.
+#
+# Three, and the number is a cost bound rather than a confidence one: the arm
+# this was written for is 29 s, so a host stepping under every take pays 87 s
+# and then says so. Raising it buys a greener run on a worse host and nothing
+# else — an arm that cannot record three steady takes in a row is not a host
+# anything here should be certified on, and the exhausted message says exactly
+# that instead of retrying into a pass.
+BASELINE_ATTEMPTS = 3
 
 # Measured on this box, clean, one arm at a time (see tests/README.md).
 ARM_SECONDS = {
@@ -1212,29 +1227,237 @@ def run_arm(root: Path, arm: str, out_dir: Path) -> tuple[int, str, str]:
     return done.returncode, done.stdout, done.stderr
 
 
-def baseline(arm: str) -> float:
-    """The arm, clean, on a staged copy. Raises `Refused` unless it passes."""
+# --------------------------------------------------------------------------
+# Re-recording a baseline the host's clock walked over (issue #258)
+# --------------------------------------------------------------------------
+#
+# Measured on the WSL2 box this repo is developed on: `--segments-only` was red
+# in **0 of 7** runs whose wall clock held still and **4 of 6** runs whose wall
+# clock stepped (issue #255). The arm is not flaky; the host is. Because
+# `baseline()` refuses to grade an injection whose clean arm already fails —
+# correctly, and that does not change — the arm's 14 entries had been unrunnable
+# here at three separate points, most recently for #260, which shipped with unit
+# grading alone.
+#
+# So one narrow thing is retried, and everything else fails exactly as before.
+# The direction of the risk is what the shape below is chosen for: a retry that
+# ran an arm until it happened to pass would certify all fourteen entries
+# against a recorder nobody had shown works, which is a worse artifact than an
+# arm that cannot run at all. Hence:
+#
+#   * the trigger is a *conjunction* — the arm went red **and** the takes it
+#     left behind wrote down a wall-clock step. Not "retry until green".
+#   * the reason comes out of the recorder's published `capture_clock`, so it
+#     names steps that are in the artifact a reader can go and look at.
+#   * it is bounded by `BASELINE_ATTEMPTS`, and exhausting it is a refusal that
+#     names the count and every reason, not a shrug.
+#   * every discarded attempt prints its own failure list, so a re-recorded
+#     baseline is louder in the output than a first-time green one and cannot
+#     be mistaken for it.
+#
+# What none of this does is make a stepping take *pass*; #256 and #259 own that.
+# On a host whose clock never steps every line of it is dead — `recorded_steps`
+# returns `[]`, `rerecord_reason` returns `None`, and `baseline()` behaves
+# exactly as it did before. Which is why it is graded in `tests/unit`, against
+# hand-written records, and not by running an arm.
+
+
+def _clock_records(node: object, path: str) -> Iterator[tuple[str, object]]:
+    """Every `capture_clock` value in a timeline document, and where it sits.
+
+    Keyed on the field name and **not** on the name `steps`, which is the trap
+    this walk exists to avoid: a stitched `timeline.json` carries a second
+    `steps` at `narration.clock_correction.steps`, and that one is an *integer
+    count* of the steps a mix was corrected for. A search by the inner name
+    would read `2` there as two wall-clock steps on a take whose clock never
+    moved, and re-record a baseline the host had no hand in.
+    """
+    if isinstance(node, dict):
+        for key, value in node.items():
+            where = f"{path}.{key}" if path else key
+            if key == "capture_clock":
+                yield where, value
+            else:
+                yield from _clock_records(value, where)
+    elif isinstance(node, list):
+        for index, item in enumerate(node):
+            yield from _clock_records(item, f"{path}[{index}]")
+
+
+def _step_text(step: object) -> str:
+    """One `capture_clock.steps` entry, in the wording `HostClock` prints."""
+    if isinstance(step, dict):
+        at, delta = step.get("t"), step.get("delta")
+        numbers = (int, float)
+        if isinstance(at, numbers) and isinstance(delta, numbers):
+            if not isinstance(at, bool) and not isinstance(delta, bool):
+                return f"{delta * 1000:+.0f} ms at {at:.1f}s"
+    return repr(step)
+
+
+def recorded_steps(out_dir: Path) -> list[str]:
+    """What the takes under `out_dir` wrote down about the host's wall clock.
+
+    One string per `capture_clock` record that lists a step, naming the file
+    and the field it came out of. Empty on a steady host, on a run that got far
+    enough to write nothing, and on a document this cannot parse.
+
+    **The recorder's own published record, deliberately.** This harness has a
+    watcher of its own — `HostClock` in `tests/smoke` — but it lives and dies
+    inside the child process, and reading `timeline.json` is what a developer
+    reading the refusal would do next. The number is not being *trusted* here
+    in the way #259 means: nothing is corrected with it. It only decides
+    whether a red run is worth recording again, and a record that invented a
+    step it never had would buy at most `BASELINE_ATTEMPTS` takes and then the
+    same refusal.
+    """
+    found: list[str] = []
+    for path in sorted(out_dir.rglob("*timeline.json")):
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        for where, record in _clock_records(doc, ""):
+            if not isinstance(record, dict):
+                continue
+            steps = record.get("steps")
+            if not isinstance(steps, list) or not steps:
+                continue
+            said = ", ".join(_step_text(step) for step in steps)
+            found.append(f"{path.relative_to(out_dir)} {where}: {said}")
+    return found
+
+
+def rerecord_reason(code: int, steps: list[str]) -> str | None:
+    """Why this baseline attempt is worth recording again, or `None`.
+
+    `None` is the answer for everything the manifest could already handle: an
+    arm that passed, and an arm that went red with a steady clock underneath
+    it. The second is the one that matters — that is the genuinely broken
+    recorder, and it must reach `Refused` on the first take exactly as it did
+    before, or this function has replaced a red baseline with a slow one.
+    """
+    if code == 0 or not steps:
+        return None
+    return "the host's wall clock stepped during it — " + "; ".join(steps)
+
+
+class Baseline(NamedTuple):
+    """One arm's clean run, and what it cost to get one."""
+
+    arm: str
+    attempts: int
+    seconds: float
+    discarded: tuple[str, ...]  # the reason each earlier attempt was re-recorded
+
+    def summary(self) -> str:
+        if not self.discarded:
+            return f"{self.arm} passes clean ({self.seconds:.0f}s)"
+        return (
+            f"{self.arm} passes clean on attempt {self.attempts} of "
+            f"{BASELINE_ATTEMPTS} ({self.seconds:.0f}s, "
+            f"{len(self.discarded)} re-recorded)"
+        )
+
+
+def rerecord_clause(baselines: list[Baseline]) -> str:
+    """What the run's **last** line adds when a baseline took more than one go.
+
+    Empty on a steady host, and it has to be: this is appended to "All N
+    injections were caught", which is the one line a reader quotes into a pull
+    request. A run that re-recorded and said so only two hundred lines earlier
+    is a run whose summary reads as a first-take green.
+    """
+    again = [base for base in baselines if base.discarded]
+    if not again:
+        return ""
+    takes = sum(len(base.discarded) for base in again)
+    return (
+        f" NOTE: not a first-take baseline — {takes} clean take(s) across "
+        f"{len(again)} arm(s) were re-recorded, see BASE above and #258."
+    )
+
+
+def rerecord_report(baselines: list[Baseline]) -> list[str]:
+    """The re-recorded baselines, one block, or no lines at all."""
+    again = [base for base in baselines if base.discarded]
+    if not again:
+        return []
+    out = [
+        f"re-recorded baselines — {len(again)} arm(s) needed more than one "
+        f"clean take before anything aimed at them could be graded (#258):"
+    ]
+    for base in again:
+        out.append(f"  {base.arm}: {base.attempts} attempt(s)")
+        for number, why in enumerate(base.discarded, 1):
+            out.append(f"    attempt {number} discarded, {why}")
+    out.append(
+        "\nA re-record happens only when the arm went red *and* the takes it "
+        "left recorded a wall-clock step. It does not make a stepping take "
+        "pass and it is not a fix for one — #255/#259 own that — so an entry "
+        "below rests on a baseline this host had to be asked for twice.\n"
+    )
+    return out
+
+
+def baseline(arm: str) -> Baseline:
+    """The arm, clean, on a staged copy. Raises `Refused` unless it passes.
+
+    Recorded up to `BASELINE_ATTEMPTS` times, and only for the reason
+    `rerecord_reason` names — see the section comment above.
+    """
     started = time.monotonic()
-    with tempfile.TemporaryDirectory(prefix="smoke-inject-") as tmp:
-        root = stage(Path(tmp))
-        code, _, err = run_arm(root, arm, Path(tmp) / "out")
-    spent = time.monotonic() - started
-    if code != 0:
+    discarded: list[str] = []
+    for attempt in range(1, BASELINE_ATTEMPTS + 1):
+        with tempfile.TemporaryDirectory(prefix="smoke-inject-") as tmp:
+            root = stage(Path(tmp))
+            out = Path(tmp) / "out"
+            code, _, err = run_arm(root, arm, out)
+            # Inside the context: the takes go with the temporary directory.
+            steps = recorded_steps(out)
+        spent = time.monotonic() - started
+        if code == 0:
+            done = Baseline(arm, attempt, spent, tuple(discarded))
+            print(f"BASE  {done.summary()}")
+            return done
         blob, lines = failure_report(err)
         if contended(lines):
             raise Refused(
                 f"another smoke run holds the machine lock, so {arm} recorded "
                 f"nothing. Wait for it — a contended arm is not a verdict."
             )
-        raise Refused(
-            f"the clean {arm} run failed, so nothing aimed at that arm can be "
-            f"graded — an assertion firing under injection would prove nothing "
-            f"if it fires without one.\n"
-            + "\n".join(f"       - {ln}" for ln in lines[:6])
-            + ("\n       " + err[-600:] if not lines else "")
+        reason = rerecord_reason(code, steps)
+        if reason is None:
+            raise Refused(
+                f"the clean {arm} run failed, so nothing aimed at that arm can "
+                f"be graded — an assertion firing under injection would prove "
+                f"nothing if it fires without one.\n"
+                + "\n".join(f"       - {ln}" for ln in lines[:6])
+                + ("\n       " + err[-600:] if not lines else "")
+            )
+        discarded.append(reason)
+        # Printed in full, every time. A re-recorded baseline has to be harder
+        # to overlook than a first-take green one, because the reader who is
+        # about to trust fourteen PASS lines is the one who needs to know that
+        # the arm they rest on took three goes.
+        print(
+            f"BASE  {arm} attempt {attempt} of {BASELINE_ATTEMPTS} went red "
+            f"and {reason}"
         )
-    print(f"BASE  {arm} passes clean ({spent:.0f}s)")
-    return spent
+        for line in lines[:6]:
+            print(f"      | {line[:160]}")
+        print("      re-recording; issue #258, and the red itself is #255/#259")
+    raise Refused(
+        f"the clean {arm} run failed on all {BASELINE_ATTEMPTS} attempts, so "
+        f"nothing aimed at that arm can be graded. Every one of them recorded "
+        f"a wall-clock step, so this is the host, the recorder, or both — "
+        f"which of those it is, this cannot say, and it is not going to record "
+        f"again until it likes the answer.\n"
+        + "\n".join(f"       attempt {n}: {why}" for n, why in enumerate(discarded, 1))
+        + "\n"
+        + "\n".join(f"       - {ln}" for ln in lines[:6])
+        + ("\n       " + err[-600:] if not lines else "")
+    )
 
 
 # --------------------------------------------------------------------------
@@ -1268,8 +1491,7 @@ def inject(entries: list[Injection]) -> int:
     )
     started = time.monotonic()
     try:
-        for arm in arms:
-            baseline(arm)
+        baselines = [baseline(arm) for arm in arms]
     except Refused as exc:
         print(f"ABORT: {exc}", file=sys.stderr)
         return 3
@@ -1324,6 +1546,8 @@ def inject(entries: list[Injection]) -> int:
         print()
 
     spent = time.monotonic() - started
+    for line in rerecord_report(baselines):
+        print(line)
     blind = ungraded()
     print(
         f"ungraded — {len(blind)} check function(s) in tests/smoke have no "
@@ -1342,10 +1566,13 @@ def inject(entries: list[Injection]) -> int:
     if missed:
         print(
             f"{missed} injection(s) went unnoticed — those assertions grade "
-            f"nothing. [{spent / 60:.1f} min]"
+            f"nothing. [{spent / 60:.1f} min]{rerecord_clause(baselines)}"
         )
         return 1
-    print(f"All {len(entries)} injections were caught. [{spent / 60:.1f} min]")
+    print(
+        f"All {len(entries)} injections were caught. "
+        f"[{spent / 60:.1f} min]{rerecord_clause(baselines)}"
+    )
     return 0
 
 

--- a/tests/unit
+++ b/tests/unit
@@ -6933,6 +6933,84 @@ class BaselineRerecord(unittest.TestCase):
             )
             self.assertEqual(self.inject.recorded_steps(out), [])
 
+    def test_a_blip_too_small_for_the_recorder_to_warn_about_is_not_a_step(self):
+        """The gate is the recorder's *out loud* bar, not its sampler's floor.
+
+        `_CaptureClock.MIN_STEP_S` is 5 ms, and by that class's own comment a
+        step under `WARN_S` leaves "the video and the log still agree about
+        which frame a beat is on". A 5 ms blip is therefore not a reason the
+        arm went red, and gating on it would buy a broken recorder three takes
+        on a host that hiccups — 8x more often than the recorder itself thinks
+        anything happened. #255's real steps are 1.0-1.4 s.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            self.take(
+                out,
+                "segments/timeline.json",
+                {"capture_clock": self.clock((1.0, -0.005))},
+            )
+            self.assertEqual(self.inject.recorded_steps(out), [])
+
+    def test_the_gate_sits_exactly_where_the_recorder_starts_warning(self):
+        # Both sides of the boundary, and the constant itself against the
+        # recorder's. The bar is hand-written in the harness on purpose, so
+        # the two drifting apart has to be a failure rather than a discovery.
+        self.assertEqual(self.inject.MIN_GATING_STEP_S, _CaptureClock.WARN_S)
+        bar = self.inject.MIN_GATING_STEP_S
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            self.take(
+                out, "a/timeline.json", {"capture_clock": self.clock((1.0, -bar))}
+            )
+            self.take(
+                out,
+                "b/timeline.json",
+                {"capture_clock": self.clock((1.0, -bar + 0.001))},
+            )
+            found = self.inject.recorded_steps(out)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("a/timeline.json", found[0])
+
+    def test_a_real_step_beside_a_blip_is_reported_without_the_blip(self):
+        # A record can carry both. The reason a developer reads should name
+        # the step that plausibly cost the take its frames, not pad itself
+        # with scheduling noise the recorder would not have mentioned.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            self.take(
+                out,
+                "segments/timeline.json",
+                {"capture_clock": self.clock((1.0, -0.005), (5.151, -1.051))},
+            )
+            found = self.inject.recorded_steps(out)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("-1051 ms at 5.2s", found[0])
+        self.assertNotIn("-5 ms", found[0])
+
+    def test_a_merged_step_says_which_capture_and_which_clock_it_is_on(self):
+        # `_merge_capture_clock` shifts a step's `t` onto the stitched clock
+        # and stamps it with the part it was measured in, while the part's own
+        # record keeps its own zero. One step then prints as two different
+        # times, and without saying which clock each is on the pair reads as a
+        # disagreement between two records.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            self.take(
+                out,
+                "segments/timeline.json",
+                {
+                    "capture_clock": {
+                        **self.clock(),
+                        "steps": [{"t": 8.9, "delta": -1.051, "segment": "part2"}],
+                    }
+                },
+            )
+            found = self.inject.recorded_steps(out)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("-1051 ms at 8.9s of the stitched demo", found[0])
+        self.assertIn("measured in part2", found[0])
+
     def test_a_capture_clock_whose_steps_is_not_a_list_says_nothing(self):
         """A malformed record is a broken recorder, not a stepping host.
 
@@ -7047,6 +7125,13 @@ class BaselineRerecord(unittest.TestCase):
         self.assertIsInstance(result, self.inject.Baseline)
         self.assertEqual((result.attempts, len(runs)), (2, 2))
         self.assertEqual(len(result.discarded), 1)
+        # The discarded take's failures travel with it, not just its reason:
+        # the end-of-run block is built from this and is the only place a
+        # reader of a 42-minute run will see that anything was red.
+        self.assertEqual(
+            result.discarded[0].failures,
+            ("segments: beat-05's frame shows the previous caption",),
+        )
         # And the discarded attempt is in the output, with what it said.
         self.assertIn("attempt 1 of 3 went red", printed)
         self.assertIn("-1051 ms at 5.2s", printed)
@@ -7126,8 +7211,20 @@ class BaselineRerecord(unittest.TestCase):
     # -- and what a reader of the output is told ------------------------------
 
     def base(self, *discarded: str):
+        """A finished baseline whose earlier attempts said `discarded`.
+
+        Each one carries a failure line of its own, because that is what the
+        end-of-run block has to reproduce: the reason alone would describe a
+        flaky red as nothing but the host's clock.
+        """
         return self.inject.Baseline(
-            "--segments-only", len(discarded) + 1, 31.0, tuple(discarded)
+            "--segments-only",
+            len(discarded) + 1,
+            31.0,
+            tuple(
+                self.inject.Discarded(why, (f"segments: something was red ({why})",))
+                for why in discarded
+            ),
         )
 
     def test_a_baseline_that_took_three_goes_says_so_where_it_is_printed(self):
@@ -7163,6 +7260,20 @@ class BaselineRerecord(unittest.TestCase):
         self.assertIn("attempt 1 discarded, stepped — a", block)
         self.assertIn("attempt 2 discarded, stepped — b", block)
         self.assertIn("3 attempt(s)", block)
+
+    def test_the_report_also_says_what_the_discarded_attempt_had_reported(self):
+        """The persistent copy of the failure list, and why it has to exist.
+
+        On a twelve-arm run this block is 40 minutes below the `BASE` line
+        that printed the failures live, and nobody scrolls back. A summary
+        carrying only the clock step describes a red that happened to be
+        flaky as nothing but the host — which is the one absorption this
+        design cannot rule out, so it must at least be legible.
+        """
+        block = "\n".join(self.inject.rerecord_report([self.base("stepped — a")]))
+        self.assertIn("it had reported 1 failure(s)", block)
+        self.assertIn("segments: something was red (stepped — a)", block)
+        self.assertIn("genuinely flaky", block)
 
 
 # --------------------------------------------------------------------------
@@ -9711,7 +9822,7 @@ INJECTIONS = [
     # The thing being broken here is a decision **not to run a check**, so its
     # failure mode is silence: a retry that swallowed a red would report all
     # fourteen `--segments-only` entries as caught against a recorder nobody
-    # had shown works. Two of the eight below are that direction specifically —
+    # had shown works. Two of the fourteen below are that direction specifically —
     # "retry until green" in `rerecord_reason` and in `baseline`'s loop — and
     # both are caught by controls rather than by cases.
     (
@@ -9726,10 +9837,44 @@ INJECTIONS = [
     (
         "a capture_clock's steps count is read as the steps themselves",
         "tests/smoke-inject",
-        "            if not isinstance(steps, list) or not steps:\n",
-        "            if not steps:\n",
+        "            if not isinstance(steps, list):\n",
+        "            if steps is None:\n",
         [
             "BaselineRerecord.test_a_capture_clock_whose_steps_is_not_a_list_says_nothing"
+        ],
+    ),
+    (
+        # The recorder's sampler floor, not its out-loud bar. A 5 ms blip is
+        # 8x under the point the recorder itself thinks anything happened, and
+        # gating there buys a broken recorder three takes on a hiccupping host.
+        "the gate drops to the sampler's floor instead of the recorder's warning",
+        "tests/smoke-inject",
+        "MIN_GATING_STEP_S = 0.04\n",
+        "MIN_GATING_STEP_S = 0.005\n",
+        [
+            "BaselineRerecord.test_a_blip_too_small_for_the_recorder_to_warn_about_is_not_a_step",
+            "BaselineRerecord.test_the_gate_sits_exactly_where_the_recorder_starts_warning",
+            "BaselineRerecord.test_a_real_step_beside_a_blip_is_reported_without_the_blip",
+        ],
+    ),
+    (
+        "any step at all opens the gate, however small the recorder said it was",
+        "tests/smoke-inject",
+        "                if step is not None and abs(step[1]) >= MIN_GATING_STEP_S\n",
+        "                if step is not None\n",
+        [
+            "BaselineRerecord.test_a_blip_too_small_for_the_recorder_to_warn_about_is_not_a_step",
+            "BaselineRerecord.test_the_gate_sits_exactly_where_the_recorder_starts_warning",
+            "BaselineRerecord.test_a_real_step_beside_a_blip_is_reported_without_the_blip",
+        ],
+    ),
+    (
+        "a merged step stops saying which capture and which clock it is on",
+        "tests/smoke-inject",
+        '        return f"{said} of the stitched demo, measured in {segment}"\n',
+        "        return said\n",
+        [
+            "BaselineRerecord.test_a_merged_step_says_which_capture_and_which_clock_it_is_on"
         ],
     ),
     (
@@ -9788,7 +9933,7 @@ INJECTIONS = [
     (
         "the re-record report stops saying why each attempt was discarded",
         "tests/smoke-inject",
-        '            out.append(f"    attempt {number} discarded, {why}")\n',
+        '            out.append(f"    attempt {number} discarded, {gone.reason}")\n',
         '            out.append("    an attempt was discarded")\n',
         [
             "BaselineRerecord.test_the_report_names_every_discarded_attempt_and_its_reason"
@@ -9801,8 +9946,8 @@ INJECTIONS = [
         # list rather than by way of the decision.
         "a take that recorded no step is read as one that recorded a step",
         "tests/smoke-inject",
-        "            if not isinstance(steps, list) or not steps:\n",
-        "            if not isinstance(steps, list):\n",
+        "            if not big:\n                continue\n",
+        "            if big is None:\n                continue\n",
         ["BaselineRerecord.test_a_steady_host_leaves_nothing_to_find"],
     ),
     (
@@ -9841,11 +9986,52 @@ INJECTIONS = [
     (
         "the reason stops saying how big the step was and when it landed",
         "tests/smoke-inject",
-        '                return f"{delta * 1000:+.0f} ms at {at:.1f}s"\n',
-        '                return "a step"\n',
+        '    said = f"{delta * 1000:+.0f} ms at {at:.1f}s"\n',
+        '    said = "a step"\n',
         [
             "BaselineRerecord.test_a_step_in_a_takes_own_record_is_found_and_quoted",
             "BaselineRerecord.test_a_step_only_one_segments_own_record_carries_is_found",
+        ],
+    ),
+    (
+        # A discarded take's failures are printed live and then thrown away, so
+        # the end-of-run block — 40 minutes below, and the only part anyone
+        # reads — describes a red that happened to be flaky as nothing but the
+        # host's clock.
+        "a discarded baseline keeps its reason and forgets what went red",
+        "tests/smoke-inject",
+        "        discarded.append(Discarded(reason, tuple(lines[:6])))\n",
+        "        discarded.append(Discarded(reason, ()))\n",
+        [
+            "BaselineRerecord.test_a_red_over_a_stepping_host_is_recorded_again_and_then_accepted"
+        ],
+    ),
+    (
+        "the end-of-run block stops reprinting what the discarded take reported",
+        "tests/smoke-inject",
+        '            out.append(f"      and it had reported {len(gone.failures)} failure(s):")\n'
+        "            for line in gone.failures:\n"
+        '                out.append(f"      | {line[:160]}")\n',
+        "            pass\n",
+        [
+            "BaselineRerecord.test_the_report_also_says_what_the_discarded_attempt_had_reported"
+        ],
+    ),
+    (
+        # The stated limit, in the artifact rather than only in the PR body.
+        "the report stops naming the flaky failure it cannot rule out",
+        "tests/smoke-inject",
+        "    out.append(\n"
+        '        "Read those failures. The one thing this cannot tell apart is a "\n'
+        '        "**genuinely flaky** failure that happened to arrive with a step and "\n'
+        '        "then happened not to recur — a deterministic red is never absorbed, "\n'
+        '        "because it comes back on every attempt and exhausts the bound, but a "\n'
+        '        "one-in-three one is greened by attempt 2 and lives only in the lines "\n'
+        '        "above.\\n"\n'
+        "    )\n",
+        "",
+        [
+            "BaselineRerecord.test_the_report_also_says_what_the_discarded_attempt_had_reported"
         ],
     ),
 ]

--- a/tests/unit
+++ b/tests/unit
@@ -2127,6 +2127,14 @@ SMOKE = Path(os.environ.get("UNIT_SMOKE", REPO / "tests" / "smoke"))
 # while an injection is in place rather than going quiet exactly then.
 README = Path(os.environ.get("UNIT_README", REPO / "tests" / "README.md"))
 
+# `tests/smoke-inject`, on the same terms. Graded here rather than by its own
+# `--self-test` because the state that matters — a baseline the host's clock
+# walked over — cannot be produced on demand, and because this file has the
+# fault-injection driver that refuses an injection which did not land.
+SMOKE_INJECT = Path(
+    os.environ.get("UNIT_SMOKE_INJECT", REPO / "tests" / "smoke-inject")
+)
+
 # Below this, `tests/smoke` was not parsed — an empty or truncated file makes
 # "nothing is unread" hold trivially, the catalogue's vacuous sweep. It is 271
 # today; this is a floor on "a suite was read", not a bar on its size.
@@ -2221,6 +2229,24 @@ def _smoke_module():
     from importlib.machinery import SourceFileLoader
 
     loader = SourceFileLoader("_smoke_under_test", str(SMOKE))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _smoke_inject_module():
+    """`tests/smoke-inject` imported as a module, so its guards can be called.
+
+    Importing it runs nothing: everything at module level is a constant, a
+    `Path` that is never touched, or the `INJECTIONS` literal. So a copy under
+    a temp directory — which is what `--fault-inject` hands this — imports as
+    happily as the original does.
+    """
+    import importlib.util
+    from importlib.machinery import SourceFileLoader
+
+    loader = SourceFileLoader("_smoke_inject_under_test", str(SMOKE_INJECT))
     spec = importlib.util.spec_from_loader(loader.name, loader)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -6777,6 +6803,368 @@ class HostClockHole(unittest.TestCase):
         self.assertEqual(self.smoke.hole_clause(None, 6.3, 6.3), "")
 
 
+class BaselineRerecord(unittest.TestCase):
+    """`tests/smoke-inject`'s re-recorded clean baseline (issue #258).
+
+    Here, and not in `tests/smoke-inject --self-test`, for the reason
+    `ClockCoverageCheck` and `HostClockHole` both give: the state this grades
+    is a baseline whose host stepped its wall clock, and that cannot be
+    produced on demand — measured 0 of 7 step-free `--segments-only` runs red
+    against 4 of 6 stepping ones (#255). **Every take below is written by
+    hand.** On a steady host the whole retry path is dead, so an assertion that
+    needed the host's help would grade the host.
+
+    What is being defended is one direction. A retry that swallowed a red would
+    certify all fourteen entries aimed at that arm against a recorder nobody
+    had shown works, which is a worse artifact than an arm that cannot run —
+    so the controls here (`…_is_not_retried`, `…_is_still_red_at_the_bound`)
+    carry more weight than the cases.
+    """
+
+    def setUp(self):
+        self.inject = _smoke_inject_module()
+
+    def take(self, out: Path, name: str, doc: dict) -> None:
+        """One `timeline.json` on disk, where a finished arm would leave it."""
+        (out / name).parent.mkdir(parents=True, exist_ok=True)
+        (out / name).write_text(json.dumps(doc), encoding="utf-8")
+
+    def clock(self, *steps: tuple[float, float]) -> dict:
+        """A `capture_clock` record, in `_CaptureClock.report`'s own shape."""
+        return {
+            "measured": True,
+            "note": None,
+            "steps": [{"t": at, "delta": delta} for at, delta in steps],
+            "total": round(sum(delta for _at, delta in steps), 4),
+            "sample_interval": 0.02,
+            "min_step": 0.005,
+            "max_gap": 0.021,
+            "max_gap_limit": 0.25,
+        }
+
+    # -- what the takes say about the host -----------------------------------
+
+    def test_a_step_in_a_takes_own_record_is_found_and_quoted(self):
+        # The measured one: −1.051 s at 5.151 s. The reason a developer reads
+        # has to name the step, not just assert one happened, or the refusal
+        # sends them to look for a take they cannot identify.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            self.take(
+                out,
+                "segments/timeline.json",
+                {"capture_clock": self.clock((5.151, -1.051))},
+            )
+            found = self.inject.recorded_steps(out)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("segments/timeline.json", found[0])
+        self.assertIn("capture_clock", found[0])
+        self.assertIn("-1051 ms at 5.2s", found[0])
+
+    def test_a_step_only_one_segments_own_record_carries_is_found(self):
+        # A stitched take's merged `capture_clock` is **null** whenever any
+        # part was not measured, and the part records survive it under
+        # `segments`. Reading the root field alone would call that host steady
+        # and report a red the step caused as a broken recorder.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            self.take(
+                out,
+                "segments/timeline.json",
+                {
+                    "capture_clock": None,
+                    "segments": [
+                        {"segment": "part-a", "capture_clock": self.clock()},
+                        {
+                            "segment": "part-b",
+                            "capture_clock": self.clock((2.2, -1.073)),
+                        },
+                    ],
+                },
+            )
+            found = self.inject.recorded_steps(out)
+        self.assertEqual(len(found), 1, found)
+        self.assertIn("segments[1].capture_clock", found[0])
+        self.assertIn("-1073 ms at 2.2s", found[0])
+
+    def test_a_steady_host_leaves_nothing_to_find(self):
+        # The control the whole feature rests on. `recorded_steps` returning
+        # anything on a steady host is a retry on every red baseline there is.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            self.take(out, "segments/timeline.json", {"capture_clock": self.clock()})
+            self.take(out, "web/web.seg.timeline.json", {"capture_clock": self.clock()})
+            self.assertEqual(self.inject.recorded_steps(out), [])
+
+    def test_a_steps_list_under_any_other_field_is_not_a_wall_clock_step(self):
+        """The scope, which is `capture_clock` and not the name `steps`.
+
+        `timeline.json` already carries a second field called `steps` —
+        `narration.clock_correction.steps`, in this fixture, an *integer*
+        count of the steps a mix was corrected for. That near-miss is why the
+        walk is keyed on the enclosing field rather than the inner name, and
+        the second record here is the version of it that a name-keyed walk
+        could not survive: a `steps` **list** somewhere that is not a clock
+        the recorder measured.
+
+        No such field exists in today's `timeline.json`, and that is the point
+        of a narrowing — it costs nothing now and it is what keeps the next
+        field added to the envelope from silently becoming a retry trigger.
+        The catalogue's wrong-scope search, in the direction that would
+        re-record a genuinely broken recorder.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            self.take(
+                out,
+                "segments/timeline.json",
+                {
+                    "capture_clock": self.clock(),
+                    "narration": {
+                        "lines": [],
+                        "clock_correction": {
+                            "applied": True,
+                            "total": -1.073,
+                            "steps": 2,
+                        },
+                    },
+                    "some_later_field": {"steps": [{"t": 1.0, "delta": -1.0}]},
+                },
+            )
+            self.assertEqual(self.inject.recorded_steps(out), [])
+
+    def test_a_capture_clock_whose_steps_is_not_a_list_says_nothing(self):
+        """A malformed record is a broken recorder, not a stepping host.
+
+        `check_capture_clock` in `tests/smoke` fails a take whose
+        `capture_clock.steps` is not a list, and `smoke-inject` carries an
+        entry that breaks exactly that. So this is the shape a red baseline
+        really can arrive in — and reading the `3` here as three steps would
+        re-record the one failure this must never absorb.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            self.take(
+                out,
+                "segments/timeline.json",
+                {"capture_clock": {**self.clock(), "steps": 3}},
+            )
+            self.assertEqual(self.inject.recorded_steps(out), [])
+
+    def test_a_run_that_wrote_no_take_and_one_that_wrote_rubbish_say_nothing(self):
+        # An arm that died before recording, and a truncated document. Both
+        # are "this cannot say the clock stepped", which is the safe answer:
+        # the red stands and the developer sees it on the first take.
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            self.assertEqual(self.inject.recorded_steps(out), [])
+            (out / "segments").mkdir()
+            (out / "segments" / "timeline.json").write_text('{"capture_c')
+            self.assertEqual(self.inject.recorded_steps(out), [])
+
+    # -- and what is done about it -------------------------------------------
+
+    def test_a_red_arm_over_a_stepping_host_is_re_recorded(self):
+        self.assertIsNotNone(self.inject.rerecord_reason(1, ["-1051 ms at 5.2s"]))
+
+    def test_a_red_arm_over_a_steady_host_is_not_retried(self):
+        """The control that keeps a genuinely broken recorder red.
+
+        This is the whole risk of #258 in one assertion: a baseline that fails
+        with no step under it has to reach `Refused` on its first take, as it
+        did before any of this existed.
+        """
+        self.assertIsNone(self.inject.rerecord_reason(1, []))
+
+    def test_an_arm_that_passed_is_never_re_recorded(self):
+        # A retry keyed on the steps alone would re-record a *green* baseline
+        # on a stepping host, and then take whichever of the two answers came
+        # last.
+        self.assertIsNone(self.inject.rerecord_reason(0, ["-1051 ms at 5.2s"]))
+
+    def test_the_number_of_attempts_is_bounded_and_small(self):
+        """An unbounded retry is "run until green" wearing a reason.
+
+        What this pins is that the bound exists and stays small enough that
+        exhausting it is a refusal a developer waits out rather than a loop.
+        What it cannot say is whether 3 is the right number; that is a cost
+        judgement, written down beside the constant.
+        """
+        self.assertGreaterEqual(self.inject.BASELINE_ATTEMPTS, 2)
+        self.assertLessEqual(self.inject.BASELINE_ATTEMPTS, 4)
+
+    # -- the loop itself, over scripted arm runs -----------------------------
+
+    def drive(self, *takes: tuple[int, list[str], list[str]]):
+        """`baseline()` over scripted runs. -> (result, printed, runs).
+
+        `takes` is one `(exit code, failure lines, recorded steps)` per arm
+        run, in order. `stage()` and `run_arm()` are replaced because the real
+        ones record a 29-second take of a browser; nothing else is — the loop,
+        its bound, its refusals and everything it prints are the shipped ones.
+
+        A run past the end of the script is an assertion failure rather than a
+        repeat of the last one: a loop that ran longer than the bound is the
+        defect here, and it must not be able to look like a pass.
+        """
+        runs: list[str] = []
+
+        def run_arm(root, arm, out_dir):
+            index = len(runs)
+            runs.append(arm)
+            self.assertLess(index, len(takes), "baseline() ran past its bound")
+            code, lines, _steps = takes[index]
+            body = "".join(f"  - {line}\n" for line in lines)
+            return code, "", f"smoke: FAILED\n{body}" if code else ""
+
+        swapped = {
+            "stage": lambda tmp: tmp,
+            "run_arm": run_arm,
+            "recorded_steps": lambda out: takes[len(runs) - 1][2],
+        }
+        original = {name: getattr(self.inject, name) for name in swapped}
+        printed = io.StringIO()
+        try:
+            for name, stub in swapped.items():
+                setattr(self.inject, name, stub)
+            with contextlib.redirect_stdout(printed):
+                try:
+                    result = self.inject.baseline("--segments-only")
+                except self.inject.Refused as exc:
+                    result = exc
+        finally:
+            for name, real in original.items():
+                setattr(self.inject, name, real)
+        return result, printed.getvalue(), runs
+
+    STEP = ["segments/timeline.json capture_clock: -1051 ms at 5.2s"]
+
+    def test_a_red_over_a_stepping_host_is_recorded_again_and_then_accepted(self):
+        result, printed, runs = self.drive(
+            (1, ["segments: beat-05's frame shows the previous caption"], self.STEP),
+            (0, [], []),
+        )
+        self.assertIsInstance(result, self.inject.Baseline)
+        self.assertEqual((result.attempts, len(runs)), (2, 2))
+        self.assertEqual(len(result.discarded), 1)
+        # And the discarded attempt is in the output, with what it said.
+        self.assertIn("attempt 1 of 3 went red", printed)
+        self.assertIn("-1051 ms at 5.2s", printed)
+        self.assertIn("beat-05's frame shows the previous caption", printed)
+        self.assertIn("passes clean on attempt 2 of 3", printed)
+
+    def test_a_red_with_a_steady_clock_is_refused_on_the_first_take(self):
+        """The one that keeps a genuinely broken recorder red.
+
+        The script here would go green on its third run. A retry that ran an
+        arm until it passed would take that green and certify all fourteen
+        entries aimed at the arm on it. `runs == 1` is the assertion; the
+        refusal's wording is not enough, because a loop that refused *after*
+        three takes would still print it.
+        """
+        result, printed, runs = self.drive(
+            (1, ["coverage: AC-3 is not in timeline.md"], []),
+            (1, ["coverage: AC-3 is not in timeline.md"], []),
+            (0, [], []),
+        )
+        self.assertIsInstance(result, self.inject.Refused)
+        self.assertEqual(runs, ["--segments-only"])
+        self.assertIn("nothing aimed at that arm can be graded", str(result))
+        self.assertIn("coverage: AC-3 is not in timeline.md", str(result))
+        self.assertNotIn("attempt", printed)
+
+    def test_a_recorder_broken_under_a_stepping_host_is_still_refused(self):
+        """The hard case: a real failure *and* a stepping clock, together.
+
+        On this host the two arrive together whenever anything is wrong, so
+        the retry cannot be allowed to outlast a fault that survives it. Three
+        takes, three reds, and the refusal has to carry the failure the arm
+        reported — not only the clock's alibi, which is what would send a
+        reader looking at #255 for a broken recorder.
+        """
+        broken = ["coverage: AC-3 is not in timeline.md"]
+        result, _printed, runs = self.drive(
+            (1, broken, self.STEP), (1, broken, self.STEP), (1, broken, self.STEP)
+        )
+        self.assertIsInstance(result, self.inject.Refused)
+        self.assertEqual(len(runs), self.inject.BASELINE_ATTEMPTS)
+        self.assertIn("failed on all 3 attempts", str(result))
+        self.assertIn("attempt 3: the host's wall clock stepped", str(result))
+        self.assertIn("coverage: AC-3 is not in timeline.md", str(result))
+        self.assertIn("the host, the recorder, or both", str(result))
+
+    # -- and the figure the README prints about all of it ---------------------
+
+    CLAIM = re.compile(r"(\d+) `tests/unit` injections break\s+`tests/smoke-inject`")
+
+    def test_the_readme_states_how_many_injections_break_this(self):
+        # `StatedInjectionCount`'s shape, for the same reason: the prose is the
+        # claim, `INJECTIONS` is the truth, and a README reworded past the
+        # pattern is a failure rather than a quiet pass.
+        found = self.CLAIM.search(README.read_text(encoding="utf-8"))
+        self.assertIsNotNone(
+            found,
+            f"{README} no longer states how many injections break "
+            f"tests/smoke-inject in the shape this reads",
+        )
+        registered = sum(1 for entry in INJECTIONS if entry[1] == "tests/smoke-inject")
+        self.assertEqual(int(found.group(1)), registered)
+        # The haystack: both sides agreeing on zero would satisfy the above.
+        self.assertGreater(registered, 5)
+
+    def test_an_arm_the_machine_lock_refused_is_not_re_recorded(self):
+        # A contended arm recorded nothing, so there is no take to read and no
+        # verdict to retry. It has always been its own refusal; a retry that
+        # reached it first would spend three arms discovering the same thing.
+        result, _printed, runs = self.drive(
+            (1, ["refusing to run a second smoke suite on this machine"], self.STEP)
+        )
+        self.assertIsInstance(result, self.inject.Refused)
+        self.assertEqual(len(runs), 1)
+        self.assertIn("holds the machine lock", str(result))
+
+    # -- and what a reader of the output is told ------------------------------
+
+    def base(self, *discarded: str):
+        return self.inject.Baseline(
+            "--segments-only", len(discarded) + 1, 31.0, tuple(discarded)
+        )
+
+    def test_a_baseline_that_took_three_goes_says_so_where_it_is_printed(self):
+        said = self.base("the host's wall clock stepped — a", "…— b").summary()
+        self.assertIn("attempt 3 of", said)
+        self.assertIn("2 re-recorded", said)
+
+    def test_a_first_take_baseline_says_only_that(self):
+        self.assertEqual(self.base().summary(), "--segments-only passes clean (31s)")
+
+    def test_the_runs_last_line_says_a_baseline_was_re_recorded(self):
+        """The line a reader quotes into a pull request.
+
+        "All 14 injections were caught" over a baseline that took three goes
+        is the artifact-lies direction: nothing in it is false, and a reviewer
+        reads a first-take green off it.
+        """
+        clause = self.inject.rerecord_clause([self.base("stepped — a")])
+        self.assertIn("not a first-take baseline", clause)
+        self.assertIn("1 clean take(s)", clause)
+        self.assertIn("#258", clause)
+
+    def test_a_run_whose_baselines_were_all_first_takes_adds_no_clause(self):
+        # The control. A clause on every run is a clause nobody reads, and it
+        # would say "not a first-take baseline" about first-take baselines.
+        self.assertEqual(self.inject.rerecord_clause([self.base()]), "")
+        self.assertEqual(self.inject.rerecord_report([self.base()]), [])
+
+    def test_the_report_names_every_discarded_attempt_and_its_reason(self):
+        block = "\n".join(
+            self.inject.rerecord_report([self.base("stepped — a", "stepped — b")])
+        )
+        self.assertIn("attempt 1 discarded, stepped — a", block)
+        self.assertIn("attempt 2 discarded, stepped — b", block)
+        self.assertIn("3 attempt(s)", block)
+
+
 # --------------------------------------------------------------------------
 
 # Issue #203, as the overlay shipped before it was fixed and after it was.
@@ -9318,6 +9706,148 @@ INJECTIONS = [
             "CheapArm.test_every_arm_a_guard_names_is_a_flag_the_script_accepts",
         ],
     ),
+    # -- the re-recorded baseline (issue #258) --------------------------------
+    #
+    # The thing being broken here is a decision **not to run a check**, so its
+    # failure mode is silence: a retry that swallowed a red would report all
+    # fourteen `--segments-only` entries as caught against a recorder nobody
+    # had shown works. Two of the eight below are that direction specifically —
+    # "retry until green" in `rerecord_reason` and in `baseline`'s loop — and
+    # both are caught by controls rather than by cases.
+    (
+        "the walk for a recorded step keys on any field, not on capture_clock",
+        "tests/smoke-inject",
+        '            if key == "capture_clock":\n',
+        '            if isinstance(value, dict) and "steps" in value:\n',
+        [
+            "BaselineRerecord.test_a_steps_list_under_any_other_field_is_not_a_wall_clock_step"
+        ],
+    ),
+    (
+        "a capture_clock's steps count is read as the steps themselves",
+        "tests/smoke-inject",
+        "            if not isinstance(steps, list) or not steps:\n",
+        "            if not steps:\n",
+        [
+            "BaselineRerecord.test_a_capture_clock_whose_steps_is_not_a_list_says_nothing"
+        ],
+    ),
+    (
+        "a red baseline is re-recorded whatever its takes said about the clock",
+        "tests/smoke-inject",
+        "    if code == 0 or not steps:\n        return None\n",
+        "    if code == 0:\n        return None\n",
+        ["BaselineRerecord.test_a_red_arm_over_a_steady_host_is_not_retried"],
+    ),
+    (
+        "a baseline that passed is re-recorded because the host stepped",
+        "tests/smoke-inject",
+        "    if code == 0 or not steps:\n        return None\n",
+        "    if not steps:\n        return None\n",
+        ["BaselineRerecord.test_an_arm_that_passed_is_never_re_recorded"],
+    ),
+    (
+        # The loop's own version of "retry until green": the reason is still
+        # computed and still printed, and it no longer decides anything.
+        "baseline() re-records every red arm and only reports the reason",
+        "tests/smoke-inject",
+        "        reason = rerecord_reason(code, steps)\n",
+        '        reason = rerecord_reason(code, steps) or "the arm went red"\n',
+        [
+            "BaselineRerecord.test_a_red_with_a_steady_clock_is_refused_on_the_first_take"
+        ],
+    ),
+    (
+        "the retry stops being bounded by a small number of attempts",
+        "tests/smoke-inject",
+        "BASELINE_ATTEMPTS = 3\n",
+        "BASELINE_ATTEMPTS = 40\n",
+        ["BaselineRerecord.test_the_number_of_attempts_is_bounded_and_small"],
+    ),
+    (
+        "a baseline that took three goes prints what a first-take one prints",
+        "tests/smoke-inject",
+        '            f"{self.arm} passes clean on attempt {self.attempts} of "\n',
+        '            f"{self.arm} passes clean, honestly, of "\n',
+        [
+            "BaselineRerecord.test_a_baseline_that_took_three_goes_says_so_where_it_is_printed",
+            "BaselineRerecord.test_a_red_over_a_stepping_host_is_recorded_again_and_then_accepted",
+        ],
+    ),
+    (
+        # The artifact-lies direction: "All 14 injections were caught" is the
+        # line that gets quoted, and over a re-recorded baseline it reads as a
+        # first-take green unless it says otherwise.
+        "the run's last line stops saying a baseline was re-recorded",
+        "tests/smoke-inject",
+        '        f" NOTE: not a first-take baseline — {takes} clean take(s) across "\n'
+        '        f"{len(again)} arm(s) were re-recorded, see BASE above and #258."\n',
+        '        ""\n',
+        ["BaselineRerecord.test_the_runs_last_line_says_a_baseline_was_re_recorded"],
+    ),
+    (
+        "the re-record report stops saying why each attempt was discarded",
+        "tests/smoke-inject",
+        '            out.append(f"    attempt {number} discarded, {why}")\n',
+        '            out.append("    an attempt was discarded")\n',
+        [
+            "BaselineRerecord.test_the_report_names_every_discarded_attempt_and_its_reason"
+        ],
+    ),
+    (
+        # The version that reads a steady take as a stepping one: a record with
+        # `steps: []` is still a record, so every red baseline on every host
+        # becomes three. "Retry until green" arriving by way of the *empty*
+        # list rather than by way of the decision.
+        "a take that recorded no step is read as one that recorded a step",
+        "tests/smoke-inject",
+        "            if not isinstance(steps, list) or not steps:\n",
+        "            if not isinstance(steps, list):\n",
+        ["BaselineRerecord.test_a_steady_host_leaves_nothing_to_find"],
+    ),
+    (
+        # A stitched take's merged record is null whenever any part was not
+        # measured, and the part records survive under `segments`. Stop
+        # descending into lists and that whole case reads as a steady host.
+        "the walk stops descending into a stitched take's segment records",
+        "tests/smoke-inject",
+        "    elif isinstance(node, list):\n"
+        "        for index, item in enumerate(node):\n"
+        '            yield from _clock_records(item, f"{path}[{index}]")\n',
+        "    elif isinstance(node, list):\n        return\n",
+        ["BaselineRerecord.test_a_step_only_one_segments_own_record_carries_is_found"],
+    ),
+    (
+        "a half-written timeline.json takes the whole manifest down with it",
+        "tests/smoke-inject",
+        "        except (OSError, ValueError):\n            continue\n",
+        "        except (OSError, ValueError):\n            raise\n",
+        [
+            "BaselineRerecord.test_a_run_that_wrote_no_take_and_one_that_wrote_rubbish_say_nothing"
+        ],
+    ),
+    (
+        # The reason has to send a reader somewhere. "The clock stepped" with
+        # no file and no field is a refusal nobody can act on.
+        "the reason stops naming the take and the field it was read from",
+        "tests/smoke-inject",
+        '            found.append(f"{path.relative_to(out_dir)} {where}: {said}")\n',
+        "            found.append(said)\n",
+        [
+            "BaselineRerecord.test_a_step_in_a_takes_own_record_is_found_and_quoted",
+            "BaselineRerecord.test_a_step_only_one_segments_own_record_carries_is_found",
+        ],
+    ),
+    (
+        "the reason stops saying how big the step was and when it landed",
+        "tests/smoke-inject",
+        '                return f"{delta * 1000:+.0f} ms at {at:.1f}s"\n',
+        '                return "a step"\n',
+        [
+            "BaselineRerecord.test_a_step_in_a_takes_own_record_is_found_and_quoted",
+            "BaselineRerecord.test_a_step_only_one_segments_own_record_carries_is_found",
+        ],
+    ),
 ]
 
 
@@ -9345,10 +9875,19 @@ def fault_inject() -> int:
             root = skill / "helpers"
             smoke = Path(tmp) / "smoke"
             shutil.copy(REPO / "tests" / "smoke", smoke)
+            # And the injection manifest, for the same reason as `smoke`: the
+            # baseline retry #258 added is a decision this suite grades, and a
+            # decision nobody has watched go the wrong way is a claim.
+            smoke_inject = Path(tmp) / "smoke-inject"
+            shutil.copy(REPO / "tests" / "smoke-inject", smoke_inject)
             unit = Path(tmp) / "unit"
             shutil.copy(Path(__file__).resolve(), unit)
             if module == "tests/smoke":
                 target = smoke
+            elif module == "tests/smoke-inject":
+                # Before the `"/" in module` branch below, which would send it
+                # into the skill directory and fail on a file that is not there.
+                target = smoke_inject
             elif module == "tests/unit":
                 target = unit
             elif module == "__init__.py" or module.endswith(".py"):
@@ -9381,6 +9920,7 @@ def fault_inject() -> int:
                     "UNIT_HELPERS": str(root),
                     "UNIT_SKILL_DIR": str(skill),
                     "UNIT_SMOKE": str(smoke),
+                    "UNIT_SMOKE_INJECT": str(smoke_inject),
                     "UNIT_README": str(REPO / "tests" / "README.md"),
                 },
             )


### PR DESCRIPTION
Fixes #258. Slice of #255.

## Acceptance criterion

> A developer on a host that steps its clock can run `tests/smoke-inject --arm segments` and get a clean baseline, without any real failure being hidden.
>
> - The baseline is green whenever the host is steady, so re-record when `capture_clock.steps` is non-empty — printing that reason, not silently.
> - A genuinely broken recorder still fails; the retry must not swallow a real red.
> - The number of retries and the reason are visible in the output.

**It ran, and the retry path was exercised by a real step.** `tests/smoke-inject --arm segments` on this WSL2 box: the first baseline went red with a measured **−1421 ms at 3.7 s**, was re-recorded, passed on attempt 2, and **all 14 entries then ran and were caught** — the first time this arm has been executed here since the sampler fix, and the first time at all for three of its entries.

## The shape, and the direction of the risk

This is the one thing in the repo whose job is to *not* run a check, so its failure mode is silence. A retry that ran an arm until it happened to pass would report all fourteen `--segments-only` entries as caught against a recorder nobody had shown works — a worse artifact than an arm that cannot run. So:

| | |
|---|---|
| **trigger** | a *conjunction*: the arm went red **and** the takes it left list a step under `capture_clock.steps`. Not "retry until green". A red baseline with a steady clock refuses on its **first** take, exactly as before. |
| **reason** | read out of the recorder's published `capture_clock`, naming the file and the field, so the refusal points at an artifact a reader can open. Nothing is *corrected* with the number — #259's question is untouched. |
| **bound** | `BASELINE_ATTEMPTS = 3`. Exhausting it is a `Refused` naming each attempt's reason **and** the failures the arm reported, because on this host a real fault and a clock step arrive together. |
| **said out loud** | every discarded attempt prints its own failure list; `BASE` says which attempt passed; a `re-recorded baselines` block precedes the ungraded roster; and the run's last line carries `NOTE: not a first-take baseline`. |

## The real run, verbatim

```
smoke-inject: 14 injection(s) over 1 arm(s), plus 1 clean baseline(s)

BASE  --segments-only attempt 1 of 3 went red and the host's wall clock stepped during it — segments/timeline.json capture_clock: -1421 ms at 3.7s; segments/timeline.json segments[0].capture_clock: -1421 ms at 3.7s
      | segments: beat 6 ('interlude') starts at 5.672s, before the previous beat ended (5.786s) — the log is not monotonic
      | segments: beat-04.png was taken at 4.013s, but beat 4 runs 5.398-5.469s and its midpoint sits at 5.434s in the video …
      | segments: beat-05.png was taken at 4.207s, but beat 5 runs 5.469-5.786s and its midpoint sits at 5.627s in the video …
      | segments: beat-04.png should show the caption 'One demo, in two parts.' and its caption band is only 0.28 from the take's caption-off baseline …
      re-recording; issue #258, and the red itself is #255/#259
BASE  --segments-only passes clean on attempt 2 of 3 (61s, 1 re-recorded)

PASS  break: the timeline stops carrying the clock the video is on  [30s]
…
PASS  break: the review sheet stops saying which clock its frames were cut on  [29s]

re-recorded baselines — 1 arm(s) needed more than one clean take before anything aimed at them could be graded (#258):
  --segments-only: 2 attempt(s)
    attempt 1 discarded, the host's wall clock stepped during it — segments/timeline.json capture_clock: -1421 ms at 3.7s; segments/timeline.json segments[0].capture_clock: -1421 ms at 3.7s

A re-record happens only when the arm went red *and* the takes it left recorded a wall-clock step. It does not make a stepping take pass and it is not a fix for one — #255/#259 own that — so an entry below rests on a baseline this host had to be asked for twice.

ungraded — 17 check function(s) in tests/smoke have no registered injection:
…
All 14 injections were caught. [7.9 min] NOTE: not a first-take baseline — 1 clean take(s) across 1 arm(s) were re-recorded, see BASE above and #258.
```

**Observed vs constructed.** The block above is *observed* — a real host step, a real re-record, fourteen real injected takes. Everything in the next section is *constructed*: hand-written `timeline.json` documents and a scripted `baseline()` loop, because the host stepped twice in one hour yesterday and not at all for the six days before, and an assertion that waited for it would grade the host.

## Evidence — every new assertion seen failing

`tests/unit --fault-inject`, which aborts unless each injection's search string matches **exactly once** and requires *every* named test to fail. 14 new entries, all caught. `tests/smoke-inject` had to become a target module of `fault_inject()` for this (staged and injected alongside `tests/smoke`, reached by the unit tests through `UNIT_SMOKE_INJECT`).

```
PASS  break: the walk for a recorded step keys on any field, not on capture_clock
      in tests/smoke-inject: if key == "capture_clock":…
      FAIL: test_a_steps_list_under_any_other_field_is_not_a_wall_clock_step

PASS  break: a capture_clock's steps count is read as the steps themselves
      in tests/smoke-inject: if not isinstance(steps, list) or not steps:…
      ERROR: test_a_capture_clock_whose_steps_is_not_a_list_says_nothing

PASS  break: a take that recorded no step is read as one that recorded a step
      in tests/smoke-inject: if not isinstance(steps, list) or not steps:…
      FAIL: test_a_steady_host_leaves_nothing_to_find
      FAIL: test_a_step_only_one_segments_own_record_carries_is_found
      FAIL: test_a_steps_list_under_any_other_field_is_not_a_wall_clock_step

PASS  break: the walk stops descending into a stitched take's segment records
      in tests/smoke-inject: elif isinstance(node, list):…
      FAIL: test_a_step_only_one_segments_own_record_carries_is_found

PASS  break: a half-written timeline.json takes the whole manifest down with it
      in tests/smoke-inject: except (OSError, ValueError):…
      ERROR: test_a_run_that_wrote_no_take_and_one_that_wrote_rubbish_say_nothing

PASS  break: the reason stops naming the take and the field it was read from
      in tests/smoke-inject: found.append(f"{path.relative_to(out_dir)} {where}: {said}")…
      FAIL: test_a_step_in_a_takes_own_record_is_found_and_quoted
      FAIL: test_a_step_only_one_segments_own_record_carries_is_found

PASS  break: the reason stops saying how big the step was and when it landed
      in tests/smoke-inject: return f"{delta * 1000:+.0f} ms at {at:.1f}s"…
      FAIL: test_a_step_in_a_takes_own_record_is_found_and_quoted
      FAIL: test_a_step_only_one_segments_own_record_carries_is_found

PASS  break: a red baseline is re-recorded whatever its takes said about the clock
      in tests/smoke-inject: if code == 0 or not steps:…
      FAIL: test_a_red_arm_over_a_steady_host_is_not_retried
      FAIL: test_a_red_with_a_steady_clock_is_refused_on_the_first_take

PASS  break: a baseline that passed is re-recorded because the host stepped
      in tests/smoke-inject: if code == 0 or not steps:…
      FAIL: test_an_arm_that_passed_is_never_re_recorded

PASS  break: baseline() re-records every red arm and only reports the reason
      in tests/smoke-inject: reason = rerecord_reason(code, steps)…
      FAIL: test_a_red_with_a_steady_clock_is_refused_on_the_first_take

PASS  break: the retry stops being bounded by a small number of attempts
      in tests/smoke-inject: BASELINE_ATTEMPTS = 3…
      FAIL: test_a_recorder_broken_under_a_stepping_host_is_still_refused
      FAIL: test_a_red_over_a_stepping_host_is_recorded_again_and_then_accepted
      FAIL: test_the_number_of_attempts_is_bounded_and_small

PASS  break: a baseline that took three goes prints what a first-take one prints
      in tests/smoke-inject: f"{self.arm} passes clean on attempt {self.attempts} of "…
      FAIL: test_a_baseline_that_took_three_goes_says_so_where_it_is_printed
      FAIL: test_a_red_over_a_stepping_host_is_recorded_again_and_then_accepted

PASS  break: the run's last line stops saying a baseline was re-recorded
      in tests/smoke-inject: f" NOTE: not a first-take baseline — {takes} clean take(s) across "…
      FAIL: test_the_runs_last_line_says_a_baseline_was_re_recorded

PASS  break: the re-record report stops saying why each attempt was discarded
      in tests/smoke-inject: out.append(f"    attempt {number} discarded, {why}")…
      FAIL: test_the_report_names_every_discarded_attempt_and_its_reason
```

Two of those fail as an **ERROR** rather than a FAIL — the injected version raises rather than answering wrongly. Both still prove the branch is reached and load-bearing, and both are named as must-fail, so the driver would not accept a silent pass.

### The three assertions that carry the whole thing

They are controls, not cases, and they are the ones to read:

- **`test_a_red_with_a_steady_clock_is_refused_on_the_first_take`** — the scripted arm is red, red, then **green**. A "retry until green" would take that green and certify fourteen entries on it. The assertion is `runs == 1`, not the wording of the refusal, because a loop that refused *after* three takes would still print the right words. Caught by two injections.
- **`test_a_recorder_broken_under_a_stepping_host_is_still_refused`** — the brief's hard case, and the one this host actually produces: a **non-clock** failure (`coverage: AC-3 is not in timeline.md`) present on all three attempts *together with* a step on all three. Result: `Refused`, exactly `BASELINE_ATTEMPTS` runs, and the message carries the coverage failure as well as the clock's alibi — so a reader is not sent to #255 about a broken recorder.
- **`test_a_steady_host_leaves_nothing_to_find`** — a take with `capture_clock.steps: []` must produce no reason. The cheapest wrong version (`if not isinstance(steps, list)`) turns every red baseline on every host into three, and it is the injection above that catches it.

### What each assertion says if the host never steps

All 20 new cases are driven by hand-written documents and a scripted loop, so **every one of them runs and passes on a steady host** — none is on an arm, and none needs the host's cooperation. That is deliberate and it is also the limit: they grade the decision, not the phenomenon. The phenomenon was graded once, by the observed run at the top of this body.

### The near-miss the walk is shaped around

`timeline.json` carries a **second** field called `steps` — `narration.clock_correction.steps`, an *integer* count of the steps a mix was corrected for. A walk keyed on the inner name would read `2` there as two wall-clock steps on a take whose own clock record says it never moved, and re-record a genuinely broken recorder. The walk is keyed on the enclosing `capture_clock` instead, and `test_a_steps_list_under_any_other_field_is_not_a_wall_clock_step` grades that narrowing against both the real int and a hypothetical `steps` list under another field.

## Counts

| | before (`0920825`) | after |
|---|---|---|
| `tests/unit` | 322 tests | **342** (20 new cases in `BaselineRerecord`) |
| `tests/unit --fault-inject` | 200 injections, all caught | **214**, all caught |
| `tests/ci-unit` | 54 tests / 18 injections | unchanged, all caught |
| `tests/smoke-inject --list` | 51 entries, 12 arms | unchanged |
| ungraded roster | 17 of 42 check functions | unchanged |
| `tests/smoke-inject --arm segments` | **could not run on this host** | **14/14 caught, 7.9 min** |

Also green: `tests/lint`, `tests/lint --self-test`, `tests/smoke-inject --self-test` (every guard refused), `tests/unit --budget` (600/600), `uvx ruff@0.16.1 format .` clean.

## Stated limits

- **Only the baseline retries. Injected takes do not.** A step during an injected run leaves the arm red for two reasons at once and `verdict()` still finds the named message, so the safe direction; but a step that stopped a run before it reached the injected assertion would be reported as `FAIL … grades nothing` — a false red, never a false green. Not seen in the observed run above; not addressed here.
- **Three is a cost bound, not a confidence one.** `test_the_number_of_attempts_is_bounded_and_small` pins that a bound exists and stays in [2, 4]; nothing grades whether 3 is right. On a host stepping every 32 s (measured in #255) three 29-second takes can all step, and then the arm is refused — correctly, and slowly.
- **`recorded_steps` believes the recorder's published record.** #259 owns whether that record describes the world. Nothing here *corrects* with the number: a record that invented a step it never had buys at most three takes and then the same refusal, so the untrusted input can cost time and cannot cost a grade.
- **`ARM_SECONDS` and the `--list` cost estimate still assume one baseline per arm.** On a stepping host a run can cost up to two extra takes per arm more than the printed estimate. The estimate is nominal and the README already says so.
- **The re-record reason prints the merged record and the per-segment record separately**, so a single step on a stitched take is listed twice (once as `capture_clock`, once as `segments[0].capture_clock`). Verbose, and it is the attribution a reader wants; not deduplicated.

## For #259's benefit — what the red take actually said

The discarded attempt is quoted in full above. Three things in it, from a take whose clock stepped **−1421 ms at 3.7 s**:

- **the beat log went non-monotonic** — `beat 6 ('interlude') starts at 5.672s, before the previous beat ended (5.786s)`. Worth noting because `MAX_LOG_EARLY_S`'s premise (#257) is about a *positive skew*; this is a different symptom of the same step and it is in the merged log, not the video.
- **two frames were cut roughly 1.4 s early** — `beat-04.png was taken at 4.013s` for a beat running `5.398-5.469s`; `beat-05.png at 4.207s` for `5.469-5.786s`. Both offsets are close to the recorded Δ, which is the over-correction #255(b) describes, in the direction #259 exists to measure against pixels.
- **and one of them shows the wrong caption** — `beat-04.png should show the caption 'One demo, in two parts.' and its caption band is only 0.28 from the take's caption-off baseline`. That is the pixel-side confirmation, for free, on a real take.

Nothing here fixes any of that, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Round two — the four review findings, closed

| # | finding | what changed |
|---|---|---|
| 1 | the gate was 8× more sensitive than the recorder's own "this matters" bar | `MIN_GATING_STEP_S = 0.04` — the recorder's `_CaptureClock.WARN_S`, one encode frame — replaces "any entry in `steps`", which was the sampler's 5 ms floor. Under `WARN_S` the video and the log still agree about which frame a beat is on, so scenario H's 5 ms blip no longer buys a broken recorder three takes. Hand-written in the harness and graded against the recorder's constant, so drift is a failure |
| 2 | a discarded attempt's failures were printed live and then dropped | they travel with the reason in a new `Discarded(reason, failures)`, the end-of-run block reprints them under `and it had reported N failure(s)`, and the block **names the flaky-absorption case itself** — see the new limit below |
| 3 | `_step_text` dropped the merged record's `segment` and did not say which clock its `t` was on | a merged step now prints `-1051 ms at 8.9s of the stitched demo, measured in part2`, so the pair of times for one step reads as two clocks rather than a disagreement |
| 4 | "Two of the **eight** below" | 20 |

### The new limit, stated where it belongs

**The one absorption this design cannot rule out is a genuinely flaky failure that arrived with a step and then did not recur.** A deterministic red is never absorbed — it returns on every attempt and exhausts the bound, which is what `test_a_recorder_broken_under_a_stepping_host_is_still_refused` grades. A one-in-three red is greened by attempt 2 and survives only as the failure lines. Those lines are now kept rather than only printed, the end-of-run block reprints them, and the block says this in its own words (graded by `assertIn("genuinely flaky", block)` and an injection that deletes the paragraph).

### Stated, not fixed

`BASELINE_ATTEMPTS` multiplies `ARM_TIMEOUT_S` as well as the normal cost: an arm that **hangs** after writing a stepping `timeline.json` now costs 3 × 20 min before refusing, where it used to cost 20 min once. Cost only — the verdict is unchanged. Written beside the constant and in `tests/README.md`.

### Six new injections, all seen failing

```
PASS  break: the gate drops to the sampler's floor instead of the recorder's warning
      in tests/smoke-inject: MIN_GATING_STEP_S = 0.04…
      FAIL: test_a_blip_too_small_for_the_recorder_to_warn_about_is_not_a_step
      FAIL: test_a_real_step_beside_a_blip_is_reported_without_the_blip
      FAIL: test_the_gate_sits_exactly_where_the_recorder_starts_warning

PASS  break: any step at all opens the gate, however small the recorder said it was
      in tests/smoke-inject: if step is not None and abs(step[1]) >= MIN_GATING_STEP_S…
      FAIL: test_a_blip_too_small_for_the_recorder_to_warn_about_is_not_a_step
      FAIL: test_a_real_step_beside_a_blip_is_reported_without_the_blip
      FAIL: test_the_gate_sits_exactly_where_the_recorder_starts_warning

PASS  break: a merged step stops saying which capture and which clock it is on
      in tests/smoke-inject: return f"{said} of the stitched demo, measured in {segment}"…
      FAIL: test_a_merged_step_says_which_capture_and_which_clock_it_is_on

PASS  break: a discarded baseline keeps its reason and forgets what went red
      in tests/smoke-inject: discarded.append(Discarded(reason, tuple(lines[:6])))…
      FAIL: test_a_red_over_a_stepping_host_is_recorded_again_and_then_accepted

PASS  break: the end-of-run block stops reprinting what the discarded take reported
      in tests/smoke-inject: out.append(f"      and it had reported {len(gone.failures)} failure(…
      FAIL: test_the_report_also_says_what_the_discarded_attempt_had_reported

PASS  break: the report stops naming the flaky failure it cannot rule out
      in tests/smoke-inject: out.append(…
      FAIL: test_the_report_also_says_what_the_discarded_attempt_had_reported
```

**Two things the driver caught in me, worth recording.** Renaming `{why}` to `{gone.reason}` left an existing injection matching **0 times**, and the run aborted rather than reporting 19 of 20 caught — the exactly-once guard doing exactly its job. And the first version of *"the report stops naming the flaky failure"* deleted only the paragraph's opening clause, left `genuinely flaky` in the next line, and was reported `FAIL … the suite passed against broken code`. Both are in the reflog of this branch; the second is the hollow-injection case the must-fail list exists for.

### A second `--arm segments` run, as the real-path control

```
All 14 injections were caught. [8.2 min]
```

No `BASE … attempt 1 of 3` line, no `re-recorded baselines` block, and **no `NOTE:` clause** — the baseline was green on its first take this time, so the whole retry path stayed dead on a real run. That is the observed control for the clause that the unit tests grade synthetically. (The injected takes *did* step — `beat-03.png … -1.461s` — which is #255/#259's territory and not the baseline's.)

### Counts after round two

| | `0920825` | round one | round two |
|---|---|---|---|
| `tests/unit` | 322 | 342 | **347** |
| `tests/unit --fault-inject` | 200 | 214 | **220**, all caught |
| `tests/ci-unit` | 54 / 18 | unchanged | 54 / 18, all caught |
| `tests/smoke-inject --list` | 51 entries, 12 arms | unchanged | unchanged |
| ungraded roster | 17 of 42 | unchanged | unchanged |
| `--arm segments` | unrunnable | 14/14, re-recorded | **14/14, first-take baseline** |

`tests/lint`, `tests/lint --self-test`, `tests/smoke-inject --self-test`, `--budget` (600/600) and `uvx ruff@0.16.1 format --check .` all green.

### For #259, from the review

`_merge_capture_clock` returns **null** unless *every* part was measured, while `recorded_steps` reads the per-segment records too. So this harness can see a step the merged record hides. Right direction here — the gate opens when it should — but it means **a merged `capture_clock: null` is not evidence of a steady host**, and #259 must not read it as one.
