### PR TITLE
Stop blaming the beat log for a skew the clock step caused (#257)

### DIFF
--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -121,10 +121,19 @@ beat, all 38 landed within **101 ms**, and within 40 ms at the caption-on edges
 (a caption fade takes two frames to cross, which is the rest).
 
 The suite's bars are asymmetric because the two directions have different
-causes: `MAX_LOG_EARLY_S = 0.25` for the log running ahead of the frame
-(nothing about capture can move an event later, so that direction is the log's
-own error) and `MAX_CAPTURE_LOSS_S = 0.75` for the video running ahead of the
-log. Both storyboards inject a small animated element for their whole length,
+causes: `MAX_LOG_EARLY_S = 0.25` for the log running ahead of the frame and
+`MAX_CAPTURE_LOSS_S = 0.75` for the video running ahead of the log. That first
+direction is the beat log's own error **on a take whose host clock held
+still**, and only then — this file used to say that nothing about capture can
+move an event later, full stop, and
+[#255](https://github.com/rogvid/skills/issues/255) measured two ways it can:
+an instant inside the window a backward step deletes, and a capture that lost
+less wall time than the step it recorded, which the correction then
+over-shoots by the difference (+540 to +970 ms on three takes). On a stepping
+take the suite now names the step first
+([#257](https://github.com/rogvid/skills/issues/257)).
+
+Both storyboards inject a small animated element for their whole length,
 which gives the capture frames to measure with — **not**, as this file
 previously claimed, protection from idle loss, which does not exist. `MAX_CAPTURE_LOSS_S`
 now bounds only the gap before the first frame: 20–140 ms idle, 500–540 ms at

--- a/tests/README.md
+++ b/tests/README.md
@@ -600,15 +600,19 @@ really did lose 0.8 s of video says so.
 
 | | bound | why |
 |---|---|---|
-| log **ahead** of the frame | 250 ms | nothing about the capture can move an event *later*, so a positive skew is the log's own error |
+| log **ahead** of the frame | 250 ms | the beat log's own error, **on a take whose host clock held still** — and only then. This row used to say that nothing about the capture can move an event later, full stop; [#255](https://github.com/rogvid/skills/issues/255) measured the correction doing it, by subtracting a step the capture only partly lost. On a stepping take the failure text names the step first ([#257](https://github.com/rogvid/skills/issues/257)) |
 | video **ahead** of the log, host clock subtracted | 750 ms | what is left once the host's steps are out: the gap before the screencast's *first* frame, which the video's zero is, plus the 40 ms sampling grid and the caption's fade. Measured at 20-140 ms over fifteen idle takes and **500-540 ms at load 3.1** — it is how long Chromium takes to paint, so it stays wide on purpose ([#78](https://github.com/rogvid/skills/issues/78) is what tightening it would become) |
 | the two probes **drifting apart** | 250 ms | whatever the capture loses at the head, it loses for every frame equally, so it cancels here — and a wall-clock step landing *between* the probes is now subtracted per probe rather than reaching this bar. **This is the sharp one, and the correction is what made it sharp:** before it, 680 ms of drift on a healthy recorder was indistinguishable from a beat log that was not being read monotonically |
 
 Observed across eight consecutive `--web-only` runs and six full runs, both
 media: first caption **-80 to -200 ms**, closing caption **-160 to 0 ms**,
-drift **0 to 80 ms**. Nothing came near the 250 ms *ahead* bound — no run has
-ever produced a positive skew — which is the point of splitting by direction:
-the tight bound guards a failure mode with no natural variation near it.
+drift **0 to 80 ms**. Nothing came near the 250 ms *ahead* bound in any of
+those runs, which is the point of splitting by direction: the tight bound
+guards a failure mode with no natural variation near it **on a steady host**.
+Every run above was one. #255 later measured +906, +540 and +970 ms of
+positive skew on takes whose clock stepped, so "no run has ever produced a
+positive skew" — which this paragraph used to say — described the hosts these
+figures were taken on and not the bound.
 `_t0` set after `_start()` instead of at page creation measures **+320 ms** and
 fails it; `_t0` set 0.9 s *early* measures **-900 ms** and fails the second
 (`tests/smoke-inject`, "every beat is stamped 0.9s after the frame it
@@ -1775,7 +1779,7 @@ paragraph whose job is to say what this manifest does not cover.
   | `check_caption` | genuinely ungraded as a *picture*. `CaptionTruth` grades which caption a beat is stamped with across a navigation (#134), never that the bar was drawn |
   | `check_verb_classification` | `VerbClassification` — every classified verb is one a recorder logs, and every verb a recorder logs is classified, with the set size asserted first so neither holds vacuously. **Merge-only since #61**: the only arms that reach it are `--content-only` and `--terminal-only`, so nothing runs it on a pull request |
   | `check_determinism` | genuinely ungraded. It reads the clock, the locale and the motion setting *out of the page*, which is the whole point of it — a constructor that stored the flag and never wired it up satisfies anything asserted on the Python side |
-  | `check_merge_offset` | genuinely ungraded. `MergeContent` grades the merge of the content *report* (#121); the per-segment caption timing this measures against two mp4s has no browser-free half |
+  | `check_merge_offset` | genuinely ungraded as timing. `MergeContent` grades the merge of the content *report* (#121); the per-segment caption timing this measures against two mp4s has no browser-free half. One claim of it is graded: `LogEarlyCause` reads the AST and requires its positive-skew message to come from `log_early_causes()` rather than from its own copy of a verdict (#257) — the wording, not the measurement |
   | `check_opening_gap` | `OpeningWarning` — `held: null` against `held: 0.0`, and the blank floor that keeps the warning readable. **Merge-only since #61**: `--web-only` is the only arm that reaches it |
   | `check_opening` | genuinely ungraded — the first frame of a web take, measured in pixels (#119). **Merge-only since #61**: `--web-only` is the only arm that reaches it, so on a pull request nothing runs it and nothing injects against it |
   | `check_opening_card` | genuinely ungraded — three statements about one sweep of one corner of a frame (#110) |

--- a/tests/smoke
+++ b/tests/smoke
@@ -778,10 +778,21 @@ DURATION_TOLERANCE_S = 0.2
 # log's:
 #
 #   * MAX_LOG_EARLY_S — the video shows the caption *after* the log says
-#     (positive skew). Nothing about the capture can produce that: a webm
-#     that drops frames only ever makes events land earlier. So a positive
-#     skew is the log's own error, and the bar is tight. `_t0` set after
-#     `_start()` instead of at page creation measures +280 to +320 ms here.
+#     (positive skew). The bar is tight because on a take whose host clock
+#     held still the beat log is the only thing that can produce it, and it
+#     produces it measurably: `_t0` set after `_start()` instead of at page
+#     creation measures +280 to +320 ms here.
+#
+#     What this comment used to say next was that *nothing* about the capture
+#     can move an event later, "so a positive skew is the log's own error".
+#     That is false, and the thing that falsifies it is on this side of the
+#     line rather than the recorder's: correcting by a step the capture only
+#     partly lost over-shoots by the difference, and the remainder lands here.
+#     Measured in issue #255 — 0.17 s lost of a recorded 1.078 s step read as
+#     +906 ms of log-ahead, 0.53 s of 1.067 s as +540 ms. So the failure text
+#     asks `log_early_causes()` which cause to name, and on a stepping take it
+#     names the step first (issue #257). The bar itself is unchanged: what was
+#     wrong was the explanation, not the width.
 #
 #   * MAX_CAPTURE_LOSS_S — the video shows it *before* the log says (negative
 #     skew). Two separate things produce that, and the whole of issue #215 is
@@ -2097,8 +2108,8 @@ class HostClock:
     def total(self) -> float:
         return sum(delta for _, delta in self.steps)
 
-    def in_video(self, t: float) -> tuple[float, float]:
-        """(where `t` is in demo.mp4, how much of it has no video) — see below.
+    def applied(self, t: float) -> list[tuple[float, float]]:
+        """The steps that moved `t`, of the ones this take recorded.
 
         **Only the steps inside `t`'s own capture count.** A capture's first
         frame is where its clock starts, so a step during an earlier part
@@ -2110,13 +2121,21 @@ class HostClock:
         *after* its own part's last frame, which sits past the next part's
         boundary and is nobody's — is kept out of the list by `joined_clock`.
 
+        A list rather than the sum, because two of them cancel: a −1 s step
+        and a +1 s step before the same beat leave `before()` at zero while
+        the file still has a hole in it, and `log_early_causes` has to be able
+        to tell that take from one whose clock held still.
+        """
+        start = max((b for b in self.boundaries if b <= t), default=0.0)
+        return [(at, delta) for at, delta in self.steps if start <= at <= t]
+
+    def in_video(self, t: float) -> tuple[float, float]:
+        """(where `t` is in demo.mp4, how much of it has no video) — see below.
+
         Hand-written here rather than shared with the recorder: the two have
         to be able to disagree, or `capture_clock` is not being graded.
         """
-        start = max((b for b in self.boundaries if b <= t), default=0.0)
-        return video_instant(
-            [(at, delta) for at, delta in self.steps if start <= at <= t], t
-        )
+        return video_instant(self.applied(t), t)
 
     def before(self, t: float) -> float:
         """How much the wall clock had stepped by `t` seconds into the video.
@@ -2212,6 +2231,86 @@ def hole_clause(clock, t: float, at: float) -> str:
         f"stepped backwards over it, so {at:.3f}s is the last moment before a "
         f"gap the video only resumes from {gap * 1000:.0f} ms later, and the "
         f"recorder is expected to have clamped to the same place (issue #256)."
+    )
+
+
+def log_early_causes(clock, t: float) -> str:
+    """Where to look when a beat sits *ahead* of the frame showing it (#257).
+
+    What this replaces was a verdict, not a lead: "nothing about the capture
+    can move an event *later*, so this is the beat log: check where `_t0` is
+    taken and where `_beat` stamps `t_start`." That is false on a take whose
+    host stepped, and it is the *correction* rather than the capture that
+    makes it false — a take that lost only part of the step it recorded is
+    over-corrected by the difference, and the remainder arrives here as
+    log-ahead. Measured in issue #255: 0.17 s lost of a recorded 1.078 s step
+    read as +906 ms, 0.53 s of 1.067 s as +540 ms, ~0.46 s of 1.074 s as
+    +970 ms. A reader sent to `_t0` and `_beat` by any of those goes hunting
+    in the recorder's beat logging for a bug that is not there.
+
+    So the take decides which cause is named first. Four answers: the three
+    states this harness can be in about a host's wall clock — unmeasured,
+    measured with no step reaching this beat, measured with one — and, inside
+    the last, the case where the steps reaching the beat correct it by
+    nothing. Two cancelling steps and a step landing on the beat itself both
+    subtract 0 ms, so the over-correction cannot be what produced the skew,
+    and offering it there would hand a reader a mechanism that provably did
+    not run.
+    Keyed on the steps `applied()` hands back rather than on the correction
+    they sum to, because two steps that cancel sum to nothing and still leave
+    the file short — and because a step in another capture is already in the
+    offset `stitch()` laid this one out by, so it is not this beat's excuse.
+
+    A whole sentence returned to the caller rather than spliced into either
+    message, for `hole_clause`'s reason: neither call site is reachable on a
+    host whose clock holds still, so `LogEarlyCause` in `tests/unit` is the
+    only thing that runs the stepping branch at all.
+    """
+    if clock is None:
+        return (
+            "No wall-clock reading was kept for this take, so this harness "
+            "cannot say which end is at fault: an unmeasured backward step "
+            "leaves the video short and the beat log where it was, and reads "
+            "from here exactly like a log stamped early. Get a reading before "
+            "reading `_t0` and `_beat` (issues #215, #255)."
+        )
+    applied = clock.applied(t)
+    if not applied:
+        return (
+            "No step of this beat's own capture lands before it, so nothing "
+            "was subtracted from this reading and nothing in the capture can "
+            "have moved the event later: this is the beat log. Check where "
+            "`_t0` is taken and where `_beat` stamps `t_start`."
+        )
+    shift = clock.before(t)
+    if abs(shift) < HOST_CLOCK_MIN_STEP_S:
+        # Steps reach this beat and the correction still comes to nothing:
+        # two that cancel, or one landing on the beat itself, where the
+        # clamp gives back exactly what the step took. Naming the
+        # over-correction here would offer a reader a mechanism that
+        # provably did not run — nothing was subtracted to over-subtract.
+        return (
+            f"**This take's clock stepped, so the beat log is not the first "
+            f"place to look**: {clock.describe()}. Nothing was subtracted "
+            f"from this reading — the steps reaching this beat come to "
+            f"{shift * 1000:+.0f} ms, because they cancel or because one "
+            f"lands on the beat itself — so over-correction is not what "
+            f"produced this skew. Neither is the beat log established as "
+            f"what did: a backward step deletes its own width of wall time "
+            f"from the file whether or not a later step puts the offset "
+            f"back, and this harness has not read those frames. Check the "
+            f"step against demo.mp4 before reading `_t0` and `_beat` "
+            f"(issue #255)."
+        )
+    return (
+        f"**This take's clock stepped, so the beat log is not the first place "
+        f"to look**: {clock.describe()}, and {shift * 1000:+.0f} ms of that "
+        f"was subtracted from this reading. A capture that lost less wall "
+        f"time than the step it recorded is over-corrected by the "
+        f"difference, and what is left reads as log-ahead — measured at "
+        f"+540 to +970 ms on takes losing 16-50% of a ~1.07 s step (issue "
+        f"#255). Check the step against demo.mp4 before reading `_t0` and "
+        f"`_beat`."
     )
 
 
@@ -6446,9 +6545,7 @@ def check_timeline(
             failures.append(
                 f"{label}: {where} — the log is {skew * 1000:.0f} ms ahead of "
                 f"the frame, over the {MAX_LOG_EARLY_S * 1000:.0f} ms bar. "
-                f"Nothing about the capture can move an event *later*, so this "
-                f"is the beat log: check where `_t0` is taken and where `_beat` "
-                f"stamps `t_start`. ({note})"
+                f"{log_early_causes(clock, t_start)} ({note})"
             )
         elif skew < -MAX_CAPTURE_LOSS_S:
             failures.append(
@@ -9198,6 +9295,16 @@ def check_merge_offset(
         # segment's own log, on the same directional bars a single take gets.
         # The differential above divides this out by construction.
         if own > MAX_LOG_EARLY_S or own < -MAX_CAPTURE_LOSS_S:
+            # Which end to name is the same question `check_timeline` asks,
+            # and it has the same two answers: a negative skew is capture
+            # loss, and a positive one is the beat log *only* on a take whose
+            # clock held still (issue #257).
+            which = (
+                log_early_causes(segment_clock, float(alone["t_start"]))
+                if own > MAX_LOG_EARLY_S
+                else "The video is ahead of the log, which is capture loss "
+                "(issues #18 and #215)."
+            )
             failures.append(
                 f"segments: {name}'s probe caption is {own * 1000:+.0f} ms off "
                 f"its beat *within {part.name}*, outside the "
@@ -9205,8 +9312,7 @@ def check_merge_offset(
                 f"a single capture is allowed, with the host's measured "
                 f"wall-clock steps already taken out. The merge is not "
                 f"involved — this segment's own beat log and its own video "
-                f"disagree (a positive skew is the log's; a negative one is "
-                f"capture loss, issues #18 and #215)."
+                f"disagree. {which}"
             )
             continue
         print(

--- a/tests/unit
+++ b/tests/unit
@@ -7276,6 +7276,184 @@ class BaselineRerecord(unittest.TestCase):
         self.assertIn("genuinely flaky", block)
 
 
+class LogEarlyCause(unittest.TestCase):
+    """Which end `tests/smoke` blames for a beat ahead of its frame (#257).
+
+    Here for `HostClockHole`'s reason, and it is the reason that made the
+    message wrong in the first place: **on a steady host the stepping branch
+    is unreachable**, so an arm of the smoke suite grades the one answer that
+    was never in doubt and prints nothing about the other. The wording it
+    replaces — "nothing about the capture can move an event *later*, so this
+    is the beat log" — was true of every take this suite has ever run green
+    and false of the four of six stepping runs issue #255 measured.
+
+    The distinction is the deliverable, so the assertions are written in
+    pairs: what the stepping answer must say, and what it must **not** say.
+    A message that names the step and still ends "so this is the beat log"
+    has not stopped sending the reader to `_t0`.
+
+    **What `VERDICTS` does and does not grade.** It is a list of literals:
+    the three wordings this repo has actually shipped for that verdict — the
+    failure text's, `MAX_LOG_EARLY_S`'s comment's, `check_merge_offset`'s own
+    copy — plus the imperative all of them end on, which is the part that
+    actually sends a reader into the recorder's beat logging. Restoring any
+    of those is caught. A verdict written in words that are not in this list
+    is **not** caught, and no assertion here could be: "does this paragraph
+    assert a cause" is not decidable from substrings. This is a tripwire
+    against reversion and against the softening that reaches for the shipped
+    phrasing, not a proof that the message asserts no verdict. Review is what
+    covers the rest, and a reviewer got past the single-phrase version of
+    this list, which is why it is a list.
+    """
+
+    # The wordings, then the imperative. The last entry is the load-bearing
+    # one: a message may end up naming the beat log in some new phrasing, but
+    # "check where `_beat` stamps `t_start`" is the instruction that costs the
+    # reader the diagnosis, and it survives a rewrite of the sentence above it.
+    VERDICTS = (
+        "this is the beat log",
+        "is the log's own error",
+        "a positive skew is the log's",
+        "`_beat` stamps",
+    )
+    VERDICT = VERDICTS[0]
+
+    def assertNoVerdict(self, said: str):
+        for phrase in self.VERDICTS:
+            self.assertNotIn(phrase, said, f"still asserts a cause: {phrase!r}")
+
+    def setUp(self):
+        self.smoke = _smoke_module()
+        self.because = self.smoke.log_early_causes
+
+    def clock(self, *steps: tuple[float, float], boundaries: list | None = None):
+        """A `HostClock` holding `steps`, sampled by nobody — see HostClockHole."""
+        clock = self.smoke.HostClock()
+        clock._t0 = 0.0
+        clock.raw = list(steps)
+        clock.boundaries = boundaries or []
+        return clock
+
+    def test_a_steady_take_is_still_told_to_read_the_beat_log(self):
+        """The control, and the answer that was always right.
+
+        Without it, "never blame the beat log" passes every assertion below
+        and throws away the diagnosis a steady take is entitled to — which is
+        the artifact-lies direction of this same fix.
+        """
+        said = self.because(self.clock(), 5.633)
+        self.assertIn("No step of this beat's own capture lands before it", said)
+        # Both halves of the diagnosis, not just the sentence: the verdict and
+        # the imperative that acts on it. A steady take is entitled to both.
+        self.assertIn(self.VERDICT, said)
+        self.assertIn("`_beat` stamps `t_start`", said)
+
+    def test_a_stepping_take_names_the_step_and_withdraws_the_verdict(self):
+        # The measured take: −1.073 s at 2.2 s, a beat at 5.633 s after it.
+        said = self.because(self.clock((2.2, -1.073)), 5.633)
+        self.assertIn("clock stepped", said)
+        self.assertIn("-1073 ms", said)
+        self.assertIn("over-corrected", said)
+        # The half that carries the meaning. A paragraph that names the step
+        # and then repeats the verdict has changed nothing for the reader.
+        self.assertNoVerdict(said)
+        self.assertNotIn("No step of this beat's own capture", said)
+
+    def test_a_step_after_the_beat_leaves_the_beat_log_named(self):
+        """The other side of the distinction, and why it is per-instant.
+
+        A step at 6.0 s took nothing out of the file before 5.633 s, so this
+        beat's reading had nothing subtracted from it and the verdict stands.
+        Keying the branch on "the take stepped" instead would withdraw the
+        one diagnosis this check can give, on any take that stepped at all.
+        """
+        said = self.because(self.clock((6.0, -1.073)), 5.633)
+        self.assertIn(self.VERDICT, said)
+
+    def test_two_steps_that_cancel_still_withdraw_the_verdict(self):
+        """The case a correction-sized test would miss.
+
+        −1.0 s at 2.0 s and +1.0 s at 4.0 s sum to a correction of zero, and
+        the file is still a second short between them. A branch keyed on the
+        number `before()` returns reads this take as steady and blames a beat
+        log that is fine.
+        """
+        clock = self.clock((2.0, -1.0), (4.0, 1.0))
+        self.assertEqual(clock.before(5.633), 0.0)
+        self.assertNoVerdict(self.because(clock, 5.633))
+
+    def test_a_correction_of_nothing_is_not_offered_the_over_correction(self):
+        """...and what that case may not say, which is the other half.
+
+        Over-correction is subtracting more than the capture lost. Nothing
+        was subtracted here, so it is a mechanism that provably did not run,
+        and printing "+0 ms was subtracted" beside it puts a number and its
+        explanation in the same paragraph contradicting each other. The
+        reader is owed the reason the correction came to nothing instead.
+        """
+        said = self.because(self.clock((2.0, -1.0), (4.0, 1.0)), 5.633)
+        self.assertIn("+0 ms", said)
+        self.assertIn("they cancel", said)
+        self.assertNotIn("over-corrected", said)
+        self.assertNoVerdict(said)
+
+    def test_a_step_landing_on_the_beat_itself_is_the_same_case(self):
+        """The other zero, and it is a different clock configuration.
+
+        A backward step at exactly the beat's own instant clamps to where the
+        beat already was, so the correction is again 0 ms while the file is
+        1.05 s short from that instant on. Two cancelling steps do not
+        exercise this: there is one step here, and its own hole opens at `t`.
+        """
+        clock = self.clock((5.633, -1.05))
+        self.assertEqual(clock.before(5.633), 0.0)
+        self.assertNotEqual(clock.applied(5.633), [])
+        said = self.because(clock, 5.633)
+        self.assertIn("lands on the beat itself", said)
+        self.assertNotIn("over-corrected", said)
+        self.assertNoVerdict(said)
+
+    def test_a_step_in_another_capture_is_not_this_beats_excuse(self):
+        # The attribution rule `applied()` carries: part one's step is already
+        # in the offset `stitch()` laid part two out by, so a beat 0.2 s into
+        # part two has no step of its own and the verdict stands.
+        clock = self.clock((5.151, -1.051), boundaries=[0.0, 5.5])
+        self.assertIn(self.VERDICT, self.because(clock, 5.7))
+
+    def test_a_take_nobody_measured_blames_neither_end(self):
+        # `check_timeline` drops an uncovered watcher and grades the take
+        # anyway with a zero correction (#247), so this state is reachable and
+        # is the one where the harness genuinely cannot say.
+        said = self.because(None, 5.633)
+        self.assertIn("No wall-clock reading was kept", said)
+        self.assertNoVerdict(said)
+
+    def test_both_failure_texts_ask_this_function_rather_than_deciding(self):
+        """The wiring, which no scripted clock can reach.
+
+        `check_merge_offset` carried its own copy of the verdict — "a positive
+        skew is the log's" — and a fix applied to `check_timeline` alone
+        leaves the segments arm saying the false thing. This is a structural
+        check and grades nothing about the wording; it grades that there is
+        one wording.
+        """
+        import ast
+
+        tree = ast.parse(SMOKE.read_text(encoding="utf-8"))
+        funcs = {n.name: n for n in tree.body if isinstance(n, ast.FunctionDef)}
+        for name in ("check_timeline", "check_merge_offset"):
+            calls = {
+                node.func.id
+                for node in ast.walk(funcs[name])
+                if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+            }
+            self.assertIn(
+                "log_early_causes",
+                calls,
+                f"{name} decides for itself which end a positive skew is",
+            )
+
+
 # --------------------------------------------------------------------------
 
 # Issue #203, as the overlay shipped before it was fixed and after it was.
@@ -7716,6 +7894,88 @@ INJECTIONS = [
         "        if gap <= MAX_CLOCK_STEP_TIME_DISAGREEMENT_S or near_edge:",
         "        if gap <= MAX_CLOCK_STEP_TIME_DISAGREEMENT_S:",
         ["HostClockHole.test_a_midpoint_near_the_step_itself_is_left_alone"],
+    ),
+    (
+        # The verdict this repo shipped until #257, restored: one answer for
+        # every take, and it names the beat log. Nothing about a steady take
+        # changes — which is the point, and why the control below has to keep
+        # passing. What goes is the distinction, so a stepping take is sent to
+        # `_t0` and `_beat` for a skew the correction produced.
+        "a positive skew is the beat log's, whatever the host's clock did",
+        "tests/smoke",
+        "    if not applied:",
+        "    if True:",
+        [
+            "LogEarlyCause."
+            "test_a_stepping_take_names_the_step_and_withdraws_the_verdict",
+            "LogEarlyCause.test_two_steps_that_cancel_still_withdraw_the_verdict",
+        ],
+    ),
+    (
+        # A correction of nothing offered the over-correction anyway. The
+        # number printed beside it is +0 ms, so the paragraph contradicts
+        # itself: nothing was subtracted, and over-correction is subtracting
+        # more than the capture lost. Unreachable on a steady host and on most
+        # stepping ones — it needs two steps that cancel, or one landing on the
+        # beat — which is why it needs a scripted clock rather than an arm.
+        "a reading nothing was subtracted from is blamed on over-correction",
+        "tests/smoke",
+        "    if abs(shift) < HOST_CLOCK_MIN_STEP_S:",
+        "    if False:",
+        [
+            "LogEarlyCause."
+            "test_a_correction_of_nothing_is_not_offered_the_over_correction",
+            "LogEarlyCause.test_a_step_landing_on_the_beat_itself_is_the_same_case",
+        ],
+    ),
+    (
+        # The decay this is actually exposed to: not a revert, but somebody
+        # softening the message back toward the verdict a phrase at a time.
+        # This is the reviewer's own construction — it names the step, and
+        # then re-asserts the cause in words the shipped sentence never used.
+        # The single-phrase guard passed it; `VERDICTS` carries the imperative
+        # as well as the sentences, and the imperative is what survives a
+        # rewrite of the sentence above it.
+        "the stepping message names the step and then blames the beat log anyway",
+        "tests/smoke",
+        '        f"#255). Check the step against demo.mp4 before reading `_t0` and "\n'
+        '        f"`_beat`."',
+        '        f"#255). That said, the fault is the beat log: check where `_t0` "\n'
+        '        f"is taken and where `_beat` stamps `t_start`."',
+        [
+            "LogEarlyCause."
+            "test_a_stepping_take_names_the_step_and_withdraws_the_verdict",
+        ],
+    ),
+    (
+        # The other way to get this wrong, and the tempting one: withdraw the
+        # verdict on any take that stepped *at all*. A step after the beat
+        # took nothing out of the file before it, and a step in another
+        # capture is already in the offset `stitch()` laid this one out by —
+        # so this trades a message that blames the beat log too often for one
+        # that never does, and the arm stays green either way.
+        "any step anywhere in the take excuses the beat log",
+        "tests/smoke",
+        "    applied = clock.applied(t)",
+        "    applied = clock.steps",
+        [
+            "LogEarlyCause.test_a_step_after_the_beat_leaves_the_beat_log_named",
+            "LogEarlyCause.test_a_step_in_another_capture_is_not_this_beats_excuse",
+        ],
+    ),
+    (
+        # ...and the same verdict left behind in the *other* message. The
+        # segments arm carried its own copy of it, so a fix applied to
+        # `check_timeline` alone is a harness that says two different things
+        # about one phenomenon depending on which check found it.
+        "the segments arm decides for itself that a positive skew is the log's",
+        "tests/smoke",
+        '                log_early_causes(segment_clock, float(alone["t_start"]))',
+        '                "A positive skew is the log\'s (issues #18 and #215)."',
+        [
+            "LogEarlyCause."
+            "test_both_failure_texts_ask_this_function_rather_than_deciding",
+        ],
     ),
     (
         # The failure text going back to naming a second the file does not


### PR DESCRIPTION
Fixes #257. Slice of #255.

## Acceptance criterion

> On a take whose clock stepped, a positive skew names the step as a candidate cause rather than asserting the beat log is at fault.
>
> - The comment and the failure text stop asserting the impossible-by-construction claim.
> - The message distinguishes a skew on a take with recorded steps from one without.
> - Graded — an injection restoring the current wording must be caught.

## What was false

`MAX_LOG_EARLY_S`'s comment said a webm that drops frames only ever makes
events land earlier, "so a positive skew is the log's own error", and both
failure texts said so to the reader. #255 measured two mechanisms that produce
exactly that skew, and neither is the capture — both are *this harness's
correction over-shooting*:

- an instant inside the hole a backward step leaves (fixed at the source by
  #256; the explanation was never corrected), and
- a take that lost only part of the step it recorded, so subtracting the full
  Δ over-corrects: seg-4 lost 0.17 s of a 1.078 s step, seg-7 0.53 s of
  1.067 s, the terminal take ~0.46 s of 1.074 s — +906, +540 and +970 ms of
  log-ahead.

## What changed

`log_early_causes(clock, t)` answers for both failure texts, in the three
states this harness can be in about a host's wall clock — plus a fourth
rendering inside the stepping state, for the readings a step reached and
corrected by nothing. `check_timeline` and `check_merge_offset` ask it instead
of each carrying its own verdict.

```
STEADY:
No step of this beat's own capture lands before it, so nothing was subtracted
from this reading and nothing in the capture can have moved the event later:
this is the beat log. Check where `_t0` is taken and where `_beat` stamps
`t_start`.

STEPPING:
**This take's clock stepped, so the beat log is not the first place to look**:
the host's wall clock stepped -1073 ms at 2.2s, and -1073 ms of that was
subtracted from this reading. A capture that lost less wall time than the step
it recorded is over-corrected by the difference, and what is left reads as
log-ahead — measured at +540 to +970 ms on takes losing 16-50% of a ~1.07 s
step (issue #255). Check the step against demo.mp4 before reading `_t0` and
`_beat`.

STEPPED, CORRECTED BY NOTHING (two steps that cancel; or one on the beat):
**This take's clock stepped, so the beat log is not the first place to look**:
the host's wall clock stepped -1000 ms at 2.0s, +1000 ms at 4.0s. Nothing was
subtracted from this reading — the steps reaching this beat come to +0 ms,
because they cancel or because one lands on the beat itself — so
over-correction is not what produced this skew. Neither is the beat log
established as what did: a backward step deletes its own width of wall time
from the file whether or not a later step puts the offset back, and this
harness has not read those frames. Check the step against demo.mp4 before
reading `_t0` and `_beat` (issue #255).

UNMEASURED:
No wall-clock reading was kept for this take, so this harness cannot say which
end is at fault: an unmeasured backward step leaves the video short and the
beat log where it was, and reads from here exactly like a log stamped early.
Get a reading before reading `_t0` and `_beat` (issues #215, #255).
```

The fourth rendering exists because the other three would have contradicted
themselves there: `+0 ms was subtracted` printed beside an over-correction,
which is by definition subtracting more than the capture lost. The number was
honest and the explanation next to it did not apply to it.

The branch is keyed on the steps `HostClock.applied()` hands back — extracted
from `in_video`, no behaviour change — rather than on the correction they sum
to. Two reasons, both graded: two steps that cancel sum to a correction of
zero and still leave the file short, and a step in another capture is already
in the offset `stitch()` laid this one out by, so it is not this beat's
excuse.

`reference/limits.md` and `tests/README.md` both carried the same claim in
prose — the README twice, once in its bars table and once as *"no run has ever
produced a positive skew"*, which #255 measured at +906/+540/+970 ms. Both are
corrected, and `grep` over `tests/`, `skills/`, `wip/` and the root README
finds no remaining assertion of it: the four hits left all quote it as
retracted.

**The bar is unchanged at 0.25 s.** What was wrong was the explanation, not
the width. Nothing here fixes the over-correction — that is #259.

## Graded

`LogEarlyCause` in `tests/unit`, on a scripted clock, for `HostClockHole`'s
reason and doubled: **on a steady host the stepping branch is unreachable**,
so a smoke arm would grade the one answer that was never in doubt. Nine tests,
written in pairs — what each answer must say, and what it must *not* say,
because a message that names the step and still ends "so this is the beat log"
has not stopped sending the reader to `_t0`.

**What the negative half does and does not cover.** `VERDICTS` is a list of
four literals: the three wordings this repo has shipped for that verdict (the
failure text's, `MAX_LOG_EARLY_S`'s comment's, `check_merge_offset`'s own
copy) plus the imperative all three end on, `` `_beat` stamps ``, which is the
part that actually sends a reader into the recorder's beat logging and the
part that survives a rewrite of the sentence above it. Restoring any of those
is caught, including the softening the reviewer constructed. **A verdict
written in words not in that list is not caught, and no substring assertion
could be** — "does this paragraph assert a cause" is not decidable that way.
It is a tripwire against reversion, not a proof that no verdict is asserted;
this is stated in the class docstring as well as here.

Five injections in `tests/unit --fault-inject`.

**1. `a positive skew is the beat log's, whatever the host's clock did`** —
`if not applied:` → `if True:` in `tests/smoke`. One answer for every take,
and it names the beat log: the verdict this repo shipped until now. The steady
control keeps passing, which is what says the injection removed the
*distinction* and nothing else.

```
FAIL: test_a_stepping_take_names_the_step_and_withdraws_the_verdict
    self.assertIn("clock stepped", said)
AssertionError: 'clock stepped' not found in "No step of this beat's own
capture lands before it, so nothing was subtracted from this reading and
nothing in the capture can have moved the event later: this is the beat log.
Check where `_t0` is taken and where `_beat` stamps `t_start`."

FAIL: test_two_steps_that_cancel_still_withdraw_the_verdict
    self.assertNotIn(self.VERDICT, self.because(clock, 5.633))
AssertionError: 'this is the beat log' unexpectedly found in "No step of this
beat's own capture lands before it, ..."
```

**2. `the segments arm decides for itself that a positive skew is the log's`**
— the `log_early_causes` call in `check_merge_offset` replaced by a literal
`"A positive skew is the log's (issues #18 and #215)."`, which is what that
message carried before.

```
FAIL: test_both_failure_texts_ask_this_function_rather_than_deciding
AssertionError: 'log_early_causes' not found in {'len', 'print', 'zip',
'isinstance', 'float', 'dict', 'caption_band', 'abs', 'caption_appearance_s',
'_probe_beat', 'merged_clock_correction'} : check_merge_offset decides for
itself which end a positive skew is
```

**3. `any step anywhere in the take excuses the beat log`** — the other way
to get this wrong, and the tempting one: `clock.applied(t)` → `clock.steps`,
so any take that stepped at all loses the diagnosis. The arm is green either
way; only the two attribution controls see it.

```
FAIL: test_a_step_after_the_beat_leaves_the_beat_log_named
AssertionError: 'this is the beat log' not found in "**This take's clock
stepped, so the beat log is not the first place to look**: the host's wall
clock stepped -1073 ms at 6.0s, and +0 ms of that was subtracted from this
reading. ..."

FAIL: test_a_step_in_another_capture_is_not_this_beats_excuse
AssertionError: 'this is the beat log' not found in "**This take's clock
stepped, ...**: the host's wall clock stepped -1051 ms at 5.2s, and +0 ms of
that was subtracted from this reading. ..."
```

**4. `a reading nothing was subtracted from is blamed on over-correction`** —
`if abs(shift) < HOST_CLOCK_MIN_STEP_S:` → `if False:`, which restores the
self-contradicting paragraph on both zero-correction configurations.

```
FAIL: test_a_correction_of_nothing_is_not_offered_the_over_correction
AssertionError: 'they cancel' not found in "... stepped -1000 ms at 2.0s,
+1000 ms at 4.0s, and +0 ms of that was subtracted from this reading. A
capture that lost less wall time than the step it recorded is over-corrected
by the difference, ..."

FAIL: test_a_step_landing_on_the_beat_itself_is_the_same_case
AssertionError: 'lands on the beat itself' not found in "... stepped -1050 ms
at 5.6s, and +0 ms of that was subtracted from this reading. A capture that
lost less wall time ... is over-corrected by the difference, ..."
```

**5. `the stepping message names the step and then blames the beat log anyway`**
— the reviewer's own construction, registered: the message keeps naming the
step and re-asserts the cause in words the shipped sentence never used. The
single-phrase guard passed it; the imperative entry catches it.

```
FAIL: test_a_stepping_take_names_the_step_and_withdraws_the_verdict
AssertionError: '`_beat` stamps' unexpectedly found in "**This take's clock
stepped, so the beat log is not the first place to look**: ... (issue #255).
That said, the fault is the beat log: check where `_t0` is taken and where
`_beat` stamps `t_start`." : still asserts a cause: '`_beat` stamps'
```

All five search strings matched exactly once; the driver aborts otherwise.
Full run: **All 225 injections were caught.**

`tests/README.md`'s ungraded roster row for `check_merge_offset` is updated to
say which one claim of it is now graded browser-free, and that it is the
wording rather than the measurement.

## Counts

Measured after rebasing onto `ef6d4e8` (#261).

| | before | after |
|---|---|---|
| `tests/unit` | 347 tests / 220 injections | 356 / 225 |
| `tests/ci-unit` | 54 / 18 | 54 / 18 |
| `tests/smoke-inject` | 51 entries | 51 |
| ungraded roster | 17 of 42 | 17 of 42 |

`tests/smoke-inject --self-test`: *"OK all 51 registered entries still match /
OK tests/README.md's 7 stated figures / Every guard refused what it exists to
refuse."* No `must_contain` broke — the reworded text is in a new helper, and
the two entries naming `check_timeline` match strings this change does not
touch.

`tests/lint`, `tests/lint --self-test`, `uvx ruff@0.16.1 format .`: clean.

## Stated limits — what this does not verify

- **No smoke arm runs the stepping branch.** It is unreachable on a steady
  host, which is the whole reason the wording was wrong for as long as it was.
  `LogEarlyCause` grades the function; nothing grades the sentence appearing
  in a real failure list on a real stepping take.
- **`check_merge_offset`'s wiring is graded structurally, not behaviourally.**
  `test_both_failure_texts_ask_this_function_rather_than_deciding` reads the
  AST for the call. It grades that there is one wording, not what that message
  reads like when the segments arm emits it.
- **The verdict guard is a list of literals, not a decision procedure.** See
  above: reversion and shipped-phrasing softening are caught; a verdict in new
  words is not.
- **`describe()` on a segmented clock lists every step of the take**, not only
  the ones attributed to this beat's capture. The correction printed beside it
  is the attributed one, so the two can differ on a stitched demo. Left alone:
  narrowing it is a change to what the message reports, not to which end it
  blames.
- **The over-correction itself is untouched** (#259). This slice only stops
  the harness lying about the cause.
