### PR TITLE
Grade the verb table, and cut three sentences back to what they claim (#287, #289, #290)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/content.py
+++ b/skills/demo-video/helpers/demo_recording/content.py
@@ -258,6 +258,11 @@ CONTENT_STATIC_WARN_S = 15.0
 # set until #165: both interlude styles log the verb `interlude` with the style
 # in `selector`, so no timeline has ever carried it, and the documentation
 # copied it out of here into a shipped table of beat verbs.
+#
+# That table — the two rows under *did a verb that acts on the app run inside
+# the stretch?* in `reference/timeline.md` — is compared to these two sets name
+# by name, also in tests/unit, since #289. It was a copy nothing graded, which
+# is how a dead member reached a shipped document in the first place.
 CONTENT_ACTING_VERBS = frozenset(
     {
         "clear",
@@ -866,10 +871,12 @@ def print_content_summary(content: dict | None, media: str) -> None:
     or one warning per entry in `content.warnings` — goes to `stderr` with the
     recorder's other diagnostics. The healthy `… shows a picture (…)` line goes
     to `stdout`, where `wrote <path>` and the take's other statements about its
-    own output already are. Every path out of here takes one of those two
-    branches and never both, so a caller redirecting one stream loses no part
-    of the summary — only the branch this take did not take. The section header
-    above says the same, and `tests/unit` pins each line to its stream.
+    own output already are. A path out of here takes **at most one** of those
+    two branches and never both — a take that encoded no mp4 has no `content`
+    to report and prints on neither stream — so a caller redirecting one stream
+    loses no part of the summary, only the branch this take did not take. The
+    section header above says the same, and `tests/unit` pins each line to its
+    stream.
     """
     if not isinstance(content, dict):
         return

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -60,7 +60,8 @@ key is fine, renaming one is not:
   starting and returning. A verb built out of other verbs (`click` glides
   first, `type_into` clicks first) is one beat, not one per internal step.
 - `caption` is the line on screen during the beat: the new text for a
-  `caption` beat, the line shown for an `interlude`, `""` when none is up.
+  `caption` beat, the line shown for an `interlude`, the declared clause a
+  `criterion` card carries, `""` when none is up.
 - `selector` is what the verb acted on, as a string — a CSS selector for the
   web verbs, the command / keys / pattern for the terminal ones, the name for
   `shot`. `null` for verbs with no target (`pause`, `hold`, a cleared
@@ -164,7 +165,10 @@ to.
   measured one. Spoken, it is a clause of the healthy `shows a picture` line —
   **stdout**, and the only place the recorder ever says it. A take that warned
   does not print that line, so on a take with warnings `held` is in this file
-  and nowhere else. Nothing else in the video is touched — the duration,
+  and nowhere else — and a take whose `held` is `0.0` gets no clause either,
+  because the clause says what was covered and nothing was, so a healthy line
+  carrying no hold is a take that opened on a painted app rather than a take
+  that hid one. Nothing else in the video is touched — the duration,
   the audio and every beat timestamp are exactly what they were, because the
   hold is an overlay switched off rather than a trim.
 - The video is therefore not a measurement of your app's load time, and was
@@ -224,8 +228,14 @@ inside the stretch?**
 
 | beats inside the held stretch | verdict |
 |---|---|
-| `caption`, `criterion`, `interlude`, `hold`, `pause`, `shot`, `wait_for*` | narrated hold — silent |
-| `run`, `send`, `key`, `click`, `type_into`, `goto`, `scroll_to`, `spotlight`, `move_to` | worth looking at — warns |
+| `caption`, `criterion`, `hold`, `interlude`, `pause`, `shot`, `wait_for`, `wait_for_prompt`, `wait_for_text` | narrated hold — silent |
+| `clear`, `click`, `click_fast`, `goto`, `key`, `move_to`, `press`, `run`, `scroll_to`, `send`, `spotlight`, `terminal`, `terminal_close`, `terminal_output`, `type_into` | worth looking at — warns |
+
+Both rows are the whole of `content.py`'s `CONTENT_PASSIVE_VERBS` and
+`CONTENT_ACTING_VERBS`, written out name by name rather than summarised. This
+skill's own repository holds a `tests/unit` that compares the two rows to those
+two sets, so a verb that drifts out of either one fails there rather than
+shipping as a table nobody grades (#289).
 
 Both interlude styles log as the verb `interlude`, with `selector` carrying the
 style (`"card"` or `"light"`) — there is no separate verb for the light one.
@@ -254,13 +264,13 @@ working one.
 
 - **A held stretch containing only narration is never reported.** This is the
   verb correlation doing its job, and it is also the one blind spot that can
-  hide a real fault: a demo that raises an interlude card and then only
-  captions, holds and takes stills behind it is silent, however long the card
-  stays up. Measured: a card over 31.5s of a 34s take, no warning. There is no
-  third answer available from the frames — with the caption band excluded, an
-  honest tour of a still screen and a card left up are byte-identical. If your
-  storyboard raises a card, take it down explicitly; do not rely on this check
-  to notice.
+  hide a real fault: a demo that raises a card (`interlude()`, `criterion()`)
+  and then only captions, holds and takes stills behind it is silent, however
+  long the card stays up. Measured: a card over 31.5s of a 34s take, no
+  warning. There is no third answer available from the frames — with the
+  caption band excluded, an honest tour of a still screen and a card left up
+  are byte-identical. If your storyboard raises a card, take it down
+  explicitly; do not rely on this check to notice.
 
 - **A caption change is invisible to the held-picture arm, by design.** The
   caption bar is the recorder's own drawing and it renders over an interlude

--- a/tests/README.md
+++ b/tests/README.md
@@ -2849,7 +2849,7 @@ knows is missing is worse than one that is openly absent.
 
 - **Whether the reference names the right *stream* for a line the recorder
   prints.** `ContentSummaryStreams` pins each half of the content summary to
-  its stream in both directions, with four injections behind it, so the *code*
+  its stream in both directions, with seven injections behind it, so the *code*
   is graded. Nothing grades the sentence in `reference/timeline.md` that tells
   a reader which stream to watch, and for a long time that sentence was wrong:
   it said `held` arrives "on stderr as it finishes", where in fact
@@ -2858,12 +2858,22 @@ knows is missing is worse than one that is openly absent.
   goes to **stdout** — and `opening_warning` names `gap` and never mentions
   `held` at all, so on a take that warned the number is in `timeline.json` and
   nowhere else. Corrected under
-  [#281](https://github.com/rogvid/skills/issues/281); still ungraded. A
-  string-matching assertion over the document would be decoration — it would
-  pin today's wording rather than the claim, and pass just as happily on a
-  reworded sentence naming the wrong stream. This is written down instead,
-  because an honest gap beats a check that cannot fail for the reason it
-  claims.
+  [#281](https://github.com/rogvid/skills/issues/281), and twice more since —
+  [#286](https://github.com/rogvid/skills/issues/286) for the take that prints
+  on neither stream, [#290](https://github.com/rogvid/skills/issues/290) for
+  the healthy take whose `held` is `0.0` and which therefore announces no hold
+  either. Three corrections to one paragraph is what an ungraded sentence
+  costs. It is still ungraded: a string-matching assertion over the document
+  would be decoration — it would pin today's wording rather than the claim, and
+  pass just as happily on a reworded sentence naming the wrong stream. This is
+  written down instead, because an honest gap beats a check that cannot fail
+  for the reason it claims.
+
+  What **is** graded, and was not before #290, is the code side of that last
+  clause: `test_a_take_that_held_nothing_announces_no_hold`, with a control
+  beside it so "no hold is announced" cannot be satisfied by a summary that
+  never mentions one. Both directions are injected — a zero hold announced,
+  and the clause silenced for every take.
 
 - **Most of where the shipped documentation points.** `tests/lint`'s
   `check_pointers()` resolves every repo-shaped path named in `skills/**/*.md`
@@ -2920,11 +2930,16 @@ knows is missing is worse than one that is openly absent.
   "somebody is on this" is invisible to it. `--self-test` holds a floor under
   how many sentences in this tree that vocabulary still matches, so it cannot
   quietly stop matching anything, and the sweep floors **both** its axes —
-  references and files. Measured here: 1,428 references across 47 files, of
-  which the top five files carry **1,087** and all of `skills/` carries 349. A
-  sweep narrowed to `tests/` reads 1,047 references from 6 files — five times
-  the reference floor, and none of the shipped documents this check exists for.
-  Depth is not breadth, and only the file floor says so.
+  references and files. Why both, measured with `tests/lint --issues` when this
+  paragraph was last touched (#290): 1,510 references across 49 files, of which
+  the top five files carry **1,146** and all of `skills/` carries 353. A sweep
+  narrowed to `tests/` reads 1,112 references from 6 files — five times the
+  reference floor, and none of the shipped documents this check exists for.
+  Depth is not breadth, and only the file floor says so. **The totals are a
+  snapshot and nothing grades them**: every commit that names an issue moves
+  them, and the figure before this one was two pull requests stale. Re-run the
+  command rather than trusting the number; what has to keep holding is the
+  shape, which is what the two floors are set against.
 
 - **The issue check runs in one direction only.** It catches a *closed* issue
   presented as pending. It says nothing about an *open* issue presented as

--- a/tests/unit
+++ b/tests/unit
@@ -987,6 +987,27 @@ class ContentSummaryStreams(unittest.TestCase):
     def test_no_content_at_all_prints_nothing_on_either_stream(self):
         self.assertEqual(self.summary(None), ("", ""))
 
+    def test_a_take_that_held_nothing_announces_no_hold(self):
+        # `opened` is gated on `held > 0`, and reference/timeline.md says so
+        # since #290. Without this the prose is the only thing that knows: a
+        # zero clause reads as "the first 0.00s is a hold", which tells a
+        # reader the recorder covered something on a take where it covered
+        # nothing — the confidently-wrong artifact, in one clause.
+        out, err = self.summary(
+            seg("a", opening={"gap": 0.0, "held": 0.0, "limit": 1.5})["content"]
+        )
+        self.assertIn("shows a picture", out)
+        self.assertNotIn("hold", out)
+        self.assertEqual(err, "")
+
+    def test_a_take_that_held_the_opening_says_so_on_stdout(self):
+        # The control for the test above, which is satisfied by a summary that
+        # never mentions a hold at all — including one with the clause deleted.
+        out, _ = self.summary(
+            seg("a", opening={"gap": 0.0, "held": 0.4, "limit": 1.5})["content"]
+        )
+        self.assertIn("the first 0.40s is a hold", out)
+
 
 # --------------------------------------------------------------------------
 # narration.py — the cache key (issue #157)
@@ -1184,6 +1205,83 @@ class SkillDocs(unittest.TestCase):
         linked = set(re.findall(r"\]\(reference/([^)#]+)", self.skill))
         self.assertGreaterEqual(len(on_disk), REFERENCE_FLOOR)
         self.assertEqual(on_disk - linked, set(), "reference files nothing links")
+
+
+# --------------------------------------------------------------------------
+# The shipped verb table, against the sets it was copied out of (issue #289)
+# --------------------------------------------------------------------------
+#
+# `reference/timeline.md` tells a storyboard author which verbs a held stretch
+# tolerates in silence and which ones make it warn. That is `content.py`'s two
+# frozensets, retyped — and until #289 nothing compared the two, so deleting
+# `criterion` from the passive row turned nothing red. It is the shape #165
+# came from, one document over: `"bridge"` sat in the passive set and was
+# copied into this table, and no timeline has ever carried that verb.
+#
+# Graded **name for name, both rows**. "The row has nine verbs" is the
+# catalogue's count standing in for the content, and nine wrong names satisfy
+# it. The acting row is graded too although #289 only names the passive one:
+# it was the same copy, and it was already six verbs short of the set.
+#
+# Order inside a row is not graded, duplication is: both sides are sorted
+# lists, so a verb written twice fails instead of being absorbed by a set. No
+# floor of its own — a row that lost every verb fails the comparison, and the
+# union is floored one class up by `VerbClassification`, which the same two
+# sets feed.
+
+VERB_TABLE_HEADER = "| beats inside the held stretch | verdict |"
+
+
+def verb_table_rows() -> list[tuple[list[str], str]]:
+    """(verbs named, verdict) for each row of the shipped held-stretch table.
+
+    Read out of the document a storyboard author actually opens, and by
+    position rather than by matching verb names: a parser that went looking for
+    the names it expects would find them however few of them were there.
+    """
+    lines = (
+        (SKILL_DIR / "reference" / "timeline.md")
+        .read_text(encoding="utf-8")
+        .splitlines()
+    )
+    at = [i for i, line in enumerate(lines) if line.strip() == VERB_TABLE_HEADER]
+    if len(at) != 1:
+        return []
+    rows = []
+    for line in lines[at[0] + 2 :]:  # +2: past the `|---|---|` rule
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if not line.startswith("|") or len(cells) != 2:
+            break
+        rows.append((re.findall(r"`([a-z_]+)`", cells[0]), cells[1]))
+    return rows
+
+
+class VerbTable(unittest.TestCase):
+    def test_the_shipped_table_names_exactly_the_verbs_the_code_classifies(self):
+        rows = verb_table_rows()
+        self.assertEqual(
+            len(rows),
+            2,
+            f"the table under {VERB_TABLE_HEADER!r} in reference/timeline.md "
+            f"parsed as {len(rows)} row(s), not the passive one and the acting "
+            f"one — nothing below is graded until it parses",
+        )
+        (passive, passive_verdict), (acting, acting_verdict) = rows
+        self.assertIn("silent", passive_verdict)
+        self.assertIn("warns", acting_verdict)
+        self.assertEqual(
+            sorted(passive),
+            sorted(CONTENT_PASSIVE_VERBS),
+            "the silent row of reference/timeline.md and CONTENT_PASSIVE_VERBS "
+            "name different verbs. A storyboard author reads that row to decide "
+            "what may sit inside a held stretch; the recorder reads the set",
+        )
+        self.assertEqual(
+            sorted(acting),
+            sorted(CONTENT_ACTING_VERBS),
+            "the warning row of reference/timeline.md and CONTENT_ACTING_VERBS "
+            "name different verbs",
+        )
 
 
 # --------------------------------------------------------------------------
@@ -2873,7 +2971,8 @@ class OneClassifier(unittest.TestCase):
 #
 # Its scope, stated: `helpers/demo_recording/*.py`, `SKILL.md`, the shipped
 # `scripts/`, and the storyboards under `examples/`. The last two were added by
-# #281 — both ship, neither was read, and `# The URL is redacted in the log.`
+# #281 — both are prose a reader trusts, neither was read, and the line
+# `# The URL is redacted in the log.`
 # added to `scripts/demo-target-guard` left the suite green when that was
 # reproduced. Not `reference/` or the skill README, and not whether the
 # surviving prose is right about anything other than masking — see
@@ -4232,6 +4331,26 @@ class CriterionCard(unittest.TestCase):
         self.assertEqual(rec._beats, [])
 
 
+class _HoldClock:
+    """A monotonic clock that only a held frame advances.
+
+    Stood in for `core.time` so a 7.5 s spoken line costs this suite
+    microseconds while the beat log still comes out with the timestamps a real
+    take would write. `_idle` is where a take spends a hold, and it is left
+    running exactly as it ships — its own `time.sleep` is what moves this
+    clock, so a hold the recorder skipped moves nothing.
+    """
+
+    def __init__(self) -> None:
+        self.mono = 0.0
+
+    def monotonic(self) -> float:
+        return self.mono
+
+    def sleep(self, seconds: float) -> None:
+        self.mono += seconds
+
+
 class CriterionHold(unittest.TestCase):
     """How long the clause stays up, and what pins the two constants.
 
@@ -4287,16 +4406,70 @@ class CriterionHold(unittest.TestCase):
     def test_a_storyboard_that_says_how_long_gets_exactly_that(self):
         self.assertEqual(self.held_for(CLAUSE, hold=0.25), 0.25)
 
-    def test_the_clause_stays_up_for_the_whole_spoken_line(self):
-        # With narration on, a card that leaves mid-sentence is the one thing
-        # this verb must not do: the voice is still reading the clause and the
-        # screen has moved on.
-        self.assertAlmostEqual(self.held_for("It works.", spoken=7.5), 7.5, delta=0.2)
+    def beats_over_line(self, text: str, spoken: float) -> list[dict]:
+        """The beat log of a take that raised a card while a line was still
+        being spoken, and then took it down with the documented clear.
+
+        Run over `_HoldClock` and with the production `_idle` — the loop, the
+        pump and the slicing against a deadline, all of it — because what is
+        being read here is `t_start`/`t_end`, and a recorder that holds nothing
+        writes a beat log where every beat is instantaneous.
+        """
+        clock = _HoldClock()
+        rec = recorder(self, cls=Recorder, page=DrawingPage(), criteria={"AC-1": text})
+        rec._t0 = 0.0
+        # What `_start_line` does for a real narration clip, without one: the
+        # line is now known to end `spoken` seconds from here. Once — the
+        # `interlude("")` that clears the card speaks nothing.
+        pending = [spoken]
+        rec._start_line = lambda clip: (  # type: ignore[method-assign]
+            setattr(rec, "_line_end", clock.monotonic() + pending.pop())
+            if pending
+            else None
+        )
+        real = core_module.time
+        core_module.time = clock  # type: ignore[assignment]
+        try:
+            rec.criterion("AC-1")
+            rec.interlude("")
+        finally:
+            core_module.time = real  # type: ignore[assignment]
+        return rec._beats
+
+    def test_the_criterion_beat_covers_the_whole_spoken_line(self):
+        # **What the `line_remaining` term actually buys, measured** (#287).
+        # Not that the card stays up: the only take-down is `interlude("")`,
+        # whose `_prepare_line("")` idles the line out before it clears, so the
+        # clause is on screen for the whole line either way. What the term
+        # decides is which beat the wait is *attributed* to — and a beat's
+        # `t_end` is what `frames.py` cuts its review frame at the midpoint of,
+        # so the wrong attribution moves the one frame a reviewer sees for this
+        # card onto a clause the voice has not reached yet.
+        criterion, cleared = self.beats_over_line("It works.", spoken=7.5)
+        self.assertEqual(criterion["verb"], "criterion")
+        self.assertAlmostEqual(criterion["t_end"], 7.5, delta=0.01)
+        self.assertEqual(
+            cleared["t_start"],
+            criterion["t_end"],
+            "the seconds the voice spent finishing the clause belong to no "
+            "beat: the criterion beat ended before the line did, and the "
+            "clear had to wait the rest of it out before its own beat opened",
+        )
+
+    def test_a_take_with_no_line_to_finish_pays_nothing_for_the_term(self):
+        # The control. Both assertions above are satisfied by a card that is
+        # *always* held to `spoken`, and by one whose beats are all glued end
+        # to end whatever the hold was — this take scripts a line that is
+        # already over, and the card falls back to reading speed.
+        criterion, cleared = self.beats_over_line("It works.", spoken=-30.0)
+        self.assertAlmostEqual(criterion["t_end"], CRITERION_HOLD_MIN_S, delta=0.01)
+        self.assertEqual(cleared["t_start"], criterion["t_end"])
 
     def test_a_line_that_already_finished_does_not_shorten_the_card(self):
-        # The control for the test above: without it, "the card rides the
-        # spoken line" is satisfied by a hold that is *always* whatever
-        # `_line_end` says, including a negative one.
+        # The same control one level down, on the hold itself rather than on
+        # the beat it lands in: without it, "the card rides the spoken line"
+        # is satisfied by a hold that is *always* whatever `_line_end` says,
+        # including a negative one.
         self.assertEqual(self.held_for("It works.", spoken=-30.0), CRITERION_HOLD_MIN_S)
 
 
@@ -10279,7 +10452,24 @@ INJECTIONS = [
         '        "caption",\n        "criterion",',
         '        "bridge",\n        "caption",\n        "criterion",',
         [
-            "VerbClassification.test_every_classified_verb_is_one_a_recorder_actually_logs"
+            "VerbClassification.test_every_classified_verb_is_one_a_recorder_actually_logs",
+            # The code half of #289's drift, in the same break: a set that grew
+            # a name the shipped table does not carry. The entry below breaks
+            # the table instead, so both directions are watched.
+            "VerbTable.test_the_shipped_table_names_exactly_the_verbs_the_code_classifies",
+        ],
+    ),
+    (
+        # #289 exactly: `criterion` deleted from the row a storyboard author
+        # reads to decide what may sit inside a held stretch. Before the check
+        # below existed this turned nothing red — the table was a copy of
+        # `CONTENT_PASSIVE_VERBS` that nothing compared to it.
+        "a verb is dropped from the shipped table of what a held stretch tolerates",
+        "reference/timeline.md",
+        "| `caption`, `criterion`, `hold`,",
+        "| `caption`, `hold`,",
+        [
+            "VerbTable.test_the_shipped_table_names_exactly_the_verbs_the_code_classifies"
         ],
     ),
     (
@@ -10347,6 +10537,28 @@ INJECTIONS = [
         [
             "ContentSummaryStreams.test_no_content_at_all_prints_nothing_on_either_stream"
         ],
+    ),
+    (
+        # A hold of zero announced as a hold. The clause exists so that a
+        # reader is told the opening frames are not frames the recording
+        # captured; on a take that covered nothing it says the opposite of
+        # what happened, in the one line the recorder prints unasked (#290).
+        "a take that covered nothing still announces an opening hold",
+        "content.py",
+        "        if isinstance(held_open, (int, float)) and held_open > 0:",
+        "        if isinstance(held_open, (int, float)):",
+        ["ContentSummaryStreams.test_a_take_that_held_nothing_announces_no_hold"],
+    ),
+    (
+        # The other direction, and the reason the test above has a control:
+        # "no hold is announced" is satisfied by a recorder that never
+        # announces one, and then `held` is in `timeline.json` and nowhere a
+        # reader of the take's own output will meet it.
+        "the opening hold stops being announced at all",
+        "content.py",
+        "        if isinstance(held_open, (int, float)) and held_open > 0:",
+        "        if isinstance(held_open, (int, float)) and held_open > 1e9:",
+        ["ContentSummaryStreams.test_a_take_that_held_the_opening_says_so_on_stdout"],
     ),
     (
         # #46 in the marker's own body: the stale branch is the case the file
@@ -11595,14 +11807,20 @@ INJECTIONS = [
         ],
     ),
     (
-        # The card leaves while the narrator is still reading the clause off
-        # it. Silent on a take recorded without speech, which is every take in
-        # CI — so the assertion that catches it has to script the line.
-        "the card comes down mid-sentence when the clause is being spoken",
+        # The seconds the voice spends finishing the clause stop belonging to
+        # the criterion beat. The card is on screen for the whole line either
+        # way — `interlude("")` idles the line out before it clears — so what
+        # this breaks is the beat log, not the picture: the criterion beat ends
+        # early, the wait falls into the gap before the clear's own beat, and
+        # the review frame `frames.py` cuts at the beat's midpoint moves onto a
+        # clause the narrator has not reached. Silent on a take recorded
+        # without speech, which is every take in CI, so the assertion that
+        # catches it has to script the line (#287).
+        "the wait for the spoken line falls outside the criterion beat",
         "core.py",
         "        return max(reading, self._line_end - time.monotonic())",
         "        return reading",
-        ["CriterionHold.test_the_clause_stays_up_for_the_whole_spoken_line"],
+        ["CriterionHold.test_the_criterion_beat_covers_the_whole_spoken_line"],
     ),
 ]
 


### PR DESCRIPTION
Three issues, one shape: a statement stronger than the thing it grades. Each was found by an independent review of a PR that had green CI.

Fixes #290
Fixes #289
Fixes #287

## What changed

**#289 — the verb table is now graded, not copied.** `reference/timeline.md`'s passive/acting rows were a retyped copy of `CONTENT_PASSIVE_VERBS` and `CONTENT_ACTING_VERBS`. Both rows are written out in full (the acting row had been six verbs short of its set) and `VerbTable.test_the_shipped_table_names_exactly_the_verbs_the_code_classifies` compares them **name for name**, not by count. Two injections, one per direction of drift.

**#290 — three sentences and two figures.** `content.py:869`'s "every path out of here takes one of those two branches and never both" is now "at most one", naming the `content is None` path that prints on neither. The reference no longer reads as though a healthy take always announces its opening hold, and the `held > 0` gate that makes that true is now graded in both directions. `tests/README.md`'s reference distribution re-measured; `tests/unit`'s "both ship" corrected to "both are prose a reader trusts", since the three `record.py` under `examples/` are not installed by `npx skills add`.

**#287 — an injection's stated reason.** `_criterion_hold` is **unchanged**; only its justification was too strong. See below.

## Fault injection

### #289 — the defect first: on `origin/main`, deleting a verb from the row is green

`criterion` deleted from the passive row of `origin/main`'s `reference/timeline.md` (exact-once replacement, asserted):

```
tests/unit    Ran 396 tests in 1.564s   OK
tests/ci-unit Ran 77 tests in 0.388s    OK
```

(`tests/lint` cannot run against an extracted tree — it needs `git ls-files` — so it is not part of that measurement.)

The same deletion, on this branch:

```
FAIL: test_the_shipped_table_names_exactly_the_verbs_the_code_classifies
AssertionError: Lists differ: ['caption', 'hold', 'interlude', 'pause', 'shot', 'wai[38 chars]ext'] != ['caption', 'criterion', 'hold', 'interlude', 'pause',[51 chars]ext']

First differing element 1:
'hold'
'criterion'

  ['caption',
+  'criterion',
   'hold',
   'interlude',
   'pause',
   'shot',
   'wait_for',
   'wait_for_prompt',
   'wait_for_text'] : the silent row of reference/timeline.md and CONTENT_PASSIVE_VERBS name different verbs. A storyboard author reads that row to decide what may sit inside a held stretch; the recorder reads the set
```

The other direction — `"bridge"` added to `CONTENT_PASSIVE_VERBS`, #165's own defect — now fails `VerbTable` as well as `VerbClassification`, and that entry's `must_fail` names both.

### #290 — the zero hold, both directions

Measured first, which is what the issue asked for (`print_content_summary` with `opening={"held": 0.0}`, both streams captured):

```
held=0.0
  stdout: 'demo.mp4 shows a picture (content 10.0 over the app rect, longest still stretch 1.0s)'
  stderr: ''
held=0.4
  stdout: '... longest still stretch 1.0s; the first 0.40s is a hold — the app had not painted yet, ...'
  stderr: ''
```

Break the gate (`held_open > 0` → `isinstance` alone):

```
FAIL: test_a_take_that_held_nothing_announces_no_hold
AssertionError: 'hold' unexpectedly found in 'demo.mp4 shows a picture (content 10.0 over the app rect, longest still stretch 1.0s; the first 0.00s is a hold — the app had not painted yet, so its first painted frame covers the gap)\n'
```

Silence the clause instead (`> 0` → `> 1e9`) and the control fires: `FAIL: test_a_take_that_held_the_opening_says_so_on_stdout`. Without it, "no hold is announced" is satisfied by a recorder that never announces one.

### #287 — what the term actually prevents

The card is on screen for the whole line either way; `interlude("")` calls `_prepare_line("")` → `_finish_line()`, which idles the line out **before** the clear. Measured over a scripted 7.5 s line, `(verb, t_start, t_end)`:

```
patched=False (shipped):  [('criterion', 0.0, 7.5), ('interlude', 7.5, 8.1)]
patched=True  (injected): [('criterion', 0.0, 2.8), ('interlude', 7.5, 8.1)]
```

4.7 s of video that belongs to no beat, and the review frame `frames.py` cuts at the criterion beat's midpoint moves from 3.75 s to 1.4 s — onto a clause the narrator has not reached. The injection is retitled *"the wait for the spoken line falls outside the criterion beat"* and now names a test that reads `t_end`:

```
FAIL: test_the_criterion_beat_covers_the_whole_spoken_line
AssertionError: 2.8 != 7.5 within 0.01 delta (4.7 difference)
```

The new test runs the **production** `_idle` — loop, pump and deadline slicing — over a stand-in clock that only `time.sleep` advances, so a hold the recorder skipped moves nothing. Its control scripts a line that is already over and requires the card to fall back to reading speed.

## Suites

```
tests/unit                    400 tests            OK
tests/unit --fault-inject     All 259 injections were caught.
tests/unit --budget           SKILL.md: 600 lines, budget 600
tests/ci-unit                 77 tests             OK
tests/ci-unit --fault-inject  All 36 injections were caught.
tests/lint                    All checks passed
tests/lint --self-test        Every guard held
tests/lint --issues           1510 reference(s) across 49 file(s)
tests/smoke-inject --self-test  Every guard refused what it exists to refuse.
ruff format --check .         15 files already formatted
mypy (1.18.2, as CI runs it)  Success: no issues found in 13 source files
```

`tests/smoke` was **not** run: nothing here changes recorder behaviour, and it holds an exclusive lock for ten minutes. `check_verb_classification` stays where it is — the new grading needs no recording, so it went to `tests/unit` beside the two set assertions #165 left there, and `tests/smoke` is untouched.

## Stated limits

- **The verb table's *verdict* column is not graded** — only the names. That the silent row really goes silent and the warning row really warns is the held-stretch correlation, graded separately; nothing checks that a verb sitting in the passive set is one a reader would agree is passive.
- **`tests/lint` carries the same stale reference figures this PR corrected in `tests/README.md`, and disagrees with itself** (1,087 in one comment, 1,017 twenty lines below). Out of scope here; filed as #292 with the measurement.
- **The #287 test reads a scripted clock, not a recording.** It grades the beat log the recorder writes, not the frame ffmpeg cuts. That the PNG at a beat's midpoint is the frame at that timestamp is `tests/smoke`'s, unchanged.
- **The reference sentence about which stream carries `held` is still ungraded prose**, now corrected three times (#281, #286, #290). `tests/README.md`'s Known gaps says so, and says why a string-matching assertion over it would be decoration.
