### PR TITLE
Render the ticket's clauses in the pull-request comment, gap first (#273)

### DIFF
--- a/.github/scripts/demo-comment
+++ b/.github/scripts/demo-comment
@@ -22,6 +22,11 @@ The comment carries two tiers, decided in issue #2:
 Tier 1 is what survives artifact retention. Tier 2 is what a reviewer clicks
 today. Neither substitutes for the other.
 
+A take recorded against a ticket carries a third thing above the beat table:
+the ticket's clauses, the ones no beat claimed named first (issue #273). It is
+a rendering of `timeline.json`'s `coverage` and it grades nothing — see
+`render_coverage`.
+
 The body opens with an HTML marker so the workflow can find and rewrite this
 comment rather than appending a new one on every push.
 """
@@ -62,6 +67,113 @@ def story_beats(beats: list[dict]) -> list[tuple[float, str]]:
     return out
 
 
+def _plural(n: int, one: str, many: str) -> str:
+    return one if n == 1 else many
+
+
+def _and_list(items: list[str]) -> str:
+    """`a`, `a and b`, `a, b and c` — the headline is read, not parsed."""
+    if len(items) < 3:
+        return " and ".join(items)
+    return ", ".join(items[:-1]) + " and " + items[-1]
+
+
+def _claim_label(rows: list[dict]) -> str:
+    """Where a clause was claimed, as beat indices — never as a time to seek to.
+
+    `coverage.claimed[*].t_start` is `time.monotonic()` and the video is on the
+    host's wall clock, so a seek printed off it would be issue #229 reproduced
+    in the artifact a reviewer actually opens. The beat index is the one
+    coordinate both the manifest and `frames/` already agree on.
+    """
+    parts: list[str] = []
+    for row in rows:
+        index = row.get("index")
+        part = "an unnumbered beat" if index is None else str(index)
+        if row.get("segment"):
+            part += f" (`{_cell(str(row['segment']))}`)"
+        parts.append(part)
+    return _plural(len(parts), "beat ", "beats ") + ", ".join(parts)
+
+
+def render_coverage(coverage: object) -> list[str]:
+    """The ticket's clauses and what claimed them, **gap first** (issue #273).
+
+    Nothing here is a verdict, and the wording is load-bearing rather than a
+    matter of taste. `coverage.py` names its columns `claimed`/`unclaimed`
+    because an `ac=` tag is a string the storyboard author typed, not evidence
+    that the frames show the clause — so this rendering says "claimed", says
+    out loud that it graded nothing, and **never says a clause was
+    demonstrated**. A comment that promoted the tag to a verdict would make the
+    manifest's caution decorative in the one artifact a reviewer is guaranteed
+    to read.
+
+    The gap leads for the same reason `timeline.md`'s section does: a reader
+    who meets the claimed table first has already formed the impression the
+    report exists to test. `unclaimed` needs no judgement — nobody even
+    asserted those clauses — which is what makes it the one line here that can
+    be stated flatly.
+
+    Which clauses nothing claimed is derived from `claimed`, not read out of
+    the manifest's own `unclaimed`, so the headline and the table below it
+    cannot disagree about the same take.
+    """
+    doc = coverage if isinstance(coverage, dict) else {}
+    criteria = doc.get("criteria")
+    if not isinstance(criteria, dict) or not criteria:
+        # No criteria declared, which is the ordinary take: it was not recorded
+        # against a ticket, and an empty acceptance section would read as a
+        # ticket it covered nothing of.
+        return []
+    claimed = doc.get("claimed") or {}
+    unclaimed = [key for key in criteria if not (claimed.get(key) or [])]
+    total, covered = len(criteria), len(criteria) - len(unclaimed)
+
+    gap: list[str] = []
+    if unclaimed:
+        ids = _and_list([f"`{_cell(key)}`" for key in unclaimed])
+        gap += [
+            f"**{ids} {_plural(len(unclaimed), 'has', 'have')} no beat "
+            f"claiming {_plural(len(unclaimed), 'it', 'them')}.**",
+            "",
+        ]
+    if covered:
+        gap.append(
+            f"{total} {_plural(total, 'clause', 'clauses')}. "
+            f"{covered} {_plural(covered, 'has', 'have')} a beat that claims "
+            f"{_plural(covered, 'it', 'them')}; whether the frames show what "
+            f"{_plural(covered, 'it claims', 'they claim')} is the reviewer's "
+            f"call. Nothing in this comment graded a claim."
+        )
+    else:
+        gap.append(
+            f"{total} {_plural(total, 'clause', 'clauses')}, and no beat "
+            f"claims any of {_plural(total, 'it', 'them')}. Nothing in this "
+            f"comment graded a claim."
+        )
+    gap.append("")
+
+    table = ["| clause | claimed at |", "|---|---|"]
+    for key, text in criteria.items():
+        rows = claimed.get(key) or []
+        where = _claim_label(rows) if rows else "*nothing claims this*"
+        table.append(f"| **{_cell(key)}** — {_cell(str(text))} | {where} |")
+    table.append("")
+
+    note = [
+        "<sub>A claim points at a beat, not at a moment to seek to: the "
+        "coverage timestamps are on the recorder's monotonic clock and the "
+        "video is on the host's wall clock, so a seek printed from them would "
+        "be [#229](https://github.com/rogvid/skills/issues/229) in a new "
+        "artifact ([#277](https://github.com/rogvid/skills/issues/277)).</sub>",
+        "",
+    ]
+    # The gap first, and the order is the whole point rather than a layout
+    # choice: a rendering that opened with the claimed table would *be* a
+    # coverage claim, whatever the words under it said.
+    return gap + table + note
+
+
 def _human_size(n: int | None) -> str:
     if not n:
         return "size unknown"
@@ -90,6 +202,12 @@ def render_demo(name: str, timeline: dict) -> str:
         f"{len(rows)} beats · {_duration(timeline)} · recorded by `{timeline.get('recorder', '?')}`"
     )
     lines.append("")
+
+    # Above the beat table, because on a take recorded against a ticket it is
+    # the reason somebody opened the comment — and a reviewer who scrolls past
+    # twenty captions first has already formed the impression the coverage
+    # report exists to test (issue #273, the same ordering `timeline.md` uses).
+    lines += render_coverage(timeline.get("coverage"))
 
     if rows:
         lines.append("| # | at | Caption |")
@@ -190,11 +308,12 @@ def render(
             f"`evidence/` and `frames/` are uploaded separately and kept "
             f"{evidence_retention_days} days, long enough to check a disputed finding."
         )
-    footnote.append(
-        "Which acceptance criterion each beat demonstrates is not reported yet "
-        "([#12](https://github.com/rogvid/skills/issues/12))."
-    )
-    lines.append("<sub>" + " ".join(footnote) + "</sub>")
+    # Only when there is something to say. Until #273 the footnote always
+    # carried the acceptance-criteria sentence, so this could not be empty;
+    # with that sentence gone, a run invoked without `--sha`, `--run-url` or an
+    # evidence retention would otherwise end the comment on a bare `<sub></sub>`.
+    if footnote:
+        lines.append("<sub>" + " ".join(footnote) + "</sub>")
     return "\n".join(lines) + "\n"
 
 

--- a/skills/demo-video/reference/ci.md
+++ b/skills/demo-video/reference/ci.md
@@ -50,6 +50,21 @@ jobs:
 2. **A deep link to the artifact** — `…/actions/runs/<id>/artifacts/<id>`, so
    watching is one click and an unzip.
 
+On a take recorded against a ticket — `Recorder(criteria={"AC-1": "…"})`, beats
+tagged `ac="AC-1"` — a third thing sits **above** the beat table: the ticket's
+clauses, with the ones **no beat claimed named first**, then a table of what
+claimed the rest and at which beat. That order is deliberate. A rendering that
+opened with the covered half would be a coverage claim whatever the sentence
+under it said, and the one finding here that needs no judgement is the clause
+nobody even asserted.
+
+**It says "claimed", never "demonstrated", and it says out loud that it graded
+nothing.** An `ac=` tag is a string the storyboard author typed; whether the
+frames show the clause is the reviewer's call, and the comment is written so it
+cannot be mistaken for having made it. A claim points at a **beat index**
+rather than a timestamp, because the coverage timestamps are on the recorder's
+monotonic clock while the video is on the host's wall clock.
+
 `demo.mp4`, `timeline.md`/`.json` and `images/` upload as the `demo-video`
 artifact on an explicit `retention-days`; `evidence/` and `frames/` upload
 separately on a short one (1–7 days, long enough to check a disputed finding

--- a/tests/README.md
+++ b/tests/README.md
@@ -1386,6 +1386,25 @@ Injections caught:
 | a merged demo is judged against only the first segment's ticket | the merge arm's union assertion |
 | timeline.md stops stating the finding | the markdown arm — the one the weaker assertion slept through |
 
+**The rendering a reviewer actually reads is graded in `tests/ci-unit`**
+([#273](https://github.com/rogvid/skills/issues/273)). Everything above is
+about `timeline.json` and `timeline.md`; the pull-request comment is the one
+artifact a human is guaranteed to open, and until #273 it rendered none of
+this and said so by pointing at an issue that had been closed for months. Its
+`Coverage` class grades four things and nothing more: that the clauses nothing
+claimed are named **before** the table of what was claimed, that every declared
+clause reaches the comment with its own text, that a clause's row names *its
+own* beats rather than another clause's, and that no sentence in the comment
+promotes a claim to a verdict. The last one is a word sweep with a control
+beside it, because a sweep for absent words passes just as happily on a comment
+that renders no coverage at all.
+
+Nine injections cover it, and two are worth naming: *the acceptance section
+leads with what was claimed instead of the gap* — which is the whole ordering
+claim, and nothing else in the suite can see it — and *every clause is pointed
+at the first claim in the report*, which leaves the table its shape, its row
+per clause and its beat numbers, and points every row at the wrong one.
+
 **What this deliberately does not grade**: whether a tagged beat *shows* what it
 claims. That is the reviewer's judgement, and the artifact is written to say so
 rather than to assert it.
@@ -2106,6 +2125,23 @@ knows is missing is worse than one that is openly absent.
   `--polish-only` run is its only exercise in the repo (see **Why the four
   middle arms stayed on the push**, which is the measurement that kept it
   there).
+
+- **Nothing here grades whether a tagged beat's frames show its criterion.**
+  `tests/unit` grades the coverage report's arithmetic, `tests/smoke
+  --coverage-only` grades that a real take emits it, and `tests/ci-unit`'s
+  `Coverage` grades that the pull-request comment renders it gap first and
+  never as a verdict. All three grade the mapping's *shape*. The mapping's
+  *truth* is a judgement over prose and pixels, the artifact says so in every
+  column name, and no suite in this repo promotes a tag to a verdict. This is
+  not a gap waiting to be filled: a check that graded it would be written from
+  the same `ac=` tags it was grading, which is the catalogue's *check that
+  shares the bug's blind spot*. The reasoning is
+  [#272](https://github.com/rogvid/skills/issues/272), question 2.
+
+  So what a green `tests/ci-unit` says about a demo's acceptance criteria is
+  exactly: the comment named every clause the storyboard declared, and named
+  first the ones no beat claimed. It says nothing about whether the beats that
+  did claim one showed it.
 
 - **Nothing calls the ElevenLabs API.** The narration take grades everything a
   cache hit reaches — the key, the pacing, the mix — and by construction never

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -747,12 +747,256 @@ class Render(unittest.TestCase):
         self.assertIn("no video", body)
         self.assertNotIn("· 0s ·", body)
 
+    def test_a_run_with_nothing_to_footnote_ends_on_no_empty_footnote(self):
+        # The footnote used to be unconditional because it always carried the
+        # acceptance-criteria sentence #273 deleted. Without a sha, a run url
+        # or an evidence retention there is nothing left to say, and an empty
+        # `<sub></sub>` renders as a blank line a reader has to account for.
+        body = self.body(sha=None, run_url=None, evidence_retention_days=None)
+        self.assertNotIn("<sub>", body)
+        # The control: with one fact to state, the footnote is still there.
+        self.assertIn("<sub>Recorded from `abcdef1`.", self.body())
+
     def test_a_caption_containing_a_pipe_does_not_break_the_table(self):
         piped = dict(TIMELINE, beats=beats((1.0, "run: cat x | wc -l")))
         rows = [ln for ln in self.body(piped).splitlines() if ln.startswith("| 1 |")]
         self.assertEqual(len(rows), 1)
         unescaped = re.sub(r"\\\|", "", rows[0])
         self.assertEqual(unescaped.count("|"), 4, rows[0])  # 4 delimiters, 3 cells
+
+
+def claim(index: int, still: str | None = None, segment: str | None = None) -> dict:
+    """One row of `coverage.claimed[id]`, shaped as `coverage_report` writes it."""
+    return {
+        "index": index,
+        "segment": segment,
+        "segment_index": index,
+        "t_start": float(index),
+        "still": still,
+    }
+
+
+# Four clauses, and the two nothing claims are **not** the last two: an
+# assertion that reads the headline as "the tail of the list" would pass on
+# this by accident, and a renderer that dropped the unclaimed rows would leave
+# a table that still looked ordered.
+COVERAGE = {
+    "criteria": {
+        "AC-1": "A search box above the queue narrows the list as you type.",
+        "AC-2": "Search and the status filter combine, and the heading agrees.",
+        "AC-3": "Search matches the requester as well as the title.",
+        "AC-4": "A search matching nothing shows the empty line.",
+    },
+    "claimed": {
+        "AC-1": [claim(3, "images/01-search-box.png")],
+        "AC-2": [],
+        "AC-3": [claim(6), claim(9, "images/03-requester.png")],
+        "AC-4": [],
+    },
+    "unclaimed": ["AC-2", "AC-4"],
+    "tagged_beats": 3,
+    "untagged_beats": 4,
+}
+TAGGED = dict(TIMELINE, coverage=COVERAGE)
+
+# Every clause claimed. Same criteria, so the two documents differ in exactly
+# the thing the headline is a statement about.
+ALL_CLAIMED = dict(
+    TIMELINE,
+    coverage=dict(
+        COVERAGE,
+        claimed={key: [claim(i)] for i, key in enumerate(COVERAGE["criteria"])},
+        unclaimed=[],
+    ),
+)
+
+# Words that would turn a claim into a verdict. `coverage.py` names its columns
+# `claimed`/`unclaimed` on purpose — an `ac=` tag is a string the storyboard
+# author typed — so the most-read artifact must not be the one place that says
+# a clause was shown. `[x]` is here because a ticked box reads as a verdict
+# even with no verb attached to it.
+VERDICT_WORDS = (
+    "demonstrat",
+    "verified",
+    "verifies",
+    "validated",
+    "proves",
+    "proven",
+    "confirmed",
+    "satisfied",
+    "[x]",
+    "✅",
+    "✔",
+)
+
+
+class Coverage(unittest.TestCase):
+    """The ticket's clauses in the pull-request comment, gap first (#273).
+
+    **What none of this grades:** whether a beat's frames show the clause it
+    tagged. That is a judgement over prose and pixels, no assertion here goes
+    near it, and the rendering these tests hold to its wording is the reason
+    the comment cannot be read as having made it.
+    """
+
+    def body(self, timeline):
+        return comment.render(
+            [("demos/x", timeline)],
+            artifact_url=None,
+            artifact_bytes=None,
+            retention_days=30,
+            evidence_retention_days=None,
+            failure_artifact_url=None,
+            run_url=None,
+            sha="abcdef1234567890",
+        )
+
+    def headline(self, body: str) -> str:
+        """The one sentence naming the clauses nothing claimed."""
+        found = [ln for ln in body.splitlines() if "no beat claiming" in ln]
+        self.assertEqual(len(found), 1, f"no single gap headline in:\n{body}")
+        return found[0]
+
+    def cell(self, body: str, key: str) -> str:
+        """The `claimed at` cell of one clause's row, and only that.
+
+        Read narrowly on purpose: `"3" in row` is satisfied by the id `AC-3`
+        itself, so a whole-row search would agree with a renderer that had lost
+        the beat indices entirely.
+        """
+        rows = [ln for ln in body.splitlines() if ln.startswith(f"| **{key}** ")]
+        self.assertEqual(len(rows), 1, f"no single row for {key}: {rows}")
+        # Escaped pipes out first, the way a markdown renderer reads them: an
+        # unescaped one in the clause text would otherwise split this row into
+        # more cells than the table has columns, which is the failure the
+        # escaping exists to prevent and is asserted below.
+        cells = re.sub(r"\\\|", "", rows[0]).split("|")
+        self.assertEqual(len(cells), 4, rows[0])  # "", clause, claimed at, ""
+        return cells[2].strip()
+
+    def test_the_gap_is_stated_before_anything_that_was_claimed(self):
+        body = self.body(TAGGED)
+        self.assertIn("| clause | claimed at |", body)  # control: a section ran
+        headline = body.index(self.headline(body))
+        self.assertLess(headline, body.index("| clause | claimed at |"))
+        self.assertLess(headline, body.index("**AC-1**"))
+        # And before the beat table, which is the rest of the comment: a
+        # reviewer who has scrolled past nine captions has already formed the
+        # impression this section exists to test.
+        self.assertLess(headline, body.index("| # | at | Caption |"))
+
+    def test_the_headline_names_the_clauses_nothing_claimed_and_only_those(self):
+        body = self.body(TAGGED)
+        line = self.headline(body)
+        self.assertIn("AC-2", line)
+        self.assertIn("AC-4", line)
+        self.assertNotIn("AC-1", line)
+        self.assertNotIn("AC-3", line)
+
+    def test_every_declared_clause_reaches_the_comment_with_its_own_text(self):
+        # Named, not counted: a row per clause is free to satisfy, and the text
+        # is what a reviewer judges the frames against.
+        body = self.body(TAGGED)
+        for key, text in COVERAGE["criteria"].items():
+            row = [ln for ln in body.splitlines() if ln.startswith(f"| **{key}** ")]
+            self.assertEqual(len(row), 1, f"{key}: {row}")
+            self.assertIn(text, row[0])
+
+    def test_a_claimed_clause_names_its_own_beats_and_not_another_clauses(self):
+        body = self.body(TAGGED)
+        self.assertEqual(self.cell(body, "AC-1"), "beat 3")
+        self.assertEqual(self.cell(body, "AC-3"), "beats 6, 9")
+
+    def test_a_clause_no_beat_claimed_says_so_where_the_beat_would_be(self):
+        body = self.body(TAGGED)
+        for key in ("AC-2", "AC-4"):
+            self.assertEqual(self.cell(body, key), "*nothing claims this*")
+
+    def test_no_sentence_promotes_a_claim_to_a_verdict(self):
+        body = self.body(TAGGED)
+        # The control on the sweep: without it every assertion below holds over
+        # a comment that renders no coverage at all.
+        self.assertIn("AC-1", body)
+        self.assertIn("claimed at", body)
+        for word in VERDICT_WORDS:
+            self.assertNotIn(word, body.lower(), f"{word!r} reads as a verdict")
+
+    def test_the_same_words_are_refused_on_a_take_that_claimed_everything(self):
+        # The clean path is where a coverage claim is most tempting to print,
+        # and it is a different branch of the renderer from the one above.
+        body = self.body(ALL_CLAIMED)
+        self.assertIn("claimed at", body)
+        for word in VERDICT_WORDS:
+            self.assertNotIn(word, body.lower(), f"{word!r} reads as a verdict")
+
+    def test_a_take_whose_clauses_are_all_claimed_prints_no_headline(self):
+        body = self.body(ALL_CLAIMED)
+        self.assertNotIn("no beat claiming", body)
+        self.assertNotIn("nothing claims this", body)
+        self.assertIn("Nothing in this comment graded a claim", body)
+
+    def test_a_take_where_no_beat_tagged_anything_still_names_every_clause(self):
+        # The third branch of the headline, and the one a reader is likeliest
+        # to meet on a storyboard written before anybody tagged a beat.
+        none_claimed = dict(
+            TIMELINE,
+            coverage=dict(
+                COVERAGE,
+                claimed={key: [] for key in COVERAGE["criteria"]},
+                unclaimed=list(COVERAGE["criteria"]),
+            ),
+        )
+        body = self.body(none_claimed)
+        line = self.headline(body)
+        for key in COVERAGE["criteria"]:
+            self.assertIn(key, line)
+            self.assertEqual(self.cell(body, key), "*nothing claims this*")
+        self.assertIn("no beat claims any of them", body)
+        for word in VERDICT_WORDS:
+            self.assertNotIn(word, body.lower(), f"{word!r} reads as a verdict")
+
+    def test_a_take_recorded_without_criteria_prints_no_acceptance_section(self):
+        # The ordinary case, and the one that must read exactly as it did
+        # before this section existed.
+        body = self.body(TIMELINE)
+        self.assertIn("| # | at | Caption |", body)  # control: still a comment
+        for absent in ("clause", "claimed at", "nothing claims this", "AC-"):
+            self.assertNotIn(absent, body)
+
+    def test_the_comment_no_longer_reports_the_binding_as_unwritten(self):
+        # The footnote this replaced said acceptance criteria were "not
+        # reported yet" and pointed at #12, which has been closed since the
+        # recorder-side feature shipped.
+        body = self.body(TAGGED)
+        self.assertIn("AC-1", body)  # control: the binding is rendered instead
+        self.assertNotIn("not reported yet", body)
+        self.assertEqual(re.findall(r"/issues/12\b", body), [])
+
+    def test_a_clause_containing_a_pipe_does_not_break_the_table(self):
+        # Criterion text is quoted from a ticket, so it is prose somebody else
+        # wrote. One `|` shifts every later column of a table a reviewer reads
+        # as the ticket's own words.
+        piped = dict(
+            TIMELINE,
+            coverage={
+                "criteria": {"AC-1": "the count is `wc -l` | not the row count"},
+                "claimed": {"AC-1": [claim(3)]},
+            },
+        )
+        cells = self.cell(self.body(piped), "AC-1")
+        self.assertEqual(cells, "beat 3")
+
+    def test_a_claim_from_a_named_segment_says_which_segment(self):
+        # A stitched demo renumbers beats, so "beat 6" alone points at the
+        # wrong picture when the reader goes back to a segment's own timeline.
+        stitched = dict(
+            TIMELINE,
+            coverage={
+                "criteria": {"AC-1": "A search box above the queue."},
+                "claimed": {"AC-1": [claim(6, segment="part2")]},
+            },
+        )
+        self.assertEqual(self.cell(self.body(stitched), "AC-1"), "beat 6 (`part2`)")
 
 
 class CommentCli(unittest.TestCase):
@@ -979,6 +1223,129 @@ INJECTIONS = [
         [
             "Cell.test_a_pipe_in_a_caption_is_escaped_so_the_table_survives",
             "Render.test_a_caption_containing_a_pipe_does_not_break_the_table",
+            # The acceptance table quotes a ticket's own prose through the same
+            # helper, so one break has to redden both tables or the second one
+            # is riding on the first's test.
+            "Coverage.test_a_clause_containing_a_pipe_does_not_break_the_table",
+        ],
+    ),
+    (
+        # The whole point of the section, and the one thing about it that is
+        # not a matter of layout: a rendering that opens with the claimed table
+        # *is* a coverage claim, whatever the sentence under it says.
+        "the acceptance section leads with what was claimed instead of the gap",
+        "demo-comment",
+        "    return gap + table + note",
+        "    return table + gap + note",
+        ["Coverage.test_the_gap_is_stated_before_anything_that_was_claimed"],
+    ),
+    (
+        # The failure mode every coverage tool has: print the covered half and
+        # call it a report. The headline survives this, so a check that only
+        # read the headline would pass.
+        "the table prints only the clauses something claimed",
+        "demo-comment",
+        "    for key, text in criteria.items():",
+        "    for key, text in [(k, v) for k, v in criteria.items() if claimed.get(k)]:",
+        [
+            "Coverage.test_every_declared_clause_reaches_the_comment_with_its_own_text",
+            "Coverage.test_a_clause_no_beat_claimed_says_so_where_the_beat_would_be",
+        ],
+    ),
+    (
+        # Correspondence, not existence: every clause is handed the first
+        # non-empty claim in the report, so the table keeps its shape, keeps a
+        # row per clause, and points every one of them at the wrong beat.
+        "every clause is pointed at the first claim in the report",
+        "demo-comment",
+        "        rows = claimed.get(key) or []",
+        "        rows = next((v for v in claimed.values() if v), [])",
+        [
+            "Coverage.test_a_claimed_clause_names_its_own_beats_and_not_another_clauses",
+            "Coverage.test_a_clause_no_beat_claimed_says_so_where_the_beat_would_be",
+        ],
+    ),
+    (
+        # The beat index is the only coordinate the comment gives a reviewer to
+        # go and look at. "a beat" is still a cell, still a table, still a row
+        # per clause.
+        "a claim stops naming the beat it points at",
+        "demo-comment",
+        '        part = "an unnumbered beat" if index is None else str(index)',
+        '        part = "an unnumbered beat" if index is None else "a beat"',
+        [
+            "Coverage.test_a_claimed_clause_names_its_own_beats_and_not_another_clauses",
+            "Coverage.test_a_claim_from_a_named_segment_says_which_segment",
+        ],
+    ),
+    (
+        # The promotion this whole rendering exists to refuse. `coverage.py`
+        # calls the columns claimed/unclaimed deliberately, and the comment is
+        # the most-read artifact — saying it here would make the manifest's
+        # caution decorative.
+        "the comment promotes a claim to a verdict",
+        "demo-comment",
+        '            f"call. Nothing in this comment graded a claim."',
+        '            f"call. Each of them was demonstrated on video."',
+        [
+            "Coverage.test_no_sentence_promotes_a_claim_to_a_verdict",
+            "Coverage.test_the_same_words_are_refused_on_a_take_that_claimed_everything",
+        ],
+    ),
+    (
+        # The same promotion in the branch a reviewer meets when nothing was
+        # tagged at all, which the two documents above never reach.
+        "the zero-claim sentence promotes the clauses instead",
+        "demo-comment",
+        '            f"comment graded a claim."',
+        '            f"comment says all {total} were demonstrated."',
+        ["Coverage.test_a_take_where_no_beat_tagged_anything_still_names_every_clause"],
+    ),
+    (
+        # The ordinary take is the one recorded outside a ticket, and an empty
+        # acceptance table on it would read as a ticket it covered none of.
+        "a take that declared no criteria gets the section anyway",
+        "demo-comment",
+        "    if not isinstance(criteria, dict) or not criteria:",
+        "    criteria = criteria if isinstance(criteria, dict) else {}\n    if False:",
+        ["Coverage.test_a_take_recorded_without_criteria_prints_no_acceptance_section"],
+    ),
+    (
+        # The wiring, which no injection above touches: `render_coverage` can
+        # be perfect and never be called.
+        "render_demo stops rendering the coverage section",
+        "demo-comment",
+        '    lines += render_coverage(timeline.get("coverage"))',
+        "    lines += []",
+        [
+            "Coverage.test_the_gap_is_stated_before_anything_that_was_claimed",
+            "Coverage.test_every_declared_clause_reaches_the_comment_with_its_own_text",
+        ],
+    ),
+    (
+        # What the deleted sentence was quietly holding up: it was the one
+        # footnote entry that was always present.
+        "the footnote is printed even when there is nothing to put in it",
+        "demo-comment",
+        "    if footnote:\n        lines.append",
+        "    if True:\n        lines.append",
+        ["Render.test_a_run_with_nothing_to_footnote_ends_on_no_empty_footnote"],
+    ),
+    (
+        # The sentence this change deletes: true about the comment, false about
+        # the skill, and pointing at an issue closed since the recorder-side
+        # feature shipped.
+        "the footnote pointing at the closed #12 comes back",
+        "demo-comment",
+        '    lines.append("<sub>" + " ".join(footnote) + "</sub>")',
+        "    footnote.append(\n"
+        '        "Which acceptance criterion each beat demonstrates is not reported yet "\n'
+        '        "([#12](https://github.com/rogvid/skills/issues/12))."\n'
+        "    )\n"
+        '    lines.append("<sub>" + " ".join(footnote) + "</sub>")',
+        [
+            "Coverage.test_the_comment_no_longer_reports_the_binding_as_unwritten",
+            "Coverage.test_no_sentence_promotes_a_claim_to_a_verdict",
         ],
     ),
     (


### PR DESCRIPTION
Slice A of #272. Fixes #273.

## What changed

`.github/scripts/demo-comment` read `beats`, `failure` and `issues` out of
`timeline.json` and never touched `coverage`, so on a take recorded against a
ticket the one artifact a reviewer is guaranteed to open said nothing about
the ticket - and said so by pointing at [#12](https://github.com/rogvid/skills/issues/12),
closed since the recorder-side feature shipped. That footnote is deleted; the
binding is rendered instead.

The section sits **above** the beat table, and inside it the gap comes first:

```
**`AC-3` and `AC-5` have no beat claiming them.**

5 clauses. 3 have a beat that claims them; whether the frames show what they
claim is the reviewer's call. Nothing in this comment graded a claim.

| clause | claimed at |
|---|---|
| **AC-1** - A search box above the queue narrows the list as you type, case-insensitively, with no button to press. | beats 2, 5, 7, 11 |
| **AC-3** - Search matches the requester as well as the title ... | *nothing claims this* |
```

(rendered from the committed reference take,
`examples/ticket-queue/demos/2026-07-28-queue-search/timeline.json`, with two
clauses' claims removed to show the gap branch.)

A take with no `coverage` - the ordinary case - prints nothing new. A take
whose clauses are all claimed prints the second sentence and no headline. A
take where nothing was tagged at all gets a third sentence.

## What this does NOT establish

**Nothing here says a clause was demonstrated. It says a beat claimed it.**

An `ac=` tag is a string the storyboard author typed. Whether the frames show
the clause is a judgement over prose and pixels; no assertion in this PR goes
near it, and a check that claimed to would be written from the same tags it
was grading - the catalogue's *check that shares the bug's blind spot*. So:

- the word "demonstrated" does not appear, and neither do "verified",
  "validated", "proves", "proven", "confirmed", "satisfied" or a ticked box;
  `Coverage.test_no_sentence_promotes_a_claim_to_a_verdict` sweeps for all of
  them, with a control beside the sweep so it cannot pass on a comment that
  rendered no coverage at all;
- the section states "Nothing in this comment graded a claim" in every branch;
- the ungradable boundary is recorded in `tests/README.md`'s **Known gaps** in
  the form #272 gives.

The one flat statement is `unclaimed`, and it is safe because it needs no
judgement: nobody even asserted those clauses.

## Stated limits (non-blocking, per `wip/verified-review/SKILL.md`)

- **A claim a failed take made still reads like a clean one.** The per-demo
  heading says "the take did not finish", but a clause claimed by a beat that
  raised renders as an ordinary claim. That is slice F, #278, and it is
  deliberately not in this change.
- **`coverage.conflicts` is not rendered.** A stitched demo whose segments
  disagree about a clause's wording shows the first segment's text with no
  note; `timeline.md` does say so. Not in slice A's acceptance criterion.
- **No timestamp, no per-clause link, no ticket identity.** A claim points at
  a beat index because the coverage timestamps are `time.monotonic()` and the
  video is on the host's wall clock ([#229](https://github.com/rogvid/skills/issues/229));
  the comment says that in one line and slice E ([#277](https://github.com/rogvid/skills/issues/277))
  is what would let it print a seek. Stills per clause are slice B (#274),
  ticket identity slice C (#275).
- **`unclaimed` is derived from `claimed`, not read off the manifest's own
  `unclaimed` key.** Deliberate: the headline and the table then cannot
  disagree about the same take. It does mean a manifest whose `unclaimed` is
  wrong is not caught here - `tests/unit` grades that field.

## Fault injections

Every assertion added here was watched failing. Ten injections were added to
`tests/ci-unit`'s `INJECTIONS` table (36 total, all caught); one existing
injection gained the new pipe-escaping test, so a single break has to redden
both tables rather than the second riding on the first's test.

```
PASS  break: the acceptance section leads with what was claimed instead of the gap
      in demo-comment: return gap + table + note...
      FAIL: test_the_gap_is_stated_before_anything_that_was_claimed (__main__.Coverage.test_the_gap_is_stated_before_anything_that_was_claimed)

PASS  break: the table prints only the clauses something claimed
      in demo-comment: for key, text in criteria.items():...
      FAIL: test_a_clause_no_beat_claimed_says_so_where_the_beat_would_be (__main__.Coverage.test_a_clause_no_beat_claimed_says_so_where_the_beat_would_be)
      FAIL: test_a_take_where_no_beat_tagged_anything_still_names_every_clause (__main__.Coverage.test_a_take_where_no_beat_tagged_anything_still_names_every_clause)
      FAIL: test_every_declared_clause_reaches_the_comment_with_its_own_text (__main__.Coverage.test_every_declared_clause_reaches_the_comment_with_its_own_text)

PASS  break: every clause is pointed at the first claim in the report
      in demo-comment: rows = claimed.get(key) or []...
      FAIL: test_a_claimed_clause_names_its_own_beats_and_not_another_clauses (__main__.Coverage.test_a_claimed_clause_names_its_own_beats_and_not_another_clauses)
      FAIL: test_a_clause_no_beat_claimed_says_so_where_the_beat_would_be (__main__.Coverage.test_a_clause_no_beat_claimed_says_so_where_the_beat_would_be)

PASS  break: a claim stops naming the beat it points at
      in demo-comment: part = "an unnumbered beat" if index is None else str(index)...
      FAIL: test_a_claim_from_a_named_segment_says_which_segment (__main__.Coverage.test_a_claim_from_a_named_segment_says_which_segment)
      FAIL: test_a_claimed_clause_names_its_own_beats_and_not_another_clauses (__main__.Coverage.test_a_claimed_clause_names_its_own_beats_and_not_another_clauses)
      FAIL: test_a_clause_containing_a_pipe_does_not_break_the_table (__main__.Coverage.test_a_clause_containing_a_pipe_does_not_break_the_table)

PASS  break: the comment promotes a claim to a verdict
      in demo-comment: f"call. Nothing in this comment graded a claim."...
      FAIL: test_a_take_whose_clauses_are_all_claimed_prints_no_headline (__main__.Coverage.test_a_take_whose_clauses_are_all_claimed_prints_no_headline)
      FAIL: test_no_sentence_promotes_a_claim_to_a_verdict (__main__.Coverage.test_no_sentence_promotes_a_claim_to_a_verdict)
      FAIL: test_the_same_words_are_refused_on_a_take_that_claimed_everything (__main__.Coverage.test_the_same_words_are_refused_on_a_take_that_claimed_everything)

PASS  break: the zero-claim sentence promotes the clauses instead
      in demo-comment: f"comment graded a claim."...
      FAIL: test_a_take_where_no_beat_tagged_anything_still_names_every_clause (__main__.Coverage.test_a_take_where_no_beat_tagged_anything_still_names_every_clause)

PASS  break: a take that declared no criteria gets the section anyway
      in demo-comment: if not isinstance(criteria, dict) or not criteria:...
      FAIL: test_a_take_recorded_without_criteria_prints_no_acceptance_section (__main__.Coverage.test_a_take_recorded_without_criteria_prints_no_acceptance_section)
      FAIL: test_a_run_with_nothing_to_footnote_ends_on_no_empty_footnote (__main__.Render.test_a_run_with_nothing_to_footnote_ends_on_no_empty_footnote)

PASS  break: render_demo stops rendering the coverage section
      in demo-comment: lines += render_coverage(timeline.get("coverage"))...
      FAIL: test_a_claim_from_a_named_segment_says_which_segment (__main__.Coverage.test_a_claim_from_a_named_segment_says_which_segment)
      FAIL: test_a_claimed_clause_names_its_own_beats_and_not_another_clauses (__main__.Coverage.test_a_claimed_clause_names_its_own_beats_and_not_another_clauses)
      FAIL: test_a_clause_containing_a_pipe_does_not_break_the_table (__main__.Coverage.test_a_clause_containing_a_pipe_does_not_break_the_table)
      FAIL: test_a_clause_no_beat_claimed_says_so_where_the_beat_would_be (__main__.Coverage.test_a_clause_no_beat_claimed_says_so_where_the_beat_would_be)

PASS  break: the footnote is printed even when there is nothing to put in it
      in demo-comment: if footnote:...
      FAIL: test_a_run_with_nothing_to_footnote_ends_on_no_empty_footnote (__main__.Render.test_a_run_with_nothing_to_footnote_ends_on_no_empty_footnote)

PASS  break: the footnote pointing at the closed #12 comes back
      in demo-comment: lines.append("<sub>" + " ".join(footnote) + "</sub>")...
      FAIL: test_a_take_where_no_beat_tagged_anything_still_names_every_clause (__main__.Coverage.test_a_take_where_no_beat_tagged_anything_still_names_every_clause)
      FAIL: test_no_sentence_promotes_a_claim_to_a_verdict (__main__.Coverage.test_no_sentence_promotes_a_claim_to_a_verdict)
      FAIL: test_the_comment_no_longer_reports_the_binding_as_unwritten (__main__.Coverage.test_the_comment_no_longer_reports_the_binding_as_unwritten)
      FAIL: test_the_same_words_are_refused_on_a_take_that_claimed_everything (__main__.Coverage.test_the_same_words_are_refused_on_a_take_that_claimed_everything)

PASS  break: the table cell stops escaping pipes          <- existing injection, new test added
      in demo-comment: out = (text or "").replace("\\", "\\\\").replace("|", "\\|")...
      FAIL: test_a_pipe_in_a_caption_is_escaped_so_the_table_survives (__main__.Cell.test_a_pipe_in_a_caption_is_escaped_so_the_table_survives)
      FAIL: test_a_clause_containing_a_pipe_does_not_break_the_table (__main__.Coverage.test_a_clause_containing_a_pipe_does_not_break_the_table)
      FAIL: test_a_caption_containing_a_pipe_does_not_break_the_table (__main__.Render.test_a_caption_containing_a_pipe_does_not_break_the_table)

All 36 injections were caught.
```

Notes on two of them, since the catalogue says to check my own work against it:

- *every clause is pointed at the first claim in the report* is the guard
  against **the count that stands in for the content**. It leaves the table
  its shape, its row per clause and its beat numbers, and gets every row
  wrong. `Coverage.cell()` reads only the `claimed at` cell for that reason -
  a whole-row search for `"3"` is satisfied by the id `AC-3` itself.
- *render_demo stops rendering the coverage section* grades the wiring, which
  no other injection touches: `render_coverage` can be perfect and never be
  called.

The deleted footnote was also the only unconditional entry in the comment's
`<sub>` line, so a run without `--sha`, `--run-url` or an evidence retention
would have ended on a bare `<sub></sub>`. Guarded, with its own test and
injection.

## Ran

`tests/ci-unit` (77 tests, OK) · `tests/ci-unit --fault-inject` (36/36) ·
`tests/unit` (382, OK) · `tests/unit --fault-inject` (246/246) ·
`tests/unit --budget` · `tests/lint` · `tests/lint --self-test` ·
`tests/lint --issues` (1448 references across 47 files, against 204 issues) ·
`ruff@0.16.1 format --check` · `mypy 1.18.2` (13 files, no issues).
`tests/smoke` not run - exclusive lock, and nothing here touches the recorder.

Not demoable, by CLAUDE.md's test: a pull-request comment is read, not
watched. #272 says the same about slices A-G.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
