### PR TITLE
Retract the partial-loss explanation, and report the merge seam overlap (#263)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/stitching.py
+++ b/skills/demo-video/helpers/demo_recording/stitching.py
@@ -332,6 +332,18 @@ def _check_stream_shapes(parts: list[Path]) -> None:
         )
 
 
+# How far a merged beat may start before the previous one ended without being
+# called an overlap. **This is `tests/smoke`'s `BEAT_ORDER_SLACK_S`, and the two
+# have to stay equal**: that is the bar the suite grades a stitched log's
+# monotonicity against, so a tighter number here prints "this stitched beat log
+# is not monotonic" over a take the suite calls healthy, and a wider one stays
+# quiet about a log the suite fails. Measured at 0.4 ms and 0.6 ms seams either
+# side of it. `MergeOverlap.test_the_slack_here_is_the_slack_the_suite_grades`
+# in tests/unit is what keeps them equal; a check that cries wolf is a check
+# that gets ignored, and then it protects nothing.
+MERGE_OVERLAP_SLACK_S = 0.005
+
+
 def _merge_overlaps(doc: dict) -> list[dict]:
     """Where a stitched beat log runs backwards, and what the video's clock says.
 
@@ -364,14 +376,36 @@ def _merge_overlaps(doc: dict) -> list[dict]:
     when no correction was possible at all, which is not the same answer as
     zero and must not read like one.
 
+    `no_video` and `previous_no_video` carry the other half of each `Placed`,
+    and they are not decoration: an endpoint inside a hole has **no frame at
+    all**, and `at` for it is the last instant the file has rather than where
+    that instant is. Publishing `video_overlap` alone would let a reader be
+    told the two beats are in order — which is true — beside a claim that the
+    frames are fine, which is false for a beat the step deleted. That is
+    exactly the defect `Placed.lost` exists to prevent (issue #256), and a
+    conservative direction does not make a false sentence acceptable.
+
     Every adjacent pair is compared, not only the pairs at a seam, because
     "this stitched log is monotonic" is a claim about the whole list — `seam`
     says which kind each one is, since only the seams are this merge's
-    arithmetic. Empty on a healthy merge: the list is the merge saying it
-    looked.
+    arithmetic. **`seam` is read off the parts' beat counts, not off the two
+    beats' `segment` strings**: nothing stops `stitch()` being handed one
+    segment name twice (`tests/smoke` treats "merged segment one twice" as a
+    real failure mode), and a genuine seam reported as "inside one segment"
+    sends the reader to the wrong file.
+
+    Empty on a healthy merge: the list is the merge saying it looked. The bar
+    is `MERGE_OVERLAP_SLACK_S`, which is the suite's own.
     """
     place, state = capture_clock_correction(doc)
     beats = doc.get("beats") or []
+    # Where each part's first beat lands in the merged list, by running total
+    # of the parts' own beat counts. Independent of what the parts are called.
+    seams: set[int] = set()
+    at = 0
+    for record in doc.get("segments") or []:
+        at += int((record or {}).get("beats") or 0)
+        seams.add(at)
     found: list[dict] = []
     for before, after in zip(beats, beats[1:], strict=False):
         ends = _shift(before.get("t_end"), 0.0)
@@ -379,20 +413,26 @@ def _merge_overlaps(doc: dict) -> list[dict]:
         if ends is None or starts is None:
             continue
         overlap = round(ends - starts, 3)
-        if overlap <= 0:
+        if overlap <= MERGE_OVERLAP_SLACK_S:
             continue
+        placed_before = place(before, ends) if state.get("applied") else None
+        placed_after = place(after, starts) if state.get("applied") else None
         found.append(
             {
                 "beat": after.get("index"),
                 "previous_beat": before.get("index"),
                 "segment": after.get("segment"),
                 "previous_segment": before.get("segment"),
-                "seam": after.get("segment") != before.get("segment"),
+                "seam": after.get("index") in seams,
                 "overlap": overlap,
-                "video_overlap": round(
-                    place(before, ends).at - place(after, starts).at, 3
-                )
-                if state.get("applied")
+                "video_overlap": round(placed_before.at - placed_after.at, 3)
+                if placed_before is not None and placed_after is not None
+                else None,
+                "previous_no_video": round(placed_before.lost, 3)
+                if placed_before is not None
+                else None,
+                "no_video": round(placed_after.lost, 3)
+                if placed_after is not None
                 else None,
             }
         )

--- a/skills/demo-video/helpers/demo_recording/stitching.py
+++ b/skills/demo-video/helpers/demo_recording/stitching.py
@@ -16,7 +16,13 @@ from pathlib import Path
 from .content import _common, media_duration, merge_content, print_content_summary
 from .coverage import _merged_coverage
 from .frames import write_beat_frames
-from .timeline import MAX_ISSUES, TIMELINE_SCHEMA, timeline_paths, write_timeline
+from .timeline import (
+    MAX_ISSUES,
+    TIMELINE_SCHEMA,
+    capture_clock_correction,
+    timeline_paths,
+    write_timeline,
+)
 
 
 def _shift(value: object, offset: float) -> float | None:
@@ -326,6 +332,73 @@ def _check_stream_shapes(parts: list[Path]) -> None:
         )
 
 
