### PR TITLE
Resolve every pointer the shipped skill hands its reader, and check it (#269)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
   lint:
     name: lint (ruff, shellcheck)
     runs-on: ubuntu-latest
+    # `tests/lint --issues` reads the tracker; the workflow-level default is
+    # `contents: read` alone, which would give it a token that cannot list one.
+    permissions:
+      contents: read
+      issues: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -56,8 +61,25 @@ jobs:
       # ruff cannot: its checker does not read `.md` at any version, and its
       # formatter reads a fence without validating it — `def f(:` comes back
       # "1 file already formatted", exit 0 (#211).
-      - name: ruff check + ruff format --check + doc fences
+      #
+      # And it resolves every repo-shaped path the *shipped* documents name,
+      # which is a claim about the installed skill rather than about this
+      # checkout: `npx skills add` copies `skills/<name>/` and nothing else, so
+      # a reference document naming `tests/smoke` is telling its reader to open
+      # a file they do not have. Offline, hence this step and not the one below.
+      - name: ruff check + ruff format --check + doc fences + shipped pointers
         run: tests/lint --github
+
+      # The other half of the same question, split off because it is the only
+      # thing in this job that needs the network: an issue reference presented
+      # as pending work must be an issue that is still open. Twelve "Tracked in
+      # #N" pointers in this repo all resolved to closed issues, a defect filed
+      # and fixed once already as #209 — a reader is told somebody is on it
+      # when nobody is. One `gh issue list` call and a regex sweep, ~2 s.
+      - name: tests/lint --issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: tests/lint --issues --github
 
       # shellcheck comes from PyPI rather than apt so this is the same binary
       # a contributor gets from the same command locally.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ jobs:
 
 It records only storyboards whose application changed, sets an explicit
 artifact retention and says it in the comment, and **refuses to record against
-a public host** — see *Recording on a pull request (CI)* in
-[`skills/demo-video/SKILL.md`](skills/demo-video/SKILL.md) for the trigger
-policy, what is published, and what the target guard does not cover.
+a public host** — see
+[`skills/demo-video/reference/ci.md`](skills/demo-video/reference/ci.md) for the
+trigger policy, what is published, and what the target guard does not cover.
 
 ## Examples
 

--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -176,9 +176,11 @@ demo-video/
 
 **SKILL.md is loaded whole into an agent's context whenever the skill triggers;
 `reference/` is read on demand.** That is why the split exists and why it is
-worth keeping: the entry point is 33 kB (~12k tokens) against the 90 kB (~33k)
-of SKILL.md plus `reference/` together, and nothing was deleted to get there.
-`tests/unit --budget` prints the current figure.
+worth keeping: the always-loaded entry point is the smaller part of the skill's
+prose by a wide margin — `reference/` is the larger — and nothing was deleted to
+get there. No figure is quoted here because it goes stale on every edit;
+`wc -c SKILL.md reference/*.md` in the installed skill directory is the current
+one.
 
 The package and every generated storyboard carry PEP 723 metadata, so the
 dependency declaration travels with the files. Each storyboard embeds

--- a/skills/demo-video/helpers/demo_recording/__init__.py
+++ b/skills/demo-video/helpers/demo_recording/__init__.py
@@ -16,9 +16,10 @@ picture. Those six are what SKILL.md and `reference/` describe, and they are the
 contract.
 
 It used to be fifty. The package re-exported every threshold, schema constant
-and writer the recorder owns, because `tests/smoke` read the recorder's own
-internals back through the front door to grade itself — the shallow module in
-its plainest form, an interface as wide as its implementation. A storyboard
+and writer the recorder owns, because the end-to-end suite in this skill's own
+repository read the recorder's internals back through the front door to grade
+itself — the shallow module in its plainest form, an interface as wide as its
+implementation. A storyboard
 author opening this file met `CONTENT_MOVED_PIXELS` before `Recorder`.
 
 **Nothing became unreachable.** Every one of those names still lives in the
@@ -29,8 +30,9 @@ module that owns it and is imported from there:
     from demo_recording.frames import scene_times
 
 That is the distinction being drawn, and it is the only one: **a test may reach
-into the module it is testing; a storyboard may not.** `tests/smoke` and
-`tests/unit` both import through the owning module now. If you are consuming
+into the module it is testing; a storyboard may not.** Those suites live in
+this skill's repository and are not installed with it; they import through the
+owning module now. If you are consuming
 `timeline.json` programmatically from outside this repository, its schema and
 its renderer are `demo_recording.timeline`'s and always were — they are not
 private, they are simply not part of the storyboard surface, and this package

--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -53,9 +53,10 @@ from .timeline import capture_clock_correction, timeline_paths
 # All three are the same mistake — guessing which pixel change was the caption.
 # The sound fix is for the recorder to *state* the mapping rather than have it
 # inferred, by rendering the beat index into the frame where extraction can
-# read it back. That changes every recording's pixels, so it is its own change:
-# issue #60. Until then these frames are handed over bare, which is what the
-# uniform sampling they replace did too — they are simply aimed better.
+# read it back. That changes every recording's pixels, so it was raised as its
+# own change — issue #60, closed as not planned for exactly that reason. So
+# these frames are handed over bare, which is what the uniform sampling they
+# replace did too; they are simply aimed better.
 #
 # `frames.md` therefore prints no caption, no verb and no selector. It is the
 # sheet handed to a **context-free** reviewer who is asked what story the
@@ -101,9 +102,10 @@ FRAMES_SCHEMA = 1
 # of these is the app: the recorder's own chrome is a fifth to a third of the
 # picture and never moves. Measured over the reference takes — a page's first
 # paint 0.041, a caption appearing 0.022-0.025, a table filtering to one row
-# 0.013, an idle hold 0.007 and under. Issue #57 proposes scoring the app's own
-# rect instead, which would make one threshold mean the same thing in both
-# media.
+# 0.013, an idle hold 0.007 and under. Scoring the app's own rect instead would
+# make one threshold mean the same thing in both media; that was issue #57, and
+# it is closed as not planned, so this threshold is the answer and not a
+# placeholder for one.
 SCENE_MIN_SPAN_S = 3.0
 SCENE_THRESHOLD = 0.02
 SCENE_MAX_EXTRA = 3

--- a/skills/demo-video/helpers/demo_recording/stitching.py
+++ b/skills/demo-video/helpers/demo_recording/stitching.py
@@ -356,8 +356,9 @@ def _merge_overlaps(doc: dict) -> list[dict]:
     beat log, so the part's log outruns its own file and the next part's first
     beat is offset to a moment the previous part's last beat has not reached
     yet. Reproduced at −1.4684 s: `beat 21 t_end 37.451`, `beat 22 t_start
-    37.441`. The overlap scales with Δ less the capture's startup and tail, so a
-    ~1.5 s step reaches most of a second.
+    37.441` — a 10 ms overlap out of a 1.4684 s step, 0.7% of it, and the only
+    measurement of the size there is. Do not derive an expected overlap from Δ;
+    one point fixes no relationship.
 
     **Reported, not clamped, and that is the decision here.** Moving the beats
     to make the numbers rise would put them at instants neither the log nor the

--- a/skills/demo-video/reference/ci.md
+++ b/skills/demo-video/reference/ci.md
@@ -84,9 +84,9 @@ invisible to it.
 `DEMO_VIDEO_ALLOW_PRIVATE` on the `Record` step. It has to be: they classify
 the target again at construction, so an input that widened only the pre-check
 would pass the guard and then refuse the take one Chromium download later.
-That is not hypothetical — it is what this workflow did until
-`WorkflowGates` in `tests/ci-unit` was written, which now requires every fact
-the guard step classifies on to reach the recorder from the same input.
+That is not hypothetical — it is what this workflow did until a check in this
+repo's own suite was written, which now requires every fact the guard step
+classifies on to reach the recorder from the same input.
 
 **The classifier is the skill's, not the workflow's, and CI is not the only
 place it runs.** The rules live in `helpers/demo_recording/target.py`, which

--- a/skills/demo-video/reference/determinism.md
+++ b/skills/demo-video/reference/determinism.md
@@ -110,7 +110,9 @@ no matter what this section does:
   never assert on a frame that only exists while something is in flight.
 - **The terminal recorder's program.** `TerminalRecorder` runs a real PTY
   child; it does not see the frozen clock, so `date` in a terminal demo prints
-  the real time. Tracked in [#26](https://github.com/rogvid/skills/issues/26).
+  the real time. This is settled rather than pending —
+  [#26](https://github.com/rogvid/skills/issues/26) is closed, and the
+  behaviour above is the answer it closed on.
 - **Animation the browser does not drive with CSS.** `element.animate()` (Web
   Animations), `requestAnimationFrame` loops, canvas and WebGL keep running —
   no stylesheet can reach them
@@ -142,7 +144,7 @@ no matter what this section does:
   position, never delivered. No rule in the overlay can place a dot for an
   event the page never sees, so the take records no cursor for its whole
   length. [#230](https://github.com/rogvid/skills/issues/230) measured 12
-  `Recorder` takes per build against `tests/fixture`: the move never reached
+  `Recorder` takes per build against this repo's `tests/fixture` app: the move never reached
   the document in 3 of 12 takes on Chromium 136, 4 of 12 on 147, 2 of 12 on 149
   and 7 of 12 on 151. The recorder's own verbs do not reach this — `rec.goto()`
   waits for `load` before it returns, so `move_to`, `click` and `scroll_to` are

--- a/skills/demo-video/reference/failures.md
+++ b/skills/demo-video/reference/failures.md
@@ -157,7 +157,9 @@ paints. That was measured and is not what happens; see `limits.md`.) The beat
 log itself is good to ~100–200 ms of the frame it describes on a host whose
 clock holds still. `timeline.json`'s `capture_clock` records the movement, and
 `capture_clock.measured` says whether the recorder could watch for it at all.
-Tracked in [#18](https://github.com/rogvid/skills/issues/18),
+[#18](https://github.com/rogvid/skills/issues/18),
 [#215](https://github.com/rogvid/skills/issues/215) and
-[#247](https://github.com/rogvid/skills/issues/247) — read them before relying
+[#247](https://github.com/rogvid/skills/issues/247) are where this was measured,
+and all three are closed: the rule they settled on is in `limits.md` under *A
+frame is aimed at a beat; it is not stamped with one*. Read that before relying
 on a beat timestamp to extract a frame.

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -26,8 +26,8 @@ nothing, and when a move can be dropped outright — [determinism.md](determinis
 ### A demo of an error path always records a problem, and `strict=True` cannot be told it was wanted
 
 Demonstrating that a program rejects bad input is an ordinary thing to demo,
-and the recorder logs it as a fault. Measured on `examples/ticket-queue`, a
-48-beat take on 2026-07-26:
+and the recorder logs it as a fault. Measured on this repo's
+`examples/ticket-queue`, a 48-beat take on 2026-07-26:
 
 ```
 demo-video: 1 problem(s) recorded during this take (nonzero_exit x1)
@@ -58,8 +58,8 @@ rendering is how a demo comes to claim something it never showed. But
 both sees `button[data-status='open']` in one file and, in the other, that same
 button carrying only `type` and `aria-pressed`.
 
-Measured from a reviewing agent's own words on the 48-beat
-`examples/ticket-queue` take: it spent a paragraph on the discrepancy, called
+Measured from a reviewing agent's own words on that 48-beat take of this repo's
+`examples/ticket-queue`: it spent a paragraph on the discrepancy, called
 it an "unresolved inconsistency in the artifacts themselves", and could not
 settle it — the three resolutions available to it were "the app is wrong", "the
 log is wrong", "the dump is wrong", and all three are false. Nothing in the
@@ -159,9 +159,13 @@ rather than by widening a bar, which is why `MAX_SKEW_DRIFT_S` could be
 restored at 250 ms after being deleted in
 [#217](https://github.com/rogvid/skills/issues/217).
 
-Three things in the recorder already apply this for you, and reading them as
-uncorrected is the way to get it wrong twice
-([#229](https://github.com/rogvid/skills/issues/229)): **the review frames
+The recorder already applies this for you wherever it publishes an instant on
+the video's clock, and reading one of those as uncorrected is the way to get it
+wrong twice ([#229](https://github.com/rogvid/skills/issues/229)). Each place
+is named below rather than counted, because a count went wrong here at three
+commits running — "Two", then "Three", then "Three" with a fourth added
+underneath it — and a reader who trusts one stops looking once they have found
+that many: **the review frames
 under `frames/` are cut on the video's clock**, midpoint plus that beat's own
 capture's steps before *that midpoint* (the rule is indexed by the instant you
 are converting, not by the beat — a step inside a beat's first half moves its
@@ -181,8 +185,14 @@ earlier than the step that moved it, and the recorder's sampler starts at frame
 zero, so `at` cannot come out negative. The floor and the field stay because
 `adelay` refuses a negative delay outright and would cost the take its whole
 audio track; read `clamped` as a guard against a malformed record, not as
-something to expect; and `timeline.md` says above its beat table when the
-clock stepped and by how much, and what that meant for the audio. `timeline.json`'s beat
+something to expect; and **a stitched take's `overlaps` are graded on the
+video's clock**, which is what `video_overlap` is and why it answers a
+different question from the raw difference beside it (described under *A
+stitched beat log can run backwards at a seam* below).
+
+`timeline.md` says above its beat table when the clock stepped and by how much,
+and what that meant for the audio — but it *reports* the correction rather than
+applying one: every timestamp in that table is the raw beat log. `timeline.json`'s beat
 timestamps are untouched — they are the log, and the log is `time.monotonic()`.
 
 **A backward step is not a slide, and correcting one as though it were puts an
@@ -237,10 +247,12 @@ while the beats keep their own `time.monotonic()` timestamps. Those are two
 clocks. A part whose host clock stepped backwards has a video shorter than its
 own beat log by the size of the step, so its last beats run past where the next
 part begins and the merged log goes non-monotonic at the seam — reproduced at
-−1.4684 s as `beat 21 t_end 37.451` against `beat 22 t_start 37.441`. The
-overlap scales with the step less the capture's startup and tail, so a ~1.5 s
-step reaches most of a second
-([#263](https://github.com/rogvid/skills/issues/263)).
+−1.4684 s as `beat 21 t_end 37.451` against `beat 22 t_start 37.441` — a
+**10 ms** overlap out of a 1.4684 s step, which is 0.7% of it
+([#263](https://github.com/rogvid/skills/issues/263)). That is the only
+measurement there is. What sets the size is not known from one point, so do not
+work out an expected overlap from the size of the step; read the number the
+take published.
 
 Nothing is clamped: a beat's merged timestamp is exactly its own part's log
 plus that part's `offset`, and the whole per-segment correction rule above
@@ -265,8 +277,8 @@ instant before the gap.
 SKILL.md says to aim for 30–60 s. That holds for a feature on one surface and
 does not hold for one that spans two, and the difference is arithmetic rather
 than discipline. Measured on the first real feature this skill was pointed at
-(`examples/ticket-queue`, PR #94, four acceptance criteria across a web UI and
-a CLI): **61.2 s**, with every caption already shortened once; the first-pass
+(this repo's `examples/ticket-queue`, PR #94, four acceptance criteria across a
+web UI and a CLI): **61.2 s**, with every caption already shortened once; the first-pass
 storyboard was 60.2 s. Neither is padded — they are one beat per criterion plus
 the two the skill's own pacing rules require around each.
 
@@ -386,8 +398,8 @@ against one app, from a clean standalone install:
 | 3 | clean, nothing covering the app | **26.74** |
 
 The two broken takes scored **23% higher** than the correct one, and stderr
-printed `demo.mp4 shows a picture` for all three. `tests/smoke`'s own overlay
-pair reproduces it harder against the fixture app: **28.07** with the scrim up
+printed `demo.mp4 shows a picture` for all three. An overlay pair recorded
+against a fixture app reproduces it harder: **28.07** with the scrim up
 against **17.02** without, 65% the wrong way round. There is no threshold that
 separates those numbers in the right direction, and restricting the rect cannot
 help — the overlay is exactly where the app is. This is the same
@@ -469,10 +481,10 @@ segment's `.seg.timeline.json` before believing the beat it names — pass
 
 `coverage_report` copies each claimed beat's `segment` into the coverage table
 (`coverage.py:117`), and `timeline.md` renders a claim as ``beat 5 (`part2`)``.
-Nothing used to pin it: `check_coverage` graded `index`, `t_start` and `still`
-against the beat list, and `check_coverage_merge` *constructed* beats carrying
-`part1` and `part2` and then asserted only on `index`. Replacing that line with
-`"segment": None` left `tests/smoke --coverage-only` green — one of six
+Nothing used to pin it: this skill's own suite graded a claimed beat's `index`,
+`t_start` and `still` against the beat list, and its merge case *constructed*
+beats carrying `part1` and `part2` and then asserted only on `index`. Replacing
+that line with `"segment": None` left the coverage arm green — one of six
 injections against that arm, and the only survivor
 ([#137](https://github.com/rogvid/skills/issues/137)).
 
@@ -480,9 +492,9 @@ Beat indices are per-segment before merging, so a reviewer of a stitched demo
 handed "beat 5" with no segment has no way to know which beat 5. Pointing a
 conformance reviewer at the right frame is the coverage table's whole job.
 
-`check_coverage_merge` now asserts the segment of each claimed beat as well as
-its index, and that exact injection is registered in `tests/smoke-inject`, so
-it runs nightly rather than having been performed once.
+That merge case now asserts the segment of each claimed beat as well as its
+index, and that exact injection is registered in the nightly manifest, so it
+runs nightly rather than having been performed once.
 
 ## What CI will and will not do for you
 
@@ -523,17 +535,16 @@ measuring 47.5 dB locally. Only one of the two readings is stable:
 
 The moved reading is content-determined and barely travels. The held one is a
 still frame, so it is entirely at the mercy of how a given x264 build
-re-quantises — 7.7 dB of spread across two machines. `CONTENT_PSNR_GAP_DB = 8.0`
-(`tests/smoke:329`) therefore has 5.9 dB of margin on the worse of the two
-encoders anyone has run it on, which is fine today and is not obviously fine on
-a third ([#122](https://github.com/rogvid/skills/issues/122)).
+re-quantises — 7.7 dB of spread across two machines. The gate the suite applies,
+`CONTENT_PSNR_GAP_DB = 8.0`, therefore has 5.9 dB of margin on the worse of the
+two encoders anyone has run it on, which is fine today and is not obviously fine
+on a third ([#122](https://github.com/rogvid/skills/issues/122)).
 
 ## Paths that only your recording takes
 
-Two branches of the recorder run nowhere in the test suite, so the first
-program to exercise either is yours. Both are listed in `tests/README.md`'s
-Known gaps, and both are stated here because they are reached by an ordinary
-storyboard rather than by a maintainer.
+These branches of the recorder run nowhere in the test suite, so the first
+program to exercise either is yours. They are stated here rather than left to a
+maintainer's notes because they are reached by an ordinary storyboard.
 
 **Nothing has ever called the ElevenLabs API.** The narration take grades
 everything a cache *hit* reaches — the key, the pacing, whether the mix carries

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -67,9 +67,10 @@ cut on the raw beat log and the sheet says so; treat their aim as unbounded.
 The practical consequence, for what is left: for a beat comfortably longer
 than that, the frame is of that beat; **for a beat shorter than the drift — a
 bare `shot()`, a `wait_for()` that returned immediately — the frame can be of
-the beat after it.** `tests/smoke` measures exactly this and shows it: with the
-drift allowance removed, the frame for a 50 ms `shot()` beat that sits against
-a caption change is already showing the next beat's screen.
+the beat after it.** This was measured directly, by this repo's `tests/smoke`
+rather than by anything shipped with the skill: with the drift allowance
+removed, the frame for a 50 ms `shot()` beat that sits against a caption change
+is already showing the next beat's screen.
 
 Read the frames as *"roughly here in the demo"*, not as *"exactly this beat"*.
 When a specific short moment matters, use `shot()` — `images/*.png` are
@@ -155,7 +156,8 @@ reviewer is asked to name the frames it checked.
 ### A caption the app contradicts is not a recording defect
 
 The verdict used to carry this too, and it was unstable. On the reference take
-at `examples/ticket-queue/demos/2026-07-28-queue-search/` — recorded against a
+kept in this repository at `examples/ticket-queue/demos/2026-07-28-queue-search/`
+— recorded against a
 ticket one of whose criteria the app does not satisfy, with the beat claiming it
 kept and captioned in the ticket's own words — two independent reviewers given
 the same frames and the same instructions returned **UNCLEAR** and **CLEAR**.
@@ -236,8 +238,8 @@ Two things are dropped, and neither is a security control:
   narration clip, so serializing it would make evidence the only place it
   exists.
 
-Both are statements about what belongs in a text dump of an element, and
-`tests/smoke` grades them directly: the evidence take injects an element
+Both are statements about what belongs in a text dump of an element, and this
+repo's `tests/smoke` grades them directly: its evidence take injects an element
 holding a `<script>` and a `srcdoc` and requires neither in the markup.
 
 **Fields are capped** — 12 000 characters of ARIA or screen text, 8 000 of

--- a/tests/README.md
+++ b/tests/README.md
@@ -773,9 +773,9 @@ happens to the web frame is the caption bar arriving, at 0.023–0.026 against
 the recorder's 0.02 threshold, while *nothing* in the terminal take reaches it:
 its largest change is two lines of shell output on a dark background at 0.011,
 against an idle 0.004. At a threshold separating those, an ordinary terminal
-repaint would be reported as a cut. Tracked in
-[#57](https://github.com/rogvid/skills/issues/57), which proposes scoring the
-app's rect instead of the whole composited frame.
+repaint would be reported as a cut. Scoring the app's rect instead of the whole
+composited frame was raised as [#57](https://github.com/rogvid/skills/issues/57)
+and closed as not planned, so this is a declared limit rather than queued work.
 
 The quiet half runs on both, over the stretch after the **last beat's logged
 end** — where the recording holds its closing frame until it stops. Anchored
@@ -2136,20 +2136,20 @@ knows is missing is worse than one that is openly absent.
   floor toward 15 would risk flake from CI font rendering. Mitigated, not
   solved, by the `getComputedStyle` check on `#refresh` — which catches the
   fixture's own stylesheet failing, but is one assertion about one property and
-  will not notice arbitrary visual regressions. Tracked in
-  [#16](https://github.com/rogvid/skills/issues/16).
+  will not notice arbitrary visual regressions. Raised as
+  [#16](https://github.com/rogvid/skills/issues/16) and closed as not planned.
 - **The terminal caption check has the thinnest margin in the harness** — 2.7
   healthy against a 1.0 floor, where everything else has 4x or better. The
   terminal's caption is a dark box on a dark terminal, so only its text carries
   any luma change. If CI font rendering ever drops it under 1.0 this will flake;
-  the DOM caption assertions would still hold. Tracked in
-  [#16](https://github.com/rogvid/skills/issues/16).
+  the DOM caption assertions would still hold. Raised as
+  [#16](https://github.com/rogvid/skills/issues/16) and closed as not planned.
 - **The content rects couple to recorder internals** (`Recorder._geom`, and the
   `#__term_host` id). Reading them at runtime means a geometry change follows
   automatically, and a *removed* `_geom` fails loudly — but a change that keeps
   the attribute while moving the app elsewhere would silently score the wrong
-  pixels. Tracked in [#17](https://github.com/rogvid/skills/issues/17), which
-  proposes the recorder expose its geometry as public API.
+  pixels. Exposing the recorder's geometry as public API was raised as
+  [#17](https://github.com/rogvid/skills/issues/17) and closed as not planned.
 - **The video and the beat log are on different clocks, and this harness
   corrects for that rather than fixing it.** Chromium stamps every screencast
   frame with the host's *wall* clock and Playwright turns that into the frame's
@@ -2386,8 +2386,10 @@ knows is missing is worse than one that is openly absent.
   the jump and the closing caption is compressed. The most likely candidate is
   what ffmpeg does with the non-monotonic cluster timestamps Playwright writes
   after Chromium's clock goes backwards, which is not something this repo can
-  measure from outside. Tracked in
-  [#224](https://github.com/rogvid/skills/issues/224).
+  measure from outside. [#224](https://github.com/rogvid/skills/issues/224) is
+  closed as not reproducing — its −900 ms was an artifact of the sampler #250
+  fixed — and the live defect at that magnitude is tracked in
+  [#255](https://github.com/rogvid/skills/issues/255), with the opposite sign.
 
   **The bars were not widened for it.** `MAX_SKEW_DRIFT_S` at 250 ms is the
   sharp claim this whole correction exists to make usable, and a bar wide
@@ -2556,9 +2558,9 @@ knows is missing is worse than one that is openly absent.
   shows" gap only as far as one bit goes: a captioned beat's frame must show a
   bar and an uncaptioned one's must not. Two beats carrying *different* captions
   are indistinguishable to it, so a stall that slid a frame from one captioned
-  beat to another captioned beat still passes. Tracked in
-  [#60](https://github.com/rogvid/skills/issues/60), which would make the
-  mapping readable off the frame instead of inferred.
+  beat to another captioned beat still passes. Making the mapping readable off
+  the frame instead of inferred was raised as
+  [#60](https://github.com/rogvid/skills/issues/60) and closed as not planned.
 - **Frames within 750 ms of a caption change are not graded for content at
   all**, and on these storyboards that is 8-9 of every take's frames. The
   exclusion is real coverage lost, not a formality: it is exactly where #18's
@@ -2599,11 +2601,12 @@ knows is missing is worse than one that is openly absent.
   `verb` and one `caption` are asserted; `t`, `url`, `line`, `status`, `method`
   are not. `t` is knowingly the *observation* time and can sit outside the beat
   it names — measured at 3.53 s for a `nonzero_exit` whose `run` beat ended at
-  3.4 s. Tracked in [#34](https://github.com/rogvid/skills/issues/34).
+  3.4 s. Raised as [#34](https://github.com/rogvid/skills/issues/34) and closed
+  as not planned.
 - **Nothing checks popups or new tabs.** The recorder watches one page, so a
   demo that opens a second one records nothing about it and `strict=True`
-  cannot refuse it. Tracked in
-  [#33](https://github.com/rogvid/skills/issues/33).
+  cannot refuse it. Raised as
+  [#33](https://github.com/rogvid/skills/issues/33) and closed as not planned.
 - **Nothing checks the 200-issue cap, or a `run()` that is never waited on.**
   `issue_count` is asserted equal to `len(issues)`, which is the uncapped case
   only — so the path where a fatal issue arrives past the cap and is counted
@@ -2643,8 +2646,11 @@ knows is missing is worse than one that is openly absent.
   issue's `t` and re-points its `beat` at the merged beat list, and the
   segmented take is a recording of a *healthy* app under `strict=True` — so it
   records no issues at all and none of that runs. An issue attributed to the
-  wrong beat of the wrong segment would pass this suite. Tracked in
-  [#51](https://github.com/rogvid/skills/issues/51).
+  wrong beat of the wrong segment would pass this suite. Raised as
+  [#51](https://github.com/rogvid/skills/issues/51), which was closed by
+  *declaring* the gap rather than covering it: the measurement lives in
+  `skills/demo-video/reference/limits.md` under *What a stitched demo's
+  artifacts promise*.
 - **The merge's error is measured at one beat per segment, not all of them.**
   Every other beat in a segment is carried by that segment's single offset, so
   one being right makes the rest right — but a merge that moved some of a
@@ -2761,6 +2767,83 @@ knows is missing is worse than one that is openly absent.
   "#142's carve-out" stays green after #142's carve-out is deleted. The list
   can only shrink, so a stale entry surfaces the moment its line is edited;
   nothing surfaces one whose line is edited nowhere.
+
+- **Most of where the shipped documentation points.** `tests/lint`'s
+  `check_pointers()` resolves every repo-shaped path named in `skills/**/*.md`
+  and in each shipped module's **docstring** — 75 of them across 25 documents
+  when it was written — and requires each to resolve inside the installed skill
+  or to be introduced as this repository's. Six things it deliberately does
+  not see:
+
+  1. **Comments, and docstrings below module level.** Twenty-eight `tests/`
+     mentions remain inside `skills/demo-video/helpers/demo_recording/` —
+     twenty-two in comments beside the constants they explain, six in function
+     docstrings. They ship with the skill, but they are read by somebody
+     already inside the source rather than handed to a reader as somewhere to
+     go, which is why the **module** docstring is in scope and these are not.
+     Counted here, not rewritten. The six in function docstrings are the ones
+     worth revisiting first, since `help()` reaches them.
+  2. **A one-segment name.** `frames.md`, `record.py` and `demo.mp4` are files
+     the *take* writes, and a bare name carries nothing that separates them
+     from a mistyped `revew.md`, so only paths containing a `/` are checked.
+  3. **A path whose first segment is not an existing directory.** That is what
+     keeps `frames/frames.md` from being reported as dead, and it would let a
+     typo in a directory name through for the same reason.
+  4. **A heading.** Root `README.md` sent its reader to a section of `SKILL.md`
+     that lives in `reference/ci.md`; the link resolved, the section did not.
+     Only reading it found that, and only reading it would find the next one.
+  5. **A path not inside a code span or a link.** `See tests/README.md for the
+     roster.` in a module docstring leaves the pointer count unmoved and lint
+     green; the same sentence with the path backticked is caught. Reproduced.
+     A backtick-free sweep of all shipped prose found **no live instance** —
+     this repo writes paths in code spans — so it is a gap without a defect
+     behind it, which is the only reason it is written here instead of fixed.
+  6. **Every word of a multi-word code span but the first.** `` `wc -c
+     SKILL.md reference/*.md` `` must not report `reference/*.md` as dead, and
+     taking only the first word is what buys that — at the cost of missing
+     `` `cd tests/fixture` ``. Three non-first path-shaped tokens exist today,
+     all benign.
+
+  The **trailing slash** was a seventh until round 2 of #270 found a live
+  pointer hiding behind it: `PATH_SHAPED` saw an empty last segment and refused
+  the token outright, so `examples/ticket-queue/demos/…/` in `review.md` was
+  invisible to a check written to catch exactly that. Normalisation strips it
+  now, and `pointer_guard` holds the same directory written both ways — with
+  the slash and without — so the shape that hid one is graded beside the shape
+  that caught one.
+
+- **Two shapes of dead issue pointer.** `tests/lint --issues` requires every
+  sentence that presents an issue as pending work to name at least one **open**
+  issue, over every tracked Markdown file, Python file and uv script. What it
+  does not grade: a sentence whose only number is a **pull request** — the
+  tracker's issue list does not carry those, so the number is skipped rather
+  than guessed at — and any phrasing outside the fixed vocabulary in `PENDING`,
+  which is `tracked in/at/as`, `is tracked`, `until then`, `still open`,
+  `remains open` and `will be fixed`. A document that invents a new way to say
+  "somebody is on this" is invisible to it. `--self-test` holds a floor under
+  how many sentences in this tree that vocabulary still matches, so it cannot
+  quietly stop matching anything, and the sweep floors **both** its axes —
+  references and files. Measured here: 1,428 references across 47 files, of
+  which the top five files carry **1,087** and all of `skills/` carries 349. A
+  sweep narrowed to `tests/` reads 1,047 references from 6 files — five times
+  the reference floor, and none of the shipped documents this check exists for.
+  Depth is not breadth, and only the file floor says so.
+
+- **The issue check runs in one direction only.** It catches a *closed* issue
+  presented as pending. It says nothing about an *open* issue presented as
+  settled — "raised as #34 and closed as not planned" — and PR #270 added
+  **fourteen** such statements across **twelve** distinct issues (`frames.py`
+  two, `determinism.md` one, `failures.md` one covering #18/#215/#247,
+  this file nine, `tests/smoke` one). All fourteen are correct as written; none
+  is graded, so a reopened issue would leave a document claiming a decision
+  that no longer holds, which is the same defect class one direction over.
+
+  The obvious symmetric rule is unsound and this file contains the
+  counterexample: the `#224` entry above says "closed" in a sentence that also
+  names `#255`, which is open and must stay open. Grading this needs the
+  settled claim **attributed to a number** rather than to a sentence, and that
+  is a design question rather than a vocabulary, which is why it is recorded
+  here rather than bolted on.
 
 Failures accumulate and print together, each naming the file or interaction and
 the number that was wrong. The process exits non-zero if there is even one, and

--- a/tests/lint
+++ b/tests/lint
@@ -6,9 +6,13 @@
 """Ruff at exactly the version CI pins, over exactly the files CI sees (#189).
 
     tests/lint                # ruff check + ruff format --check + doc fences
+                              #   + the paths the shipped skill points at
     tests/lint --github       # ...with GitHub annotations; what ci.yml runs
-    tests/lint --self-test    # prove the pin, the file set and the fence
-                              #   checker are live rather than decorative
+    tests/lint --issues       # the half that needs the network: every issue
+                              #   a document presents as pending is still open
+    tests/lint --self-test    # prove the pin, the file set, the fence checker
+                              #   and both pointer checks are live rather than
+                              #   decorative
 
 **Why this file exists rather than a line in a README.** `.github/workflows/
 ci.yml` pins ruff and runs it as `uv run --with "ruff==$RUFF_VERSION" ruff …`.
@@ -41,11 +45,25 @@ by `def f(:` and it prints "1 file already formatted" and exits 0 — and its
 checker does not look at `.md` at any version. So the examples an agent copies
 out of a SKILL.md were the one Python in this repo nothing parsed (#211).
 `check_fences()` compiles them.
+
+**Nor does anything read where the documentation points.** A skill is installed
+by copying `skills/<name>/` out of this repo, so a shipped document naming
+`tests/smoke` or `tests/README.md` is addressing a reader who does not have the
+file — and an audit found ten such symbols inside `demo-video` alone, plus two
+issue pointers of the `Tracked in …` shape aimed at issues that are closed.
+That second family had been filed and fixed once already, as #209, and came
+back. `check_pointers()` is the offline half: every
+repo-shaped path a shipped document names must resolve inside the installed
+skill, unless the sentence naming it says it is in this repository.
+`check_issue_refs()` is the half that needs the network, hence `--issues`
+rather than a step of the ordinary run.
 """
 
 from __future__ import annotations
 
 import argparse
+import ast
+import json
 import re
 import shutil
 import subprocess
@@ -380,6 +398,480 @@ def check_fences(github: bool = False) -> int:
     return len(problems)
 
 
+# --- where the shipped documentation points ----------------------------------
+
+
+def shipped_prose() -> list[tuple[str, str, int]]:
+    """(path, prose, the file line the prose starts on) for a consumer's reading.
+
+    `npx skills add` copies `skills/<name>/` and nothing else, so this is the
+    Markdown under `skills/`, plus each shipped module's **docstring** — which
+    ships too, and is what a reader meets on an import error.
+
+    The third element exists so a finding in a docstring is reported at the
+    line it is on **in the file**, not at its offset inside the string. An
+    annotation pointing at the wrong line is a worse artifact than no
+    annotation: a reader who opens it and finds nothing distrusts the check
+    rather than the document. `clean=False` for the same reason — the cleaned
+    form re-indents, and a shifted column is the same lie one axis over.
+
+    Comments, and docstrings below module level, are deliberately out of
+    scope: `# measured by tests/smoke` beside the constant it explains is read
+    by somebody already inside the source. Twenty-eight such mentions remain in
+    `demo_recording/` — twenty-two comments and six function docstrings — and
+    that boundary is stated in tests/README.md under *Known gaps*, with the
+    count, rather than left implied.
+    """
+    out: list[tuple[str, str, int]] = []
+    for rel in tracked("skills/*"):
+        path = REPO / rel
+        if path.is_symlink() or not path.is_file():
+            continue
+        if rel.endswith(".md"):
+            out.append((rel, path.read_text(encoding="utf-8"), 1))
+        elif rel.endswith(".py"):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:  # ruff check above is what reports this
+                continue
+            doc = ast.get_docstring(tree, clean=False)
+            if doc and isinstance(first := tree.body[0], ast.Expr):
+                out.append((rel, doc, first.lineno))
+    return out
+
+
+# A skill's documentation may name a path outside the installed set when it
+# says where that path is. This is the "say so" the audit asked for: the
+# sentence carries the fact that the reader is being told about this repository
+# rather than about their own checkout.
+REPO_MARKER = re.compile(
+    r"(?i)\bthis (?:repo|repository)\b|\bthis skill's (?:own )?repo"
+)
+
+# A markdown link with an absolute target resolves for any reader, so neither
+# it nor anything in its label is a pointer into a checkout. Removed before the
+# scan rather than special-cased inside it.
+ABSOLUTE_LINK = re.compile(r"\[[^\]\n]*\]\((?:https?:|mailto:)[^)\s]*\)")
+
+# What is left: an inline code span, or a link with a relative target.
+POINTER = re.compile(r"`([^`\n]+)`|\[[^\]\n]*\]\((?!https?:|mailto:|#)([^)\s]+)\)")
+
+# Path-shaped: a `./` or `../` prefix, or at least one interior `/`. A trailing
+# `:123` (a line reference) and surrounding punctuation are stripped before this
+# is applied.
+#
+# **A bare `review.md` is therefore not checked**, and that is a deliberate
+# limit rather than an oversight: the shipped documents name `frames.md`,
+# `frames.json`, `record.py` and `demo.mp4` constantly, and every one of those
+# is a file the *take* writes, which cannot exist in the repository and must
+# not be reported as dead. A one-segment name carries nothing that tells the
+# two apart. Stated in tests/README.md under *Known gaps*.
+PATH_SHAPED = re.compile(
+    r"^(?:\.{1,2}/)+[\w.@*-]+(?:/[\w.@*-]+)*$|^[\w.@-]+(?:/[\w.@*-]+)+$"
+)
+
+# A blank line, or the start of a list item — the two things that end a block
+# of prose. Sentence scope is computed inside a block so that a marker in one
+# bullet cannot license a path named in another.
+BLOCK_BREAK = re.compile(r"^\s*$|^\s*(?:[-*+]|\d+\.)\s")
+
+# The floors. Every finding below is the absence of a problem, and an absence
+# holds perfectly over an empty haystack: a walker that stopped finding
+# documents, or a regex that stopped matching code spans, reports a clean tree
+# in exactly the same words a clean tree does. Measured at 25 documents and 75
+# path-shaped pointers; the floors are controls rather than targets, and sit
+# well under both.
+MIN_SHIPPED_DOCS = 15
+MIN_POINTERS = 40
+
+# Pointers that are prose *about* a path rather than a pointer to one, each
+# with the reason. Graded exactly like `KNOWN_FRAGMENTS` above: an entry whose
+# document no longer names that token, or names it without a problem, **fails**
+# rather than being ignored, so the list can only shrink and no entry outlives
+# its cause. Keyed by (repo-relative document, the token as extracted).
+KNOWN_ABSENT: dict[tuple[str, str], str] = {
+    (
+        "skills/script-conventions/SKILL.md",
+        "./scripts/mytool",
+    ): "the sentence exists to say this path does not resolve from where an "
+    "agent starts; a reader who found the file would have missed the point",
+}
+
+
+def strip_fences(text: str) -> str:
+    """The prose, with fenced blocks blanked and the line count preserved.
+
+    A fence is an example, not a pointer: `# .github/workflows/demo.yml` in the
+    YAML a consumer is told to copy names a file in *their* repository.
+    """
+    lines = text.splitlines()
+    for line, _lang, body in fences(text):
+        for i in range(line - 1, min(line + len(body.splitlines()) + 1, len(lines))):
+            lines[i] = ""
+    return "\n".join(lines)
+
+
+def blocks(text: str) -> list[tuple[int, str]]:
+    """(1-based first line, text) for each block of prose."""
+    found: list[tuple[int, str]] = []
+    current: list[str] = []
+    start = 1
+    for n, line in enumerate(text.splitlines(), 1):
+        if BLOCK_BREAK.match(line):
+            if current:
+                found.append((start, "\n".join(current)))
+            current = [line] if line.strip() else []
+            start = n
+            continue
+        if not current:
+            start = n
+        current.append(line)
+    if current:
+        found.append((start, "\n".join(current)))
+    return found
+
+
+def sentence_at(block: str, pos: int) -> str:
+    """The sentence of `block` containing character `pos`, on one line.
+
+    Collapsed, because a sentence in Markdown is wrapped wherever the column
+    ran out: "and this\\nrepo's `tests/smoke`" is the same sentence as "and
+    this repo's `tests/smoke`", and a marker that only matched the second
+    would grade the line width.
+    """
+    cuts = [0] + [m.end() for m in re.finditer(r"(?<=[.!?])\s+", block)] + [len(block)]
+    for lo, hi in zip(cuts, cuts[1:], strict=True):
+        if lo <= pos < hi:
+            return " ".join(block[lo:hi].split())
+    return " ".join(block.split())
+
+
+def pointers(text: str) -> list[tuple[int, str, str]]:
+    """(1-based line, path-shaped token, the sentence naming it)."""
+    found: list[tuple[int, str, str]] = []
+    for first, block in blocks(strip_fences(text)):
+        scanned = ABSOLUTE_LINK.sub(lambda m: " " * len(m.group(0)), block)
+        for match in POINTER.finditer(scanned):
+            span = match.group(1) or match.group(2) or ""
+            token = span.split()[0] if span.split() else ""
+            # Trailing dots go; leading ones must not, or `../SKILL.md` — the
+            # one shape every reference document uses to name the entry point
+            # — comes out as `/SKILL.md` and resolves to the filesystem root.
+            #
+            # **And the trailing slash**, which is how a document names a
+            # directory. Without this line `PATH_SHAPED` sees an empty last
+            # segment and refuses the token outright, so the check goes quiet
+            # on exactly the pointers written as directories — which is how
+            # `examples/ticket-queue/demos/…/` survived the first version of
+            # this file. `fence_guard`'s lesson, one check over: the shape that
+            # hid a defect has to be in the table beside the shape that caught
+            # one.
+            token = re.sub(r":\d+$", "", token.strip("`,;:'\"()[]").rstrip("./"))
+            if not PATH_SHAPED.match(token):
+                continue
+            line = first + scanned[: match.start()].count("\n")
+            found.append((line, token, sentence_at(block, match.start())))
+    return found
+
+
+def resolve(rel: str, token: str) -> tuple[Path | None, Path]:
+    """(the file `token` names, the skill it was named from).
+
+    Tried against the naming document's own directory first, then the skill
+    root, which is how both a `../SKILL.md` and a bare `reference/ci.md` are
+    written in this tree. `None` when nothing of that name exists anywhere.
+    """
+    skill = REPO / "/".join(rel.split("/")[:2])
+    for base in ((REPO / rel).parent, skill, REPO):
+        candidate = (base / token).resolve()
+        if candidate.exists():
+            return candidate, skill
+    return None, skill
+
+
+def verdict(rel: str, token: str, sentence: str) -> tuple[str, str]:
+    """(verdict, why) for one pointer. The whole rule, in one place.
+
+    `--self-test` calls this rather than restating the branches, because a
+    guard holding its own copy of the logic grades the copy.
+
+    Four answers, and only the last is a problem twice over:
+
+    * `inside` — it resolves within the installed skill;
+    * `marked` — it is elsewhere in this repository and the sentence says so;
+    * `elsewhere` — it is not a repository path at all (`frames/frames.md` is
+      written by the take, not by anybody's checkout);
+    * `unreachable` / `dead` — the reader cannot open it.
+    """
+    target, skill = resolve(rel, token)
+    if target is not None and target.is_relative_to(skill):
+        return "inside", ""
+    if target is not None:
+        if REPO_MARKER.search(sentence):
+            return "marked", ""
+        return "unreachable", (
+            f"`{token}` is in this repository but not in the installed skill, "
+            f"and the sentence naming it does not say so — a reader who ran "
+            f"`npx skills add` has no such path"
+        )
+    head = token.split("/")[0]
+    if (REPO / head).is_dir() or (skill / head).is_dir():
+        return "dead", f"`{token}` does not exist, here or in the skill"
+    return "elsewhere", ""
+
+
+def check_pointers(github: bool = False) -> int:
+    """Does a shipped document point at anything its reader cannot open?"""
+    problems: list[tuple[str, int, str]] = []
+    docs = shipped_prose()
+    waived: set[tuple[str, str]] = set()
+    seen = 0
+    outside = 0
+
+    for rel, text, at in docs:
+        for line, token, sentence in pointers(text):
+            seen += 1
+            said, why = verdict(rel, token, sentence)
+            outside += 1 if said == "marked" else 0
+            if not why:
+                continue
+            if (rel, token) in KNOWN_ABSENT:
+                waived.add((rel, token))
+                continue
+            problems.append((rel, at + line - 1, why))
+
+    for key in KNOWN_ABSENT:
+        if key not in waived:
+            problems.append(
+                (
+                    key[0],
+                    1,
+                    f"KNOWN_ABSENT waives `{key[1]}`, which this document no "
+                    f"longer names as a problem — delete the entry",
+                )
+            )
+
+    # The controls. Both numbers below are what tells "nothing is wrong" apart
+    # from "nothing was read", and the second is the sharper one: every check
+    # above is skipped for a token that resolves inside the skill, so a walker
+    # that only ever found those would also be silent.
+    if len(docs) < MIN_SHIPPED_DOCS:
+        problems.append(
+            (
+                "tests/lint",
+                1,
+                f"only {len(docs)} shipped document(s) were read, under the "
+                f"{MIN_SHIPPED_DOCS} floor — this reads as a walker that stopped "
+                f"finding `skills/`, not as a skill that ships no prose",
+            )
+        )
+    if seen < MIN_POINTERS:
+        problems.append(
+            (
+                "tests/lint",
+                1,
+                f"only {seen} path-shaped pointer(s) were examined, under the "
+                f"{MIN_POINTERS} floor — the extractor is not reading what it "
+                f"used to, so a clean result here means nothing",
+            )
+        )
+
+    print(
+        f"pointers: {seen} path(s) named across {len(docs)} shipped document(s); "
+        f"{outside} named as this repository's"
+        + (f", {len(waived)} waived" if waived else "")
+    )
+    for rel, line, message in problems:
+        if github:
+            print(f"::error file={rel},line={line}::{message}")
+        print(f"pointers: {rel}:{line}: {message}", file=sys.stderr)
+    if problems:
+        print(f"lint: {len(problems)} pointer problem(s)")
+    return len(problems)
+
+
+# --- issue references that are presented as pending work ----------------------
+
+# Phrasings that tell a reader "this is known and somebody is on it". Kept
+# deliberately small and literal: the family the audit found was "Tracked in
+# #N", twelve of them and every one closed, and a vocabulary wide enough to
+# guess at intent would fire on every issue this repo cites as a measurement.
+PENDING = re.compile(
+    r"(?i)\b(?:tracked (?:in|at|as)|is tracked|until then|still open|"
+    r"remains open|will be fixed)\b"
+)
+
+# `#12` and the long form of the same link. Both, because a document may write
+# either, and the check would be trivially avoidable if it read only one.
+ISSUE_REF = re.compile(r"#(\d{1,5})\b|/issues/(\d{1,5})\b")
+
+# Sweeping every tracked document, not only the shipped ones: this repo's own
+# `tests/README.md` held ten of the twelve, and a contributor reading a closed
+# issue as open wastes the same afternoon a consumer would.
+#
+# **Two floors, because one of them is satisfiable without reading the tree.**
+# The references cluster hard: of 1,428 across 47 files, the top five carry
+# 1,087 and all of `skills/` carries 349. Narrowing the sweep to `tests/` reads
+# 1,047 from 6 files — five times the reference floor, and none of the shipped
+# documents this check exists for. Depth is not breadth; the file floor is the
+# only one that says so.
+MIN_ISSUE_REFS = 200
+MIN_ISSUE_FILES = 30
+
+# Real pointers the vocabulary above must still match: sentences that both read
+# as pending **and name an issue**, anywhere in the tracked Markdown. Two today,
+# both at open issues. The number is deliberately not the count — a control
+# sitting exactly on its measurement fires when somebody legitimately closes one
+# of them, and this claim only needs to be "the regex still describes how this
+# repository writes". Requiring a number is what keeps `tests/README.md`'s own
+# listing of the vocabulary, which quotes every phrase and points at no issue,
+# from satisfying the control that grades that vocabulary.
+MIN_PENDING_SENTENCES = 1
+
+
+def issue_states() -> dict[int, str]:
+    """Every issue in this repository, by number. Needs the network.
+
+    Every way this can go wrong raises `Refused`, which `main()` turns into
+    exit 3 and a one-line reason — including `gh` not being installed, which
+    otherwise came out as a `FileNotFoundError` traceback and exit 1. Four
+    failure modes reported four different ways is three chances for somebody
+    to read one of them as "the check ran and found nothing".
+    """
+    try:
+        done = subprocess.run(
+            [
+                "gh",
+                "issue",
+                "list",
+                "--state",
+                "all",
+                "--limit",
+                "1000",
+                "--json",
+                "number,state",
+            ],
+            cwd=REPO,
+            text=True,
+            capture_output=True,
+        )
+    except OSError as exc:
+        raise Refused(
+            f"`gh` could not be run, so no issue pointer was graded: {exc}"
+        ) from exc
+    if done.returncode != 0:
+        raise Refused(
+            f"`gh issue list` failed, so nothing below was graded: "
+            f"{done.stderr.strip()[:200]}"
+        )
+    try:
+        rows = json.loads(done.stdout)
+    except json.JSONDecodeError as exc:
+        raise Refused(f"`gh issue list` did not return JSON: {exc}") from exc
+    states = {int(row["number"]): str(row["state"]).upper() for row in rows}
+    if not any(s == "OPEN" for s in states.values()) or not any(
+        s == "CLOSED" for s in states.values()
+    ):
+        raise Refused(
+            f"the issue list came back with {len(states)} issue(s) and not both "
+            f"states in it — a list that is all one state cannot distinguish a "
+            f"live pointer from a dead one"
+        )
+    return states
+
+
+def stale_refs(text: str, states: dict[int, str]) -> list[tuple[int, str, list[int]]]:
+    """(line, sentence, the closed issues) for each pointer presented as pending.
+
+    A sentence is only reported when **every** issue it names is closed. One
+    naming an open issue beside a closed one is a history, not a dead pointer,
+    and a number the list does not carry at all is a pull request — neither is
+    graded here, and both are counted by the caller.
+    """
+    found: list[tuple[int, str, list[int]]] = []
+    for first, block in blocks(text):
+        for hit in PENDING.finditer(block):
+            sentence = sentence_at(block, hit.start())
+            numbers = sorted(
+                {int(a or b) for a, b in ISSUE_REF.findall(sentence)} & states.keys()
+            )
+            if not numbers or any(states[n] == "OPEN" for n in numbers):
+                continue
+            line = first + block[: hit.start()].count("\n")
+            found.append((line, " ".join(sentence.split())[:160], numbers))
+    return found
+
+
+def check_issue_refs(github: bool = False) -> int:
+    """Every issue a document presents as pending work is an issue that is open."""
+    states = issue_states()
+    problems: list[tuple[str, int, str]] = []
+    refs = 0
+    docs = 0
+
+    for rel in tracked():
+        path = REPO / rel
+        if path.is_symlink() or not path.is_file():
+            continue
+        if not rel.endswith((".md", ".py")) and not _is_uv_script(path):
+            continue
+        text = path.read_text(encoding="utf-8", errors="replace")
+        docs += 1
+        refs += len(ISSUE_REF.findall(text))
+        for line, sentence, numbers in stale_refs(text, states):
+            closed = ", ".join(f"#{n}" for n in numbers)
+            problems.append(
+                (
+                    rel,
+                    line,
+                    f"presented as pending work, but {closed} "
+                    f"{'is' if len(numbers) == 1 else 'are'} closed: {sentence!r}",
+                )
+            )
+
+    if refs < MIN_ISSUE_REFS:
+        problems.append(
+            (
+                "tests/lint",
+                1,
+                f"only {refs} issue reference(s) were read across {docs} file(s), "
+                f"under the {MIN_ISSUE_REFS} floor — the sweep is not reading "
+                f"this repository's documents",
+            )
+        )
+    # Depth is not breadth. Five files carry 1,017 of the references here, so a
+    # sweep that had narrowed to `tests/` would clear the floor above five
+    # times over while reading none of `skills/`.
+    if docs < MIN_ISSUE_FILES:
+        problems.append(
+            (
+                "tests/lint",
+                1,
+                f"only {docs} file(s) were swept, under the {MIN_ISSUE_FILES} "
+                f"floor — {refs} reference(s) out of a handful of documents is "
+                f"what a sweep narrowed to one directory also reports",
+            )
+        )
+
+    print(
+        f"issues: {refs} reference(s) across {docs} file(s), against "
+        f"{len(states)} issue(s) on the tracker"
+    )
+    for rel, line, message in problems:
+        if github:
+            print(f"::error file={rel},line={line}::{message}")
+        print(f"issues: {rel}:{line}: {message}", file=sys.stderr)
+    if problems:
+        print(f"lint: {len(problems)} dead issue pointer(s)")
+    return len(problems)
+
+
+def _is_uv_script(path: Path) -> bool:
+    with path.open("rb") as handle:
+        first = handle.readline(200).decode("utf-8", "replace").strip()
+    return first.startswith("#!") and "uv run" in first and "--script" in first
+
+
 def run(github: bool) -> int:
     version = pinned_version(CI.read_text(encoding="utf-8"))
     print(f"lint: ruff {version}, pinned by .github/workflows/ci.yml")
@@ -414,6 +906,11 @@ def run(github: bool) -> int:
     # check` at every version, and the formatter reads one without validating
     # it (#211). Run last so its one summary line is not lost above ruff's.
     failed += 1 if check_fences(github) else 0
+
+    # And the half ruff would not have an opinion about either: where the
+    # shipped documentation points. Offline, so it belongs here; the issue
+    # half needs the tracker and is `--issues`.
+    failed += 1 if check_pointers(github) else 0
     return 1 if failed else 0
 
 
@@ -568,6 +1065,159 @@ def fence_guard() -> int:
     return bad
 
 
+def pointer_guard() -> int:
+    """Prove the pointer checker can fail, and on exactly the right documents.
+
+    Every case fixes **two** numbers, how many path-shaped pointers the document
+    contains and how many of them are problems, for the reason `fence_guard`
+    does: "no problems" is what an extractor that found nothing also says. The
+    cases that expect a pointer and no problem are the ones that keep the
+    marker rule from being an unconditional pass.
+
+    Graded against a real file's position in the tree — `skills/demo-video/
+    reference/limits.md` — because resolution is relative to the naming
+    document, and a synthetic path would grade nothing about that.
+    """
+    bad = 0
+    here = "skills/demo-video/reference/limits.md"
+    cases = (
+        ("a sibling reference file", "See `reference/review.md` for it.", 1, 0),
+        ("a one-segment name, out of scope", "`frames.md` embeds them.", 0, 0),
+        (
+            "the skill's own helpers",
+            "`helpers/demo_recording/frames.py` cuts them.",
+            1,
+            0,
+        ),
+        ("a path up out of reference/", "`../SKILL.md` is the entry point.", 1, 0),
+        ("a suite the reader does not have", "`tests/smoke` measures this.", 1, 1),
+        # The same pointer written both ways, because the second is the shape
+        # that hid a live one: `PATH_SHAPED` saw an empty last segment and
+        # refused the token, so the check went quiet rather than red on
+        # `examples/ticket-queue/demos/…/`. A table holding only the first
+        # would still pass with the `.rstrip("/")` deleted.
+        ("a directory the reader does not have", "`examples/ticket-queue`.", 1, 1),
+        (
+            "the same directory, with the trailing slash it is written with",
+            "`examples/ticket-queue/`.",
+            1,
+            1,
+        ),
+        (
+            "the same suite, said to be this repository's",
+            "Measured by this repo's `tests/smoke`.",
+            1,
+            0,
+        ),
+        (
+            "a marker in a different sentence",
+            "This repo is where it was measured. `tests/smoke` grades it.",
+            1,
+            1,
+        ),
+        (
+            "a marker in a different bullet",
+            "- Measured in this repository.\n- `tests/smoke` grades it.",
+            1,
+            1,
+        ),
+        ("a file that exists nowhere", "`reference/gone.md` says why.", 1, 1),
+        ("an output the take writes, seen and allowed", "`frames/frames.md`.", 1, 0),
+        (
+            "an absolute link, label and all",
+            "see [`tests/README.md`](https://github.com/rogvid/skills/blob/main/tests/README.md)",
+            0,
+            0,
+        ),
+        (
+            "a fenced example naming the reader's own tree",
+            "```yaml\n# .github/workflows/demo.yml\non: [push]\n```\n",
+            0,
+            0,
+        ),
+    )
+    for what, document, expect_seen, expect_bad in cases:
+        found = pointers(document)
+        problems = sum(
+            1 for _line, token, sentence in found if verdict(here, token, sentence)[1]
+        )
+        if (len(found), problems) == (expect_seen, expect_bad):
+            print(f"{'CATCHES ' if expect_bad else 'ALLOWS  '} {what}")
+        else:
+            bad += 1
+            print(
+                f"BLIND    {what}: {len(found)} pointer(s) and {problems} "
+                f"problem(s), expected {expect_seen} and {expect_bad}"
+            )
+
+    # And the sweep over the real tree, which is where the floors live. Run
+    # here rather than trusted from `run()`: a --self-test that graded only
+    # synthetic documents would pass on a repository with no `skills/` in it.
+    bad += 1 if check_pointers() else 0
+    return bad
+
+
+def issue_guard() -> int:
+    """Prove the issue checker reads the state, and only fires on pending prose.
+
+    Offline: the states are supplied rather than fetched, so the grading of
+    `stale_refs` runs on every push while the fetch itself only runs where
+    there is a network. What the table pins is the two ways this check could
+    be hollow — firing on any mention of a closed issue (it must not), and
+    never firing at all (the last case is a real "Tracked in" against a closed
+    number).
+    """
+    bad = 0
+    states = {26: "CLOSED", 255: "OPEN"}
+    cases = (
+        ("a closed issue presented as pending", "Tracked in [#26](x).", 1),
+        ("an open issue presented as pending", "Tracked in [#255](x).", 0),
+        ("a closed issue cited as a measurement", "Measured in #26.", 0),
+        ("a closed issue beside an open one", "Tracked in #26 and #255.", 0),
+        ("a number the tracker does not carry", "Tracked in PR #9001.", 0),
+        ("a closed issue named only by URL", "Until then, see /issues/26.", 1),
+        (
+            "pending prose two sentences from the number",
+            "It is tracked in the usual place. Nobody reads #26.",
+            0,
+        ),
+    )
+    for what, document, expect in cases:
+        found = len(stale_refs(document, states))
+        if found == expect:
+            print(f"{'CATCHES ' if expect else 'ALLOWS  '} {what}")
+        else:
+            bad += 1
+            print(f"BLIND    {what}: {found} finding(s), expected {expect}")
+
+    # The control the table cannot give: that the vocabulary above still
+    # matches this repository's prose at all. A `PENDING` that stopped matching
+    # would pass every case above by finding nothing, twice. Counted as
+    # `stale_refs` counts — a pending sentence that names an issue — with every
+    # number treated as open, so what is measured is the reach of the regex and
+    # not the state of the tracker.
+    live = 0
+    for rel in tracked("*.md"):
+        if (REPO / rel).is_symlink():
+            continue
+        text = (REPO / rel).read_text(encoding="utf-8", errors="replace")
+        for _first, block in blocks(text):
+            for hit in PENDING.finditer(block):
+                sentence = sentence_at(block, hit.start())
+                live += 1 if ISSUE_REF.search(sentence) else 0
+    if live >= MIN_PENDING_SENTENCES:
+        print(f"OK       {live} pending sentence(s) in this tree name an issue")
+    else:
+        bad += 1
+        print(
+            f"DEAD     only {live} sentence(s) in the whole tree match the pending "
+            f"vocabulary, under the {MIN_PENDING_SENTENCES} floor — it has stopped "
+            f"describing how this repo writes, so every case above is being graded "
+            f"on synthetic text alone"
+        )
+    return bad
+
+
 def _compiles(body: str) -> bool:
     try:
         compile(body, "<fence>", "exec")
@@ -653,6 +1303,14 @@ def self_test() -> int:
     # 6. The documentation checker can fail, and only for the right reason.
     bad += fence_guard()
 
+    # 7. And the two that grade where the documentation points: that a path a
+    #    reader cannot open is caught, that saying where it is clears it, and
+    #    that a closed issue offered as pending work is caught. Both are run
+    #    against synthetic documents whose answers are known, plus a control
+    #    that the vocabulary still matches this tree.
+    bad += pointer_guard()
+    bad += issue_guard()
+
     if bad:
         print(f"\n{bad} guard(s) did not hold: this command cannot be trusted.")
         return 1
@@ -666,14 +1324,21 @@ def main() -> int:
         "--github", action="store_true", help="GitHub annotations (what ci.yml runs)"
     )
     parser.add_argument(
+        "--issues",
+        action="store_true",
+        help="the network half: no document points at a closed issue as pending",
+    )
+    parser.add_argument(
         "--self-test",
         action="store_true",
-        help="prove the pin, the file set and the fence checker are live",
+        help="prove the pin, the file set and both doc checkers are live",
     )
     args = parser.parse_args()
     if args.self_test:
         return self_test()
     try:
+        if args.issues:
+            return 1 if check_issue_refs(args.github) else 0
         return run(args.github)
     except Refused as exc:
         print(f"lint: {exc}", file=sys.stderr)

--- a/tests/smoke
+++ b/tests/smoke
@@ -2887,8 +2887,8 @@ def check_caption(b: Beats, page, expected: str) -> None:
 #
 # 3/3 idle takes stalled; 3/3 ticking takes did not. So the harness removes the
 # confound rather than widening a bar around it — the drift itself is the
-# recorder's problem to solve, tracked in issue #18, and tests/README.md says
-# plainly that this axis no longer sees it.
+# recorder's problem, which issue #18 measured and closed, and tests/README.md
+# says plainly that this axis no longer sees it.
 #
 # Sized so it cannot be mistaken for content: 8x8 px at 2-6% opacity is about
 # one pixel of the 160x90 luma reduction, moving a handful of levels. It adds


### PR DESCRIPTION
Fixes #269.

**Acceptance criterion**: every pointer in the shipped skill resolves to
something the reader can actually reach, and a check in CI fails when a new one
does not.

## What changed

| family | sites | what they say now |
|---|---|---|
| (a) closed issue presented as pending | 14 sentences, 4 shipped | what actually happened — closed as not planned, closed by declaring the gap, or (#224) closed as not reproducing with #255 named as the live defect |
| (b) `tests/` symbol a consumer cannot reach | 17 in shipped Markdown and module docstrings | the property, or "this repository's" |
| (c) a count of items that drifts | `limits.md`'s "Three things … apply this for you" | enumerated, unnumbered, and the item that applies nothing is separated from the three that do |
| false claim | `limits.md:242` + `stitching.py:359` | the measurement (−1.4684 s step → **10 ms**, 0.7%) and an explicit "do not extrapolate from one point" |

`timeline.py:1197` calls `capture_clock_correction(doc)[1]` — the state, never
the `place` callable — so `timeline.md` *reports* the correction rather than
applying one. The real third applier is `overlaps[].video_overlap`
(`stitching.py:400`), which the same PR that wrote "Three" had added.

Root `README.md:71` now points at `reference/ci.md`, where the section actually
lives. `skills/demo-video/README.md`'s "33 kB (~12k tokens) / 90 kB (~33k)"
measured 39,648 B and 145,307 B; the figures are removed rather than corrected,
because they go stale on every edit.

## The check

Split on whether it needs the network, as #269 asked:

- **`check_pointers()`** — offline, runs as part of `tests/lint`. Every
  repo-shaped path named in `skills/**/*.md` or in a shipped module's
  **docstring** must resolve inside the installed skill, or the sentence naming
  it must say it is in this repository. 70 pointers across 25 documents.
- **`tests/lint --issues`** — its own CI step, `issues: read`, `GH_TOKEN:
  ${{ github.token }}`. One `gh issue list` and a sweep of 1,393 references
  across 47 files. ~2 s; nothing was added to the smoke path.

Non-vacuity is asserted in four places: floors on documents read (15) and
pointers examined (40); a floor on issue references swept (200); and a
`--self-test` control that the pending vocabulary still matches real prose in
this tree. `KNOWN_ABSENT` is a waiver list graded like `KNOWN_FRAGMENTS` — an
entry that stops being a problem **fails**, so it can only shrink. It holds one
entry, `script-conventions/SKILL.md`'s `./scripts/mytool`, whose sentence exists
to say that path does not resolve.

## Fault injection

Every injection below was applied by a driver that **aborts unless its pattern
matches exactly once**, ran the command, and restored the file.

<details><summary>1. an unreachable path loses its marker → caught</summary>

```
--- injected into skills/demo-video/reference/review.md ---
-   This was measured directly, by this repo's `tests/smoke`
+   This was measured directly by `tests/smoke`
--- tests/lint ---
pointers: 70 path(s) named across 25 shipped document(s); 5 named as this repository's, 1 waived
pointers: skills/demo-video/reference/review.md:70: `tests/smoke` is in this repository but not in the installed skill, and the sentence naming it does not say so — a reader who ran `npx skills add` has no such path
--- exit 1 ---
```
</details>

<details><summary>2. a path inside the skill stops existing → caught</summary>

```
--- injected into skills/demo-video/reference/ci.md ---
-   `helpers/demo_recording/target.py`
+   `helpers/demo_recording/targets.py`
pointers: 70 path(s) named across 25 shipped document(s); 6 named as this repository's, 1 waived
pointers: skills/demo-video/reference/ci.md:92: `helpers/demo_recording/targets.py` does not exist, here or in the skill
--- exit 1 ---
```
</details>

<details><summary>3. the walker stops finding <code>skills/</code> → both floors and the stale waiver fire</summary>

This is the vacuous sweep, injected directly: a clean tree and a dead
measurement print the same "no problems" without these.

```
--- injected into tests/lint ---
-   for rel in tracked("skills/*"):
+   for rel in tracked("skills/nowhere/*"):
pointers: 0 path(s) named across 0 shipped document(s); 0 named as this repository's
pointers: skills/script-conventions/SKILL.md:1: KNOWN_ABSENT waives `./scripts/mytool`, which this document no longer names as a problem — delete the entry
pointers: tests/lint:1: only 0 shipped document(s) were read, under the 15 floor — this reads as a walker that stopped finding `skills/`, not as a skill that ships no prose
pointers: tests/lint:1: only 0 path-shaped pointer(s) were examined, under the 40 floor — the extractor is not reading what it used to, so a clean result here means nothing
--- exit 1 ---
```
</details>

<details><summary>4. a waiver that no longer waives anything → caught</summary>

```
--- injected into tests/lint ---
-   "./scripts/mytool",
+   "./scripts/mytool-gone",
pointers: 70 path(s) named across 25 shipped document(s); 6 named as this repository's
pointers: skills/script-conventions/SKILL.md:58: `./scripts/mytool` does not exist, here or in the skill
pointers: skills/script-conventions/SKILL.md:1: KNOWN_ABSENT waives `./scripts/mytool-gone`, which this document no longer names as a problem — delete the entry
--- exit 1 ---
```
</details>

<details><summary>5. a "Tracked in #N" pointer put back at a closed issue → caught</summary>

```
--- injected into tests/README.md ---
-   3.4 s. Raised as [#34](https://github.com/rogvid/skills/issues/34) and closed
+   3.4 s. Tracked in [#34](https://github.com/rogvid/skills/issues/34).
issues: 1393 reference(s) across 47 file(s), against 193 issue(s) on the tracker
issues: tests/README.md:2604: presented as pending work, but #34 is closed: 'Tracked in [#34](https://github.com/rogvid/skills/issues/34).'
--- exit 1 ---
```
</details>

<details><summary>6. the issue sweep stops reading the tree → the floor fires</summary>

```
--- injected into tests/lint ---
-   for rel in tracked():
+   for rel in tracked("wip/*"):
issues: 0 reference(s) across 1 file(s), against 193 issue(s) on the tracker
issues: tests/lint:1: only 0 issue reference(s) were read across 1 file(s), under the 200 floor — the sweep is not reading this repository's documents
--- exit 1 ---
```
</details>

<details><summary>7. <code>gh</code> fails, and 8. <code>gh</code> returns a list that is all one state → refused, not passed</summary>

An unreachable tracker must not read as "no dead pointers".

```
$ PATH=<a gh that exits 4>:$PATH tests/lint --issues
lint: `gh issue list` failed, so nothing below was graded: gh: not logged in
exit=3

$ PATH=<a gh that returns only CLOSED issues>:$PATH tests/lint --issues
lint: the issue list came back with 2 issue(s) and not both states in it — a list that is all one state cannot distinguish a live pointer from a dead one
exit=3
```
</details>

<details><summary>9. the pending vocabulary stops matching anything → the control fires</summary>

Without this the seven `issue_guard` cases are graded on synthetic text alone.

```
--- injected into tests/lint ---
-   r"(?i)\b(?:tracked (?:in|at|as)|is tracked|until then|still open|"
+   r"(?i)\b(?:trakced (?:in|at|as)|is trakced|untill then|still opne|"
BLIND    a closed issue presented as pending: 0 finding(s), expected 1
BLIND    a closed issue named only by URL: 0 finding(s), expected 1
DEAD     only 0 sentence(s) in the whole tree match the pending vocabulary, under the 1 floor — it has stopped describing how this repo writes, so every case above is being graded on synthetic text alone

3 guard(s) did not hold: this command cannot be trusted.
--- exit 1 ---
```
</details>

Two of the guard tables also caught **my own** mistakes before this was pushed,
which is the argument for them: `../SKILL.md` was being stripped to `/SKILL.md`
by an over-eager `.strip(".")` and resolved to the filesystem root, and
`pointer_guard` was restating the classification rather than calling it, so its
copy had already diverged. Both are fixed; `verdict()` is now the single place
the rule lives and the guard calls it.

## Stated limits

Written into `tests/README.md` under *Known gaps*, with counts, rather than
covered by a check that could not catch them:

1. **Implementation comments are out of scope.** Twenty `tests/smoke` /
   `tests/unit` mentions sit beside the constants they explain inside
   `helpers/demo_recording/`. They ship, but they are read by somebody already
   in the source rather than handed to a reader as somewhere to go. Counted,
   not rewritten — rewriting them would have been a larger change than the
   defect, and several sit in files another branch is editing.
2. **A one-segment name is not checked.** `frames.md`, `record.py`, `demo.mp4`
   are files the *take* writes; nothing separates them from a mistyped
   `revew.md`, so only paths containing a `/` are examined.
3. **A typo in a directory name gets through.** The dead-path rule fires only
   when the first segment is an existing directory, which is what keeps
   `frames/frames.md` from being reported as dead.
4. **No heading is checked.** `README.md:71` is fixed by hand; the next one
   would be too.
5. **The pending vocabulary is a fixed list**, and a sentence whose only number
   is a pull request is skipped rather than guessed at.

## Already in flight, not touched here

Per the split with the parallel branch, `skills/demo-video/SKILL.md` was not
edited. `check_pointers()` reports nothing in it today. Prose about
masking/scrubbing in `core.py`, `failure.py` and `timeline.py` was also left
alone; the `timeline.py` finding in #269 is a *statement about* `timeline.py`
in `limits.md`, and that is where it was fixed.

## Verification

`tests/unit` (379), `tests/unit --fault-inject` (245 injections),
`tests/unit --budget`, `tests/ci-unit` (63), `tests/ci-unit --fault-inject`
(26), `tests/smoke-inject --self-test`, `tests/lint`, `tests/lint --self-test`,
`tests/lint --issues`, `ruff format --check`, mypy, actionlint — all green.
`tests/smoke` was not run (exclusive machine lock); nothing here touches a
recording path.
