### PR TITLE
Say what the target guard classifies, and stop the source claiming a mask that was removed

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -30,15 +30,22 @@ works almost always is worse than none, because it is what persuades somebody
 it is safe to point the recorder at production. The absence is the stronger
 guarantee ([#138](https://github.com/rogvid/skills/issues/138)).
 
-**The recorder refuses a public target, in CI and on your machine**, at
-construction, before a browser opens. `Recorder` classifies its `base_url`;
-*both* recorders classify `DEMO_VIDEO_BASE_URL`, which is the only target a
-`TerminalRecorder` has and is checked **even when a storyboard passes a
-loopback `base_url`** — a shell exporting production and a storyboard saying
-otherwise is refused rather than quietly resolved. Loopback passes, a private
-host needs `allow_private=True`, a public one is refused and no option permits
-it. CI runs the same classifier over `extra-env` and each storyboard's source
+**The recorder classifies its target at construction, in CI and on your
+machine, before a browser opens** — and it classifies exactly two strings.
+`Recorder` classifies the `base_url` it resolved; *both* recorders classify
+`DEMO_VIDEO_BASE_URL`, which is the only target a `TerminalRecorder` has and is
+checked **even when a storyboard passes a loopback `base_url`** — a shell
+exporting production and a storyboard saying otherwise is refused rather than
+quietly resolved. Loopback passes, a private host needs `allow_private=True`, a
+public one is refused and no option permits it. CI runs the same classifier
+over `extra-env` and each storyboard's source
 ([reference/ci.md](reference/ci.md)).
+
+**Nothing else is classified, and `goto()` is where that shows.** It passes an
+absolute URL straight through, so `rec.goto("https://app.acme.com/")` records
+production and nothing refuses it; `rec.page` is further out still. The guard
+catches a target you *misconfigured*, not one you *named* — it is not a
+control, and the paragraphs above are still the whole of the guidance.
 
 ## Overview
 
@@ -53,8 +60,8 @@ Two subjects, one engine. **`Recorder`** drives a **web app** through a
 Playwright page. **`TerminalRecorder`** runs a **CLI or TUI** in a real PTY
 rendered by an in-browser terminal — so captions, narration, stills,
 segments, and verification all work identically. This document leads with
-the web recorder; the **Terminal demos** section below covers what differs.
-Terminal recording is **Unix-only** (it uses a PTY).
+the web recorder; the **Terminal demos** section below covers what differs,
+and is **Unix-only** because it uses a PTY.
 
 Both record into a **framed window on a soft pastel background** (rounded
 window, title bar, traffic-light buttons) so the eye has an obvious focus —
@@ -95,20 +102,20 @@ behind every one, are in [reference/limits.md](reference/limits.md).
 - **It will not tell you a card was left up.** A held picture is reported only
   when a verb that *acts on the app* ran while it was held, so a demo that
   raises an `interlude()` and then only captions, holds and takes stills behind
-  it passes in silence — measured at 31.5 s of a 34 s take. Take cards down
-  explicitly. A caption long enough to wrap can also silence the same warning
-  on an app's own modal, so keep captions to one line.
+  it passes in silence for almost its whole length. Take cards down explicitly.
+  A caption long enough to wrap can also silence the same warning on an app's
+  own modal, so keep captions to one line.
 - **A frame is aimed at a beat, not stamped with one.** Chromium stamps frames
   with the host's **wall** clock, the beat log uses a monotonic one, so on a
   host whose clock steps an event lands earlier in `demo.mp4` — by the step,
-  once per step, and no measured figure keeps — one WSL2 box gave −0.78 s
-  every 32.2 s, then −0.50 s every 5.5 s. `timeline.json`'s `capture_clock`
-  records each: correct with it once its `measured` flag says it watched.
+  once per step, and no measured figure keeps. `timeline.json`'s
+  `capture_clock` records each: correct with it once its `measured` flag says
+  it watched.
 - **Sixty seconds buys about twenty screens.** At the pacing floors below, a
-  demo shows roughly one new screen every 3 s — 69% of a real 61.2 s take was
-  a picture already shown. A feature spanning two surfaces does not fit the
-  30–60 s target, and the honest answers are a longer video or two demos, not
-  faster captions.
+  demo shows roughly one new screen every 3 s, and two thirds of a measured
+  61 s take was a picture already shown. A feature spanning two surfaces does
+  not fit the 30–60 s target, and the honest answers are a longer video or two
+  demos, not faster captions.
 - **A demo of an error path records a problem.** A non-zero exit is logged as
   an issue and is fatal under `strict=True`, with no way to say it was the
   point — so leave strict off for that demo, and say in the pull request which
@@ -168,11 +175,10 @@ skill's folder, so it must be installed wherever demos are re-recorded.
 Each `record.py` is a self-contained uv script — PEP 723 metadata brings
 Playwright without any project environment. You are writing this file,
 and you know where this skill is installed (you are reading it) — so
-**fill `_DEFAULT_SKILL_DIR` with that actual location**. Prefer a
-repo-relative expression via `Path(__file__)` when the skill lives in
-the same repo (survives clones), an absolute path otherwise. Do not
-assume any particular layout — `.claude/skills/`, `.agents/`, a global
-directory are all just whatever path happens to be true.
+**replace `_DEFAULT_SKILL_DIR` with that actual location**. What ships in
+it is a guess at the commonest one, not a layout to assume: prefer a
+repo-relative expression via `Path(__file__)` when the skill lives in the
+same repo (survives clones), an absolute path otherwise.
 `DEMO_VIDEO_SKILL_DIR` overrides the constant at runtime, covering moves
 and unusual setups.
 
@@ -185,10 +191,12 @@ and unusual setups.
 import os, sys
 from pathlib import Path
 
-# Filled in by the writing agent with the skill's real location;
-# DEMO_VIDEO_SKILL_DIR takes precedence.
-_DEFAULT_SKILL_DIR = "<fill in: the demo-video skill folder>"
-SKILL_DIR = Path(os.environ.get("DEMO_VIDEO_SKILL_DIR") or _DEFAULT_SKILL_DIR)
+# Replace with this skill's real location; DEMO_VIDEO_SKILL_DIR wins at
+# runtime. To find it:  find . ~ -name demo-video -type d 2>/dev/null
+_DEFAULT_SKILL_DIR = "~/.claude/skills/demo-video"
+SKILL_DIR = Path(
+    os.environ.get("DEMO_VIDEO_SKILL_DIR") or _DEFAULT_SKILL_DIR
+).expanduser()
 if not (SKILL_DIR / "helpers" / "demo_recording" / "__init__.py").exists():
     sys.exit(f"demo-video skill not found at {SKILL_DIR} — set DEMO_VIDEO_SKILL_DIR")
 sys.path.insert(0, str(SKILL_DIR / "helpers"))
@@ -349,8 +357,7 @@ with TerminalRecorder(Path(__file__).parent) as rec:
 **Read [reference/terminal.md](reference/terminal.md) before writing one.** It
 carries the full verb table (`run`, `send`, `key`, `wait_for_prompt`,
 `wait_for_text`), how to open a segment on a title card, the four patterns a
-terminal demo takes, and the gotchas — pagers, echo, prompts that never
-return.
+terminal demo takes, and the gotchas — pagers, echo, prompts that never return.
 
 ## Process
 
@@ -365,12 +372,10 @@ return.
    `Recorder(out_dir, segment="part1")`, poll between segments until the
    work is done, open the next segment with `rec.interlude("…a few minutes
    later…")` on `about:blank` before navigating, and
-   `from demo_recording import stitch` to concatenate them into
-   demo.mp4. A **terminal** segment takes its opening card as
+   `from demo_recording import stitch` to concatenate them into demo.mp4. A
+   **terminal** segment takes its opening card as
    `TerminalRecorder(interlude="…")` instead — see
-   [reference/terminal.md](reference/terminal.md). `stitch()` also merges the segments' beat logs into one
-   `timeline.json` / `timeline.md`, so a segmented demo commits the same two
-   files as any other — you do not have to do anything for that.
+   [reference/terminal.md](reference/terminal.md).
 2. **Write `record.py`** in the demo folder as a short storyboard. Capture
    a still (`rec.shot("NN-name")`) at each moment a written guide would
    narrate. Make retakes idempotent — clean up state earlier takes created,
@@ -513,11 +518,10 @@ return.
    of that name anywhere in the repo), `.tts/` narration caches, and
    `<demo folder>/evidence/` — the last two are **working files**, inputs to
    a review that happens once, and the file table at the top of this skill
-   says so in the same column that says the mp4 is not committed.
-
-   **`evidence/` is not committed either, and for a stronger reason than the
-   mp4** — it is greppable plaintext of a real app's DOM; `timeline.md` is what
-   a reader six months from now gets ([reference/review.md](reference/review.md)).
+   says so in the same column that says the mp4 is not committed. `evidence/`
+   has the stronger reason of the two: it is greppable plaintext of a real
+   app's DOM, and `timeline.md` is what a reader six months from now gets
+   ([reference/review.md](reference/review.md)).
 
    To put the demo in front of a reviewer, drag `demo.mp4` into a PR
    comment box — GitHub hosts it and renders a real player. That upload has
@@ -564,17 +568,13 @@ return.
   timeline over a recording nobody can watch. Check `content` in the same file
   — that is the field that describes the frames
   ([reference/timeline.md](reference/timeline.md)).
-- **Reading `content.score` as "the app was visible".** It is luma variance
-  over the app rect, so a translucent overlay *adds* to it: a scrim left over
-  the app measured **32.94** against a clean take's **26.74**, and both printed
-  `demo.mp4 shows a picture`. `warnings` is the field that answers the
-  question. An interlude *this recorder* raised and you did not clear is named
-  there by element id; an app's own modal is named by nothing
-  ([reference/limits.md](reference/limits.md)).
-- **Reading `content.static_for` as a score.** It is not one. A healthy demo
-  that narrates a rendered screen holds it for 20s or more, which is what a
-  covering card also measures. Read `warnings`; the number alone means nothing
-  without the beats beside it.
+- **Reading `content.score` or `content.static_for` as "the app was visible".**
+  Neither is a verdict. The score is luma variance over the app rect, so a
+  translucent overlay left over the app *raises* it, and a healthy demo
+  narrating one screen holds as still as a covering card does — both measured,
+  both in [reference/limits.md](reference/limits.md). `warnings` is the field
+  that answers the question: an interlude *this recorder* raised and you did
+  not clear is named there by element id, an app's own modal by nothing.
 - **Embedding video in markdown.** Repo-relative mp4s don't play inline in
   rendered markdown, and `demo.mp4` isn't committed anyway — open the guide
   with a still and point at the re-record command instead. GitHub plays only
@@ -584,17 +584,17 @@ return.
 ## Sharing this skill
 
 The skill is self-contained: this file, the `reference/` directory it links
-into, the `helpers/demo_recording/` package, `scripts/` with `ensure.sh`, the
-vendored `helpers/assets/xterm/` terminal assets, and `README.md`. Install it with the `skills` CLI — into the current project:
+into, the `helpers/demo_recording/` package, `ensure.sh` at the skill root,
+`scripts/demo-target-guard`, the vendored `helpers/assets/xterm/` terminal
+assets, and `README.md`. Install it with the `skills` CLI — into the current project:
 
 ```sh
 npx skills add https://github.com/rogvid/skills/tree/main/skills/demo-video
 ```
 
 add `-g` to install it globally (`~/`) so it is available everywhere. Then run
-Setup in the project where you record. The skill is not tied to the
-`.claude/skills/` convention: each storyboard embeds the skill's location as
-written at creation time, and `DEMO_VIDEO_SKILL_DIR` overrides it — so
-`.agents/` folders, global installs, or any other harness layout work the same
-way. Re-recording a committed storyboard requires the skill to be installed —
-that is the one setup step a fresh clone needs.
+Setup in the project where you record. No layout is assumed — a storyboard
+embeds the skill's location as written and `DEMO_VIDEO_SKILL_DIR` overrides it,
+so `.agents/`, a global install, or any other harness works the same way.
+Re-recording a committed storyboard requires the skill to be installed, which
+is the one setup step a fresh clone needs.

--- a/skills/demo-video/helpers/demo_recording/content.py
+++ b/skills/demo-video/helpers/demo_recording/content.py
@@ -67,8 +67,8 @@ def media_duration(path: Path) -> float:
 # Two independent arms, because the failure above defeats one of them:
 #
 #   score       median luma standard deviation over the content rect. Catches
-#               a recording that never rises above blank — a black take, a page
-#               that never painted, a mask that covered everything.
+#               a recording that never rises above blank — a black take, or a
+#               page that never painted.
 #   static_for  the longest run of consecutive sampled frames that do not
 #               change, in seconds. Catches a recording that is *covered* or
 #               frozen, which the score cannot: the #91 card is dark with a
@@ -749,9 +749,9 @@ def _content_report(
     report["static_from"] = round(began, 2)
 
     # What the storyboard was doing while the picture stood still. Verb and
-    # index only — never the selector: a selector can hold a value somebody
-    # registered as a secret, and this string goes to stderr before the take's
-    # scrubbing has run. The index is enough; the beat is in the same file.
+    # index only — never the selector: this line goes to stderr, where it ends
+    # up in build logs nobody prunes, and nothing anywhere in this recorder
+    # would filter it (#138). The index is enough; the beat is in the same file.
     spanned = None if beats is None else _beats_within(beats, began, ended)
     acting = [b for b in (spanned or []) if b["acting"]]
     if spanned is not None:

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1644,9 +1644,10 @@ class _DemoBase:
             yield None
             return
         self._in_beat = True
-        # Scrubbed rather than fatal, because none of these is text a viewer
-        # reads off the screen. Caption text reaches the screen through
-        # caption(), which refuses it outright.
+        # Every field goes in as the storyboard gave it — the caption, the
+        # selector, the still's name. Nothing here filters, and `caption()`
+        # refuses nothing either (#138), so `timeline.json` is committed
+        # carrying whatever the storyboard put in these arguments.
         record: dict = {
             "index": len(self._beats),
             "t_start": round(time.monotonic() - self._t0, 3),
@@ -1735,9 +1736,11 @@ class _DemoBase:
         """Extract this take's review frames (a no-op for a segment).
 
         The frames come out of the recording rather than being re-derived
-        it: every one of them is a frame of `demo.mp4`, which is masked in the
-        page before it is ever captured. `tests/smoke` measures that on the
-        frames themselves instead of taking this paragraph's word for it.
+        from the page: every one of them is a frame of `demo.mp4`, so a
+        reviewer reads what the video showed and not a second render that
+        could differ from it. `tests/smoke` requires each PNG to be
+        byte-identical to that second cut out of the mp4 again, instead of
+        taking this paragraph's word for it.
         """
         write_beat_frames(self.out_dir, doc, "this take")
 
@@ -1908,14 +1911,15 @@ take with fewer beats than the last one would otherwise leave the
     def _failure_screen(self) -> str | None:
         """The medium's page text, for a failure dump. None if it has none.
 
-        Called on the failure path only, **after `_stop()` and before
-        the medium has been stopped** — that slot is the whole design. After
-        `_stop()` because a medium can be sitting on output (the terminal
-        scrubber withholds a trailing fragment and flushes it there), so an
+        Called on the failure path only, **after `_stop()` and before the
+        medium has been stopped** — that slot is the whole design. After
+        `_stop()` because a medium can be sitting on output (`TerminalRecorder`
+        holds back a possible half exit-marker and flushes it there), so an
         earlier reading is not the screen the recording ends on. Before the
-        verifier because the verifier is what decides whether any of this may
-        be kept: read after it, this would be page text nothing has vouched
-        for, which is the exact hole PR #58 was blocked on.
+        browser goes away, because there is no page to read afterwards. The
+        third constraint this slot used to satisfy — read it *before* the
+        redaction verifier, the hole PR #58 was blocked on — went with that
+        verifier in #144, and nothing vouches for this text now.
         """
         return None
 
@@ -1936,13 +1940,14 @@ take with fewer beats than the last one would otherwise leave the
             )
 
     def _failure_doc(self, failure: dict) -> dict:
-        """The machine-readable half of `failure/`, masked and checked.
+        """The machine-readable half of `failure/`.
 
-        Same order and same reasons as `_evidence_doc`: mask first, check the
-        serialized bytes last, raise rather than write. Nothing in here is read
-        from the page — `screen` was buffered before the verifier ran, the
-        issues and the beats have been in memory since they happened, and the
-        media is named rather than opened.
+        Envelope, the failing beat in full, the issue log, and what was
+        recorded — all of it as it came, because there is no masking anywhere
+        in this recorder (#138). Nothing in here is read from the page either:
+        the page text was buffered by `_capture_failure_screen` and only its
+        presence is reported here, the issues and the beats have been in memory
+        since they happened, and the media is named rather than opened.
         """
         beat = failed_beat(self._beats)
         doc: dict = {
@@ -2263,9 +2268,9 @@ take with fewer beats than the last one would otherwise leave the
             # it could not be measured. Never silently absent.
             #
             # It carries no selector today and deliberately so (see
-            # `_content_report`): this file is committed, and a field that
-            # grows a quoted string
-            # later must not be the one place the mask does not reach.
+            # `_content_report`): this file is committed, nothing in this
+            # recorder filters what goes into it, so a field that grows a
+            # quoted string later publishes that string as it was written.
             "content": self._content,
             # The clock demo.mp4 is actually on, and the only field here that
             # is not a reading of `time.monotonic()` (issues #18, #215). See
@@ -2282,9 +2287,9 @@ take with fewer beats than the last one would otherwise leave the
             # track this could describe. Taken from `_convert`, not recomputed
             # here: what belongs in the artifact is what the mix did.
             "narration": self._narration,
-            # Built from the *scrubbed* beats, not from `self._beats`, so a
-            # still path or a caption that the mask reached is masked here too
-            # rather than reappearing in the coverage table (issue #12).
+            # Built from the same `beats` list this document publishes, not
+            # from `self._beats` again, so the coverage table and the beat log
+            # can never disagree about what a beat claimed (issue #12).
             # Null on a take recorded outside a ticket.
             "coverage": coverage_report(self._criteria, beats),
             "beats": beats,

--- a/skills/demo-video/helpers/demo_recording/failure.py
+++ b/skills/demo-video/helpers/demo_recording/failure.py
@@ -114,8 +114,13 @@ def failure_summary(
 ) -> dict:
     """What came out of the `with`, and which beat it came out of.
 
-    Unscrubbed: every consumer (`_timeline_doc`, the dump, the marker)
-    masks it on the way to its own file, and each has a different mask.
+    Verbatim, and every consumer (`_timeline_doc`, the dump, the marker)
+    writes it out that way — nothing between here and any of those three
+    files removes anything (#138). `str(exc)` on a `wait_for_text()` timeout
+    is a thousand characters of terminal screen, and it lands in each of them
+    as the program printed it. Only the length caps act — this one's is
+    `FAILURE_MESSAGE_CHARS` and the marker's is tighter still — and a length
+    cap is not a filter.
     """
     beat = failed_beat(beats)
     message = str(exc) if exc is not None else ""
@@ -128,8 +133,8 @@ def failure_summary(
 
 
 def render_failure_md(doc: dict) -> str:
-    """The human half. Pure function of the document above, so it inherits
-    its masking rather than re-deriving it."""
+    """The human half. Pure function of the document above, so it says
+    exactly what that document says and derives nothing of its own."""
     failure = doc.get("failure") or {}
     beat = doc.get("beat") or {}
     where = (

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -299,8 +299,11 @@ from .markdown import _fmt_t, _md_cell
 #   exit_code int?   — TerminalRecorder `run` beats only: the shell's status
 #                      for that command, or null if it could not be read
 #   error     dict?  — **absent** on a verb that returned. Present, with the
-#                      exception's `type` and its scrubbed `message`, on a verb
-#                      that raised. Absent-on-success rather than
+#                      exception's `type` and its `message` **verbatim**, on a
+#                      verb that raised — `wait_for_text()` puts a thousand
+#                      characters of terminal screen in there and nothing
+#                      filters it, which is a reason not to point the recorder
+#                      at anything real (#138). Absent-on-success rather than
 #                      `error: null`-on-success on purpose: a consumer asking
 #                      "did this beat do what it says" wants the answer to be
 #                      structurally missing when there is nothing to say, and

--- a/tests/README.md
+++ b/tests/README.md
@@ -2740,10 +2740,27 @@ knows is missing is worse than one that is openly absent.
   And the standing one, which is a scope statement rather than a gap:
   **anything the take reaches other than its classified target.** A page that
   fetches another origin, a terminal storyboard that curls one, a URL computed
-  at run time. This is a static classifier over configuration and source text,
-  not an egress control, and `target.py`'s docstring says so in the same
-  words. `scripts/demo-target-guard` is also outside mypy's scope, which runs
-  over `skills/demo-video/helpers/` only.
+  at run time — and, named because it is the one a storyboard author reaches
+  for by accident, **`goto()`'s own argument**: `web.py` passes an absolute URL
+  straight through, so `rec.goto("https://app.acme.com/")` records production
+  and no assertion here notices
+  ([#268](https://github.com/rogvid/skills/issues/268)). This is a static
+  classifier over configuration and source text, not an egress control, and
+  `target.py`'s docstring says so in the same words. `SKILL.md` now says it too
+  ([#267](https://github.com/rogvid/skills/issues/267)), which is what stops a
+  caller reading the guard as one. `scripts/demo-target-guard` is also outside
+  mypy's scope, which runs over `skills/demo-video/helpers/` only.
+
+- **Whether prose about masking is *otherwise* true, and prose anywhere but
+  the two places `MaskProse` reads.** `tests/unit`'s sweep flags every mention
+  of mask/scrub/redact in `helpers/demo_recording/*.py` and `SKILL.md` and
+  makes each one earn a hand-written waiver, which is what catches a sentence
+  asserting a layer that #138 removed. It does not read `reference/*.md` or the
+  skill's `README.md`, and it cannot tell a waivered denial that is accurate
+  from one that has quietly gone stale about *something else* — a waiver saying
+  "#142's carve-out" stays green after #142's carve-out is deleted. The list
+  can only shrink, so a stale entry surfaces the moment its line is edited;
+  nothing surfaces one whose line is edited nowhere.
 
 Failures accumulate and print together, each naming the file or interaction and
 the number that was wrong. The process exits non-zero if there is even one, and

--- a/tests/unit
+++ b/tests/unit
@@ -2827,6 +2827,153 @@ class OneClassifier(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# No shipped source says something is masked (issues #138, #142, #144, #267)
+# --------------------------------------------------------------------------
+#
+# The masking layer was removed on purpose, and the prose describing it was
+# not. #267 found eleven sites: `failure.py:15` said "There is no mask (#138)"
+# and `failure.py:117` said every consumer "masks it on the way to its own
+# file"; `_failure_doc` said "masked and checked" 148 lines below
+# `_evidence_doc`'s "there is no masking anywhere in this recorder"; the
+# timeline builder said its coverage table was "built from the *scrubbed*
+# beats" one line after `beats = [dict(beat) for beat in self._beats]`.
+#
+# The dangerous one was `timeline.py`'s published schema, which told a reader
+# that a beat's `error.message` — up to a thousand characters of terminal
+# screen, in a **committed** file — arrives *scrubbed*.
+#
+# This sweep is not an exact-phrase denylist, which would only fail for
+# somebody re-typing a sentence nobody is going to re-type. It flags **every**
+# mention of the word family in the files this change owns, and requires each
+# one to be waivered by hand. New prose asserting a mask fails until a human
+# writes it down here, which is the decision the eleven sites never got.
+#
+# Its scope, stated: `helpers/demo_recording/*.py` and `SKILL.md`. Not
+# `reference/` or the skill README, and not whether the surviving prose is
+# right about anything other than masking — see tests/README.md's Known gaps.
+
+MASK_WORDS = re.compile(
+    r"\b(?:mask|masks|masked|masker|maskers|masking"
+    r"|scrub|scrubs|scrubbed|scrubber|scrubbing"
+    r"|redact|redacts|redacted|redaction)\b",
+    re.I,
+)
+
+# Waivered like `tests/lint`'s `KNOWN_FRAGMENTS`: an entry whose line has gone
+# **fails** rather than being ignored, so the list can only shrink. Keyed by
+# file and by the line exactly as it appears stripped, because editing the
+# sentence at all takes it back out of the waiver and into the check.
+#
+# Every entry below is a denial ("no masking, no scrubbing and no redaction",
+# "this recorder scrubs nothing"), a past-tense note about machinery that was
+# removed (#142's carve-out, #144's verifier), or the video sense of the word
+# — a reviewer scrubbing a timeline, which has nothing to do with secrets.
+MASK_PROSE_WAIVED: dict[str, tuple[str, ...]] = {
+    "SKILL.md": (
+        "- The tool has **no masking, no scrubbing and no redaction**. It does not hide",
+        "used to look like one was removed rather than improved. A masking system that",
+    ),
+    "core.py": (
+        "# The redaction verifier that used to run last was what this sequence",
+        "# The one thing that used to keep *nothing* was an unverifiable mask,",
+        "# A third way in — a take whose mask could not be verified, which",
+        "# through verbatim — this recorder scrubs nothing (#138).",
+        '`{"omitted": reason}` payload for text the mask could not vouch for,',
+        "went with the mask in #144. A capture that *raises* still gets a file,",
+        "masking anywhere in this recorder.",
+        "redaction verifier, the hole PR #58 was blocked on — went with that",
+        "recorded — all of it as it came, because there is no masking anywhere",
+    ),
+    "failure.py": (
+        'if the mask cannot be vouched for". There is no mask (#138); a document is built',
+    ),
+    "frames.py": (
+        "long enough to record in parts is a demo nobody wants to scrub by hand.",
+    ),
+    "stitching.py": (
+        "not a defect in the file a reviewer scrubs. Above zero means the recorded",
+        "only one that matches the file a reviewer scrubs: Chromium's screencast",
+        "# the one nobody wants to review by scrubbing. Written here rather than in",
+    ),
+    "target.py": (
+        "whole design (issue #138): the skill has no masking, no scrubbing and no",
+        "redaction, because a masker that works almost always is what persuades somebody",
+    ),
+    "web.py": (
+        "# The mask-elision arm went with #142. What is left is a statement about what",
+        "# **Kept deliberately when the masking went** — #142's carve-out.",
+        "# is a statement about a mask and about nothing else.",
+        'the mask". There is no mask, so nothing consumes it. The *listener* is',
+        "job and has nothing to do with masking.",
+        "the snapshot, retried until they agreed — because the mask had to be",
+        "between the two reads produced a mask with a hole in it. With no mask",
+    ),
+}
+
+# Everything the sweep is supposed to open: the thirteen package modules and
+# SKILL.md. Set to the whole set rather than to a comfortable floor — a module
+# that stops being read makes "no file says it is masked" hold over a file
+# nobody opened, and this is the only assertion that would notice.
+MASK_SWEEP_FILE_FLOOR = 14
+
+
+class MaskProse(unittest.TestCase):
+    """The removed masking layer is not described as though it were there."""
+
+    def swept(self):
+        yield SKILL_DIR / "SKILL.md"
+        yield from sorted((_PKG_PARENT / "demo_recording").glob("*.py"))
+
+    def hits(self) -> dict[str, list[str]]:
+        found: dict[str, list[str]] = {}
+        for path in self.swept():
+            for line in path.read_text(encoding="utf-8").splitlines():
+                if MASK_WORDS.search(line):
+                    found.setdefault(path.name, []).append(line.strip())
+        return found
+
+    def test_no_shipped_source_claims_a_mask_that_does_not_exist(self):
+        found = self.hits()
+        unwaived = sorted(
+            f"{name}: {line}"
+            for name, lines in found.items()
+            for line in lines
+            if line not in MASK_PROSE_WAIVED.get(name, ())
+        )
+        self.assertEqual(
+            unwaived,
+            [],
+            f"{len(unwaived)} line(s) name a mask, a scrub or a redaction that "
+            f"this skill does not have: {unwaived}. There is none of it (#138) "
+            f"— say what the field actually carries, and that it carries it "
+            f"verbatim. If the line denies masking or describes machinery that "
+            f"was removed, waive it in MASK_PROSE_WAIVED with that reason.",
+        )
+
+    def test_the_sweep_read_the_files_it_claims_to_have_read(self):
+        # The haystack, both halves. Every assertion above is satisfied by a
+        # sweep that opened nothing, and by one that found no occurrences at
+        # all — which is also what a regex that stopped matching looks like.
+        self.assertGreaterEqual(len(list(self.swept())), MASK_SWEEP_FILE_FLOOR)
+        found = self.hits()
+        self.assertIn("SKILL.md", found, "SKILL.md's own denial was not found")
+        self.assertGreater(sum(len(v) for v in found.values()), 15)
+
+    def test_a_waiver_cannot_outlive_the_line_it_waives(self):
+        # Otherwise the list only grows, and a stale entry silently permits a
+        # sentence somebody re-adds later. It is also the tightest control on
+        # the sweep itself: one line the regex stops seeing turns this red.
+        found = self.hits()
+        stale = sorted(
+            f"{name}: {line}"
+            for name, lines in MASK_PROSE_WAIVED.items()
+            for line in lines
+            if line not in found.get(name, [])
+        )
+        self.assertEqual(stale, [], f"waivers for lines that are gone: {stale}")
+
+
+# --------------------------------------------------------------------------
 # The beat log says what was true of the screen (issues #134, #177)
 # --------------------------------------------------------------------------
 #
@@ -9581,6 +9728,18 @@ INJECTIONS = [
         "import argparse\nimport sys",
         "import argparse\nimport ipaddress\nimport sys",
         ["OneClassifier.test_the_classification_lives_in_exactly_one_shipped_file"],
+    ),
+    (
+        # **The line #267 was actually about**, restored exactly. It is the
+        # published schema for `error.message`, in the file a consumer reads
+        # to learn what `timeline.json` means, and it tells them a committed
+        # artifact holding up to a thousand characters of terminal screen has
+        # been cleaned. Nothing about the take changes; only the reader does.
+        "the beat schema goes back to calling a beat's error message scrubbed",
+        "timeline.py",
+        "#                      exception's `type` and its `message` **verbatim**, on a",
+        "#                      exception's `type` and its scrubbed `message`, on a",
+        ["MaskProse.test_no_shipped_source_claims_a_mask_that_does_not_exist"],
     ),
     (
         # The CI path, and the one no other assertion here walks: every other


### PR DESCRIPTION
Fixes #267. Documentation truth only - no behaviour changes.

**Acceptance criterion:** a reader of the shipped skill is no longer told something false about what the guard protects, and no shipped source file describes a masking layer that does not exist.

## 1. `SKILL.md` said the guard covers more than it does

The section's last word was, unqualified:

> **The recorder refuses a public target, in CI and on your machine**, at construction, before a browser opens.

It classifies exactly two strings - `DEMO_VIDEO_BASE_URL` (`core.py:898`) and the resolved `base_url` (`web.py:505`). `goto()` classifies nothing; `web.py:863` is `url = path if path.startswith("http") else self.base_url + path`. The section now says so, as its last word:

> **Nothing else is classified, and `goto()` is where that shows.** It passes an absolute URL straight through, so `rec.goto("https://app.acme.com/")` records production and nothing refuses it; `rec.page` is further out still. The guard catches a target you *misconfigured*, not one you *named* - it is not a control, and the paragraphs above are still the whole of the guidance.

The four load-bearing statements above it survive verbatim in substance: no masking/scrubbing/redaction, "if a real credential can appear in the app you are recording, do not record it", the corollary that such a demo cannot be made, and no `allow_public` in any spelling.

**Classifying `goto()`'s argument in code is #268**, with the measurement: all 25 `rec.goto()` calls in this repo pass relative paths, so nothing here would change; what it would break is a storyboard navigating to an absolute loopback URL, and a refusal at beat 12 rather than at construction has an exit path `reference/failures.md` would have to absorb.

## 2. Eleven pieces of prose asserted a masking layer removed by #138/#142/#144

`failure.py:15` said "There is no mask (#138)" and `failure.py:117` said every consumer "masks it on the way to its own file". `_failure_doc` said "masked and checked" 148 lines below `_evidence_doc`'s "there is no masking anywhere in this recorder". The coverage table said it was "built from the *scrubbed* beats, not from `self._beats`" one line after `beats = [dict(beat) for beat in self._beats]`.

The dangerous one was `timeline.py:302` - the **published schema** for a beat's `error.message`, telling a reader that up to a thousand characters of terminal screen, in a **committed** file, arrive scrubbed. `reference/timeline.md:75` and `core.py:1715` both say verbatim, and verbatim is what the code does. It now says verbatim too, and says why that is a reason not to point the recorder at anything real.

Also corrected: `core.py:1647` ("Scrubbed rather than fatal", and a `caption()` refusal that does not exist), `core.py:1738` (`demo.mp4` "masked in the page"), `core.py:1914` (a "terminal scrubber" that is an exit-marker flush), `core.py:1921` (a redaction verifier that gates nothing since #144), `core.py:2266`, `content.py:71`, `content.py:754`.

**No code was writing a count of things it claimed to have masked** - swept for, none found.

Scope: `helpers/demo_recording/*.py` and `SKILL.md`. `reference/*.md` and the skill `README.md` were swept and every mention in them is already a denial, so they are untouched.

## 3. Two small ones in the same file

- `SKILL.md:587` sent a reader to `scripts/` for `ensure.sh`, which is at the skill root. Now names `ensure.sh` at the root and `scripts/demo-target-guard`.
- `_DEFAULT_SKILL_DIR = "<fill in: …>"` was unrunnable with no way to discover the value. Now `"~/.claude/skills/demo-video"` with `.expanduser()` and the `find` command in the comment - a wrong guess still hits the existing `sys.exit` with the path it tried.

## Budget

**600/600 lines, exactly as before.** The room came from measurements duplicated in `reference/limits.md` and `reference/timeline.md` (the 32.94/26.74 figures were in three files) and three sentences `SKILL.md` already said elsewhere in itself. No limit and no rule was dropped, only figures that live in the reference file the section already points at.

## The assertion, and it has been watched failing

`MaskProse` in `tests/unit` flags **every** mention of the mask/scrub/redact word family in `helpers/demo_recording/*.py` and `SKILL.md`, and requires each to earn a hand-written waiver. Deliberately not an exact-phrase denylist, which would only fail for somebody re-typing a sentence nobody is going to re-type.

Waivered like `tests/lint`'s `KNOWN_FRAGMENTS`: a waiver whose line has gone **fails**, so the list can only shrink.

### Registered injection (`tests/unit --fault-inject`)

```
PASS  break: the beat schema goes back to calling a beat's error message scrubbed
      in timeline.py: #                      exception's `type` and its `message` **verbat…
      FAIL: test_no_shipped_source_claims_a_mask_that_does_not_exist (__main__.MaskProse.test_no_shipped_source_claims_a_mask_that_does_not_exist)
```

### Four more breaks by hand, each with the match count asserted at exactly 1 first

**(a) The false claim put back in `failure.py`:**

```
FAIL: test_no_shipped_source_claims_a_mask_that_does_not_exist
AssertionError: Lists differ: ['failure.py: masks it on the way to its o[36 chars]sk.'] != []
- ['failure.py: masks it on the way to its own file, and each has a different '
```

**(b) The false claim put back in `core.py` - a different file, a different sentence:**

```
FAIL: test_no_shipped_source_claims_a_mask_that_does_not_exist
AssertionError: Lists differ: ['core.py: # Built from the *scrubbed* beats, not from `self._beats`, so a'] != []
```

**(c) `MASK_WORDS` blinded to one word of the family** - the catalogue's "check that shares the bug's blind spot", and the two controls catch it:

```
FAIL: test_a_waiver_cannot_outlive_the_line_it_waives
AssertionError: Lists differ: ['core.py: # A third way in — a take whose[770 chars] be'] != []
FAIL: test_the_sweep_read_the_files_it_claims_to_have_read
AssertionError: 15 not greater than 15
```

**(d) The sweep stops opening one module** - the vacuous sweep, where "no file says it is masked" would hold over a file nobody opened:

```
FAIL: test_the_sweep_read_the_files_it_claims_to_have_read
AssertionError: 13 not greater than or equal to 14
FAIL: test_a_waiver_cannot_outlive_the_line_it_waives
AssertionError: Lists differ: ["web.py: # **Kept deliberately when the m[478 chars] be'] != []
```

**(e) One I did not plan.** Mid-review I reflowed a waivered line in `core.py` for readability and the staleness check went red on its own, which is the check doing exactly the job it exists for:

```
FAIL: test_a_waiver_cannot_outlive_the_line_it_waives
AssertionError: Lists differ: ['core.py: redaction verifier, which is the hole PR #58 was blocked on — went'] != []
```

All five breaks were undone; the tree is clean.

## Stated limits

- **The sweep does not read `reference/*.md` or the skill's `README.md`.** Both were checked by hand for this change and every mention in them is a denial. Recorded in `tests/README.md`'s Known gaps.
- **It cannot tell a waivered denial that is accurate from one that has gone stale about something else.** A waiver saying "#142's carve-out" stays green after #142's carve-out is deleted. The list can only shrink, so a stale entry surfaces the moment its line is edited; nothing surfaces one whose line is edited nowhere.
- **Nothing grades the `goto()` paragraph itself.** A future editor can delete it and no check notices - that claim is graded by a reader, and adding a check that pretends otherwise would be worse than the gap. #268 is where it stops being only prose.
- `tests/README.md`'s standing scope statement now names `goto()` and links #268, so the gap is written down in the place a test author looks.

## Verification

```
tests/unit                    382 tests OK
tests/unit --fault-inject     All 246 injections were caught.
tests/unit --budget           SKILL.md: 600 lines (~14,196 tokens), budget 600 lines
tests/ci-unit                 63 tests OK
tests/ci-unit --fault-inject  All 26 injections were caught.
tests/lint                    All checks passed! / 14 files already formatted / 10 python fences parse
tests/lint --self-test        One pin, one file set, one command
ruff format --check .         14 files already formatted
mypy (1.18.2)                 Success: no issues found in 13 source files
```

`tests/smoke` not run - the recorder path is untouched, this change is comments and documents.

No demo video: none of this is verifiable by watching. Per CLAUDE.md's test, a video of it would be ceremony.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
