### PR TITLE
Sweep the word that names a protection, not just the word for the act (#281)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/content.py
+++ b/skills/demo-video/helpers/demo_recording/content.py
@@ -93,10 +93,11 @@ def media_duration(path: Path) -> float:
 #
 # **Warn, never refuse.** A demo legitimately holding one frame through a long
 # narrated beat is ordinary, and a heuristic that fails takes is worse than a
-# heuristic that misses one — the same argument that scoped the terminal
-# verifier to registered values only (issue #5). Nothing here raises, nothing
-# here deletes an artifact, and a check that cannot run says so in `content`
-# rather than being silently absent.
+# heuristic that misses one. That argument once scoped a terminal verifier to
+# registered values only (issue #5) — machinery #144 removed, so it is
+# precedent for this decision and not a live claim about anything this recorder
+# does. Nothing here raises, nothing here deletes an artifact, and a check that
+# cannot run says so in `content` rather than being silently absent.
 #
 # **What this deliberately does not do** is judge whether the demo shows the
 # *right* thing. That is issue #12's job, and a human's. This answers exactly

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -2003,12 +2003,16 @@ take with fewer beats than the last one would otherwise leave the
     def _write_failure(self) -> None:
         """Put the built dump on disk, plus the last frame of the recording.
 
-        The frame comes out of the mp4 with ffmpeg rather than off the page:
-        it is a frame of the recording the take already
-        vouched for, so it inherits that guarantee whole and reads nothing
-        after the verifier ran. Gated on `self._converted`, not on the file
-        existing — a previous run's demo.mp4 is not a picture of this crash
-        (issue #20).
+        The frame comes out of the mp4 with ffmpeg rather than off the page
+        because by the time this runs there is no page: `__exit__` closes the
+        context, the browser and Playwright before `_convert`, and this is
+        called after all of it. It used to be argued for the other way round —
+        the frame inheriting a guarantee the take had already earned — and the
+        machinery that issued that guarantee went in #144. The PNG carries none
+        now: it is the last frame of this take's recording, as it was recorded,
+        and no more is claimed for it than for any other artifact here. Gated on
+        `self._converted`, not on the file existing — a previous run's demo.mp4
+        is not a picture of this crash (issue #20).
         """
         if self._failure_json is None:
             return

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -134,6 +134,16 @@ the encoded frame, and writes down what it found:
   recorder did about it. Read the next section: `held` above zero means the
   first frames of your video are not frames the recording captured.
 
+**What the take says out loud, and on which stream.** Which line the take
+prints decides the stream: **anything wrong — a warning, or the note that the
+check could not run — goes to stderr; the healthy `shows a picture` line goes
+to stdout.** A take takes at most one of those branches and never both: a take
+that warned prints no `shows a picture` line, a take that printed one recorded
+no warnings, and a take that encoded no mp4 has no `content` to report and says
+nothing here at all. So capturing one stream in a script never gives you half a
+summary; it gives you the whole summary of one kind of take and silence for
+the other, which is the thing to know before redirecting either.
+
 ### `opening` — the first frames of a web take are a hold
 
 Chromium starts recording when the page is created, and the page is
@@ -150,8 +160,11 @@ to.
 **Two things follow, and neither is hidden from you:**
 
 - Those opening frames show the app slightly before it painted. `held` is how
-  many seconds were covered, it is in `timeline.json`, and the take says it on
-  stderr as it finishes. Nothing else in the video is touched — the duration,
+  many seconds were covered, and it is in `timeline.json` on every take that
+  measured one. Spoken, it is a clause of the healthy `shows a picture` line —
+  **stdout**, and the only place the recorder ever says it. A take that warned
+  does not print that line, so on a take with warnings `held` is in this file
+  and nowhere else. Nothing else in the video is touched — the duration,
   the audio and every beat timestamp are exactly what they were, because the
   hold is an overlay switched off rather than a trim.
 - The video is therefore not a measurement of your app's load time, and was

--- a/tests/README.md
+++ b/tests/README.md
@@ -2793,16 +2793,53 @@ knows is missing is worse than one that is openly absent.
   caller reading the guard as one. `scripts/demo-target-guard` is also outside
   mypy's scope, which runs over `skills/demo-video/helpers/` only.
 
-- **Whether prose about masking is *otherwise* true, and prose anywhere but
-  the two places `MaskProse` reads.** `tests/unit`'s sweep flags every mention
-  of mask/scrub/redact in `helpers/demo_recording/*.py` and `SKILL.md` and
-  makes each one earn a hand-written waiver, which is what catches a sentence
-  asserting a layer that #138 removed. It does not read `reference/*.md` or the
-  skill's `README.md`, and it cannot tell a waivered denial that is accurate
-  from one that has quietly gone stale about *something else* — a waiver saying
-  "#142's carve-out" stays green after #142's carve-out is deleted. The list
-  can only shrink, so a stale entry surfaces the moment its line is edited;
-  nothing surfaces one whose line is edited nowhere.
+- **Whether prose about masking is *otherwise* true, and prose anywhere
+  `MaskProse` does not read.** `tests/unit`'s sweep flags every mention of
+  mask/scrub/redact — and, since
+  [#281](https://github.com/rogvid/skills/issues/281), vouch/verifier — in
+  `helpers/demo_recording/*.py`, `SKILL.md`, `scripts/*` and the storyboards
+  under `examples/`, and makes each one earn a hand-written waiver, which is
+  what catches a sentence asserting a layer that #138 removed. It does not read
+  `reference/*.md` or the skill's `README.md`, and it cannot tell a waivered
+  denial that is accurate from one that has quietly gone stale about
+  *something else* — a waiver saying "#142's carve-out" stays green after
+  #142's carve-out is deleted. The list can only shrink, so a stale entry
+  surfaces the moment its line is edited; nothing surfaces one whose line is
+  edited nowhere. Three further limits, all deliberate:
+
+  1. **Synonyms defeat it, by design.** `sanitized`, `obscured`, `cleaned`,
+     `verified` and the rest are not in the family and were reproduced passing
+     during #281. The word list is bounded on purpose: "no prose ever implies a
+     protection" has no done state, and chasing it trades a check that
+     terminates for one that does not. The two families in it are the two that
+     have actually shipped a false claim here — three times.
+  2. **The waivers are keyed on exact line text, so a pure reflow turns the
+     suite red.** Re-wrapping a waived paragraph without changing a word costs
+     a retyped waiver. That is the price of the property in the sentence above:
+     any looser key — a fragment, normalised whitespace — lets an edited
+     sentence keep a waiver written for a sentence it no longer is.
+  3. **It grades the word, not the claim.** A sentence that describes a
+     removed protection in words nobody thought to list reads exactly like
+     prose. #281's site — a failure frame the take "already vouched for" —
+     shipped for that reason and was found by a human, not by this.
+
+- **Whether the reference names the right *stream* for a line the recorder
+  prints.** `ContentSummaryStreams` pins each half of the content summary to
+  its stream in both directions, with four injections behind it, so the *code*
+  is graded. Nothing grades the sentence in `reference/timeline.md` that tells
+  a reader which stream to watch, and for a long time that sentence was wrong:
+  it said `held` arrives "on stderr as it finishes", where in fact
+  `print_content_summary` says it in one place only — the `opened` clause of
+  the healthy `shows a picture` line, which carries no `file=` and therefore
+  goes to **stdout** — and `opening_warning` names `gap` and never mentions
+  `held` at all, so on a take that warned the number is in `timeline.json` and
+  nowhere else. Corrected under
+  [#281](https://github.com/rogvid/skills/issues/281); still ungraded. A
+  string-matching assertion over the document would be decoration — it would
+  pin today's wording rather than the claim, and pass just as happily on a
+  reworded sentence naming the wrong stream. This is written down instead,
+  because an honest gap beats a check that cannot fail for the reason it
+  claims.
 
 - **Most of where the shipped documentation points.** `tests/lint`'s
   `check_pointers()` resolves every repo-shaped path named in `skills/**/*.md`

--- a/tests/unit
+++ b/tests/unit
@@ -1090,6 +1090,12 @@ class TtsKey(unittest.TestCase):
 
 SKILL_DIR = Path(os.environ.get("UNIT_SKILL_DIR", REPO / "skills" / "demo-video"))
 
+# The storyboards in the proving ground. Shipped in this repository rather than
+# by `npx skills add`, and read here for the same reason `SKILL.md` is: they are
+# prose a reader trusts. Overridable for the same reason `SKILL_DIR` is — an
+# injection has to be able to break a copy of them (see `fault_inject`).
+_EXAMPLES = Path(os.environ.get("UNIT_EXAMPLES", REPO / "examples"))
+
 # Lines SKILL.md may occupy before `--budget` says so. It is 510 today. The
 # headroom is for ordinary growth — a verb, a mistake worth naming — and the
 # number is deliberately tight enough that a *section* cannot fit inside it.
@@ -2827,7 +2833,8 @@ class OneClassifier(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
-# No shipped source says something is masked (issues #138, #142, #144, #267)
+# No shipped source says something is masked (issues #138, #142, #144, #267,
+# #281)
 # --------------------------------------------------------------------------
 #
 # The masking layer was removed on purpose, and the prose describing it was
@@ -2848,14 +2855,34 @@ class OneClassifier(unittest.TestCase):
 # one to be waivered by hand. New prose asserting a mask fails until a human
 # writes it down here, which is the decision the eleven sites never got.
 #
-# Its scope, stated: `helpers/demo_recording/*.py` and `SKILL.md`. Not
-# `reference/` or the skill README, and not whether the surviving prose is
-# right about anything other than masking — see tests/README.md's Known gaps.
+# **The vouch/verifier half is #281**, and it is why the word family is not
+# just the three mask words. #267's list was enumerated by eye, so a sentence
+# that asserted the *same removed protection* without using any of those words
+# was structurally unreachable: `_write_failure` told a reader the failure
+# frame "is a frame of the recording the take already vouched for, so it
+# inherits that guarantee whole and reads nothing after the verifier ran" —
+# 88 lines below the same module's correct "nothing vouches for this text now".
+# Both shipped. A protection named by the machinery that used to enforce it is
+# the same claim as one named by the machinery's verb, so both are swept.
+#
+# Its scope, stated: `helpers/demo_recording/*.py`, `SKILL.md`, the shipped
+# `scripts/`, and the storyboards under `examples/`. The last two were added by
+# #281 — both ship, neither was read, and `# The URL is redacted in the log.`
+# added to `scripts/demo-target-guard` left the suite green when that was
+# reproduced. Not `reference/` or the skill README, and not whether the
+# surviving prose is right about anything other than masking — see
+# tests/README.md's Known gaps.
+#
+# Synonyms are **deliberately out of scope**: `sanitized`, `obscured` and the
+# rest defeat this by design. Chasing the full word family trades a bounded
+# check for an unbounded one, and the boundary is written down rather than
+# widened.
 
 MASK_WORDS = re.compile(
     r"\b(?:mask|masks|masked|masker|maskers|masking"
     r"|scrub|scrubs|scrubbed|scrubber|scrubbing"
-    r"|redact|redacts|redacted|redaction)\b",
+    r"|redact|redacts|redacted|redaction"
+    r"|vouch|vouches|vouched|vouching|verifier|verifiers)\b",
     re.I,
 )
 
@@ -2864,11 +2891,22 @@ MASK_WORDS = re.compile(
 # file and by the line exactly as it appears stripped, because editing the
 # sentence at all takes it back out of the waiver and into the check.
 #
+# That key is brittle on purpose and brittle in one direction that is worth
+# knowing before you reflow a paragraph: re-wrapping a waived line, changing
+# nothing about what it says, turns this suite red until the waiver is retyped.
+# The alternative — matching a fragment, or normalising whitespace — is what
+# lets an edited sentence keep a waiver written for a sentence it no longer is.
+#
 # Every entry below is a denial ("no masking, no scrubbing and no redaction",
 # "this recorder scrubs nothing"), a past-tense note about machinery that was
-# removed (#142's carve-out, #144's verifier), or the video sense of the word
-# — a reviewer scrubbing a timeline, which has nothing to do with secrets.
+# removed (#142's carve-out, #144's verifier — including the two lines that say
+# in so many words that nothing vouches for a thing any more), or the video
+# sense of the word — a reviewer scrubbing a timeline, which has nothing to do
+# with secrets.
 MASK_PROSE_WAIVED: dict[str, tuple[str, ...]] = {
+    "content.py": (
+        "# heuristic that misses one. That argument once scoped a terminal verifier to",
+    ),
     "SKILL.md": (
         "- The tool has **no masking, no scrubbing and no redaction**. It does not hide",
         "used to look like one was removed rather than improved. A masking system that",
@@ -2882,6 +2920,7 @@ MASK_PROSE_WAIVED: dict[str, tuple[str, ...]] = {
         "went with the mask in #144. A capture that *raises* still gets a file,",
         "masking anywhere in this recorder.",
         "redaction verifier, the hole PR #58 was blocked on — went with that",
+        "verifier in #144, and nothing vouches for this text now.",
         "recorded — all of it as it came, because there is no masking anywhere",
     ),
     "failure.py": (
@@ -2910,26 +2949,42 @@ MASK_PROSE_WAIVED: dict[str, tuple[str, ...]] = {
     ),
 }
 
-# Everything the sweep is supposed to open: the thirteen package modules and
-# SKILL.md. Set to the whole set rather than to a comfortable floor — a module
-# that stops being read makes "no file says it is masked" hold over a file
-# nobody opened, and this is the only assertion that would notice.
-MASK_SWEEP_FILE_FLOOR = 14
+# Everything the sweep is supposed to open: the thirteen package modules,
+# `SKILL.md`, `scripts/demo-target-guard`, and the three example storyboards.
+# Set to the whole set rather than to a comfortable floor — a module that stops
+# being read makes "no file says it is masked" hold over a file nobody opened,
+# and this is the only assertion that would notice. It was 14 before #281 added
+# the last four; a fourth demo directory raises the real count without needing
+# this number moved, which is why it is a floor and not an equality.
+MASK_SWEEP_FILE_FLOOR = 18
 
 
 class MaskProse(unittest.TestCase):
     """The removed masking layer is not described as though it were there."""
 
     def swept(self):
-        yield SKILL_DIR / "SKILL.md"
-        yield from sorted((_PKG_PARENT / "demo_recording").glob("*.py"))
+        """`(label, path)` for every file the sweep opens.
+
+        The label, not `path.name`, is what waivers are keyed on: three
+        different `record.py` files are swept, and keying on the bare name
+        would merge them into one bucket where a waiver written for one file
+        silently covers the other two.
+        """
+        yield "SKILL.md", SKILL_DIR / "SKILL.md"
+        for path in sorted((_PKG_PARENT / "demo_recording").glob("*.py")):
+            yield path.name, path
+        for path in sorted((SKILL_DIR / "scripts").glob("*")):
+            if path.is_file():
+                yield f"scripts/{path.name}", path
+        for path in sorted(_EXAMPLES.rglob("record.py")):
+            yield f"examples/{path.relative_to(_EXAMPLES).as_posix()}", path
 
     def hits(self) -> dict[str, list[str]]:
         found: dict[str, list[str]] = {}
-        for path in self.swept():
+        for label, path in self.swept():
             for line in path.read_text(encoding="utf-8").splitlines():
                 if MASK_WORDS.search(line):
-                    found.setdefault(path.name, []).append(line.strip())
+                    found.setdefault(label, []).append(line.strip())
         return found
 
     def test_no_shipped_source_claims_a_mask_that_does_not_exist(self):
@@ -9742,6 +9797,65 @@ INJECTIONS = [
         ["MaskProse.test_no_shipped_source_claims_a_mask_that_does_not_exist"],
     ),
     (
+        # **The line #281 was actually about**, restored exactly. It is the
+        # docstring of the method that writes `failure/last-frame.png`, and it
+        # tells a reader that the PNG inherited a guarantee from a verifier
+        # #144 deleted — 88 lines below the same module saying nothing vouches
+        # for anything now. Both shipped. It contains no mask, scrub or redact
+        # word, which is why the sweep could not reach it until #281 widened
+        # the family; this is the entry that proves the widening grades.
+        "the failure frame goes back to claiming a verifier vouched for it",
+        "core.py",
+        "        because by the time this runs there is no page: `__exit__` closes the\n"
+        "        context, the browser and Playwright before `_convert`, and this is\n"
+        "        called after all of it. It used to be argued for the other way round —\n"
+        "        the frame inheriting a guarantee the take had already earned — and the\n"
+        "        machinery that issued that guarantee went in #144. The PNG carries none\n"
+        "        now: it is the last frame of this take's recording, as it was recorded,\n"
+        "        and no more is claimed for it than for any other artifact here. Gated on\n",
+        "        it is a frame of the recording the take already vouched for, so it\n"
+        "        inherits that guarantee whole and reads nothing after the verifier\n"
+        "        ran. Gated on\n",
+        ["MaskProse.test_no_shipped_source_claims_a_mask_that_does_not_exist"],
+    ),
+    (
+        # The shipped CLI, which the sweep did not open before #281. Reproduced
+        # by hand during the review of #271: this exact line left the whole
+        # suite green, because `scripts/` was outside the glob.
+        "the shipped guard CLI says it redacts a URL it prints verbatim",
+        "scripts/demo-target-guard",
+        "import argparse\nimport sys",
+        "import argparse\nimport sys\n\n# The URL is redacted in the log.",
+        ["MaskProse.test_no_shipped_source_claims_a_mask_that_does_not_exist"],
+    ),
+    (
+        # And a storyboard, the other half of the #281 extension. An example is
+        # the first thing somebody copies, so a sentence here promising a mask
+        # travels straight into their own recorder.
+        "an example storyboard promises the recorder scrubs what it records",
+        "examples/ticket-queue/demos/2026-07-27-empty-state/record.py",
+        '"""A filter that matches nothing explains itself instead of going blank.',
+        '"""A filter that matches nothing explains itself instead of going blank.\n\n'
+        "The recorder scrubs the queue contents before they reach the video.",
+        ["MaskProse.test_no_shipped_source_claims_a_mask_that_does_not_exist"],
+    ),
+    (
+        # The floor, not the content. Narrow the sweep back to its pre-#281
+        # scope and the mask assertion stays green over the files it stopped
+        # opening — which is the vacuous sweep, and this is the only assertion
+        # that notices. Injected into this file because that is where the glob
+        # lives; the inner run is the copy, so it reads the narrowed version.
+        "the sweep quietly stops opening the files #281 added to it",
+        "tests/unit",
+        '        for path in sorted((SKILL_DIR / "scripts").glob("*")):\n'
+        "            if path.is_file():\n"
+        '                yield f"scripts/{path.name}", path\n'
+        '        for path in sorted(_EXAMPLES.rglob("record.py")):\n'
+        '            yield f"examples/{path.relative_to(_EXAMPLES).as_posix()}", path\n',
+        "        return\n",
+        ["MaskProse.test_the_sweep_read_the_files_it_claims_to_have_read"],
+    ),
+    (
         # The CI path, and the one no other assertion here walks: every other
         # test writes `"1"`, which a workflow never sends. Dropping `true`
         # leaves both suites green and puts the pre-check and the recorder
@@ -11214,9 +11328,19 @@ def fault_inject() -> int:
             # break is a document whose guard nobody has watched fire.
             readme = Path(tmp) / "README.md"
             shutil.copy(REPO / "tests" / "README.md", readme)
+            # ...and the proving ground, which `MaskProse` now sweeps. Copied
+            # for the same reason as everything above: an injection has to be
+            # able to break one of these storyboards, and a sweep reading the
+            # working tree would grade the pristine file instead.
+            examples = Path(tmp) / "examples"
+            shutil.copytree(REPO / "examples", examples)
             unit = Path(tmp) / "unit"
             shutil.copy(Path(__file__).resolve(), unit)
-            if module == "tests/smoke":
+            if module.startswith("examples/"):
+                # Before the `"/" in module` branch below, which would send it
+                # into the skill directory.
+                target = examples / module[len("examples/") :]
+            elif module == "tests/smoke":
                 target = smoke
             elif module == "tests/smoke-inject":
                 # Before the `"/" in module` branch below, which would send it
@@ -11260,6 +11384,7 @@ def fault_inject() -> int:
                     "UNIT_SMOKE": str(smoke),
                     "UNIT_SMOKE_INJECT": str(smoke_inject),
                     "UNIT_README": str(readme),
+                    "UNIT_EXAMPLES": str(examples),
                 },
             )
             noticed = {t for t in must_fail if t in done.stderr}


### PR DESCRIPTION
Fixes #281.

## Acceptance criterion

> No shipped file asserts that any artifact was vouched for, verified, or
> guaranteed by machinery that no longer exists, **and the sweep that grades
> this fails when a new one is written.**

## Part 1 — the sweep

`MASK_WORDS` gains `vouch|vouches|vouched|vouching|verifier|verifiers`. The
glob gains `skills/demo-video/scripts/*` and `examples/**/record.py`, taking
`MASK_SWEEP_FILE_FLOOR` from **14 to 18**. Waivers are now keyed on a path
label (`scripts/demo-target-guard`, `examples/…/record.py`) rather than
`path.name`, because three different `record.py` files would otherwise share
one bucket and one waiver would silently cover all three.

Two shipped sites rewritten: `core.py`'s `_write_failure` docstring (the
`#281` defect) and `content.py:97`'s reference to the removed terminal
verifier. Two lines waived: `core.py:1922` and `content.py`'s rewritten line.

### The sweep going red on the shipped line, before it was fixed

`core.py:2008` is the line the issue asked to see fail. Run with the word
family added and no prose touched:

```
FAIL: test_no_shipped_source_claims_a_mask_that_does_not_exist (__main__.MaskProse.test_no_shipped_source_claims_a_mask_that_does_not_exist)
AssertionError: Lists differ: ['content.py: # verifier to registered val[274 chars]ing'] != []

- ['content.py: # verifier to registered values only (issue #5). Nothing here '
-  'raises, nothing',
-  'core.py: after the verifier ran. Gated on `self._converted`, not on the file',
-  'core.py: verifier in #144, and nothing vouches for this text now.',
-  'core.py: vouched for, so it inherits that guarantee whole and reads nothing']
```

All four sites the issue enumerated, and nothing else.

## Injections — four new, each seen failing

`tests/unit --fault-inject`: **All 250 injections were caught.**

**1. The `#281` defect restored exactly** (`core.py`) — the docstring that
shipped, back verbatim:

```
# injection 'the failure frame goes back to claiming a verifier vouched for it' matched 1 time(s) in core.py
FAIL: test_no_shipped_source_claims_a_mask_that_does_not_exist
AssertionError: Lists differ: ['core.py: inherits that guarantee whole a[111 chars] it'] != []
- ['core.py: inherits that guarantee whole and reads nothing after the verifier',
-  'core.py: it is a frame of the recording the take already vouched for, so it']
```

**2. The shipped CLI, which was outside the glob** — this is the exact line
reproduced during the review of #271, which left the whole suite green then:

```
# injection 'the shipped guard CLI says it redacts a URL it prints verbatim' matched 1 time(s) in scripts/demo-target-guard
FAIL: test_no_shipped_source_claims_a_mask_that_does_not_exist
AssertionError: Lists differ: ['scripts/demo-target-guard: # The URL is redacted in the log.'] != []
```

**3. A storyboard under `examples/`**, the other half of the extension:

```
# injection 'an example storyboard promises the recorder scrubs what it records' matched 1 time(s) in examples/ticket-queue/demos/2026-07-27-empty-state/record.py
FAIL: test_no_shipped_source_claims_a_mask_that_does_not_exist
- ['examples/ticket-queue/demos/2026-07-27-empty-state/record.py: The recorder '
-  'scrubs the queue contents before they reach the video.']
```

**4. The glob narrowed back to its pre-#281 scope**, injected into
`tests/unit` itself. This is the measurement the issue named — the file floor
is what proves the extension landed, and nothing else notices a sweep that
quietly stops opening files:

```
# injection 'the sweep quietly stops opening the files #281 added to it' matched 1 time(s) in tests/unit
FAIL: test_the_sweep_read_the_files_it_claims_to_have_read
  self.assertGreaterEqual(len(list(self.swept())), MASK_SWEEP_FILE_FLOOR)
AssertionError: 14 not greater than or equal to 18
```

Every injection reported `matched 1 time(s)` — the harness ABORTs otherwise,
so each one landed.

`--fault-inject` now copies `examples/` into its temp tree and passes
`UNIT_EXAMPLES`, preserving the harness's stated invariant that the inner run
reads nothing from the working tree.

## Stated limits

**Synonyms are deliberately out of scope.** `sanitized`, `obscured`,
`cleaned`, `verified` and the rest defeat this sweep by design. Reproduced:
appending `# The screen text is sanitized and obscured before it is written.`
to `failure.py` leaves `MaskProse` green, and `scripts/demo-target-guard`
ships the sentence "It now says that nothing was verified" today without a
hit. "No prose ever implies a protection" has no done state, and chasing the
full word family trades a bounded check for an unbounded one. The two families
in the list are the two that have actually shipped a false claim in this
repository — three times now. Written into `tests/README.md`'s Known gaps
rather than widened.

**The waiver list is keyed on exact line text, so a pure reflow turns the
suite red.** Re-wrapping a waived paragraph without changing a word costs a
retyped waiver. That is intended and it is the price of the property that
makes the list useful: any looser key — a fragment, normalised whitespace —
lets an edited sentence keep a waiver written for a sentence it no longer is.
It bit once inside this change: reflowing `content.py`'s new paragraph for
line width required the waiver to be retyped.

**The sweep grades the word, not the claim.** `#281`'s site described exactly
the removed protection while using none of the listed words, which is why it
shipped and why a human found it. The widened family closes this instance; it
does not close the class.

## Part 2 — `reference/timeline.md` names the wrong stream

Cherry-picked from `05762a1` on the abandoned `review-process` branch
(31 July, never landed) and re-verified line by line against today's code.

### Verified against today's code, not taken on trust

- `print_content_summary` (`content.py:855`) builds the `opened` clause at
  `content.py:904-911` and emits it only in the final `print(...)` at
  `content.py:912-915`, which carries **no `file=`** — so **stdout**.
  Confirmed by reading the call, not the commit message.
- That print is reached only past the `measured` guard (`content.py:874-880`)
  and the `warnings` guard (`content.py:881-884`), so a warning take never
  prints it.
- **The claim I was asked to check independently: it holds.**
  `opening_warning` (`content.py:498-520`) formats **`gap`** into its
  sentence and reads `held` only as a gate (`if held is None: return None`).
  It never mentions `held`. So on a warning take the number is in
  `timeline.json` and on neither stream. The document was wrong twice, and
  the correction says so.
- `grep` over the whole package confirms `content.py:909` is the **only**
  place `held` is formatted into any string — so "the only place the recorder
  ever says it" is exact.

### Corrected beyond the 31 July commit

The commit said "A take takes one of those branches and never both". A take
that encoded no mp4 has `content: null` and takes **neither** —
`test_no_content_at_all_prints_nothing_on_either_stream` pins that. Changed to
"at most one", with the no-mp4 case named.

### Deliberately no new check

Whether a sentence names the right stream is not gradable by the mask or
pointer sweeps, and a document-string-matching assertion would pass just as
happily on a reworded sentence naming the wrong stream — the decorative check
the house rule says to leave out. `ContentSummaryStreams` already pins each
summary line to its stream in both directions, with four injections behind it,
so the **code** half is graded. The **prose** half is recorded in
`tests/README.md`'s Known gaps as ungraded, and said plainly there.

#169 is closed and stays closed: its `content.py` half landed separately, and
`content.py:55-66` documents the split correctly today. This lands the
reference half only.

## Verification

`tests/unit` (382 ok) · `tests/unit --fault-inject` (250/250 caught) ·
`tests/unit --budget` · `tests/ci-unit` (77 ok) ·
`tests/ci-unit --fault-inject` (36/36 caught) · `tests/lint` ·
`tests/lint --self-test` · `tests/lint --issues` · `ruff format --check .` ·
`mypy` (13 files, clean). All re-run after rebasing onto `d9345d2`.

`tests/smoke` was **not** run: no recorder behaviour changes here, only prose
and the test sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
