### PR TITLE
A host that is a number is not a bare hostname (#265)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/target.py
+++ b/skills/demo-video/helpers/demo_recording/target.py
@@ -12,11 +12,34 @@ So the target is classified, not trusted:
 | loopback | `127.0.0.1`, `localhost`, `[::1]` | always allowed |
 | private | `10.x`, `192.168.x`, `svc.internal`, a bare hostname | allowed only with the private opt-in |
 | public | `demo.example.com`, `93.184.216.34` | **refused, with no option that permits it** |
+| malformed | `ftp://x`, `3639549472`, `0x8080808` | refused, and no opt-in reaches it either |
 
 There is deliberately **no `allow_public`**, in any form — no parameter, no
 environment variable, no workflow input. Recording against a public host is not
 a thing this skill should make easy to configure; a team that truly needs it has
 to write their own runner and own that decision explicitly.
+
+**A host that is a number is malformed, not a bare hostname.** `3639549472`,
+`0x8080808` and `127.1` carry no dot, and reading them as single-label service
+names is how a public host got through the guard: the WHATWG URL parser, every
+browser and every resolver read a host whose last label is a number as an IPv4
+address, so `http://3639549472/` is `216.239.30.32`. This module does not decode
+those forms, it refuses them — a second implementation of that parser (decimal,
+octal, hex, and the 1-, 2- and 3-part shorthands) would be another thing to get
+right, and getting it wrong in the permissive direction is exactly the failure
+being fixed. The caller writes the address out as a dotted quad or a bracketed
+IPv6 literal, and the classifier grades the address rather than a guess at it.
+
+**Two edges that are correct and surprising**, so they are written down rather
+than rediscovered:
+
+- `100.64.0.0/10` — the CGNAT range — is **public**, and therefore refused with
+  no way to permit it. A team whose test network hands out addresses in that
+  range cannot record against them at all; give the host a name under one of the
+  reserved suffixes above, or record against loopback.
+- `169.254.169.254` — cloud instance metadata — is link-local and therefore
+  **private**, so the private opt-in allows it. The opt-in exists for a service
+  name on a container network, and it permits this too.
 
 **This is a target classifier, not a secret scanner.** The distinction is the
 whole design (issue #138): the skill has no masking, no scrubbing and no
@@ -30,12 +53,24 @@ environment variable this module was not given, from a config file, by string
 concatenation — is invisible to `scan`, and a recorder guarded on `base_url`
 does not see a `fetch` the page makes to somewhere else. This is a static check
 on the configuration and the source text, not a network egress control.
+
+**The second limit: this is not a UTS-46 implementation.** A host is folded with
+`unicodedata.normalize` and the three full stops UTS-46 maps to `.` before the
+dot test, because `evil。com` has no ASCII dot and used to classify as a bare
+hostname while Chromium navigated to `evil.com`. What that stdlib fold does
+*not* do, and a third-party `idna` dependency in a shipped skill would: decode
+`xn--` labels, reject characters IDNA disallows, apply the bidi and
+joiner rules, or notice a homoglyph (`gοogle.com` with a Greek omicron is a
+different name from `google.com` and both classify public here, which is the
+harmless direction). Every gap listed is a host that classifies *public* or
+*malformed* — refused — rather than one that slips through as private.
 """
 
 from __future__ import annotations
 
 import ipaddress
 import re
+import unicodedata
 from urllib.parse import urlsplit
 
 LOOPBACK, PRIVATE, PUBLIC, MALFORMED = "loopback", "private", "public", "malformed"
@@ -52,6 +87,24 @@ _PRIVATE_SUFFIXES = (
 )
 
 URL_LITERAL = re.compile(r"https?://[^\s'\"`<>)\]}\\]+")
+
+# The three characters UTS-46 (and RFC 3490 §3.1) map to `.`, spelled out
+# rather than left to `unicodedata.normalize`: that turns U+FF0E into a full
+# stop and U+FF61 into U+3002, but nothing in the stdlib turns U+3002 into `.`,
+# and a host with no ASCII dot in it used to read as a bare hostname.
+_FULL_STOPS = str.maketrans(
+    {
+        "。": ".",  # IDEOGRAPHIC FULL STOP
+        "．": ".",  # FULLWIDTH FULL STOP
+        "｡": ".",  # HALFWIDTH IDEOGRAPHIC FULL STOP
+    }
+)
+
+# A label a URL parser reads as an IPv4 number: decimal or octal (`0100`) as
+# digits, or `0x`-prefixed hex — `0x` alone is a valid zero. Anchored with
+# `fullmatch` at the call site.
+_DECIMAL_LABEL = re.compile(r"[0-9]+")
+_HEX_LABEL = re.compile(r"0x[0-9a-f]*")
 
 # How a caller words the way out of a *private* refusal. There is no equivalent
 # for a public one, and that asymmetry is the point of the module.
@@ -72,6 +125,24 @@ class TargetRefused(RuntimeError):
     """The recorder will not be pointed at this host."""
 
 
+def _fold(host: str) -> str:
+    """A host in the form the rules below read: dotted, width-folded, lower."""
+    host = unicodedata.normalize("NFKC", host)
+    return host.translate(_FULL_STOPS).rstrip(".").lower()
+
+
+def _ends_in_a_number(host: str) -> bool:
+    """Whether a URL parser would read this host as an address, not a name.
+
+    The WHATWG rule, and the one browsers implement: a host whose **last** label
+    is a number is an IPv4 address in some notation, never a DNS name. Callers
+    reach this only after `ipaddress` has already declined the host, so anything
+    it answers True for is a notation this module refuses to decode.
+    """
+    last = host.rpartition(".")[2]
+    return bool(_DECIMAL_LABEL.fullmatch(last) or _HEX_LABEL.fullmatch(last))
+
+
 def classify(url: str) -> tuple[str, str]:
     """Return (class, why) for a URL string."""
     try:
@@ -86,7 +157,9 @@ def classify(url: str) -> tuple[str, str]:
         return MALFORMED, f"unparseable host ({exc})"
     if not host:
         return MALFORMED, "no host"
-    host = host.rstrip(".").lower()
+    host = _fold(host)
+    if not host:
+        return MALFORMED, "no host"
 
     try:
         ip = ipaddress.ip_address(host)
@@ -99,6 +172,15 @@ def classify(url: str) -> tuple[str, str]:
             return PRIVATE, f"private address {ip}"
         return PUBLIC, f"publicly routable address {ip}"
 
+    if _ends_in_a_number(host):
+        # Before the single-label branch below, which is what used to answer
+        # for these: `ipaddress` has already declined the host, so this is a
+        # number written in a notation this module will not decode.
+        return MALFORMED, (
+            f"{host} is a number, not a host name — a browser reads it as an "
+            "IPv4 address, and this classifier will not guess which one. "
+            "Write it as a dotted quad, or as a bracketed IPv6 literal"
+        )
     if host == "localhost" or host.endswith(".localhost"):
         return LOOPBACK, f"{host} resolves to loopback by RFC 6761"
     if host.endswith(_PRIVATE_SUFFIXES):

--- a/skills/demo-video/reference/ci.md
+++ b/skills/demo-video/reference/ci.md
@@ -107,6 +107,22 @@ paying for a browser first. `--allow-private` mirrors
 `allow-private-network-target`; there is no `--allow-public`, and adding one
 to the workflow would not help, because the recorder refuses independently.
 
+**A guard run that checked nothing says so.** `--url ""` — a step passing a
+variable nobody exported — prints `0 URL(s) checked — nothing was verified` and
+exits 0, where it used to print `all loopback`. Exit 0 is deliberate: a terminal
+storyboard has no URL, and a guard that failed those would be turned off. A
+caller who knows a URL should have been there passes `--require`, which turns
+the empty run into a refusal. The workflow does not, for the terminal-storyboard
+reason above; a job whose target is always a URL should add it.
+
+**A host that is a number is refused, not read as a service name.**
+`http://3639549472/`, `http://0x8080808/` and `http://127.1/` are all IPv4
+addresses to a browser (the first is 216.239.30.32), and they carry no dot, so
+they used to classify as a container service name — which
+`allow-private-network-target` permits. They are malformed now: write the
+address as a dotted quad. The same applies to a host whose labels are separated
+by U+3002, U+FF0E or U+FF61 rather than `.`, which Chromium reads as full stops.
+
 **Two things the recorders check that the CLI does not**, so a clean guard run
 is not a promise the take will start. `DEMO_VIDEO_BASE_URL` in the *recording*
 environment is classified by both recorders even when the storyboard passes a

--- a/skills/demo-video/scripts/demo-target-guard
+++ b/skills/demo-video/scripts/demo-target-guard
@@ -21,6 +21,14 @@ same rule to `http(s)://` literals inside a storyboard (or any other file, such
 as a workflow's `extra-env` block), so a hardcoded production URL is refused
 before the browser opens.
 
+**Checking nothing is not a pass.** A step that passes an unset variable —
+`--url "$DEMO_VIDEO_BASE_URL"` with nothing exported — used to print
+`0 URL(s) checked, all loopback` and exit 0, a green line asserting a property
+of a set it never looked at. It now says that nothing was verified, and
+`--require` turns that into a refusal for a caller who knows a URL should have
+been there. The default stays 0 because a terminal storyboard legitimately has
+no URL at all, and a guard that failed those would be turned off.
+
 Exit status: 0 when everything checked may be recorded against, 2 when
 something may not, and 1 for a usage error.
 """
@@ -50,6 +58,11 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument(
         "--allow-private", action="store_true", help="permit private/internal hosts"
     )
+    ap.add_argument(
+        "--require",
+        action="store_true",
+        help="refuse if no URL was checked at all (an unset variable is not a target)",
+    )
     args = ap.parse_args(argv)
 
     problems: list[str] = []
@@ -72,6 +85,12 @@ def main(argv: list[str] | None = None) -> int:
             if (reason := check(url, args.allow_private)) is not None:
                 problems.append(f"{path}: {reason}")
 
+    if args.require and checked == 0:
+        problems.append(
+            "no URL reached the classifier, and --require says one should have. "
+            "An empty --url is an unset variable, not a loopback target."
+        )
+
     if problems:
         print(
             "Refusing to record. A demo recorded in CI is an outbound artifact.",
@@ -80,6 +99,15 @@ def main(argv: list[str] | None = None) -> int:
         for line in problems:
             print(f"  - {line}", file=sys.stderr)
         return 2
+
+    if checked == 0:
+        # Not "all loopback": there was no "all". Saying so is the difference
+        # between a guard that ran and a guard that had nothing to look at.
+        print(
+            "target guard: 0 URL(s) checked — nothing was verified. "
+            "Pass --require to make that a refusal."
+        )
+        return 0
 
     print(
         f"target guard: {checked} URL(s) checked, all loopback"

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -231,6 +231,70 @@ class Classify(unittest.TestCase):
         self.assertEqual(guard.classify("file:///etc/passwd")[0], guard.MALFORMED)
         self.assertEqual(guard.classify("not a url")[0], guard.MALFORMED)
 
+    def test_a_numeric_host_is_not_a_bare_hostname(self):
+        # The fail-open this class shipped: no dot, so "a single label, so
+        # private", so `--allow-private` — the ordinary CI setting for a
+        # container service name — let it through. Each of these is an IPv4
+        # address to the WHATWG parser and to every browser and resolver:
+        # `3639549472` is 216.239.30.32, `010.0.0.1` is 8.0.0.1 read as octal.
+        for url in (
+            "http://3639549472/",
+            "http://127.1/",
+            "http://010.0.0.1/",
+            "http://1.2.3.4.5/",
+        ):
+            with self.subTest(url=url):
+                self.assertEqual(guard.classify(url)[0], guard.MALFORMED)
+
+    def test_a_hex_host_is_a_number_too(self):
+        # Graded apart from the decimal forms because it is a separate pattern
+        # in the module, and a rule that read only digits would leave the hex
+        # spelling of the same address classified private.
+        for url in ("http://0x8080808/", "http://1.2.3.0x4/"):
+            with self.subTest(url=url):
+                self.assertEqual(guard.classify(url)[0], guard.MALFORMED)
+
+    def test_a_name_that_merely_contains_digits_is_not_a_number(self):
+        # The control on the two above, and the boundary the rule is drawn at:
+        # "the last label is a number" is the browsers' rule, so digits
+        # anywhere else are part of a name. Without this, a classifier that
+        # called *everything* malformed would satisfy both tests above.
+        self.assertEqual(guard.classify("http://api2/")[0], guard.PRIVATE)
+        self.assertEqual(guard.classify("http://3com.com/")[0], guard.PUBLIC)
+        self.assertEqual(guard.classify("http://127.0.0.1:8901/")[0], guard.LOOPBACK)
+
+    def test_a_unicode_full_stop_separates_labels_like_an_ascii_one(self):
+        # UTS-46 maps all three to `.`, so Chromium navigates to evil.com.
+        # None of them contains an ASCII dot, so all three used to classify as
+        # a single-label private name. The reason is asserted as well as the
+        # class: what makes this public is the fold, and a verdict alone would
+        # also be reached by a rule that called every unparseable host public.
+        for url in ("http://evil。com/", "http://evil．com/", "http://evil｡com/"):
+            with self.subTest(url=url):
+                kind, why = guard.classify(url)
+                self.assertEqual(kind, guard.PUBLIC)
+                self.assertIn("evil.com", why)
+
+    def test_a_fullwidth_number_is_still_a_number(self):
+        # The other half of the fold, and the reason it is not three character
+        # substitutions: the digits have widths too, and a browser reads
+        # U+FF13… as 3639549472 before it reads it as an address.
+        self.assertEqual(
+            guard.classify("http://３６３９５４９４７２/")[0],
+            guard.MALFORMED,
+        )
+
+    def test_the_two_edges_the_module_documents(self):
+        # Both are correct, both surprise people, and neither was pinned by a
+        # test before. CGNAT is publicly routable as far as this module is
+        # concerned — so a team whose test network uses 100.64/10 cannot record
+        # against it at all, with no opt-in that helps.
+        self.assertEqual(guard.classify("http://100.64.1.1/")[0], guard.PUBLIC)
+        # Cloud instance metadata is link-local, so it is private, so the
+        # private opt-in reaches it. The opt-in exists for a service name on a
+        # container network and it permits this too.
+        self.assertEqual(guard.classify("http://169.254.169.254/")[0], guard.PRIVATE)
+
 
 class Check(unittest.TestCase):
     def test_loopback_passes_without_any_opt_in(self):
@@ -295,6 +359,31 @@ class GuardExitCode(unittest.TestCase):
         done = self._run("--url", "https://tickets.acme.com", "--allow-private")
         self.assertEqual(done.returncode, 2)
         self.assertIn("tickets.acme.com", done.stderr)
+
+    def test_a_numeric_host_exits_two_even_with_the_private_opt_in(self):
+        # `--allow-private` is what a workflow passes for a container service
+        # name, and it is the configuration this host reached exit 0 under.
+        done = self._run("--url", "http://3639549472/", "--allow-private")
+        self.assertEqual(done.returncode, 2)
+        self.assertIn("3639549472", done.stderr)
+
+    def test_checking_nothing_is_not_reported_as_checking_everything(self):
+        # A step that passes an unset variable. Exit 0 is deliberate — a
+        # terminal storyboard has no URL — but the line must not claim a
+        # property of the empty set it never looked at.
+        done = self._run("--url", "")
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertNotIn("all loopback", done.stdout)
+        self.assertIn("0 URL(s) checked", done.stdout)
+
+    def test_require_refuses_when_nothing_reached_the_classifier(self):
+        done = self._run("--url", "", "--require")
+        self.assertEqual(done.returncode, 2)
+        self.assertIn("no URL reached the classifier", done.stderr)
+        # And it is about the count, not about --require itself: a run that
+        # did check something is unaffected by the flag.
+        checked = self._run("--url", "http://127.0.0.1:8901", "--require")
+        self.assertEqual(checked.returncode, 0, checked.stderr)
 
 
 # --------------------------------------------------------------------------
@@ -790,6 +879,85 @@ INJECTIONS = [
         ],
     ),
     (
+        # The fail-open as it shipped: with this branch gone, a host that is a
+        # number falls through to "no dot, so a single-label service name",
+        # which `--allow-private` permits. Graded through both doors again.
+        "a numeric host reads as a bare hostname the private opt-in covers",
+        "target.py",
+        "    if _ends_in_a_number(host):",
+        "    if False:",
+        [
+            "Classify.test_a_numeric_host_is_not_a_bare_hostname",
+            "Classify.test_a_hex_host_is_a_number_too",
+            "Classify.test_a_fullwidth_number_is_still_a_number",
+            "GuardExitCode.test_a_numeric_host_exits_two_even_with_the_private_opt_in",
+        ],
+    ),
+    (
+        # One notation deep rather than the whole branch: the decimal forms
+        # keep classifying, and only the hex spelling of the same address
+        # stops. A single break at the branch above would not tell them apart.
+        "the hex notation stops being read as a number",
+        "target.py",
+        '_HEX_LABEL = re.compile(r"0x[0-9a-f]*")',
+        '_HEX_LABEL = re.compile(r"(?!x)x")',
+        ["Classify.test_a_hex_host_is_a_number_too"],
+    ),
+    (
+        "the Unicode label separators stop being folded to a dot",
+        "target.py",
+        '    return host.translate(_FULL_STOPS).rstrip(".").lower()',
+        '    return host.rstrip(".").lower()',
+        ["Classify.test_a_unicode_full_stop_separates_labels_like_an_ascii_one"],
+    ),
+    (
+        # The other half of the fold, and it is invisible to the test above,
+        # which U+FF0E survives on the explicit table alone.
+        "the width fold goes, so a fullwidth number is a name again",
+        "target.py",
+        '    host = unicodedata.normalize("NFKC", host)',
+        "    host = host",
+        ["Classify.test_a_fullwidth_number_is_still_a_number"],
+    ),
+    (
+        # The documented edge, broken the way somebody would actually break
+        # it: a carve-out for the metadata endpoint, which reads as hardening
+        # and silently makes the module's table wrong. Deleting `is_link_local`
+        # instead was tried and grades nothing — every IPv4 link-local address
+        # is also `is_private`, so the branch answers the same either way.
+        "the link-local range is carved out of private",
+        "target.py",
+        "        if ip.is_private or ip.is_link_local or ip.is_unspecified:",
+        '        if ip.is_link_local:\n            return PUBLIC, f"link-local {ip}"\n'
+        "        if ip.is_private or ip.is_unspecified:",
+        ["Classify.test_the_two_edges_the_module_documents"],
+    ),
+    (
+        # And the same edge broken the other way: CGNAT quietly permitted
+        # under the private opt-in, which is what the documented verdict
+        # exists to say does not happen.
+        "the CGNAT range starts classifying private",
+        "target.py",
+        "        if ip.is_private or ip.is_link_local or ip.is_unspecified:",
+        "        if ip.is_private or ip.is_link_local or ip.is_unspecified or ip.version == 4 and ip in ipaddress.ip_network('100.64.0.0/10'):",
+        ["Classify.test_the_two_edges_the_module_documents"],
+    ),
+    (
+        "checking nothing reports as checking everything",
+        "scripts/demo-target-guard",
+        '        print(\n            "target guard: 0 URL(s) checked — nothing was verified. "\n'
+        '            "Pass --require to make that a refusal."\n        )\n        return 0\n',
+        "        pass\n",
+        ["GuardExitCode.test_checking_nothing_is_not_reported_as_checking_everything"],
+    ),
+    (
+        "--require is accepted and ignored",
+        "scripts/demo-target-guard",
+        "    if args.require and checked == 0:",
+        "    if False:",
+        ["GuardExitCode.test_require_refuses_when_nothing_reached_the_classifier"],
+    ),
+    (
         "the guard forgets the --allow-private opt-in and lets private through",
         "target.py",
         "    if kind == PRIVATE and allow_private:\n        return None",
@@ -948,6 +1116,10 @@ def fault_inject() -> int:
             shutil.copy(Path(__file__).resolve(), inner)
             if script == "target.py":
                 target = skill / "helpers" / "demo_recording" / script
+            elif script == "scripts/demo-target-guard":
+                # The CLI ships with the skill rather than under
+                # `.github/scripts/`, and `GuardExitCode` runs the copy.
+                target = skill / script
             elif script == "demo-video.yml":
                 target = workflow
             elif script == "tests/ci-unit":

--- a/tests/unit
+++ b/tests/unit
@@ -2555,6 +2555,11 @@ class VendoredAssets(unittest.TestCase):
 TARGET_LOOPBACK = "http://127.0.0.1:8901"
 TARGET_PRIVATE = "http://10.0.0.4:8080"
 TARGET_PUBLIC = "https://tickets.acme.com"
+# Two public hosts that carry no ASCII dot, which is what a bare hostname was
+# recognised by. `3639549472` is 216.239.30.32 to every URL parser there is,
+# and U+3002 is a label separator to UTS-46, so Chromium loads evil.com.
+TARGET_NUMERIC = "http://3639549472"
+TARGET_UNICODE_DOT = "http://evil。com"
 
 # The variables the guard reads. Pinned rather than inherited wherever a
 # recorder is constructed in this file: a suite whose recorders refuse or allow
@@ -2637,6 +2642,23 @@ class TargetGuard(unittest.TestCase):
             ).base_url,
             TARGET_PRIVATE,
         )
+
+    def test_the_private_opt_in_does_not_reach_a_host_that_is_a_number(self):
+        # The configuration this got through under, and it is the ordinary
+        # one: `allow_private=True` is what a container service name needs, and
+        # a host with no dot in it used to be read as exactly that. Written
+        # from the caller's side like everything else here — what is graded is
+        # that the recorder refuses, not which class the rule assigns.
+        for settings in ({}, {"allow_private": True}):
+            with self.subTest(settings=settings):
+                with self.assertRaises(TargetRefused) as caught:
+                    self.build(base_url=TARGET_NUMERIC, **settings)
+                self.assertIn(TARGET_NUMERIC, str(caught.exception))
+
+    def test_the_private_opt_in_does_not_reach_a_unicode_label_separator(self):
+        with self.assertRaises(TargetRefused) as caught:
+            self.build(base_url=TARGET_UNICODE_DOT, allow_private=True)
+        self.assertIn(TARGET_UNICODE_DOT, str(caught.exception))
 
     def test_the_spelling_a_boolean_workflow_input_renders_is_accepted(self):
         # Every other test here writes `"1"`, and the CI path never does. The
@@ -9472,6 +9494,25 @@ INJECTIONS = [
         '    if kind == PUBLIC:\n        return f"{url} — classified {PUBLIC}: {why}. {PUBLIC_REFUSAL}"',
         "    if kind == PUBLIC:\n        return None",
         ["TargetGuard.test_nothing_gets_a_public_target_through"],
+    ),
+    (
+        # The fail-open, at the recorder rather than at the CLI: without this
+        # branch a host that is a number falls through to "no dot, so a
+        # single-label service name", which the private opt-in permits.
+        "the rule reads a numeric host as a bare hostname again",
+        "target.py",
+        "    if _ends_in_a_number(host):",
+        "    if False:",
+        ["TargetGuard.test_the_private_opt_in_does_not_reach_a_host_that_is_a_number"],
+    ),
+    (
+        "the rule stops folding the Unicode label separators",
+        "target.py",
+        '    return host.translate(_FULL_STOPS).rstrip(".").lower()',
+        '    return host.rstrip(".").lower()',
+        [
+            "TargetGuard.test_the_private_opt_in_does_not_reach_a_unicode_label_separator"
+        ],
     ),
     (
         "the web recorder resolves base_url and never classifies it",


### PR DESCRIPTION
Fixes #265.

**Acceptance criterion.** No spelling of a public host classifies private, and
no line the guard prints claims a verdict it did not reach. Three defects, all
fail-open, all reachable under `--allow-private` — the ordinary CI setting for
a container service-name target — and all in the one security-shaped thing this
skill ships.

## What changed

**A host whose last label is a number is malformed.** `3639549472` is
216.239.30.32 to the WHATWG parser and to every browser and resolver;
`0x8080808` is 8.8.8.8. Both carry no dot, so `classify` read them as
single-label service names. They are refused now rather than decoded: a second
implementation of that parser (decimal, octal, hex, and the 1-, 2- and 3-part
shorthands) is another thing to get right, and getting it wrong permissively is
the defect being fixed. The caller writes the address out as a dotted quad, and
the classifier grades the address rather than a guess at it. There is no new
option, and nothing added permits a public target.

**The host is folded before the dot test.** `unicodedata.normalize("NFKC", …)`
plus an explicit table for U+3002 / U+FF0E / U+FF61, which is what UTS-46 maps
to `.`. No `idna` dependency: the module is dependency-free and the CLI is a
PEP 723 script with `dependencies = []`. What the stdlib fold does *not* do is
in the module docstring — no punycode decoding, no IDNA-disallowed characters,
no bidi or joiner rules, no homoglyph detection. **Every one of those gaps is a
host that classifies public or malformed, i.e. refused; none of them is a host
that slips through as private**, which is the property that matters here.

**Checking nothing no longer reads as passing.** `--url ""` prints
`0 URL(s) checked — nothing was verified` instead of `0 URL(s) checked, all
loopback`, and `--require` turns the empty run into a refusal (exit 2). The
default stays exit 0 because a terminal storyboard legitimately has no URL, and
a guard that failed those would be turned off; the shipped workflow therefore
does not pass `--require`. That is a stated limit, not an oversight — see below.

**The two fail-closed edges are now in the module's table and pinned by a test:**
`100.64.0.0/10` (CGNAT) is public and refused with no opt-in that helps, so a
team whose test network uses it cannot record at all; `169.254.169.254` (cloud
instance metadata) is link-local, therefore private, therefore permitted by the
private opt-in.

## Classifications, before and after

`allowed`/`refused` is `check(url, allow_private=True)` — the permissive
setting, which is where the fail-opens lived.

| URL | | before | after |
|---|---|---|---|
| `http://3639549472/` | 216.239.30.32 in integer form | private / **allowed** | malformed / refused |
| `http://0x8080808/` | 8.8.8.8 in hex | private / **allowed** | malformed / refused |
| `http://evil。com/` | U+3002 separator | private / **allowed** | public / refused |
| `http://evil．com/` | U+FF0E separator | private / **allowed** | public / refused |
| `http://evil｡com/` | U+FF61 separator | private / **allowed** | public / refused |
| `http://127.1/` | shorthand for 127.0.0.1 | public / refused | malformed / refused |
| `http://010.0.0.1/` | 8.0.0.1, read as octal | public / refused | malformed / refused |
| `http://100.64.1.1/` | CGNAT | public / refused | public / refused |
| `http://169.254.169.254/` | cloud instance metadata | private / allowed | private / allowed |
| `http://0.0.0.0/` | unspecified | private / allowed | private / allowed |
| `http://[::1]/` | IPv6 loopback | loopback / allowed | loopback / allowed |
| `http://[::ffff:127.0.0.1]/` | IPv4-mapped loopback | private / allowed | private / allowed |
| `http://example.com./` | trailing dot | public / refused | public / refused |
| `http://evil.example.com@127.0.0.1/` | userinfo, not a host | loopback / allowed | loopback / allowed |
| `http://web/` | container service name | private / allowed | private / allowed |
| `http://api2/` | a name that ends in a digit | private / allowed | private / allowed |
| `http://3com.com/` | a name that starts with one | public / refused | public / refused |

Zero URLs, which is the CLI rather than the classifier:

| command | before | after |
|---|---|---|
| `demo-target-guard --url ""` | `0 URL(s) checked, all loopback`, exit 0 | `0 URL(s) checked — nothing was verified.`, exit 0 |
| `demo-target-guard --url "" --require` | (no such flag) | `no URL reached the classifier`, exit 2 |
| `demo-target-guard --url http://127.0.0.1:8901 --require` | (no such flag) | `1 URL(s) checked, all loopback`, exit 0 |

Two rows changed class without changing verdict — `127.1` and `010.0.0.1` went
public → malformed. Both were already refused; what changes is that the message
now tells the reader to write the address out instead of calling a number a DNS
name.

**No existing test asserted the old behaviour for numeric hosts.** Both suites
were green, unchanged, against the fixed module before a single new assertion
was added (377 and 54). Nothing was edited to make a test pass.

## Assertions, and each one watched failing

Nine new tests, eight new injections in `tests/ci-unit` (18 → 26) and two in
`tests/unit` (243 → 245). `tests/ci-unit`'s injection dispatch grew a branch for
`scripts/demo-target-guard`, which lives under the skill rather than under
`.github/scripts/`; without it the two CLI injections would have aborted the run
rather than reported a pass.

```
PASS  break: a numeric host reads as a bare hostname the private opt-in covers
      in target.py: if _ends_in_a_number(host):…
      FAIL: test_a_fullwidth_number_is_still_a_number (Classify)
      FAIL: test_a_hex_host_is_a_number_too (Classify) (url='http://0x8080808/')
      FAIL: test_a_hex_host_is_a_number_too (Classify) (url='http://1.2.3.0x4/')
      FAIL: test_a_numeric_host_is_not_a_bare_hostname (Classify) (url='http://3639549472/')

PASS  break: the hex notation stops being read as a number
      in target.py: _HEX_LABEL = re.compile(r"0x[0-9a-f]*")…
      FAIL: test_a_hex_host_is_a_number_too (Classify) (url='http://0x8080808/')
      FAIL: test_a_hex_host_is_a_number_too (Classify) (url='http://1.2.3.0x4/')

PASS  break: the Unicode label separators stop being folded to a dot
      in target.py: return host.translate(_FULL_STOPS).rstrip(".").lower()…
      FAIL: test_a_unicode_full_stop_separates_labels_like_an_ascii_one (url='http://evil。com/')
      FAIL: test_a_unicode_full_stop_separates_labels_like_an_ascii_one (url='http://evil｡com/')

PASS  break: the width fold goes, so a fullwidth number is a name again
      in target.py: host = unicodedata.normalize("NFKC", host)…
      FAIL: test_a_fullwidth_number_is_still_a_number (Classify)

PASS  break: the link-local range is carved out of private
      in target.py: if ip.is_private or ip.is_link_local or ip.is_unspecified:…
      FAIL: test_the_two_edges_the_module_documents (Classify)

PASS  break: the CGNAT range starts classifying private
      in target.py: if ip.is_private or ip.is_link_local or ip.is_unspecified:…
      FAIL: test_the_two_edges_the_module_documents (Classify)

PASS  break: checking nothing reports as checking everything
      in scripts/demo-target-guard: print(…
      FAIL: test_checking_nothing_is_not_reported_as_checking_everything (GuardExitCode)

PASS  break: --require is accepted and ignored
      in scripts/demo-target-guard: if args.require and checked == 0:…
      FAIL: test_require_refuses_when_nothing_reached_the_classifier (GuardExitCode)

PASS  break: the rule reads a numeric host as a bare hostname again
      in target.py: if _ends_in_a_number(host):…
      FAIL: test_the_private_opt_in_does_not_reach_a_host_that_is_a_number (TargetGuard) (settings={'allow_private': True})

PASS  break: the rule stops folding the Unicode label separators
      in target.py: return host.translate(_FULL_STOPS).rstrip(".").lower()…
      FAIL: test_the_private_opt_in_does_not_reach_a_unicode_label_separator (TargetGuard)
```

Two things the injection pass caught that reading would not have:

- **An injection that graded nothing.** The first attempt at the metadata edge
  deleted `is_link_local` from the private branch — and the suite stayed green,
  because every IPv4 link-local address is also `is_private`, so the branch
  answers the same either way. The break in the manifest is the one somebody
  would actually make: a carve-out that reclassifies link-local as public, which
  reads as hardening and silently makes the module's table wrong. Recorded in a
  comment beside the entry so the dead version is not tried again.
- **Depth.** The hex notation and the width fold each have their own injection
  rather than sharing the branch-level one, so "the numeric rule is
  load-bearing" cannot stand in for "each notation is read".

Controls on the new assertions, since a classifier test fed only valid hosts
grades the parser and not the policy:
`test_a_name_that_merely_contains_digits_is_not_a_number` pins `api2` private,
`3com.com` public and `127.0.0.1:8901` loopback — a rule that called everything
malformed would satisfy every other new test and fails this one. The Unicode
test asserts the *reason* names `evil.com`, not only that the verdict is public,
which a rule refusing all unparseable hosts would also produce.

## Verification

Run on this branch. Baseline at `6581837` was `tests/unit` 377, `tests/ci-unit`
54 / 18 injections.

| command | result |
|---|---|
| `tests/unit` | Ran 379 tests — OK |
| `tests/unit --fault-inject` | All 245 injections were caught |
| `tests/unit --budget` | SKILL.md: 600 lines, budget 600 (unchanged; SKILL.md not touched) |
| `tests/ci-unit` | Ran 63 tests — OK |
| `tests/ci-unit --fault-inject` | All 26 injections were caught |
| `tests/lint` | All checks passed; 14 files already formatted |
| `tests/lint --self-test` | Every guard refused what it exists to refuse |
| `tests/smoke-inject --self-test` | Every guard refused what it exists to refuse; all 51 registered entries still match |
| `uvx ruff@0.16.1 format .` | 14 files left unchanged |
| `mypy 1.18.2 skills/demo-video/helpers/` | Success: no issues found in 13 source files |

`tests/smoke` was not run: it takes an exclusive machine lock and about ten
minutes, and nothing here touches the recorder's execution path.

**The CGNAT and metadata verdicts are not this machine's.** Both come from
`ipaddress`, whose ranges have moved between releases, so they were checked on
every interpreter the scripts accept (`requires-python >= 3.10`): 3.10.18,
3.11.14, 3.12.3, 3.13.11 and 3.14.6 all report `100.64.1.1` not private and
`169.254.169.254` private.

## Stated limits

- **The shipped workflow does not pass `--require`.** A terminal storyboard has
  no URL, and `base-url` can legitimately be empty, so requiring one would fail
  a valid configuration. A job whose target is always a URL should add the flag;
  the message change means the un-required case no longer lies either way.
- **Not UTS-46.** Listed above and in the module docstring. Adding `idna` would
  close it, at the cost of the first dependency in a shipped skill.
- **Numeric hosts are refused, not decoded.** `http://2130706433/` is loopback
  to a browser and malformed here; the caller writes `http://127.0.0.1/`. This
  is the deliberate direction — the alternative is a hand-rolled IPv4 parser
  whose bugs are fail-open.
- **Unchanged, and still true:** this is a static check on configuration and
  source text, not an egress control, and it is a target classifier, not a
  secret scanner (#138).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