+def _merge_overlaps(doc: dict) -> list[dict]:
+    """Where a stitched beat log runs backwards, and what the video's clock says.
+
+    **The merge lays the parts out on two different clocks and the seam is where
+    they meet** (issue #263). Each part's beats keep their own
+    `time.monotonic()` timestamps; the offset that moves them is the part's real
+    **ffprobe duration**, which is on the wall clock the encoder stamped. Those
+    agree until a part's host clock steps backwards — a step of −Δ deletes Δ of
+    wall time from that part's video without taking a millisecond out of its
+    beat log, so the part's log outruns its own file and the next part's first
+    beat is offset to a moment the previous part's last beat has not reached
+    yet. Reproduced at −1.4684 s: `beat 21 t_end 37.451`, `beat 22 t_start
+    37.441`. The overlap scales with Δ less the capture's startup and tail, so a
+    ~1.5 s step reaches most of a second.
+
+    **Reported, not clamped, and that is the decision here.** Moving the beats
+    to make the numbers rise would put them at instants neither the log nor the
+    video has: the merged timestamp of a beat is exactly its own log's plus its
+    own part's offset, and every consumer that corrects a beat by its own
+    capture's steps (see `_merge_capture_clock`) depends on that identity. A
+    clamp would buy a monotonic column by making the column mean nothing. So the
+    overlap is published instead, with the one thing a reader actually needs:
+
+    `video_overlap` is the same difference **after** putting both instants on
+    the video's clock by the documented rule — each corrected by the steps of
+    its own capture. Zero or below means the two frames really are in order and
+    only the log's column runs backwards, which is the mechanism above and is
+    not a defect in the file a reviewer scrubs. Above zero means the recorded
+    steps do not account for it and something else moved the beats. **Null**
+    when no correction was possible at all, which is not the same answer as
+    zero and must not read like one.
+
+    Every adjacent pair is compared, not only the pairs at a seam, because
+    "this stitched log is monotonic" is a claim about the whole list — `seam`
+    says which kind each one is, since only the seams are this merge's
+    arithmetic. Empty on a healthy merge: the list is the merge saying it
+    looked.
+    """
+    place, state = capture_clock_correction(doc)
+    beats = doc.get("beats") or []
+    found: list[dict] = []
+    for before, after in zip(beats, beats[1:], strict=False):
+        ends = _shift(before.get("t_end"), 0.0)
+        starts = _shift(after.get("t_start"), 0.0)
+        if ends is None or starts is None:
+            continue
+        overlap = round(ends - starts, 3)
+        if overlap <= 0:
+            continue
+        found.append(
+            {
+                "beat": after.get("index"),
+                "previous_beat": before.get("index"),
+                "segment": after.get("segment"),
+                "previous_segment": before.get("segment"),
+                "seam": after.get("segment") != before.get("segment"),
+                "overlap": overlap,
+                "video_overlap": round(
+                    place(before, ends).at - place(after, starts).at, 3
+                )
+                if state.get("applied")
+                else None,
+            }
+        )
+    return found
+
+
 def _merged_timeline(
     segments: list[str],
     parts: list[Path],
@@ -416,7 +489,7 @@ def _merged_timeline(
             total = round(media_duration(demo), 3)
         except (subprocess.CalledProcessError, ValueError, OSError):
             total = None  # a timeline without it still beats none
-    return {
+    doc = {
         "schema": TIMELINE_SCHEMA,
         "generated_by": "demo-video",
         "recorder": _common([r["recorder"] for r in records], "mixed"),
@@ -446,6 +519,12 @@ def _merged_timeline(
         "issues": issues[:MAX_ISSUES],
         "issue_count": issue_count,
     }
+    # Last, and off the assembled document rather than off the loop above: the
+    # answer needs the merged `capture_clock` this function has only just
+    # finished building, and a reader asking "is this log monotonic" is asking
+    # about the list as it shipped.
+    doc["overlaps"] = _merge_overlaps(doc)
+    return doc
 
 
 def stitch(out_dir: Path, segments: list[str], keep_parts: bool = False) -> None:

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -221,6 +221,29 @@ from .markdown import _fmt_t, _md_cell
 #                          On a stitched demo it is recomputed over the merged
 #                          beats, so its indices match this file. See
 #                          "acceptance criteria and coverage".
+#   overlaps      list?  — merged demos only (`stitch`), and **empty on a
+#                          healthy merge**, which is the merge saying it
+#                          looked. One record per adjacent pair of beats where
+#                          the later one starts before the earlier one ended:
+#                          `beat` / `previous_beat` (their `index` in this
+#                          file), `segment` / `previous_segment`, `seam` (do
+#                          the two belong to different parts), `overlap`
+#                          (seconds, on the clock the table above is on) and
+#                          `video_overlap` (the same difference with both
+#                          instants put on the *video's* clock by the rule
+#                          `capture_clock` documents; **null** when no
+#                          correction was possible, which is not zero).
+#                          A merged timestamp is its part's own
+#                          `time.monotonic()` plus that part's `offset`, and
+#                          the offset is the part's real ffprobe duration — a
+#                          wall clock. A part whose host clock stepped
+#                          backwards has a video shorter than its own beat log
+#                          by the size of the step, so its last beats run past
+#                          where the next part begins (issue #263). Nothing is
+#                          moved to fix it: `video_overlap` at or below zero
+#                          says the frames are in order and only this column
+#                          runs backwards. Absent from a timeline a single take
+#                          wrote.
 #   beats         list   — the beats, in the order they ran
 #   strict        bool   — whether strict mode was on for this take (on a
 #                          merged demo: only if it was on for every segment)
@@ -780,6 +803,66 @@ def _capture_clock_md(state: dict) -> list[str]:
     ]
 
 
+def _overlaps_md(overlaps: object) -> list[str]:
+    """What `timeline.md` says when its own beat table runs backwards (#263).
+
+    Silent on every take that has none, and on every take recorded in one
+    piece, which carries no such field at all. It speaks where a reader would
+    otherwise scroll past a row starting before the row above it ended and
+    conclude the log is corrupt — or, worse, not notice.
+
+    `stitch()` publishes the list; this only renders it. The sentence a reader
+    needs is the second one: whether the frames are in order even though the
+    column is not.
+    """
+    if not isinstance(overlaps, list) or not overlaps:
+        return []
+    out = [
+        f"**This stitched beat log is not monotonic**: "
+        f"{len(overlaps)} beat(s) below start before the beat before them "
+        f"ended. Nothing was moved to hide it — a merged timestamp is the "
+        f"part's own `time.monotonic()` log plus that part's `offset`, and "
+        f"the offset is the part's real ffprobe **duration**, which is on the "
+        f"wall clock the encoder stamped. A part whose host clock stepped "
+        f"backwards has a video shorter than its own beat log by the size of "
+        f"the step, so its last beats run past where the next part begins "
+        f"(issue #263). `timeline.json`'s `overlaps` carries the same list.",
+        "",
+    ]
+    for overlap in overlaps:
+        if not isinstance(overlap, dict):
+            continue
+        where = "at the seam" if overlap.get("seam") else "inside one segment"
+        video = overlap.get("video_overlap")
+        if not isinstance(video, (int, float)) or isinstance(video, bool):
+            verdict = (
+                "nothing here can say whether the video puts them in order: "
+                "this demo carries no `capture_clock` a reader could correct "
+                "them with"
+            )
+        elif video <= 0:
+            verdict = (
+                f"corrected by each capture's own steps they are "
+                f"{abs(float(video)):.3f}s apart and **in order** — the frames "
+                f"are fine and it is the log's column that runs backwards"
+            )
+        else:
+            verdict = (
+                f"corrected by each capture's own steps they **still** overlap "
+                f"by {float(video):.3f}s, which the recorded steps do not "
+                f"explain"
+            )
+        out.append(
+            f"- beat {_md_cell(overlap.get('previous_beat'))} → "
+            f"{_md_cell(overlap.get('beat'))} "
+            f"(`{_md_cell(overlap.get('previous_segment'))}` → "
+            f"`{_md_cell(overlap.get('segment'))}`, {where}) overlap by "
+            f"**{float(overlap.get('overlap') or 0.0):.3f}s**; {verdict}."
+        )
+    out.append("")
+    return out
+
+
 def _narration_md(narration: object) -> list[str]:
     """What `timeline.md` says about where the spoken lines ended up.
 
@@ -1075,6 +1158,11 @@ def render_timeline_md(doc: dict) -> str:
     # paragraph derived from the record would keep claiming a correction if
     # the mix ever stopped applying one.
     out += _narration_md(doc.get("narration"))
+    # Last before the table, because it is the sharpest statement about it: a
+    # reader who meets a row starting before the row above it ended without
+    # this paragraph concludes the log is corrupt, and one who does not meet it
+    # at all reads a number that is not where that beat is (issue #263).
+    out += _overlaps_md(doc.get("overlaps"))
     # The exit column only exists when something in this take has one — a web
     # timeline would otherwise carry an empty column on every row. A `run` beat
     # whose status could not be read shows "?" rather than blank, so the

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -226,13 +226,22 @@ from .markdown import _fmt_t, _md_cell
 #                          looked. One record per adjacent pair of beats where
 #                          the later one starts before the earlier one ended:
 #                          `beat` / `previous_beat` (their `index` in this
-#                          file), `segment` / `previous_segment`, `seam` (do
-#                          the two belong to different parts), `overlap`
-#                          (seconds, on the clock the table above is on) and
+#                          file), `segment` / `previous_segment`, `seam` (is
+#                          the later beat the first of its part — read off the
+#                          parts' beat counts, not off the two segment names,
+#                          which nothing stops being equal), `overlap`
+#                          (seconds, on the clock the table above is on),
 #                          `video_overlap` (the same difference with both
 #                          instants put on the *video's* clock by the rule
 #                          `capture_clock` documents; **null** when no
-#                          correction was possible, which is not zero).
+#                          correction was possible, which is not zero) and
+#                          `no_video` / `previous_no_video`, the `lost` of
+#                          each endpoint's `Placed`: non-zero when a backward
+#                          step deleted that instant from the file, in which
+#                          case it has **no frame at all** and the pair being
+#                          "in order" says nothing about it. Only reported
+#                          past `MERGE_OVERLAP_SLACK_S` (5 ms), which is the
+#                          bar `tests/smoke` grades a merged log against.
 #                          A merged timestamp is its part's own
 #                          `time.monotonic()` plus that part's `offset`, and
 #                          the offset is the part's real ffprobe duration — a
@@ -813,13 +822,22 @@ def _overlaps_md(overlaps: object) -> list[str]:
 
     `stitch()` publishes the list; this only renders it. The sentence a reader
     needs is the second one: whether the frames are in order even though the
-    column is not.
+    column is not — and, when an endpoint sits in a hole a backward step
+    deleted, that "in order" is **not** the same as "the frames are fine",
+    because one of the two beats has no frame at all (issue #256).
+
+    The count in the header is of the rows this actually prints, not of the
+    list handed in: a hand-edited `timeline.json` can carry an entry this
+    cannot render, and a header that counted those would disagree with the
+    bullets under it in the one document whose job is to be read.
     """
-    if not isinstance(overlaps, list) or not overlaps:
+    listed = overlaps if isinstance(overlaps, list) else []
+    rows = [entry for entry in listed if isinstance(entry, dict)]
+    if not rows:
         return []
     out = [
         f"**This stitched beat log is not monotonic**: "
-        f"{len(overlaps)} beat(s) below start before the beat before them "
+        f"{len(rows)} beat(s) below start before the beat before them "
         f"ended. Nothing was moved to hide it — a merged timestamp is the "
         f"part's own `time.monotonic()` log plus that part's `offset`, and "
         f"the offset is the part's real ffprobe **duration**, which is on the "
@@ -829,16 +847,42 @@ def _overlaps_md(overlaps: object) -> list[str]:
         f"(issue #263). `timeline.json`'s `overlaps` carries the same list.",
         "",
     ]
-    for overlap in overlaps:
-        if not isinstance(overlap, dict):
-            continue
+    for overlap in rows:
         where = "at the seam" if overlap.get("seam") else "inside one segment"
         video = overlap.get("video_overlap")
+        # Which of the two endpoints, if either, the step deleted from the
+        # file. Named by beat, because "one of these has no frame" is not
+        # something a reader can act on.
+        deleted = [
+            (f"beat {_md_cell(overlap.get(beat))}", float(overlap.get(key) or 0.0))
+            for beat, key in (
+                ("previous_beat", "previous_no_video"),
+                ("beat", "no_video"),
+            )
+            if isinstance(overlap.get(key), (int, float))
+            and not isinstance(overlap.get(key), bool)
+            and overlap.get(key)
+        ]
         if not isinstance(video, (int, float)) or isinstance(video, bool):
             verdict = (
                 "nothing here can say whether the video puts them in order: "
                 "this demo carries no `capture_clock` a reader could correct "
                 "them with"
+            )
+        elif video <= 0 and deleted:
+            # In order, and still not fine: `at` for a deleted instant is the
+            # last moment the file has, not where that instant is. Saying only
+            # the first half is the #256 defect in a new artifact.
+            verdict = (
+                f"corrected by each capture's own steps they are "
+                f"{abs(float(video)):.3f}s apart and **in order** — but the "
+                f"file has no frame for "
+                + ", ".join(
+                    f"{name} at all, the video resuming {gap * 1000:.0f} ms later"
+                    for name, gap in deleted
+                )
+                + " (issue #256), so this is not a demo whose frames are all "
+                "there"
             )
         elif video <= 0:
             verdict = (

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -126,12 +126,29 @@ causes: `MAX_LOG_EARLY_S = 0.25` for the log running ahead of the frame and
 direction is the beat log's own error **on a take whose host clock held
 still**, and only then — this file used to say that nothing about capture can
 move an event later, full stop, and
-[#255](https://github.com/rogvid/skills/issues/255) measured two ways it can:
-an instant inside the window a backward step deletes, and a capture that lost
-less wall time than the step it recorded, which the correction then
-over-shoots by the difference (+540 to +970 ms on three takes). On a stepping
-take the suite now names the step first
+[#255](https://github.com/rogvid/skills/issues/255) measured +906, +540 and
++970 ms of it on takes whose clock stepped. The cause is an instant inside the
+window a backward step deletes: it has no frame of its own, so a reading that
+subtracts the whole step instead of clamping to the hole's edge is left with up
+to a whole step of log-ahead
+([#256](https://github.com/rogvid/skills/issues/256)). On a stitched demo there
+is a second cause, and it is the merge rather than the capture — see the seam
+below ([#263](https://github.com/rogvid/skills/issues/263)). On a stepping take
+the suite now names the step first
 ([#257](https://github.com/rogvid/skills/issues/257)).
+
+**What this file said between #257 and #255's retraction, which was wrong.** It
+explained the same skew as a capture losing a *fraction* of the step it
+recorded, over-shot by the difference. There is no such fraction. Playwright
+1.62.0 stamps `frameNumber = floor((wall_ts − first_wall_ts) · 25)` into the
+matroska clusters and CFR conversion drops everything until the wall clock
+climbs back, so the video's clock is the wall clock's high-water mark and the
+muxer cannot produce a partial shift — measured at **97.0–100.2 %** of the
+recorded step across 10 steps in 9 takes, at 2–60 Hz paint, through plain
+Playwright and through the real `Recorder`. The three figures above were
+in-hole instants read as though they were shifts, which reads as
+`(t − hole_start)/Δ` and is uniform on [0,1]. Do not correct by a proportion;
+there is nothing to take a proportion of.
 
 Both storyboards inject a small animated element for their whole length,
 which gives the capture frames to measure with — **not**, as this file
@@ -212,6 +229,29 @@ frame as *around* its beat, do not build anything that needs a beat timestamp
 to be exact to the frame, and when a frame and its caption disagree by a
 fraction of a second, suspect the capture before the
 storyboard ([#18](https://github.com/rogvid/skills/issues/18)).
+
+### A stitched beat log can run backwards at a seam, and says so
+
+`stitch()` moves each part's beats by that part's real **ffprobe duration**
+while the beats keep their own `time.monotonic()` timestamps. Those are two
+clocks. A part whose host clock stepped backwards has a video shorter than its
+own beat log by the size of the step, so its last beats run past where the next
+part begins and the merged log goes non-monotonic at the seam — reproduced at
+−1.4684 s as `beat 21 t_end 37.451` against `beat 22 t_start 37.441`. The
+overlap scales with the step less the capture's startup and tail, so a ~1.5 s
+step reaches most of a second
+([#263](https://github.com/rogvid/skills/issues/263)).
+
+Nothing is clamped: a beat's merged timestamp is exactly its own part's log
+plus that part's `offset`, and the whole per-segment correction rule above
+depends on that identity. The overlap is published instead, as `overlaps` in
+`timeline.json` and as a paragraph above the beat table in `timeline.md`. Empty
+on a healthy merge. Read `video_overlap` first — the same difference with both
+instants put on the video's clock by the rule above. At or below zero the
+frames really are in order and only the log's column runs backwards, which is
+the mechanism in this section; above zero the recorded steps do not account for
+it; `null` means no correction was possible at all, which is not the same
+answer as zero.
 
 ### Sixty seconds buys about twenty screens
 

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -246,12 +246,19 @@ Nothing is clamped: a beat's merged timestamp is exactly its own part's log
 plus that part's `offset`, and the whole per-segment correction rule above
 depends on that identity. The overlap is published instead, as `overlaps` in
 `timeline.json` and as a paragraph above the beat table in `timeline.md`. Empty
-on a healthy merge. Read `video_overlap` first — the same difference with both
-instants put on the video's clock by the rule above. At or below zero the
-frames really are in order and only the log's column runs backwards, which is
-the mechanism in this section; above zero the recorded steps do not account for
-it; `null` means no correction was possible at all, which is not the same
-answer as zero.
+on a healthy merge, and only reported past 5 ms, which is the same slack this
+repo's suite grades a merged log's beat order against — a report tighter than
+the bar it is checked by would call a healthy take broken.
+
+Read `video_overlap` first — the same difference with both instants put on the
+video's clock by the rule above. At or below zero the frames really are in
+order and only the log's column runs backwards, which is the mechanism in this
+section; above zero the recorded steps do not account for it; `null` means no
+correction was possible at all, which is not the same answer as zero. Then read
+`no_video` and `previous_no_video`, which are each endpoint's `lost`:
+**"in order" is not "the frames are all there"**, because an endpoint the step
+deleted has no frame at all and its place on the video's clock is the last
+instant before the gap.
 
 ### Sixty seconds buys about twenty screens
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -600,7 +600,7 @@ really did lose 0.8 s of video says so.
 
 | | bound | why |
 |---|---|---|
-| log **ahead** of the frame | 250 ms | the beat log's own error, **on a take whose host clock held still** — and only then. This row used to say that nothing about the capture can move an event later, full stop; [#255](https://github.com/rogvid/skills/issues/255) measured the correction doing it, by subtracting a step the capture only partly lost. On a stepping take the failure text names the step first ([#257](https://github.com/rogvid/skills/issues/257)) |
+| log **ahead** of the frame | 250 ms | the beat log's own error, **on a take whose host clock held still** — and only then. This row used to say that nothing about the capture can move an event later, full stop; [#255](https://github.com/rogvid/skills/issues/255) measured the correction doing it, by subtracting the whole of a step from an instant inside the hole that step deleted, which has no frame of its own ([#256](https://github.com/rogvid/skills/issues/256)). On a stitched log the other cause is the merge seam ([#263](https://github.com/rogvid/skills/issues/263)). On a stepping take the failure text names the step first ([#257](https://github.com/rogvid/skills/issues/257)) |
 | video **ahead** of the log, host clock subtracted | 750 ms | what is left once the host's steps are out: the gap before the screencast's *first* frame, which the video's zero is, plus the 40 ms sampling grid and the caption's fade. Measured at 20-140 ms over fifteen idle takes and **500-540 ms at load 3.1** — it is how long Chromium takes to paint, so it stays wide on purpose ([#78](https://github.com/rogvid/skills/issues/78) is what tightening it would become) |
 | the two probes **drifting apart** | 250 ms | whatever the capture loses at the head, it loses for every frame equally, so it cancels here — and a wall-clock step landing *between* the probes is now subtracted per probe rather than reaching this bar. **This is the sharp one, and the correction is what made it sharp:** before it, 680 ms of drift on a healthy recorder was indistinguishable from a beat log that was not being read monotonically |
 
@@ -2003,21 +2003,25 @@ knows is missing is worse than one that is openly absent.
   `check_timeline`'s identical guard at `tests/smoke:6195` has been uninjected
   since #245 — and it is written down here rather than left to be noticed.
 
-  **And the correction narration applies can still be over-large on this
-  host, by an amount nothing here measures.** #224's diagnosis found two
-  things. The first — that a −Δ wall-clock step **deletes a Δ-wide hole** from
-  the file rather than sliding it, so a line spoken inside that hole was
-  placed up to a whole step early — is fixed at the source in
+  **And nothing here reads the recorded step back off the pixels.** #224's
+  diagnosis found that a −Δ wall-clock step **deletes a Δ-wide hole** from the
+  file rather than sliding it, so a line spoken inside that hole was placed up
+  to a whole step early. That is fixed at the source in
   [#256](https://github.com/rogvid/skills/issues/256), for the review frames,
   the smoke harness's own `before()` and the narration mix at once; a line in
-  a hole now carries `no_video` and `timeline.md` names it. The second is
-  open: some takes lose only **16–50 %** of the recorded step, so subtracting
-  all of it aims a clip Δ−loss too early even outside a hole. Nothing in this
-  repo checks the recorded step against the pixels, which is
+  a hole now carries `no_video` and `timeline.md` names it. What is open is
+  the check rather than a second mechanism: nothing in this repo compares the
+  step a take recorded against the frames it produced, which is
   [#259](https://github.com/rogvid/skills/issues/259).
-  [#255](https://github.com/rogvid/skills/issues/255) carries both
-  measurements. Nothing about either is narration-specific and nothing in
-  `narration.py` should chase them.
+
+  #224 also read three takes as losing a *proportion* of the recorded step,
+  and this list carried that as a second open defect. **It is retracted**
+  ([#255](https://github.com/rogvid/skills/issues/255)): the muxer stamps the
+  wall clock and will not rewrite a stamp, the shift measured 97.0–100.2 % of
+  the step across 10 steps in 9 takes, and the three readings were in-hole
+  instants measured as though they were shifts. There is no proportion, and a
+  correction scaled by one would be worse than none. Nothing about any of it
+  is narration-specific and nothing in `narration.py` should chase it.
 
 - **That a real Chromium hands a click's deferred document event to
   `evaluate("0")`.** [#214](https://github.com/rogvid/skills/issues/214) is
@@ -2436,6 +2440,32 @@ knows is missing is worse than one that is openly absent.
   and counted in the arm's output, because two samplers on their own 20 ms
   grids do not both know which side of that beat the step fell on — and the
   alternative, a bar as wide as a step, would grade nothing.
+
+- **~~A stitched beat log can go backwards at a seam and say nothing.~~
+  Reported** ([#263](https://github.com/rogvid/skills/issues/263)). The merge
+  moves each part's beats by that part's ffprobe **duration** while the beats
+  keep their own `time.monotonic()` stamps, so a part whose clock stepped
+  backwards has a video shorter than its own log and its last beats run past
+  where the next part begins — reproduced at −1.4684 s as `beat 21 t_end
+  37.451` against `beat 22 t_start 37.441`, which is what PR #261 saw in its
+  discarded take. Nothing is clamped: a merged timestamp is its part's own log
+  plus that part's offset, and every per-segment correction depends on that
+  identity. The merge publishes `overlaps` in `timeline.json` and a paragraph
+  above the beat table in `timeline.md`, each carrying `video_overlap` — the
+  same difference with both instants on the video's clock, which is at or
+  below zero when the frames are in order and only the log's column runs
+  backwards.
+
+  **Graded by `MergeOverlap` in `tests/unit` on hand-written documents, and by
+  nothing else.** Six `tests/unit` injections break it — detection off,
+  detection on for every seam, the verdict's sign, the verdict claimed where
+  nothing was measured, the clamp this change refused, and `timeline.md`
+  dropping the paragraph. There is **no arm**: the overlap needs a host that
+  steps its wall clock inside a segment, `--segments-only` cannot be made to
+  produce one, and an assertion that only bites on a stepping box grades the
+  box. What no assertion here can say is that a real stepping host produces
+  the arithmetic these documents assume; that was measured by hand on the
+  takes in #255 and #263.
 
 - **~~`--web-only` still goes red when the capture loses more than 0.75 s, and
   the bars were not widened to stop it.~~ Diagnosed and fixed** — the cause was

--- a/tests/README.md
+++ b/tests/README.md
@@ -2454,13 +2454,26 @@ knows is missing is worse than one that is openly absent.
   above the beat table in `timeline.md`, each carrying `video_overlap` — the
   same difference with both instants on the video's clock, which is at or
   below zero when the frames are in order and only the log's column runs
-  backwards.
+  backwards — beside `no_video` / `previous_no_video`, which are the `lost` of
+  each endpoint's `Placed`. **In order is not the same answer as fine**: an
+  endpoint a backward step deleted has no frame at all, and a paragraph
+  claiming the first without the second is
+  [#256](https://github.com/rogvid/skills/issues/256) in a new artifact. The
+  bar is `MERGE_OVERLAP_SLACK_S`, which **is** `check_beats`'
+  `BEAT_ORDER_SLACK_S` — a merge with a tighter bar than the suite's calls a
+  0.6 ms seam non-monotonic on a take the suite passes, and a check that cries
+  wolf gets ignored. `seam` is read off the parts' beat counts and not off the
+  two `segment` strings, because nothing refuses one segment name twice.
 
   **Graded by `MergeOverlap` in `tests/unit` on hand-written documents, and by
-  nothing else.** Six `tests/unit` injections break it — detection off,
+  nothing else.** Thirteen `tests/unit` injections break it — detection off,
   detection on for every seam, the verdict's sign, the verdict claimed where
-  nothing was measured, the clamp this change refused, and `timeline.md`
-  dropping the paragraph. There is **no arm**: the overlap needs a host that
+  nothing was measured, the clamp this change refused, `timeline.md` dropping
+  the paragraph, `Placed.lost` dropped from the record and from the sentence,
+  the hole warning given to every overlap, the bar tightened past the suite's
+  and the constant drifted from it, `seam` keyed on the segment names, and the
+  header counting rows the renderer skips. There is **no arm**: the overlap
+  needs a host that
   steps its wall clock inside a segment, `--segments-only` cannot be made to
   produce one, and an assertion that only bites on a stepping box grades the
   box. What no assertion here can say is that a real stepping host produces

--- a/tests/smoke
+++ b/tests/smoke
@@ -785,14 +785,30 @@ DURATION_TOLERANCE_S = 0.2
 #
 #     What this comment used to say next was that *nothing* about the capture
 #     can move an event later, "so a positive skew is the log's own error".
-#     That is false, and the thing that falsifies it is on this side of the
-#     line rather than the recorder's: correcting by a step the capture only
-#     partly lost over-shoots by the difference, and the remainder lands here.
-#     Measured in issue #255 — 0.17 s lost of a recorded 1.078 s step read as
-#     +906 ms of log-ahead, 0.53 s of 1.067 s as +540 ms. So the failure text
-#     asks `log_early_causes()` which cause to name, and on a stepping take it
+#     That is false on a take whose host clock stepped, and what falsifies it
+#     is on this side of the line rather than the recorder's: a backward step
+#     of Δ deletes the window (T, T+Δ) from the file, and an instant inside
+#     that hole has no frame of its own — subtract the whole step from it
+#     instead of clamping to the hole's edge and the remainder, up to a whole
+#     Δ, lands here as log-ahead (issue #256). Measured in issue #255 at +906,
+#     +540 and +970 ms on stepping takes. So the failure text asks
+#     `log_early_causes()` which cause to name, and on a stepping take it
 #     names the step first (issue #257). The bar itself is unchanged: what was
 #     wrong was the explanation, not the width.
+#
+#     **The explanation #257 put here in place of that one was also wrong**,
+#     and it is worth naming because it read as a measurement. It
+#     said a capture could lose a fraction of the step it recorded and be
+#     over-shot by the difference. There is no such fraction. Playwright
+#     1.62.0 stamps `frameNumber = floor((wall_ts − first_wall_ts) · 25)` into
+#     the clusters and CFR conversion drops everything until the wall clock
+#     climbs back, so the video's clock is the wall clock's high-water mark and
+#     the muxer cannot produce a partial shift: measured at 97.0-100.2% of the
+#     recorded step over 10 steps in 9 takes, at 2-60 Hz paint, through plain
+#     Playwright and through the real `Recorder`. The three figures above were
+#     in-hole instants read as though they were shifts — `(t − hole_start)/Δ`,
+#     uniform on [0,1] — and not three measurements of a mechanism (issue
+#     #255).
 #
 #   * MAX_CAPTURE_LOSS_S — the video shows it *before* the log says (negative
 #     skew). Two separate things produce that, and the whole of issue #215 is
@@ -2241,12 +2257,27 @@ def log_early_causes(clock, t: float) -> str:
     can move an event *later*, so this is the beat log: check where `_t0` is
     taken and where `_beat` stamps `t_start`." That is false on a take whose
     host stepped, and it is the *correction* rather than the capture that
-    makes it false — a take that lost only part of the step it recorded is
-    over-corrected by the difference, and the remainder arrives here as
-    log-ahead. Measured in issue #255: 0.17 s lost of a recorded 1.078 s step
-    read as +906 ms, 0.53 s of 1.067 s as +540 ms, ~0.46 s of 1.074 s as
-    +970 ms. A reader sent to `_t0` and `_beat` by any of those goes hunting
-    in the recorder's beat logging for a bug that is not there.
+    makes it false — a backward step of Δ deletes the window `(T, T+Δ)` from
+    the file, so an instant inside that hole has no frame of its own, and a
+    reading that subtracts the whole step from it instead of clamping to the
+    hole's edge is left with up to a whole Δ of log-ahead (issue #256).
+    Measured in issue #255 at +906, +540 and +970 ms. A reader sent to `_t0`
+    and `_beat` by any of those goes hunting in the recorder's beat logging
+    for a bug that is not there.
+
+    **The lead #257 first gave instead was itself false**, which is why the
+    branch below now names the hole and its width rather than a proportion. It
+    said a capture could lose a fraction of the step it recorded and be
+    over-shot by the difference. The muxer cannot do that: Playwright 1.62.0
+    stamps `frameNumber = floor((wall_ts − first_wall_ts) · 25)` and CFR
+    conversion drops frames until the wall clock climbs back, so the video's
+    clock is the wall clock's **high-water mark** — measured at 97.0-100.2% of
+    the recorded step over 10 steps in 9 takes, both code paths, 2-60 Hz
+    paint. The three figures above were in-hole instants read as though they
+    were shifts, `(t − hole_start)/Δ` and uniform on [0,1] (issue #255). The
+    other cause a stepping take has is the merge seam, where a part's beats
+    run past where the next part's offset puts it — published as `overlaps` in
+    a stitched `timeline.json` (issue #263).
 
     So the take decides which cause is named first. Four answers: the three
     states this harness can be in about a host's wall clock — unmeasured,
@@ -2302,15 +2333,35 @@ def log_early_causes(clock, t: float) -> str:
             f"step against demo.mp4 before reading `_t0` and `_beat` "
             f"(issue #255)."
         )
+    # The hole, in milliseconds, because it is the number the skew should be
+    # compared against rather than a paragraph the reader has to believe: an
+    # instant a backward step deleted from the file is over-corrected by
+    # exactly this much when the whole step is subtracted from it instead of
+    # clamping, so a skew of this size is that mechanism and a skew of some
+    # other size is not.
+    gap = clock.hole(t)
+    inside = (
+        f" **The file has no frame for this instant at all**: the step "
+        f"deleted the wall time it happened in, and the video only resumes "
+        f"{gap * 1000:.0f} ms later — so a reading over-corrected by the "
+        f"whole step instead of clamping to the hole's edge is left with "
+        f"exactly that much log-ahead (issue #256)."
+        if gap
+        else " This instant is outside every hole those steps left, so the "
+        "video has a frame of its own for it and the correction above is the "
+        "whole of what the steps took."
+    )
     return (
         f"**This take's clock stepped, so the beat log is not the first place "
         f"to look**: {clock.describe()}, and {shift * 1000:+.0f} ms of that "
-        f"was subtracted from this reading. A capture that lost less wall "
-        f"time than the step it recorded is over-corrected by the "
-        f"difference, and what is left reads as log-ahead — measured at "
-        f"+540 to +970 ms on takes losing 16-50% of a ~1.07 s step (issue "
-        f"#255). Check the step against demo.mp4 before reading `_t0` and "
-        f"`_beat`."
+        f"was subtracted from this reading.{inside} A step is never lost by "
+        f"halves — the video's clock is the wall clock's high-water mark, "
+        f"measured at 97.0-100.2% of the recorded step over 10 steps in 9 "
+        f"takes — so the two things that produce a skew here are the hole "
+        f"above and, on a stitched log, the merge seam, where a part's beats "
+        f"run past where the next part's offset puts it and `overlaps` in "
+        f"timeline.json says so (issues #255, #263). Check the step against "
+        f"demo.mp4 before reading `_t0` and `_beat`."
     )
 
 

--- a/tests/unit
+++ b/tests/unit
@@ -2123,8 +2123,10 @@ SMOKE = Path(os.environ.get("UNIT_SMOKE", REPO / "tests" / "smoke"))
 
 # `tests/README.md`, overridable for the same reason `SMOKE` is: under
 # `--fault-inject` this file runs from a temp directory, where `REPO` points at
-# nothing. The runner passes the real path, so the figures below stay graded
-# while an injection is in place rather than going quiet exactly then.
+# nothing. The runner passes a copy, so the figures and the prose below stay
+# graded while an injection is in place rather than going quiet exactly then —
+# and so an injection can be aimed at this document, which is one of the three
+# that carried the retracted explanation of a positive skew.
 README = Path(os.environ.get("UNIT_README", REPO / "tests" / "README.md"))
 
 # `tests/smoke-inject`, on the same terms. Graded here rather than by its own
@@ -5164,6 +5166,219 @@ def clock_record(*steps: tuple[float, float], measured: bool = True) -> dict:
     }
 
 
+def merged_with_beats(
+    parts: list[list[tuple[float, float]]],
+    durations: list[float],
+    clocks: list[object] | None = None,
+) -> dict:
+    """A stitched timeline whose parts carry exactly the beats `parts` names.
+
+    `merged_of` above pins its beats at 0.5 s and 2.0 s, which is short of
+    every part's duration and so can never produce a seam that overlaps.
+    Here the spans are the input: a part's log is allowed to outrun its own
+    `.seg.mp4`, which is what a backward wall-clock step does to a capture and
+    is the only way to construct issue #263 on a host whose clock holds still.
+    """
+    names = [f"part{n + 1}" for n in range(len(parts))]
+    docs = [
+        {
+            "recorder": "Recorder",
+            "segment": name,
+            "beats": [
+                {
+                    "index": n,
+                    "segment": name,
+                    "verb": "caption",
+                    "caption": f"{name} beat {n}",
+                    "t_start": start,
+                    "t_end": end,
+                }
+                for n, (start, end) in enumerate(beats)
+            ],
+            "capture_clock": clock,
+        }
+        for name, beats, clock in zip(
+            names, parts, clocks or [None] * len(parts), strict=True
+        )
+    ]
+    return _merged_timeline(
+        names,
+        [Path(f"{name}.seg.mp4") for name in names],
+        docs,
+        durations,
+        Path("demo.mp4"),
+    )
+
+
+class MergeOverlap(unittest.TestCase):
+    """Whether a stitched log is monotonic, and what it says when it is not (#263).
+
+    `_merged_timeline` moves each part's beats by the part's real **ffprobe
+    duration** while the beats keep their own `time.monotonic()` timestamps.
+    Those are two clocks, and a part whose host clock stepped backwards has a
+    video shorter than its own beat log by the size of the step — so its last
+    beats run past where the next part begins, and the merged log goes
+    backwards at the seam. Measured at −1.4684 s: `beat 21 t_end 37.451`,
+    `beat 22 t_start 37.441`.
+
+    **Constructed, and it has to be.** A box either steps its wall clock or it
+    does not, and on one that does not every part's log ends inside its own
+    duration and this whole file is unreachable — which is exactly why the
+    defect survived to be found by hand in a discarded take (PR #261). The
+    parts below are hand-written documents; nothing here records anything.
+
+    What no assertion here can say is that a real stepping host produces the
+    arithmetic these documents assume. That was measured on the takes in
+    issues #255 and #263 and belongs to `tests/smoke`.
+    """
+
+    # A part 6.0 s long on disk whose beat log runs to 7.4 s, because its host
+    # clock stepped −1.5 s partway through: 7.4 − 1.5 = 5.9, inside the file.
+    STEPPED_BEATS = [(0.5, 0.6), (7.0, 7.4)]
+    STEADY_BEATS = [(0.5, 0.6), (4.0, 4.4)]
+    SECOND_PART = [(0.0, 0.4)]
+    DURATIONS = [6.0, 5.0]
+
+    def stitched(self, clocks: list[object] | None = None) -> dict:
+        return merged_with_beats(
+            [self.STEPPED_BEATS, self.SECOND_PART], self.DURATIONS, clocks
+        )
+
+    def measured(self) -> list[object]:
+        return [clock_record((3.0, -1.5)), clock_record()]
+
+    def test_a_seam_the_step_pushed_past_is_reported_with_its_size(self):
+        doc = self.stitched(self.measured())
+        self.assertEqual(len(doc["overlaps"]), 1)
+        found = doc["overlaps"][0]
+        self.assertEqual((found["previous_beat"], found["beat"]), (1, 2))
+        self.assertEqual(
+            (found["previous_segment"], found["segment"]), ("part1", "part2")
+        )
+        self.assertIs(found["seam"], True)
+        # 7.4 s of beat log against a 6.0 s file: the second part starts 1.4 s
+        # before the first part's last beat says it ended.
+        self.assertAlmostEqual(found["overlap"], 1.4, places=3)
+
+    def test_the_overlapping_beats_are_reported_rather_than_moved(self):
+        """The decision, graded rather than described.
+
+        Clamping would buy a rising column by putting a beat at an instant
+        neither its log nor its video has, and every consumer that corrects a
+        beat by its own capture's steps reads the merged timestamp as *its own
+        part's log plus that part's offset*. So the numbers stay, and the
+        overlap is published beside them.
+        """
+        doc = self.stitched(self.measured())
+        by_index = {b["index"]: b for b in doc["beats"]}
+        self.assertAlmostEqual(by_index[1]["t_end"], 7.4, places=3)
+        # part2's offset is part1's ffprobe duration, and its first beat is at
+        # 0.0 in its own log — so 6.0, unchanged by the overlap beside it.
+        self.assertAlmostEqual(by_index[2]["t_start"], 6.0, places=3)
+        self.assertEqual(doc["segments"][1]["offset"], 6.0)
+
+    def test_the_steps_that_caused_it_are_shown_to_put_the_frames_in_order(self):
+        """The sentence that makes the report worth reading.
+
+        The column runs backwards; the *frames* do not. Beat 1's end is at
+        7.4 − 1.5 = 5.9 s in the video and beat 2's start is at 6.0 s, so the
+        two are 0.1 s apart and in order. Without this a reader cannot tell
+        this from a merge that lost a second of somebody's demo.
+        """
+        found = self.stitched(self.measured())["overlaps"][0]
+        self.assertAlmostEqual(found["video_overlap"], -0.1, places=3)
+
+    def test_an_overlap_the_recorded_steps_do_not_explain_says_so(self):
+        # The same beats against a clock that watched and saw nothing. The
+        # correction is then the identity, the two instants stay 1.4 s out of
+        # order on the video's clock too, and the record must not report that
+        # as the benign case.
+        found = self.stitched([clock_record(), clock_record()])["overlaps"][0]
+        self.assertAlmostEqual(found["video_overlap"], 1.4, places=3)
+
+    def test_an_unmeasured_clock_leaves_the_verdict_null_rather_than_zero(self):
+        # Null is a third answer and the artifact has to be able to give it: a
+        # merge with no usable `capture_clock` cannot say whether the frames
+        # are in order, and 0.0 there would read as "checked, and they are".
+        found = self.stitched([None, None])["overlaps"][0]
+        self.assertIsNone(found["video_overlap"])
+
+    def test_a_merge_whose_parts_fit_their_own_videos_reports_none(self):
+        """The control, and the one that stops "always overlapping" passing.
+
+        Every assertion above is satisfied by a merge that reports an overlap
+        at every seam. This is the take a healthy host produces, and it has to
+        come back with an empty list — *empty*, not absent: the merge looked.
+        """
+        doc = merged_with_beats(
+            [self.STEADY_BEATS, self.SECOND_PART], self.DURATIONS, self.measured()
+        )
+        self.assertEqual(doc["overlaps"], [])
+
+    def test_a_pair_inside_one_segment_is_reported_and_not_called_a_seam(self):
+        # "This stitched log is monotonic" is a claim about the whole list, so
+        # every adjacent pair is compared — but only a seam is this merge's
+        # arithmetic, and a reader sent to `stitch()` for a segment's own log
+        # is sent to the wrong file.
+        doc = merged_with_beats(
+            [[(1.0, 2.0), (1.5, 1.8)], self.SECOND_PART],
+            self.DURATIONS,
+            self.measured(),
+        )
+        found = doc["overlaps"][0]
+        self.assertEqual((found["previous_beat"], found["beat"]), (0, 1))
+        self.assertIs(found["seam"], False)
+        self.assertAlmostEqual(found["overlap"], 0.5, places=3)
+
+    def test_a_beat_with_no_end_is_skipped_rather_than_raising(self):
+        # `beats` comes out of a segment's own timeline.json, so a missing
+        # `t_end` is reachable, and the failure mode is a stitch dying after
+        # the concat has already written demo.mp4.
+        doc = merged_with_beats(
+            [[(0.5, 0.6), (7.0, None)], self.SECOND_PART],  # type: ignore[list-item]
+            self.DURATIONS,
+            self.measured(),
+        )
+        self.assertEqual(doc["overlaps"], [])
+
+    # -- what timeline.md says about it -------------------------------------
+
+    def test_the_markdown_names_the_beats_the_size_and_the_verdict(self):
+        """`timeline.json` is not where a reviewer meets this.
+
+        The beat table is, and a row starting before the row above it ended
+        reads as a corrupt file unless the page says otherwise.
+        """
+        rendered = render_timeline_md(self.stitched(self.measured()))
+        self.assertIn("not monotonic", rendered)
+        self.assertIn("beat 1 → 2", rendered)
+        self.assertIn("1.400s", rendered)
+        self.assertIn("0.100s apart and **in order**", rendered)
+        self.assertIn("#263", rendered)
+        # Above the table it is about, not under it.
+        self.assertLess(rendered.index("not monotonic"), rendered.index("| # | start"))
+
+    def test_the_markdown_does_not_claim_an_order_nobody_could_check(self):
+        rendered = render_timeline_md(self.stitched([None, None]))
+        self.assertIn("not monotonic", rendered)
+        self.assertIn("no `capture_clock` a reader could correct them with", rendered)
+        # The affirmative verdict specifically. "in order" alone is in the
+        # header ("stitched from 2 segments, in order") and in the refusal
+        # above, so asserting on it would pass whatever this branch printed.
+        self.assertNotIn("apart and **in order**", rendered)
+
+    def test_a_healthy_merge_and_a_single_take_say_nothing_at_all(self):
+        # A paragraph on every timeline is a paragraph nobody reads, and a
+        # single take has no seams to have this problem at.
+        healthy = merged_with_beats(
+            [self.STEADY_BEATS, self.SECOND_PART], self.DURATIONS, self.measured()
+        )
+        self.assertNotIn("not monotonic", render_timeline_md(healthy))
+        alone = envelope(duration=9.0, beats=[beat(0, "caption", 0.5, t_end=1.0)])
+        self.assertNotIn("overlaps", alone)
+        self.assertNotIn("not monotonic", render_timeline_md(alone))
+
+
 class FrameClockCorrection(unittest.TestCase):
     """Where the review sheet cuts each frame, and what it says about it (#229).
 
@@ -7304,6 +7519,18 @@ class LogEarlyCause(unittest.TestCase):
     phrasing, not a proof that the message asserts no verdict. Review is what
     covers the rest, and a reviewer got past the single-phrase version of
     this list, which is why it is a list.
+
+    **`RETRACTED` is the same kind of list about the replacement**, and it is
+    here because the replacement was wrong too. #257 stopped blaming the beat
+    log and put a *partial loss* in its place — a capture that lost some
+    fraction of the step it recorded, over-shot by the difference. That
+    mechanism does not exist: the muxer stamps frames with the wall clock and
+    will not rewrite a stamp, so the video's clock is that clock's high-water
+    mark, and the shift is the whole step (97.0-100.2% over 10 steps in 9
+    takes, issue #255). The three figures it cited were in-hole instants read
+    as shifts. Same limits as `VERDICTS`, said plainly: this catches the
+    shipped wording coming back, in the three documents that carried it, and
+    it cannot catch the same claim written in new words.
     """
 
     # The wordings, then the imperative. The last entry is the load-bearing
@@ -7318,9 +7545,33 @@ class LogEarlyCause(unittest.TestCase):
     )
     VERDICT = VERDICTS[0]
 
+    # The false mechanism, in the words the three documents shipped it in. The
+    # summary terms for it — "a partial loss", "a fraction of the step" — are
+    # deliberately **not** here: a document has to be able to say what was
+    # retracted, and a ban on naming it would leave the next reader deriving
+    # the retraction from silence.
+    RETRACTED = (
+        "lost less wall time",
+        "only part of the step it recorded",
+        "partly lost",
+        "16-50",
+        "16–50",
+    )
+
+    # Where that claim was shipped. The smoke harness's failure text and its
+    # `MAX_LOG_EARLY_S` comment, the skill's published limits, and the suite's
+    # own README — three documents, one claim, and it was corrected in one
+    # place at a time twice before.
+    def carriers(self) -> list[Path]:
+        return [SMOKE, SKILL_DIR / "reference" / "limits.md", README]
+
     def assertNoVerdict(self, said: str):
         for phrase in self.VERDICTS:
             self.assertNotIn(phrase, said, f"still asserts a cause: {phrase!r}")
+
+    def assertNotRetracted(self, said: str):
+        for phrase in self.RETRACTED:
+            self.assertNotIn(phrase, said, f"retracted mechanism is back: {phrase!r}")
 
     def setUp(self):
         self.smoke = _smoke_module()
@@ -7353,11 +7604,86 @@ class LogEarlyCause(unittest.TestCase):
         said = self.because(self.clock((2.2, -1.073)), 5.633)
         self.assertIn("clock stepped", said)
         self.assertIn("-1073 ms", said)
-        self.assertIn("over-corrected", said)
+        self.assertIn("high-water mark", said)
         # The half that carries the meaning. A paragraph that names the step
         # and then repeats the verdict has changed nothing for the reader.
         self.assertNoVerdict(said)
+        self.assertNotRetracted(said)
         self.assertNotIn("No step of this beat's own capture", said)
+
+    def test_a_beat_inside_the_hole_is_told_how_wide_the_hole_is(self):
+        """The mechanism that is real, carried as a number rather than a claim.
+
+        A −1.05 s step at 2.2 s deletes the monotonic window (2.2, 3.25) from
+        the file, so a beat at 2.5 s has no frame: the video's clock stops at
+        2.2 s and resumes 750 ms of wall time later. That 750 ms is exactly
+        what a reading which subtracted the whole step instead of clamping is
+        left holding, so it is the size the skew has to be compared against —
+        and a message that only asserted a mechanism in prose would say the
+        same thing whatever the clock had done.
+        """
+        said = self.because(self.clock((2.2, -1.05)), 2.5)
+        self.assertIn("no frame for this instant", said)
+        self.assertIn("750 ms later", said)
+        self.assertIn("over-corrected", said)
+        self.assertNoVerdict(said)
+        self.assertNotRetracted(said)
+
+    def test_a_beat_with_a_frame_of_its_own_is_not_offered_a_hole(self):
+        """...and the other side of it, which is what makes the number mean
+        something.
+
+        The same take, a beat at 5.633 s: past the step's hole, so the file
+        does have a frame for it and the correction is exact. Offering a hole
+        here would send a reader looking for missing video that is not
+        missing, and a branch that always named one would satisfy the test
+        above on its own.
+        """
+        said = self.because(self.clock((2.2, -1.05)), 5.633)
+        self.assertIn("outside every hole", said)
+        self.assertNotIn("no frame for this instant", said)
+        self.assertNotIn("over-corrected", said)
+        self.assertNotRetracted(said)
+
+    def test_the_retracted_partial_loss_is_in_none_of_the_four_answers(self):
+        """Every branch, including the two that never mentioned it.
+
+        Mostly, but not wholly, covered by the document sweep below: this
+        message is a literal in `tests/smoke`, so a phrase pasted back into it
+        is visible in both. What only this can see is a message that assembles
+        the claim at run time — out of a constant, a variable, a `format` —
+        where the source carries no such substring and the reader still gets
+        the retracted mechanism.
+        """
+        for said in (
+            self.because(None, 5.633),
+            self.because(self.clock(), 5.633),
+            self.because(self.clock((2.0, -1.0), (4.0, 1.0)), 5.633),
+            self.because(self.clock((2.2, -1.073)), 5.633),
+        ):
+            self.assertNotRetracted(said)
+
+    def test_no_document_still_explains_a_positive_skew_as_a_partial_loss(self):
+        """The prose, not only the failure text (#257's correction missed it).
+
+        The claim was shipped in three documents and corrected in one of them
+        at a time, twice — so the guard reads all three. It is a substring
+        tripwire and nothing more: see the class docstring for what it cannot
+        see.
+        """
+        for path in self.carriers():
+            text = path.read_text(encoding="utf-8")
+            # The haystack, before anything is claimed about it: a path that
+            # moved would otherwise make every assertion below hold over an
+            # empty string.
+            self.assertGreater(len(text), 20_000, f"{path} is not the document")
+            for phrase in self.RETRACTED:
+                self.assertNotIn(
+                    phrase,
+                    text,
+                    f"{path.name} explains a positive skew as a partial loss "
+                    f"of the step ({phrase!r}), which issue #255 retracted",
+                )
 
     def test_a_step_after_the_beat_leaves_the_beat_log_named(self):
         """The other side of the distinction, and why it is per-instant.
@@ -7938,14 +8264,78 @@ INJECTIONS = [
         # rewrite of the sentence above it.
         "the stepping message names the step and then blames the beat log anyway",
         "tests/smoke",
-        '        f"#255). Check the step against demo.mp4 before reading `_t0` and "\n'
-        '        f"`_beat`."',
-        '        f"#255). That said, the fault is the beat log: check where `_t0` "\n'
-        '        f"is taken and where `_beat` stamps `t_start`."',
+        '        f"timeline.json says so (issues #255, #263). Check the step against "\n'
+        '        f"demo.mp4 before reading `_t0` and `_beat`."',
+        '        f"timeline.json says so (issues #255, #263). That said, the fault is "\n'
+        '        f"the beat log: check where `_beat` stamps `t_start`."',
         [
             "LogEarlyCause."
             "test_a_stepping_take_names_the_step_and_withdraws_the_verdict",
         ],
+    ),
+    (
+        # **The explanation #257 shipped in place of the verdict, restored.**
+        # It read as a measurement and it described a mechanism that does not
+        # exist: the muxer will not rewrite a frame stamp, so a capture loses
+        # the whole step or none of it (97.0-100.2% over 10 steps in 9 takes,
+        # issue #255). A reader handed this looks for a proportion to correct
+        # by, and there is nothing to take a proportion of.
+        "the stepping message goes back to blaming a partial loss of the step",
+        "tests/smoke",
+        '        f"was subtracted from this reading.{inside} A step is never lost by "',
+        '        f"was subtracted from this reading. A capture that lost less wall time "',
+        [
+            "LogEarlyCause.test_the_retracted_partial_loss_is_in_none_of_the_four_answers",
+            "LogEarlyCause."
+            "test_no_document_still_explains_a_positive_skew_as_a_partial_loss",
+            "LogEarlyCause.test_a_beat_inside_the_hole_is_told_how_wide_the_hole_is",
+        ],
+    ),
+    (
+        # ...and the same claim in the skill's published limits, which is the
+        # document a storyboard author reads and the one nothing in this suite
+        # watched until now. #257 corrected the harness and left this.
+        "reference/limits.md goes back to explaining the skew as a partial loss",
+        "reference/limits.md",
+        "muxer cannot produce a partial shift — measured at **97.0–100.2 %** of the",
+        "capture that lost less wall time than the step it recorded — at the",
+        [
+            "LogEarlyCause."
+            "test_no_document_still_explains_a_positive_skew_as_a_partial_loss",
+        ],
+    ),
+    (
+        # ...and in this suite's own README, the third document that carried
+        # it. Three documents, one claim, corrected one at a time twice.
+        "tests/README.md goes back to explaining the skew as a partial loss",
+        "tests/README.md",
+        "and this list carried that as a second open defect. **It is retracted**",
+        "and some takes lose only 16–50 % of it. **It is open**",
+        [
+            "LogEarlyCause."
+            "test_no_document_still_explains_a_positive_skew_as_a_partial_loss",
+        ],
+    ),
+    (
+        # The hole's width, which is the whole reason the corrected message is
+        # a lead rather than another paragraph: it is the number the skew has
+        # to be compared against. Zeroed, the message still names the step and
+        # still withdraws the verdict, and says nothing a reader can check.
+        "the stepping message stops measuring the hole it is about",
+        "tests/smoke",
+        "    gap = clock.hole(t)\n    inside = (",
+        "    gap = 0.0\n    inside = (",
+        ["LogEarlyCause.test_a_beat_inside_the_hole_is_told_how_wide_the_hole_is"],
+    ),
+    (
+        # ...and the other direction, which is what makes that number mean
+        # anything: a hole announced for every beat of a stepping take sends a
+        # reader looking for missing video on beats the file has frames for.
+        "every beat of a stepping take is told the video has no frame for it",
+        "tests/smoke",
+        '        if gap\n        else " This instant is outside every hole those steps',
+        '        if True\n        else " This instant is outside every hole those steps',
+        ["LogEarlyCause.test_a_beat_with_a_frame_of_its_own_is_not_offered_a_hole"],
     ),
     (
         # The other way to get this wrong, and the tempting one: withdraw the
@@ -10278,6 +10668,96 @@ INJECTIONS = [
         ],
     ),
     (
+        # **The defect issue #263 is about, restored**: a stitched log that
+        # goes backwards at the seam and says nothing. Every other assertion
+        # about the merge still passes — the beats are where they always were,
+        # and it is the report beside them that is gone.
+        "a stitched log overlaps at the seam and the artifact says nothing",
+        "stitching.py",
+        "        if overlap <= 0:\n            continue",
+        "        if True:\n            continue",
+        [
+            "MergeOverlap.test_a_seam_the_step_pushed_past_is_reported_with_its_size",
+            "MergeOverlap.test_the_markdown_names_the_beats_the_size_and_the_verdict",
+        ],
+    ),
+    (
+        # ...and the other way, which is the one a count would not catch: a
+        # merge that reports an overlap at every seam. Every assertion about
+        # the stepping case above passes against it, and `timeline.md` grows a
+        # paragraph about a defect on every healthy stitched demo.
+        "every seam is reported as an overlap, including the ones in order",
+        "stitching.py",
+        "        if overlap <= 0:\n            continue",
+        "        if False:\n            continue",
+        [
+            "MergeOverlap.test_a_merge_whose_parts_fit_their_own_videos_reports_none",
+            "MergeOverlap.test_a_healthy_merge_and_a_single_take_say_nothing_at_all",
+        ],
+    ),
+    (
+        # The verdict a reader acts on, reversed. A `video_overlap` with the
+        # wrong sign reports the benign case — the log's column runs backwards,
+        # the frames are in order — as an overlap the recorded steps cannot
+        # explain, and the unexplained one as benign. The list is still there
+        # and still the right length, which is why the count is not the check.
+        "the video's clock is read backwards, so the verdict is inverted",
+        "stitching.py",
+        "                    place(before, ends).at - place(after, starts).at, 3",
+        "                    place(after, starts).at - place(before, ends).at, 3",
+        [
+            "MergeOverlap.test_the_steps_that_caused_it_are_shown_to_put_the_frames_in_order",
+            "MergeOverlap.test_an_overlap_the_recorded_steps_do_not_explain_says_so",
+        ],
+    ),
+    (
+        # A demo nobody could correct told that its frames are in order. The
+        # correction is the identity when no record can supply one, so this
+        # prints a number computed from nothing where the honest answer is
+        # null — the artifact-lies direction, and the one that reads best.
+        "an overlap nobody could check is reported as if the clock had explained it",
+        "stitching.py",
+        '                if state.get("applied")\n                else None,',
+        "                if True\n                else None,",
+        [
+            "MergeOverlap.test_an_unmeasured_clock_leaves_the_verdict_null_rather_than_zero",
+            "MergeOverlap.test_the_markdown_does_not_claim_an_order_nobody_could_check",
+        ],
+    ),
+    (
+        # The option this change did **not** take, taken: clamp the beats up
+        # to the previous one's end and the column rises, the overlap list
+        # empties, and every beat of a stepping part is now at an instant
+        # neither its own log nor its video has. `timeline.json` reads clean
+        # and is further from the file a reviewer scrubs than it was before.
+        "the merge clamps the overlap away instead of reporting it",
+        "stitching.py",
+        '            merged["t_start"] = _shift(beat.get("t_start"), offset)',
+        '            merged["t_start"] = max(\n'
+        '                _shift(beat.get("t_start"), offset),\n'
+        '                beats[-1]["t_end"] if beats else 0.0,\n'
+        "            )",
+        [
+            "MergeOverlap.test_the_overlapping_beats_are_reported_rather_than_moved",
+            "MergeOverlap.test_a_seam_the_step_pushed_past_is_reported_with_its_size",
+        ],
+    ),
+    (
+        # And the rendering: the JSON keeps the list, `timeline.md` drops the
+        # paragraph. Nobody reviewing a demo through this skill opens the JSON,
+        # so this is the version of the defect a reviewer actually meets — a
+        # beat table with a row starting before the row above it ended and no
+        # sentence anywhere saying why.
+        "timeline.md stops saying its own beat table runs backwards",
+        "timeline.py",
+        "    if not isinstance(overlaps, list) or not overlaps:\n        return []",
+        "    if True:\n        return []",
+        [
+            "MergeOverlap.test_the_markdown_names_the_beats_the_size_and_the_verdict",
+            "MergeOverlap.test_the_markdown_does_not_claim_an_order_nobody_could_check",
+        ],
+    ),
+    (
         # The stated limit, in the artifact rather than only in the PR body.
         "the report stops naming the flaky failure it cannot rule out",
         "tests/smoke-inject",
@@ -10326,6 +10806,13 @@ def fault_inject() -> int:
             # decision nobody has watched go the wrong way is a claim.
             smoke_inject = Path(tmp) / "smoke-inject"
             shutil.copy(REPO / "tests" / "smoke-inject", smoke_inject)
+            # ...and this suite's own README, which used to be read straight
+            # out of the working tree. It carries prose that assertions here
+            # grade — a stated figure, and the explanation of a positive skew
+            # this repo shipped and retracted — and a document nothing can
+            # break is a document whose guard nobody has watched fire.
+            readme = Path(tmp) / "README.md"
+            shutil.copy(REPO / "tests" / "README.md", readme)
             unit = Path(tmp) / "unit"
             shutil.copy(Path(__file__).resolve(), unit)
             if module == "tests/smoke":
@@ -10334,6 +10821,10 @@ def fault_inject() -> int:
                 # Before the `"/" in module` branch below, which would send it
                 # into the skill directory and fail on a file that is not there.
                 target = smoke_inject
+            elif module == "tests/README.md":
+                # Before the `.md` branch below, which would look for it under
+                # the skill directory.
+                target = readme
             elif module == "tests/unit":
                 target = unit
             elif module == "__init__.py" or module.endswith(".py"):
@@ -10367,7 +10858,7 @@ def fault_inject() -> int:
                     "UNIT_SKILL_DIR": str(skill),
                     "UNIT_SMOKE": str(smoke),
                     "UNIT_SMOKE_INJECT": str(smoke_inject),
-                    "UNIT_README": str(REPO / "tests" / "README.md"),
+                    "UNIT_README": str(readme),
                 },
             )
             noticed = {t for t in must_fail if t in done.stderr}

--- a/tests/unit
+++ b/tests/unit
@@ -103,7 +103,10 @@ from demo_recording.narration import (  # noqa: E402
     _tts_key,
     mix_plan,
 )
-from demo_recording.stitching import _merged_timeline  # noqa: E402
+from demo_recording.stitching import (  # noqa: E402
+    MERGE_OVERLAP_SLACK_S,
+    _merged_timeline,
+)
 from demo_recording.target import TargetRefused  # noqa: E402
 from demo_recording.timeline import (  # noqa: E402
     ISSUE_KINDS,
@@ -5166,10 +5169,19 @@ def clock_record(*steps: tuple[float, float], measured: bool = True) -> dict:
     }
 
 
+# A `demo.mp4` that cannot exist: its parent directory is never created by
+# anything. `_merged_timeline` probes the path only to fill `duration`, and a
+# relative "demo.mp4" would make this shell out to ffprobe against whatever
+# happens to be in the working directory — a unit test grading a stranger's
+# recording. See the stale-input entry in wip/verified-review.
+ABSENT_DEMO = Path(tempfile.gettempdir()) / "demo-video-unit-no-such-dir" / "demo.mp4"
+
+
 def merged_with_beats(
     parts: list[list[tuple[float, float]]],
     durations: list[float],
     clocks: list[object] | None = None,
+    names: list[str] | None = None,
 ) -> dict:
     """A stitched timeline whose parts carry exactly the beats `parts` names.
 
@@ -5178,8 +5190,12 @@ def merged_with_beats(
     Here the spans are the input: a part's log is allowed to outrun its own
     `.seg.mp4`, which is what a backward wall-clock step does to a capture and
     is the only way to construct issue #263 on a host whose clock holds still.
+
+    `names` is an input too, because nothing in `stitch()` stops two parts
+    being handed the same segment name and the merge has to stay right when
+    they are.
     """
-    names = [f"part{n + 1}" for n in range(len(parts))]
+    names = names or [f"part{n + 1}" for n in range(len(parts))]
     docs = [
         {
             "recorder": "Recorder",
@@ -5206,7 +5222,7 @@ def merged_with_beats(
         [Path(f"{name}.seg.mp4") for name in names],
         docs,
         durations,
-        Path("demo.mp4"),
+        ABSENT_DEMO,
     )
 
 
@@ -5314,6 +5330,101 @@ class MergeOverlap(unittest.TestCase):
             [self.STEADY_BEATS, self.SECOND_PART], self.DURATIONS, self.measured()
         )
         self.assertEqual(doc["overlaps"], [])
+
+    def test_an_endpoint_the_step_deleted_is_not_reported_as_a_frame(self):
+        """In order is not the same answer as fine (#256).
+
+        A part 3.0 s long on disk, a −1.5 s step at 3.0 s, and its last beat
+        ending at 3.8 s — inside the hole that step left. `place` clamps that
+        to 3.0 s and hands back `lost=0.700`, so the pair reads 0.2 s apart
+        and in order, which is true. What is false is "the frames are fine":
+        the file has no frame for that beat at all. `Placed.lost` exists to
+        stop a consumer publishing `at` without it, and a merge that dropped
+        it is that consumer.
+        """
+        doc = merged_with_beats(
+            [[(0.5, 0.6), (3.4, 3.8)], [(0.2, 0.6)]],
+            [3.0, 5.0],
+            [clock_record((3.0, -1.5)), clock_record()],
+        )
+        found = doc["overlaps"][0]
+        self.assertAlmostEqual(found["overlap"], 0.6, places=3)
+        self.assertAlmostEqual(found["video_overlap"], -0.2, places=3)
+        self.assertAlmostEqual(found["previous_no_video"], 0.7, places=3)
+        self.assertEqual(found["no_video"], 0.0)
+        rendered = render_timeline_md(doc)
+        self.assertIn("**in order**", rendered)
+        self.assertIn("no frame for beat 1 at all", rendered)
+        self.assertIn("700 ms later", rendered)
+        self.assertNotIn("frames are fine", rendered)
+
+    def test_a_pair_whose_endpoints_both_have_frames_still_says_they_are_fine(self):
+        # The control for the sentence above: without it, "never say the
+        # frames are fine" passes and the benign case loses the one line that
+        # tells a reviewer not to go looking.
+        rendered = render_timeline_md(self.stitched(self.measured()))
+        self.assertIn("frames are fine", rendered)
+        self.assertNotIn("no frame for beat", rendered)
+
+    def test_the_slack_here_is_the_slack_the_suite_grades(self):
+        """A bar of its own would cry wolf, and a check that cries wolf is off.
+
+        `tests/smoke`'s `check_beats` accepts a seam within
+        `BEAT_ORDER_SLACK_S`. A tighter bar here prints "this stitched beat
+        log is not monotonic" over a take the suite calls healthy; a wider one
+        stays quiet about a log the suite fails.
+        """
+        self.assertEqual(MERGE_OVERLAP_SLACK_S, _smoke_module().BEAT_ORDER_SLACK_S)
+
+    def test_a_seam_inside_the_slack_is_not_called_an_overlap(self):
+        """At the bar, not comfortably inside it — and at the case measured.
+
+        0.6 ms is the seam the first version of this reported, on a take
+        `check_beats` calls healthy. 4 ms and 6 ms are either side of the bar
+        itself, because a constant only tested well past it is one nothing
+        pins.
+        """
+        for last_end in (6.0006, 6.004):
+            with self.subTest(t_end=last_end):
+                quiet = merged_with_beats(
+                    [[(0.5, last_end)], self.SECOND_PART],
+                    self.DURATIONS,
+                    self.measured(),
+                )
+                self.assertEqual(quiet["overlaps"], [])
+        loud = merged_with_beats(
+            [[(0.5, 6.006)], self.SECOND_PART], self.DURATIONS, self.measured()
+        )
+        self.assertEqual(len(loud["overlaps"]), 1)
+        self.assertAlmostEqual(loud["overlaps"][0]["overlap"], 0.006, places=3)
+
+    def test_a_seam_between_two_parts_of_the_same_name_is_still_a_seam(self):
+        """`seam` is the merge's own arithmetic, so it is read off the merge.
+
+        Nothing in `stitch()` refuses one segment name twice, and
+        `tests/smoke` treats "merged segment one twice" as a real failure
+        mode. Keyed on the two beats' `segment` strings, a genuine seam there
+        reads as "inside one segment" and sends the reader to a part's own log
+        for a defect the merge produced.
+        """
+        doc = merged_with_beats(
+            [self.STEPPED_BEATS, self.SECOND_PART],
+            self.DURATIONS,
+            names=["part1", "part1"],
+        )
+        found = doc["overlaps"][0]
+        self.assertEqual((found["previous_beat"], found["beat"]), (1, 2))
+        self.assertEqual(found["previous_segment"], found["segment"])
+        self.assertIs(found["seam"], True)
+
+    def test_the_markdown_counts_the_rows_it_prints(self):
+        # Reachable from a hand-edited timeline.json only, and two lines: a
+        # header saying "2 beat(s)" over one bullet is the artifact
+        # disagreeing with itself in the document whose job is to be read.
+        doc = self.stitched(self.measured())
+        doc["overlaps"] = [*doc["overlaps"], "not a record"]
+        rendered = render_timeline_md(doc)
+        self.assertIn("1 beat(s) below start before", rendered)
 
     def test_a_pair_inside_one_segment_is_reported_and_not_called_a_seam(self):
         # "This stitched log is monotonic" is a claim about the whole list, so
@@ -10674,7 +10785,7 @@ INJECTIONS = [
         # and it is the report beside them that is gone.
         "a stitched log overlaps at the seam and the artifact says nothing",
         "stitching.py",
-        "        if overlap <= 0:\n            continue",
+        "        if overlap <= MERGE_OVERLAP_SLACK_S:\n            continue",
         "        if True:\n            continue",
         [
             "MergeOverlap.test_a_seam_the_step_pushed_past_is_reported_with_its_size",
@@ -10688,7 +10799,7 @@ INJECTIONS = [
         # paragraph about a defect on every healthy stitched demo.
         "every seam is reported as an overlap, including the ones in order",
         "stitching.py",
-        "        if overlap <= 0:\n            continue",
+        "        if overlap <= MERGE_OVERLAP_SLACK_S:\n            continue",
         "        if False:\n            continue",
         [
             "MergeOverlap.test_a_merge_whose_parts_fit_their_own_videos_reports_none",
@@ -10703,8 +10814,8 @@ INJECTIONS = [
         # and still the right length, which is why the count is not the check.
         "the video's clock is read backwards, so the verdict is inverted",
         "stitching.py",
-        "                    place(before, ends).at - place(after, starts).at, 3",
-        "                    place(after, starts).at - place(before, ends).at, 3",
+        '                "video_overlap": round(placed_before.at - placed_after.at, 3)',
+        '                "video_overlap": round(placed_after.at - placed_before.at, 3)',
         [
             "MergeOverlap.test_the_steps_that_caused_it_are_shown_to_put_the_frames_in_order",
             "MergeOverlap.test_an_overlap_the_recorded_steps_do_not_explain_says_so",
@@ -10717,8 +10828,10 @@ INJECTIONS = [
         # null — the artifact-lies direction, and the one that reads best.
         "an overlap nobody could check is reported as if the clock had explained it",
         "stitching.py",
-        '                if state.get("applied")\n                else None,',
-        "                if True\n                else None,",
+        '        placed_before = place(before, ends) if state.get("applied") else None\n'
+        '        placed_after = place(after, starts) if state.get("applied") else None',
+        "        placed_before = place(before, ends)\n"
+        "        placed_after = place(after, starts)",
         [
             "MergeOverlap.test_an_unmeasured_clock_leaves_the_verdict_null_rather_than_zero",
             "MergeOverlap.test_the_markdown_does_not_claim_an_order_nobody_could_check",
@@ -10743,6 +10856,94 @@ INJECTIONS = [
         ],
     ),
     (
+        # `Placed.lost` thrown away, which is the shape of #256 in a new
+        # artifact: the pair really is in order, so the ordering claim stays
+        # true, and the sentence beside it tells a reviewer the frames are
+        # fine when one of the two beats has no frame at all.
+        "an endpoint the step deleted is published as though it had a frame",
+        "stitching.py",
+        '                "previous_no_video": round(placed_before.lost, 3)',
+        '                "previous_no_video": 0.0',
+        [
+            "MergeOverlap.test_an_endpoint_the_step_deleted_is_not_reported_as_a_frame",
+        ],
+    ),
+    (
+        # ...and the same thing one level up, in the sentence itself. The
+        # record still carries the hole; `timeline.md` prints "the frames are
+        # fine" over it, and `timeline.md` is the file a reviewer opens.
+        "timeline.md calls the frames fine over a beat the step deleted",
+        "timeline.py",
+        "        elif video <= 0 and deleted:",
+        "        elif False:",
+        [
+            "MergeOverlap.test_an_endpoint_the_step_deleted_is_not_reported_as_a_frame",
+        ],
+    ),
+    (
+        # ...and the leniency half, which is the direction a "never say the
+        # frames are fine" fix would take: every benign overlap now warns
+        # about missing video that is not missing, and the one line telling a
+        # reviewer not to go looking is gone from the case that earned it.
+        "every overlap is reported as having a beat with no video",
+        "timeline.py",
+        "        elif video <= 0 and deleted:",
+        "        elif video <= 0 or deleted:",
+        [
+            "MergeOverlap."
+            "test_a_pair_whose_endpoints_both_have_frames_still_says_they_are_fine",
+        ],
+    ),
+    (
+        # The bar, back to a strictly-positive one. `check_beats` tolerates
+        # 5 ms of seam, so this prints "**This stitched beat log is not
+        # monotonic**" over takes the suite calls healthy — measured at a
+        # 0.6 ms seam. A check that cries wolf is a check that gets ignored.
+        "the merge reports a seam the suite's own bar tolerates",
+        "stitching.py",
+        "        if overlap <= MERGE_OVERLAP_SLACK_S:",
+        "        if overlap <= 0:",
+        ["MergeOverlap.test_a_seam_inside_the_slack_is_not_called_an_overlap"],
+    ),
+    (
+        # ...and the two bars drifting apart in the other direction, which is
+        # the silent one: a merge that stays quiet about a log `check_beats`
+        # fails.
+        "the merge's slack stops being the slack the suite grades",
+        "stitching.py",
+        "MERGE_OVERLAP_SLACK_S = 0.005",
+        "MERGE_OVERLAP_SLACK_S = 0.05",
+        [
+            "MergeOverlap.test_the_slack_here_is_the_slack_the_suite_grades",
+            "MergeOverlap.test_a_seam_inside_the_slack_is_not_called_an_overlap",
+        ],
+    ),
+    (
+        # `seam` keyed on the two beats' segment names, which is what this
+        # shipped as. Nothing in `stitch()` refuses one segment name twice —
+        # `tests/smoke` treats "merged segment one twice" as a real failure
+        # mode — and a genuine seam reported as "inside one segment" sends the
+        # reader into a part's own log for a defect the merge produced.
+        "a seam between two parts of one name is reported as inside a segment",
+        "stitching.py",
+        '                "seam": after.get("index") in seams,',
+        '                "seam": after.get("segment") != before.get("segment"),',
+        [
+            "MergeOverlap.test_a_seam_between_two_parts_of_the_same_name_is_still_a_seam",
+        ],
+    ),
+    (
+        # A header counting entries the loop below skips. Only a hand-edited
+        # `timeline.json` gets there, and it is two lines — but the artifact
+        # disagreeing with itself is the one thing this paragraph exists to
+        # stop happening to a reader.
+        "the overlap header counts rows timeline.md does not print",
+        "timeline.py",
+        '        f"{len(rows)} beat(s) below start before the beat before them "',
+        '        f"{len(listed)} beat(s) below start before the beat before them "',
+        ["MergeOverlap.test_the_markdown_counts_the_rows_it_prints"],
+    ),
+    (
         # And the rendering: the JSON keeps the list, `timeline.md` drops the
         # paragraph. Nobody reviewing a demo through this skill opens the JSON,
         # so this is the version of the defect a reviewer actually meets — a
@@ -10750,7 +10951,7 @@ INJECTIONS = [
         # sentence anywhere saying why.
         "timeline.md stops saying its own beat table runs backwards",
         "timeline.py",
-        "    if not isinstance(overlaps, list) or not overlaps:\n        return []",
+        "    if not rows:\n        return []",
         "    if True:\n        return []",
         [
             "MergeOverlap.test_the_markdown_names_the_beats_the_size_and_the_verdict",


### PR DESCRIPTION
Two corrections, both falling out of the same diagnosis. `Fixes #263`.

## Part A — a false explanation this repo shipped, now retracted

`f0fccc6` (#257/#262) was right to stop blaming the beat log for a positive skew. **Its replacement was wrong.** `log_early_causes` attributed the skew to *a capture that lost less wall time than the step it recorded*, over-corrected by the difference — and that mechanism does not exist.

Playwright 1.62.0 stamps `frameNumber = floor((wall_ts − first_wall_ts) · 25)` into the matroska clusters and CFR conversion drops everything until the wall clock climbs back, so the video's clock is the **high-water mark** of the wall clock and the muxer cannot produce a fractional shift. Measured: 10 steps across 9 takes, both code paths, 2–60 Hz paint, shift **97.0–100.2 %** of the recorded step ([#255's retraction](https://github.com/rogvid/skills/issues/255)). What looked like partial loss was an instant *inside the hole* measured as though it were a shift — `(t − hole_start)/Δ`, uniform on [0,1]. The +906/+540/+970 ms figures are three draws from that distribution, not three measurements of a mechanism.

So the real causes of a positive skew are **an instant inside the hole** (which `_placed` / `video_instant` have modelled since #256) and **the merge seam in Part B**.

Corrected in all three documents that carried it — `tests/smoke` (both the `MAX_LOG_EARLY_S` comment and `log_early_causes`), `skills/demo-video/reference/limits.md`, `tests/README.md` — and each says what was retracted rather than quietly dropping it. A grep across the repo for the shipped phrasings now returns only the guard's own list.

**The message stopped being a paragraph and became a number.** On a stepping take `log_early_causes` now measures `clock.hole(t)` and prints it: an in-hole instant is over-corrected by *exactly* that much when the whole step is subtracted instead of clamping, so the reader has a size to compare the skew against. Outside a hole it says so and offers no hole. That is what makes the correction gradeable rather than another claim.

**Guard.** `LogEarlyCause.RETRACTED` joins `VERDICTS` as a list of literals — the wordings actually shipped — checked against all four branches of `log_early_causes()` *and* against the three documents. Its docstring says plainly what it is: a tripwire against reversion and against softening that reaches for the shipped phrasing, not a proof. The summary terms ("a partial loss", "a fraction of the step") are deliberately **not** banned, so a document can still say what was retracted.

## Part B — #263, the merge overlap

`_merge_timeline` offsets part 2 by part 1's **ffprobe duration** while part 1's beats keep their own monotonic timestamps. When part 1's clock stepped, those disagree and the merged log goes non-monotonic:

```
beat 21  t_end   37.451
beat 22  t_start 37.441
```

**Reported, not clamped.** A merged timestamp is exactly its part's own log plus that part's `offset`, and every consumer that corrects a beat by its own capture's steps depends on that identity. Clamping would buy a rising column by putting beats at instants neither the log nor the video has.

`timeline.json` grows `overlaps` — one record per adjacent pair that runs backwards, with `beat` / `previous_beat`, `segment` / `previous_segment`, `seam`, `overlap`, **`video_overlap`** (the same difference with both instants put on the video's clock by the documented rule) and **`no_video` / `previous_no_video`** (each endpoint's `Placed.lost`). `video_overlap` at or below zero means the frames really are in order and only the log's column runs backwards; above zero the recorded steps do not account for it; `null` when no correction was possible, which is not the same answer as zero. **"In order" is not "the frames are all there"** — an endpoint a backward step deleted has no frame at all, so the sentence names it instead of saying the frames are fine. `timeline.md` carries the same thing as a paragraph **above** the beat table. Empty list on a healthy merge — the merge saying it looked. Absent from a single take's timeline.

Every adjacent pair is compared, not only the seams, because "this stitched log is monotonic" is a claim about the whole list. `seam` is read off the **parts' beat counts**, not off the two `segment` strings: nothing in `stitch()` refuses one segment name twice and `tests/smoke` treats "merged segment one twice" as a real failure mode, so a genuine seam reported as "inside one segment" would send the reader to the wrong file. The bar is `MERGE_OVERLAP_SLACK_S = 0.005`, which **is** `tests/smoke`'s `BEAT_ORDER_SLACK_S`, held equal by an assertion — a report tighter than the bar it is checked against calls a healthy take broken, and a check that cries wolf gets ignored.

## Round 2 — the five review findings, closed

| # | finding | fix |
|---|---|---|
| 1 | `video_overlap` discarded `Placed.lost`, so `timeline.md` said *the frames are fine* over a beat with no frame | `no_video` / `previous_no_video` published; the sentence names the deleted beat and its gap instead |
| 2 | 0.5 ms bar against the harness's 5 ms — a 0.6 ms seam called non-monotonic on a healthy take | `MERGE_OVERLAP_SLACK_S`, equal to `BEAT_ORDER_SLACK_S`, with a test holding them equal |
| 3 | `seam` keyed on segment names, which two parts can share | keyed on the parts' beat counts |
| 4 | header counted entries the renderer skipped | counts the rows it prints |
| 5 | `merged_with_beats` used a relative `demo.mp4`, so a file in the cwd would make a unit test shell out to ffprobe | path whose parent is never created |

The reviewer's finding 1 case is now a test verbatim: part1 3.0 s on disk, step `−1.5 @ 3.0`, last beat `t_end 3.8` → `Placed(at=3.0, lost=0.700)`, `video_overlap: -0.2`, and the sheet prints *"…0.200s apart and **in order** — but the file has no frame for beat 1 at all, the video resuming 700 ms later (issue #256), so this is not a demo whose frames are all there."* The benign case keeps *"the frames are fine"*, under its own control test, and both md branches are broken in both directions.

## Constructed, because the host cannot be relied on to step

Both parts are unreachable on a steady box. `MergeOverlap` builds two-part documents by hand — a part 6.0 s long on disk whose beat log runs to 7.4 s, which is what a −1.5 s step does to a capture — and `LogEarlyCause` drives a scripted `HostClock`. Nothing here records anything.

## Evidence — every new assertion seen failing

`tests/unit --fault-inject` refuses to proceed unless the injected literal matched **exactly once**. All 11 new entries:

```
PASS  break: the stepping message goes back to blaming a partial loss of the step
      in tests/smoke: f"was subtracted from this reading.{inside} A step is never lost by …
      FAIL: test_a_beat_inside_the_hole_is_told_how_wide_the_hole_is
      FAIL: test_a_beat_with_a_frame_of_its_own_is_not_offered_a_hole
      FAIL: test_a_stepping_take_names_the_step_and_withdraws_the_verdict
      FAIL: test_no_document_still_explains_a_positive_skew_as_a_partial_loss

PASS  break: reference/limits.md goes back to explaining the skew as a partial loss
      in reference/limits.md: muxer cannot produce a partial shift — measured at **97.0–100.2 %** …
      FAIL: test_no_document_still_explains_a_positive_skew_as_a_partial_loss

PASS  break: tests/README.md goes back to explaining the skew as a partial loss
      in tests/README.md: and this list carried that as a second open defect. **It is retracte…
      FAIL: test_no_document_still_explains_a_positive_skew_as_a_partial_loss

PASS  break: the stepping message stops measuring the hole it is about
      in tests/smoke: gap = clock.hole(t)…
      FAIL: test_a_beat_inside_the_hole_is_told_how_wide_the_hole_is

PASS  break: every beat of a stepping take is told the video has no frame for it
      in tests/smoke: if gap…
      FAIL: test_a_beat_with_a_frame_of_its_own_is_not_offered_a_hole

PASS  break: a stitched log overlaps at the seam and the artifact says nothing
      in stitching.py: if overlap <= 0:…
      ERROR: test_a_pair_inside_one_segment_is_reported_and_not_called_a_seam
      ERROR: test_an_overlap_the_recorded_steps_do_not_explain_says_so
      ERROR: test_an_unmeasured_clock_leaves_the_verdict_null_rather_than_zero
      ERROR: test_the_steps_that_caused_it_are_shown_to_put_the_frames_in_order

PASS  break: every seam is reported as an overlap, including the ones in order
      in stitching.py: if overlap <= 0:…
      FAIL: test_a_beat_with_no_end_is_skipped_rather_than_raising
      FAIL: test_a_healthy_merge_and_a_single_take_say_nothing_at_all
      FAIL: test_a_merge_whose_parts_fit_their_own_videos_reports_none
      FAIL: test_a_seam_the_step_pushed_past_is_reported_with_its_size

PASS  break: the video's clock is read backwards, so the verdict is inverted
      in stitching.py: place(before, ends).at - place(after, starts).at, 3…
      FAIL: test_an_overlap_the_recorded_steps_do_not_explain_says_so
      FAIL: test_the_markdown_names_the_beats_the_size_and_the_verdict
      FAIL: test_the_steps_that_caused_it_are_shown_to_put_the_frames_in_order

PASS  break: an overlap nobody could check is reported as if the clock had explained it
      in stitching.py: if state.get("applied")…
      FAIL: test_an_unmeasured_clock_leaves_the_verdict_null_rather_than_zero
      FAIL: test_the_markdown_does_not_claim_an_order_nobody_could_check

PASS  break: the merge clamps the overlap away instead of reporting it
      in stitching.py: merged["t_start"] = _shift(beat.get("t_start"), offset)…
      ERROR: test_a_beat_with_no_end_is_skipped_rather_than_raising
      ERROR: test_a_pair_inside_one_segment_is_reported_and_not_called_a_seam
      ERROR: test_an_overlap_the_recorded_steps_do_not_explain_says_so
      ERROR: test_an_unmeasured_clock_leaves_the_verdict_null_rather_than_zero

PASS  break: timeline.md stops saying its own beat table runs backwards
      in timeline.py: if not rows:…
      FAIL: test_the_markdown_does_not_claim_an_order_nobody_could_check
      FAIL: test_the_markdown_names_the_beats_the_size_and_the_verdict
```

Round 2's seven, same driver:

```
PASS  break: an endpoint the step deleted is published as though it had a frame
      in stitching.py: "previous_no_video": round(placed_before.lost, 3)…
      FAIL: test_an_endpoint_the_step_deleted_is_not_reported_as_a_frame

PASS  break: timeline.md calls the frames fine over a beat the step deleted
      in timeline.py: elif video <= 0 and deleted:…
      FAIL: test_an_endpoint_the_step_deleted_is_not_reported_as_a_frame

PASS  break: every overlap is reported as having a beat with no video
      in timeline.py: elif video <= 0 and deleted:…
      FAIL: test_a_pair_whose_endpoints_both_have_frames_still_says_they_are_fine

PASS  break: the merge reports a seam the suite's own bar tolerates
      in stitching.py: if overlap <= MERGE_OVERLAP_SLACK_S:…
      FAIL: test_a_seam_inside_the_slack_is_not_called_an_overlap (t_end=6.0006)
      FAIL: test_a_seam_inside_the_slack_is_not_called_an_overlap (t_end=6.004)

PASS  break: the merge's slack stops being the slack the suite grades
      in stitching.py: MERGE_OVERLAP_SLACK_S = 0.005…
      FAIL: test_a_seam_inside_the_slack_is_not_called_an_overlap
      FAIL: test_the_slack_here_is_the_slack_the_suite_grades

PASS  break: a seam between two parts of one name is reported as inside a segment
      in stitching.py: "seam": after.get("index") in seams,…
      FAIL: test_a_seam_between_two_parts_of_the_same_name_is_still_a_seam

PASS  break: the overlap header counts rows timeline.md does not print
      in timeline.py: f"{len(rows)} beat(s) below start before the beat before them "…
      FAIL: test_the_markdown_counts_the_rows_it_prints
```

The 0.6 ms seam the reviewer measured is now a *quiet* case in `test_a_seam_inside_the_slack_is_not_called_an_overlap`, alongside 4 ms and 6 ms either side of the bar itself, so the constant is pinned at its boundary rather than well inside it.

Round 2 also broke three existing round-1 entries whose literals it moved; the driver's exactly-once rule caught all three (`ABORT: injection … matched 0 times`) rather than letting them pass over nothing.

One injection failed on its first run and is worth recording: `A capture that lost less wall ` did **not** contain the banned literal `lost less wall time`, so the two retraction tests stayed green and the driver reported *these tests did NOT fail*. The replacement was corrected to carry the whole phrase.

`tests/README.md` could not be fault-injected before this change — the driver read it out of the working tree. It is now copied into the temp tree and `UNIT_README` points at the copy, which is what makes the third document's guard provable.

## Before / after

| | before (`f0fccc6`) | round 1 | after round 2 |
|---|---|---|---|
| `tests/unit` | 356 tests, 225 injections | 371 / 236 | **377 tests, 243 injections** |
| `tests/ci-unit` | 54 tests, 18 injections | 54 / 18 | 54 / 18 (unchanged) |
| `tests/smoke-inject` | 51 entries, 17 of 42 ungraded | unchanged | unchanged |

```
$ tests/unit                     -> Ran 377 tests ... OK
$ tests/unit --fault-inject      -> All 243 injections were caught.
$ tests/unit --budget            -> SKILL.md: 600 lines (~14,250 tokens), budget 600 lines
$ tests/ci-unit                  -> Ran 54 tests ... OK
$ tests/ci-unit --fault-inject   -> All 18 injections were caught.
$ tests/lint                     -> All checks passed! / 14 files already formatted
$ tests/lint --self-test         -> One pin, one file set, one command
$ tests/smoke-inject --self-test -> Every guard refused what it exists to refuse.
$ uvx ruff@0.16.1 format .       -> 14 files left unchanged
$ mypy skills/demo-video/helpers/ -> Success: no issues found in 13 source files
```

No demo video: neither part can be verified by watching. The overlap is a field in a JSON file and the retraction is prose.

## Stated limits — none of these block, and none is measured here

- **No smoke arm reaches the overlap.** It needs a host that steps its wall clock inside a segment; `--segments-only` cannot be made to produce one, and an assertion that only bites on a stepping box grades the box. `MergeOverlap` grades the arithmetic on hand-written documents and nothing grades it against a real stepping stitch.
- **`stitch()` prints nothing about it on stderr.** The criterion is about the artifacts, and a live warning inside `stitch()` would be code no browser-free test can reach.
- **`RETRACTED` is a substring tripwire.** The same claim written in new words is not caught, and no assertion could be — "does this paragraph assert a false mechanism" is not decidable from substrings. Same limit `VERDICTS` already states.
- **`test_the_retracted_partial_loss_is_in_none_of_the_four_answers` is mostly dominated** by the document sweep, since the message is a literal in `tests/smoke`. What it alone can see is a claim assembled at run time. Kept and labelled rather than dropped.
- **Unverified assumption, raised in review and not settled here:** whether #18's idle loss — a segment's video being routinely shorter than the time its beats say it took — could exceed a capture's tail on some host and produce a seam overlap on a **clock-steady** box. Circumstantial evidence says no: `check_beats` has enforced 5 ms of seam monotonicity on merged logs since before this PR, and `--segments-only` has been green. That is inference, not measurement, and nothing here measures it.
- **Not re-measured:** that #255's three original takes were in-hole readings specifically. Their artifacts are gone; the reinterpretation is inference from the muxer's structure plus 10 direct measurements.
- **Untouched, as scoped:** `.github/`, `target.py`, `core.py`'s target guard, and #259's caption-band verification pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
