### PR TITLE
Hand the reviewer one picture per clause, and name the clauses with none (#274)

### DIFF
--- a/.github/scripts/demo-comment
+++ b/.github/scripts/demo-comment
@@ -338,11 +338,26 @@ def demo_dir(demo_root: str, name: str) -> Path:
     return Path(demo_root) / name if demo_root else Path(name)
 
 
+def repo_path(prefix: str, name: str) -> str:
+    """`name` as the *repository* sees it, not as the workflow ran it.
+
+    A `--demo` path is relative to the caller's `working-directory`, which the
+    workflow re-roots storyboards to: this repository's own reference call sets
+    it to `examples/ticket-queue`, so the demo the comment calls
+    `demos/2026-07-28-queue-search` is four directories down in git. A still
+    linked without that prefix is a 404 that looks exactly like a working link,
+    which is why the prefix is passed in rather than inferred.
+    """
+    parts = [p for p in f"{prefix}/{name}".split("/") if p not in ("", ".")]
+    return "/".join(parts)
+
+
 def render_demo(
     name: str,
     timeline: dict,
     *,
     demo_root: str,
+    path_prefix: str,
     repo_url: str | None,
     sha: str | None,
 ) -> str:
@@ -366,7 +381,7 @@ def render_demo(
     # report exists to test (issue #273, the same ordering `timeline.md` uses).
     lines += render_coverage(
         timeline.get("coverage"),
-        demo=name,
+        demo=repo_path(path_prefix, name),
         directory=demo_dir(demo_root, name),
         repo_url=repo_url,
         sha=sha,
@@ -431,6 +446,7 @@ def render(
     sha: str | None,
     repo_url: str | None,
     demo_root: str,
+    path_prefix: str,
 ) -> str:
     failed = any(t.get("failure") for _, t in demos)
     lines = [MARKER, ""]
@@ -446,6 +462,7 @@ def render(
                 name,
                 timeline,
                 demo_root=demo_root,
+                path_prefix=path_prefix,
                 repo_url=repo_url,
                 sha=sha,
             )
@@ -537,6 +554,16 @@ def main(argv: list[str] | None = None) -> int:
             "has; with neither given, a still is named rather than linked."
         ),
     )
+    ap.add_argument(
+        "--path-prefix",
+        default="",
+        help=(
+            "where the --demo paths sit in the repository, when they are not "
+            "at its root — the workflow's working-directory. Prefixed to the "
+            "still links only; without it a demo recorded under "
+            "examples/ticket-queue is linked at the repository root and 404s."
+        ),
+    )
     ap.add_argument("--out", required=True, help="where to write the comment body")
     args = ap.parse_args(argv)
 
@@ -582,6 +609,7 @@ def main(argv: list[str] | None = None) -> int:
         sha=args.sha,
         repo_url=args.repo_url or None,
         demo_root=args.demo_root,
+        path_prefix=args.path_prefix,
     )
     Path(args.out).write_text(body, encoding="utf-8")
     if summary := os.environ.get("GITHUB_STEP_SUMMARY"):

--- a/.github/scripts/demo-comment
+++ b/.github/scripts/demo-comment
@@ -23,8 +23,9 @@ Tier 1 is what survives artifact retention. Tier 2 is what a reviewer clicks
 today. Neither substitutes for the other.
 
 A take recorded against a ticket carries a third thing above the beat table:
-the ticket's clauses, the ones no beat claimed named first (issue #273). It is
-a rendering of `timeline.json`'s `coverage` and it grades nothing — see
+the ticket's clauses, the ones no beat claimed named first (issue #273), each
+claimed clause pointed at the committed still a reviewer can open (issue #274).
+It is a rendering of `timeline.json`'s `coverage` and it grades nothing — see
 `render_coverage`.
 
 The body opens with an HTML marker so the workflow can find and rewrite this
@@ -37,6 +38,8 @@ import argparse
 import json
 import os
 from pathlib import Path
+from typing import NamedTuple
+from urllib.parse import quote
 
 MARKER = "<!-- demo-video-ci: one comment per pull request, rewritten on every push -->"
 
@@ -96,7 +99,108 @@ def _claim_label(rows: list[dict]) -> str:
     return _plural(len(parts), "beat ", "beats ") + ", ".join(parts)
 
 
-def render_coverage(coverage: object) -> list[str]:
+class _Picture(NamedTuple):
+    """What the `look at` column says for one clause, and whether it is one."""
+
+    cell: str
+    found: bool  # a still this take published, which the cell points at
+
+
+def _inside_demo(still: str) -> str | None:
+    """`still` as a path inside the demo directory, or None if it is not one.
+
+    `timeline.json` is a committed, pull-request-editable file, and its `still`
+    is pasted into a URL below. A value of `../../elsewhere.png` can exist on
+    disk and would resolve to a picture that has nothing to do with this demo,
+    so it is named in the table rather than linked.
+    """
+    if still.startswith("/") or "\\" in still:
+        return None
+    parts = [p for p in still.split("/") if p not in ("", ".")]
+    if not parts or ".." in parts:
+        return None
+    return "/".join(parts)
+
+
+def _still_href(repo_url: str | None, sha: str | None, path: str) -> str | None:
+    """A URL for a committed still, at the commit the take was recorded from.
+
+    None when the caller gave no repository or no commit: a link built without
+    both would point at the wrong bytes, and naming the file is better than
+    handing a reviewer a picture from some other revision.
+    """
+    base = (repo_url or "").rstrip("/")
+    if not base or not sha:
+        return None
+    return f"{base}/raw/{quote(sha)}/{quote(path)}"
+
+
+def _picture(
+    rows: list[dict],
+    *,
+    demo: str,
+    directory: Path,
+    repo_url: str | None,
+    sha: str | None,
+) -> _Picture:
+    """The one still a reviewer can open for this clause, or why there is none.
+
+    `images/*.png` are committed, so a blob at the head SHA is the only piece
+    of a take that has a URL at all: `demo.mp4` and `frames/` are both inside
+    Actions artifact zips and `frames/` is gitignored, which is why this is a
+    still and not a seek into the video (issue #272).
+
+    Existence is checked in the directory this take's `timeline.json` was read
+    from — in CI the staging copy, which the freshness filter has already
+    applied — so a still left behind by a *previous* recording is named as
+    missing rather than linked as this take's. A still the manifest names and
+    nothing published is the artifact-lies case: it is reported, never skipped
+    and never linked.
+    """
+    if not rows:
+        return _Picture("—", False)
+    named: list[str] = []
+    outside: list[str] = []
+    for row in rows:
+        still = row.get("still")
+        if not isinstance(still, str) or not still.strip():
+            continue
+        raw = still.strip()
+        named.append(raw)
+        rel = _inside_demo(raw)
+        if rel is None:
+            outside.append(raw)
+            continue
+        if not (directory / rel).exists():
+            continue
+        href = _still_href(repo_url, sha, f"{demo}/{rel}")
+        # The file name alone in the cell: the row already says which clause
+        # and which demo, and the full path crowds a three-column table.
+        label = _cell(rel.rsplit("/", 1)[-1])
+        return _Picture(f"[{label}]({href})" if href else f"`{_cell(rel)}`", True)
+    if outside:
+        return _Picture(
+            f"*`{_cell(outside[0])}` is not a path inside this demo, "
+            f"so it is not linked*",
+            False,
+        )
+    if named:
+        return _Picture(
+            f"*`{_cell(named[0])}` is named here, but this take published "
+            f"no such file*",
+            False,
+        )
+    return _Picture("*no still*", False)
+
+
+def render_coverage(
+    coverage: object,
+    *,
+    demo: str,
+    directory: Path,
+    repo_url: str | None,
+    sha: str | None,
+) -> list[str]:
     """The ticket's clauses and what claimed them, **gap first** (issue #273).
 
     Nothing here is a verdict, and the wording is load-bearing rather than a
@@ -116,7 +220,14 @@ def render_coverage(coverage: object) -> list[str]:
 
     Which clauses nothing claimed is derived from `claimed`, not read out of
     the manifest's own `unclaimed`, so the headline and the table below it
-    cannot disagree about the same take.
+    cannot disagree about the same take. The clauses with no picture are
+    derived the same way, and from the same pass that fills the `look at`
+    column, for the same reason.
+
+    A clause claimed only by a caption gives a reviewer nothing to open, and
+    until issue #274 it looked exactly like a well-illustrated one. It is named
+    with the other gaps, above the table: it is the second finding here that
+    takes no judgement, being a fact about which files exist.
     """
     doc = coverage if isinstance(coverage, dict) else {}
     criteria = doc.get("criteria")
@@ -128,6 +239,19 @@ def render_coverage(coverage: object) -> list[str]:
     claimed = doc.get("claimed") or {}
     unclaimed = [key for key in criteria if not (claimed.get(key) or [])]
     total, covered = len(criteria), len(criteria) - len(unclaimed)
+    pictures = {
+        key: _picture(
+            claimed.get(key) or [],
+            demo=demo,
+            directory=directory,
+            repo_url=repo_url,
+            sha=sha,
+        )
+        for key in criteria
+    }
+    unillustrated = [
+        key for key in criteria if key not in unclaimed and not pictures[key].found
+    ]
 
     gap: list[str] = []
     if unclaimed:
@@ -135,6 +259,15 @@ def render_coverage(coverage: object) -> list[str]:
         gap += [
             f"**{ids} {_plural(len(unclaimed), 'has', 'have')} no beat "
             f"claiming {_plural(len(unclaimed), 'it', 'them')}.**",
+            "",
+        ]
+    if unillustrated:
+        ids = _and_list([f"`{_cell(key)}`" for key in unillustrated])
+        gap += [
+            f"**{ids} {_plural(len(unillustrated), 'is', 'are')} claimed, but "
+            f"no still was published for "
+            f"{_plural(len(unillustrated), 'it', 'them')}, so there is nothing "
+            f"here to open.**",
             "",
         ]
     if covered:
@@ -153,11 +286,14 @@ def render_coverage(coverage: object) -> list[str]:
         )
     gap.append("")
 
-    table = ["| clause | claimed at |", "|---|---|"]
+    table = ["| clause | claimed at | look at |", "|---|---|---|"]
     for key, text in criteria.items():
         rows = claimed.get(key) or []
         where = _claim_label(rows) if rows else "*nothing claims this*"
-        table.append(f"| **{_cell(key)}** — {_cell(str(text))} | {where} |")
+        table.append(
+            f"| **{_cell(key)}** — {_cell(str(text))} | {where} "
+            f"| {pictures[key].cell} |"
+        )
     table.append("")
 
     note = [
@@ -165,7 +301,10 @@ def render_coverage(coverage: object) -> list[str]:
         "coverage timestamps are on the recorder's monotonic clock and the "
         "video is on the host's wall clock, so a seek printed from them would "
         "be [#229](https://github.com/rogvid/skills/issues/229) in a new "
-        "artifact ([#277](https://github.com/rogvid/skills/issues/277)).</sub>",
+        "artifact ([#277](https://github.com/rogvid/skills/issues/277)). A "
+        "picture is the still that beat wrote, linked in this repository at "
+        "the commit this take was recorded from; what it is a picture of is "
+        "the reviewer's call.</sub>",
         "",
     ]
     # The gap first, and the order is the whole point rather than a layout
@@ -188,7 +327,25 @@ def _duration(timeline: dict) -> str:
     return f"{float(d):.0f}s"
 
 
-def render_demo(name: str, timeline: dict) -> str:
+def demo_dir(demo_root: str, name: str) -> Path:
+    """Where this demo's published files are, `--demo-root` or not.
+
+    One implementation, because `main` reads `timeline.json` out of it and
+    `render_coverage` checks the stills that timeline names against it: two
+    copies of this rule would let the comment link a picture from a directory
+    other than the one it described.
+    """
+    return Path(demo_root) / name if demo_root else Path(name)
+
+
+def render_demo(
+    name: str,
+    timeline: dict,
+    *,
+    demo_root: str,
+    repo_url: str | None,
+    sha: str | None,
+) -> str:
     """One demo's section: the heading, the beat table, and what went wrong."""
     beats = timeline.get("beats") or []
     rows = story_beats(beats)
@@ -207,7 +364,13 @@ def render_demo(name: str, timeline: dict) -> str:
     # the reason somebody opened the comment — and a reviewer who scrolls past
     # twenty captions first has already formed the impression the coverage
     # report exists to test (issue #273, the same ordering `timeline.md` uses).
-    lines += render_coverage(timeline.get("coverage"))
+    lines += render_coverage(
+        timeline.get("coverage"),
+        demo=name,
+        directory=demo_dir(demo_root, name),
+        repo_url=repo_url,
+        sha=sha,
+    )
 
     if rows:
         lines.append("| # | at | Caption |")
@@ -266,6 +429,8 @@ def render(
     failure_artifact_url: str | None,
     run_url: str | None,
     sha: str | None,
+    repo_url: str | None,
+    demo_root: str,
 ) -> str:
     failed = any(t.get("failure") for _, t in demos)
     lines = [MARKER, ""]
@@ -276,7 +441,15 @@ def render(
         return "\n".join(lines) + "\n"
 
     for name, timeline in demos:
-        lines.append(render_demo(name, timeline))
+        lines.append(
+            render_demo(
+                name,
+                timeline,
+                demo_root=demo_root,
+                repo_url=repo_url,
+                sha=sha,
+            )
+        )
 
     if artifact_url:
         size = _human_size(artifact_bytes)
@@ -317,6 +490,18 @@ def render(
     return "\n".join(lines) + "\n"
 
 
+def _default_repo_url() -> str:
+    """`$GITHUB_SERVER_URL/$GITHUB_REPOSITORY`, or "" outside Actions.
+
+    Both are set in every Actions step, so the workflow needs no new argument
+    for the still links to work; the server URL is read rather than hardcoded
+    so a GitHub Enterprise host links its own blobs and not github.com's.
+    """
+    server = (os.environ.get("GITHUB_SERVER_URL") or "https://github.com").rstrip("/")
+    repo = (os.environ.get("GITHUB_REPOSITORY") or "").strip("/")
+    return f"{server}/{repo}" if repo else ""
+
+
 def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument(
@@ -341,14 +526,24 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--failure-artifact-url")
     ap.add_argument("--run-url")
     ap.add_argument("--sha")
+    ap.add_argument(
+        "--repo-url",
+        default=_default_repo_url(),
+        help=(
+            "the repository's web URL, e.g. https://github.com/o/r. Each "
+            "claimed still is linked under it at --sha, because `images/` is "
+            "committed and the video is not. Defaults to "
+            "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY, which every Actions step "
+            "has; with neither given, a still is named rather than linked."
+        ),
+    )
     ap.add_argument("--out", required=True, help="where to write the comment body")
     args = ap.parse_args(argv)
 
     demos: list[tuple[str, dict]] = []
     for raw in args.demo:
         name = raw.rstrip("/")
-        directory = Path(args.demo_root) / name if args.demo_root else Path(name)
-        timeline_path = directory / "timeline.json"
+        timeline_path = demo_dir(args.demo_root, name) / "timeline.json"
         if not timeline_path.exists():
             # A take that refused before writing anything, or one whose
             # timeline was held back as not this take's. Say so rather than
@@ -385,6 +580,8 @@ def main(argv: list[str] | None = None) -> int:
         failure_artifact_url=args.failure_artifact_url,
         run_url=args.run_url,
         sha=args.sha,
+        repo_url=args.repo_url or None,
+        demo_root=args.demo_root,
     )
     Path(args.out).write_text(body, encoding="utf-8")
     if summary := os.environ.get("GITHUB_STEP_SUMMARY"):

--- a/.github/workflows/demo-video.yml
+++ b/.github/workflows/demo-video.yml
@@ -518,6 +518,10 @@ jobs:
           EVIDENCE_RETENTION: ${{ inputs.evidence-retention-days }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          # Where the --demo paths sit in the repository. They are relative to
+          # working-directory, so a still linked without this is a 404 that
+          # looks exactly like a working link.
+          WORKDIR: ${{ inputs.working-directory }}
         run: |
           set -euo pipefail
           args=()
@@ -539,6 +543,7 @@ jobs:
             --retention-days "$RETENTION" \
             --evidence-retention-days "$EVIDENCE_RETENTION" \
             --run-url "$RUN_URL" --sha "$HEAD_SHA" \
+            --path-prefix "$WORKDIR" \
             --out "$COMMENT_BODY"
 
       # One comment, found by its marker and rewritten. A branch with ten

--- a/skills/demo-video/reference/ci.md
+++ b/skills/demo-video/reference/ci.md
@@ -53,10 +53,28 @@ jobs:
 On a take recorded against a ticket — `Recorder(criteria={"AC-1": "…"})`, beats
 tagged `ac="AC-1"` — a third thing sits **above** the beat table: the ticket's
 clauses, with the ones **no beat claimed named first**, then a table of what
-claimed the rest and at which beat. That order is deliberate. A rendering that
-opened with the covered half would be a coverage claim whatever the sentence
-under it said, and the one finding here that needs no judgement is the clause
-nobody even asserted.
+claimed the rest, at which beat, and which picture to open. That order is
+deliberate. A rendering that opened with the covered half would be a coverage
+claim whatever the sentence under it said, and the findings here that need no
+judgement are the clause nobody even asserted and the clause nobody left a
+picture of.
+
+**The picture is a committed still, and clauses with none are named as a gap.**
+`shot("01-search-box", ac="AC-1")` writes `images/01-search-box.png`, which is
+a committed file and therefore the only piece of a take that has a URL: the
+video and `frames/` are both inside artifact zips, so there is no timestamp to
+deep-link and none is printed. The comment links each clause's still in your
+repository at the head commit, and a still the manifest names that this take
+did not publish is reported as absent rather than linked — last week's picture
+under this week's clause is worse than no picture at all.
+
+A clause claimed only by `caption(text, ac=…)` has no still, so it hands a
+reviewer nothing to open, and it is named above the table with the unclaimed
+ones. The rule that follows: **tag a `shot()` for every clause, not only a
+caption.** A caption tag says where to look; a still tag is the thing that can
+be looked at. Neither is evidence that the clause was demonstrated — a picture
+next to a clause is a frame the storyboard chose, and what it is a picture of
+is still the reviewer's call.
 
 **It says "claimed", never "demonstrated", and it says out loud that it graded
 nothing.** An `ac=` tag is a string the storyboard author typed; whether the

--- a/skills/demo-video/reference/ci.md
+++ b/skills/demo-video/reference/ci.md
@@ -64,9 +64,10 @@ picture of.
 a committed file and therefore the only piece of a take that has a URL: the
 video and `frames/` are both inside artifact zips, so there is no timestamp to
 deep-link and none is printed. The comment links each clause's still in your
-repository at the head commit, and a still the manifest names that this take
-did not publish is reported as absent rather than linked — last week's picture
-under this week's clause is worse than no picture at all.
+repository at the head commit — under `working-directory`, which is where git
+holds them — and a still the manifest names that this take did not publish is
+reported as absent rather than linked: last week's picture under this week's
+clause is worse than no picture at all.
 
 A clause claimed only by `caption(text, ac=…)` has no still, so it hands a
 reviewer nothing to open, and it is named above the table with the unclaimed

--- a/tests/README.md
+++ b/tests/README.md
@@ -1445,6 +1445,14 @@ because a link that resolves to the wrong bytes is worse than no link:
   injection for this one stages a real `../../leaked.png`, because existence
   alone lets it through.
 
+`CommentStep` grades the one fact only the workflow holds: a `--demo` path is
+relative to `working-directory`, and this repository's own reference call sets
+that to `examples/ticket-queue`. Without it every still is linked at the
+repository root — a 404 that renders exactly like a working link, and one that
+no reading of `demo-comment` alone can see. Two injections cover it, the same
+pair `WorkflowGates` uses: the argument dropped, and the variable exported and
+then not passed.
+
 The two sentences #274 adds are swept for verdict words on fixtures that
 render them, which `TAGGED` does not: it has a picture for every clause it
 claims. The gap sentence is also reached by `ALL_CLAIMED`; the absent-still

--- a/tests/README.md
+++ b/tests/README.md
@@ -1410,13 +1410,51 @@ would find the clause on a take whose card never reached the browser.
 about `timeline.json` and `timeline.md`; the pull-request comment is the one
 artifact a human is guaranteed to open, and until #273 it rendered none of
 this and said so by pointing at an issue that had been closed for months. Its
-`Coverage` class grades four things and nothing more: that the clauses nothing
+`Coverage` class grades five things and nothing more: that the clauses nothing
 claimed are named **before** the table of what was claimed, that every declared
 clause reaches the comment with its own text, that a clause's row names *its
-own* beats rather than another clause's, and that no sentence in the comment
-promotes a claim to a verdict. The last one is a word sweep with a control
-beside it, because a sweep for absent words passes just as happily on a comment
-that renders no coverage at all.
+own* beats rather than another clause's, that a claimed clause's row points at
+*its own* published still, and that no sentence in the comment promotes a claim
+to a verdict. The last one is a word sweep with a control beside it, because a
+sweep for absent words passes just as happily on a comment that renders no
+coverage at all.
+
+**The picture, and the clauses that have none**
+([#274](https://github.com/rogvid/skills/issues/274)). A clause whose only
+claim is a caption hands the reviewer nothing to look at, and before #274 it
+rendered exactly like a well-illustrated one. The `look at` column carries a
+link to the still the beat wrote, and the clauses with no still are named with
+the other gaps, above the table. Four properties of that link are graded,
+because a link that resolves to the wrong bytes is worse than no link:
+
+- the **whole href**, by equality — repository, full sha, the demo directory
+  the still belongs to, and the recorded path. A short sha resolves today and
+  is ambiguous later, and a still linked at the repository root 404s; both
+  leave the comment's shape, its row per clause and its link count intact,
+  which is what the equality is for;
+- **which row it lands in.** *Every clause is pointed at the first still in the
+  report* gives every clause a picture and every picture resolves — the
+  catalogue's *count that stands in for the content*, in a new column;
+- **that the file exists**, checked in the directory the timeline was read from
+  — in CI the staging copy, so a still the freshness filter held back as a
+  previous recording's is named as absent rather than linked as this take's.
+  Absent is *reported*: skipping it silently would make a clause with a broken
+  claim read like one nobody illustrated;
+- **that the path is inside the demo.** `timeline.json` is committed and a pull
+  request may edit it, so its `still` is untrusted text pasted into a URL. The
+  injection for this one stages a real `../../leaked.png`, because existence
+  alone lets it through.
+
+The two sentences #274 adds are swept for verdict words on fixtures that
+render them, which `TAGGED` does not: it has a picture for every clause it
+claims. The gap sentence is also reached by `ALL_CLAIMED`; the absent-still
+cell is reached by `ABSENT_STILL` and nothing else, and its injection reddens
+that one test alone — the measurement that says the fixture is carrying it
+rather than decorating it.
+
+What none of this says is that the picture shows the clause. It says a file
+exists, resolves, and belongs to the beat that claimed it — the same boundary
+as everything else here.
 
 **The sweep grades the sentences the renderer writes, not the ones it quotes**
 ([#283](https://github.com/rogvid/skills/issues/283)). Clause text belongs to
@@ -1443,8 +1481,11 @@ writes are swept. Clause **ids** are not exempted either — they are too short
 to subtract safely, so a ticket with a clause called `verified` would redden
 this suite.
 
-Nineteen injections cover it — nine from #273 and the ten #283 added above —
-and two of the first nine are worth naming: *the acceptance section
+The injections that cover the acceptance section are enumerated in `ci-unit`'s
+`INJECTIONS`, and the number they add up to is deliberately not written here:
+it went stale the first time somebody added one, which is
+[#295](https://github.com/rogvid/skills/issues/295) item 4 and the same
+conclusion #264 and #269 reached. Two are worth naming: *the acceptance section
 leads with what was claimed instead of the gap* — which is the whole ordering
 claim, and nothing else in the suite can see it — and *every clause is pointed
 at the first claim in the report*, which leaves the table its shape, its row
@@ -2238,9 +2279,19 @@ knows is missing is worse than one that is openly absent.
   [#272](https://github.com/rogvid/skills/issues/272), question 2.
 
   So what a green `tests/ci-unit` says about a demo's acceptance criteria is
-  exactly: the comment named every clause the storyboard declared, and named
-  first the ones no beat claimed. It says nothing about whether the beats that
-  did claim one showed it.
+  exactly: the comment named every clause the storyboard declared, named first
+  the ones no beat claimed and the ones with no still to open, and pointed
+  each of the rest at a picture that is on disk beside the timeline that named
+  it. It says nothing about whether the beats that did claim one showed it.
+
+- **Nothing here opens the link the comment prints.** The href is graded by
+  equality against the one the arguments imply, and the file it names is
+  graded as existing in the directory the timeline was read from. Neither is
+  an HTTP request: a still this take wrote and nobody committed at the head
+  sha will be linked here and 404 for the reader, and only a run of the
+  workflow on a real pull request can see that. What makes it worth doing
+  anyway is that the alternative — no link — is what
+  [#274](https://github.com/rogvid/skills/issues/274) was filed about.
 
 - **Nothing calls the ElevenLabs API.** The narration take grades everything a
   cache hit reaches — the key, the pacing, the mix — and by construction never

--- a/tests/README.md
+++ b/tests/README.md
@@ -1472,10 +1472,6 @@ second and third rows each have an injection that reddens
 which is the measurement that says their fixtures are carrying those sentences
 rather than decorating an existing test.
 
-What none of this says is that the picture shows the clause. It says a file
-exists, resolves, and belongs to the beat that claimed it — the same boundary
-as everything else here.
-
 **The sweep grades the sentences the renderer writes, not the ones it quotes**
 ([#283](https://github.com/rogvid/skills/issues/283)). Clause text belongs to
 whoever wrote the ticket and captions to whoever wrote the storyboard, and both
@@ -1513,8 +1509,12 @@ per clause and its beat numbers, and points every row at the wrong one.
 
 **What this deliberately does not grade**, two things:
 
-- Whether a tagged beat *shows* what it claims. That is the reviewer's
-  judgement, and the artifact is written to say so rather than to assert it.
+- Whether a tagged beat *shows* what it claims — including, since
+  [#274](https://github.com/rogvid/skills/issues/274), whether the picture
+  linked beside a clause is a picture *of* it. What the link grades is that a
+  file exists, resolves, and belongs to the beat that claimed it. That is the
+  reviewer's judgement, and the artifact is written to say so rather than to
+  assert it.
 - **Whether the criterion card is legible.** "The clause reached the page" is
   not "a human can read it": a card rendered off-frame, under an app overlay,
   or clipped by an over-long clause puts exactly the same text in exactly the

--- a/tests/README.md
+++ b/tests/README.md
@@ -1453,12 +1453,24 @@ no reading of `demo-comment` alone can see. Two injections cover it, the same
 pair `WorkflowGates` uses: the argument dropped, and the variable exported and
 then not passed.
 
-The two sentences #274 adds are swept for verdict words on fixtures that
-render them, which `TAGGED` does not: it has a picture for every clause it
-claims. The gap sentence is also reached by `ALL_CLAIMED`; the absent-still
-cell is reached by `ABSENT_STILL` and nothing else, and its injection reddens
-that one test alone — the measurement that says the fixture is carrying it
-rather than decorating it.
+Each sentence #274 adds is swept for verdict words on a fixture that renders
+it, and they are enumerated rather than counted, because the count is what went
+wrong here first: the loop had two fixtures in it, this paragraph said "the two
+sentences", and the renderer wrote three. Replacing the third with *"so nothing
+here is proved or verified"* left the whole suite green.
+
+| sentence the renderer writes | fixture that reaches it |
+|---|---|
+| the clauses with no picture, above the table | `CAPTION_ONLY`, and `ALL_CLAIMED` |
+| *`…` is named here, but this take published no such file* | `ABSENT_STILL` |
+| *`…` is not a path inside this demo, so it is not linked* | `OUTSIDE_STILL` |
+
+`TAGGED` reaches none of them — it has a picture for every clause it claims —
+so a sweep run only there would grade these three by never seeing them. The
+second and third rows each have an injection that reddens
+`test_the_same_words_are_refused_where_a_clause_has_no_picture` **alone**,
+which is the measurement that says their fixtures are carrying those sentences
+rather than decorating an existing test.
 
 What none of this says is that the picture shows the clause. It says a file
 exists, resolves, and belongs to the beat that claimed it — the same boundary

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -679,6 +679,8 @@ class Render(unittest.TestCase):
             failure_artifact_url=None,
             run_url="https://github.com/o/r/actions/runs/1",
             sha="abcdef1234567890",
+            repo_url="https://github.com/o/r",
+            demo_root="",
         )
         opts.update(kw)
         return comment.render([("demos/x", timeline or TIMELINE)], **opts)
@@ -800,12 +802,66 @@ COVERAGE = {
 TAGGED = dict(TIMELINE, coverage=COVERAGE)
 
 # Every clause claimed. Same criteria, so the two documents differ in exactly
-# the thing the headline is a statement about.
+# the thing the headline is a statement about. No claim carries a still, so
+# every clause is also one a reviewer has nothing to open for (#274).
 ALL_CLAIMED = dict(
     TIMELINE,
     coverage=dict(
         COVERAGE,
         claimed={key: [claim(i)] for i, key in enumerate(COVERAGE["criteria"])},
+        unclaimed=[],
+    ),
+)
+
+# The take #274 describes: AC-1 claimed by a `shot()`, AC-2 by a `caption()`
+# alone. The two are indistinguishable in the manifest's `claimed` — same shape,
+# same beat fields — and differ only in whether a `still` was written, which is
+# the whole reason the finding is a fact about files rather than a judgement.
+STILL, MISSING = "images/01-search-box.png", "images/09-never-written.png"
+CAPTION_ONLY = dict(
+    TIMELINE,
+    coverage=dict(
+        COVERAGE,
+        claimed={
+            "AC-1": [claim(3, STILL)],
+            "AC-2": [claim(5)],
+            "AC-3": [claim(6), claim(9, "images/03-requester.png")],
+            "AC-4": [],
+        },
+        unclaimed=["AC-4"],
+    ),
+)
+
+# A claim naming a still nothing published — a `shot()` on a take that died
+# before it, or a still the freshness filter held back as a previous
+# recording's. The manifest looks exactly like CAPTION_ONLY's AC-1 row.
+ABSENT_STILL = dict(
+    TIMELINE,
+    coverage=dict(
+        COVERAGE,
+        claimed={
+            "AC-1": [claim(3, STILL)],
+            "AC-2": [claim(5, MISSING)],
+            "AC-3": [claim(9, "images/03-requester.png")],
+            "AC-4": [claim(11)],
+        },
+        unclaimed=[],
+    ),
+)
+
+# The clean path: every clause claimed, every claim carrying a still that this
+# take published. Neither gap headline has anything to say about it, which is
+# the branch a coverage claim is most tempting to print into.
+ALL_ILLUSTRATED = dict(
+    TIMELINE,
+    coverage=dict(
+        COVERAGE,
+        claimed={
+            "AC-1": [claim(3, STILL)],
+            "AC-2": [claim(5, "images/03-requester.png")],
+            "AC-3": [claim(9, STILL)],
+            "AC-4": [claim(11, "images/03-requester.png")],
+        },
         unclaimed=[],
     ),
 )
@@ -958,23 +1014,71 @@ class Coverage(unittest.TestCase):
     the comment cannot be read as having made it.
     """
 
-    def body(self, timeline):
-        return comment.render(
-            [("demos/x", timeline)],
+    #: The commit the stills are linked at. Full, never the seven-character
+    #: form the footnote prints: a short sha is ambiguous, and a link that
+    #: resolves today to a different object later is the artifact lying slowly.
+    SHA = "abcdef1234567890abcdef1234567890abcdef12"
+    REPO_URL = "https://github.com/o/r"
+
+    def setUp(self):
+        """A staging directory holding the stills the fixtures name.
+
+        The renderer decides between a link and "nothing published this" by
+        looking on disk, so these tests need files rather than a mock: the
+        thing being graded *is* the answer to whether the take wrote one.
+        """
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        images = self.root / "demos/x/images"
+        images.mkdir(parents=True)
+        for name in ("01-search-box.png", "03-requester.png"):
+            (images / name).write_bytes(b"\x89PNG")
+        # Outside the demo, and deliberately real: the guard that refuses to
+        # link it has to be the reason, not the file's absence.
+        (self.root / "leaked.png").write_bytes(b"\x89PNG")
+
+    def body(self, timeline, **kw):
+        opts = dict(
             artifact_url=None,
             artifact_bytes=None,
             retention_days=30,
             evidence_retention_days=None,
             failure_artifact_url=None,
             run_url=None,
-            sha="abcdef1234567890",
+            sha=self.SHA,
+            repo_url=self.REPO_URL,
+            demo_root=str(self.root),
         )
+        opts.update(kw)
+        return comment.render([("demos/x", timeline)], **opts)
 
     def headline(self, body: str) -> str:
         """The one sentence naming the clauses nothing claimed."""
         found = [ln for ln in body.splitlines() if "no beat claiming" in ln]
         self.assertEqual(len(found), 1, f"no single gap headline in:\n{body}")
         return found[0]
+
+    def no_still_headline(self, body: str) -> str:
+        """The one sentence naming the clauses with no picture to open (#274)."""
+        found = [ln for ln in body.splitlines() if "no still was published" in ln]
+        self.assertEqual(len(found), 1, f"no single no-still headline in:\n{body}")
+        return found[0]
+
+    def row(self, body: str, key: str) -> list[str]:
+        """One clause's row, split into its cells.
+
+        Escaped pipes out first, the way a markdown renderer reads them: an
+        unescaped one in the clause text would otherwise split this row into
+        more cells than the table has columns, which is the failure the
+        escaping exists to prevent and is asserted below.
+        """
+        rows = [ln for ln in body.splitlines() if ln.startswith(f"| **{key}** ")]
+        self.assertEqual(len(rows), 1, f"no single row for {key}: {rows}")
+        cells = re.sub(r"\\\|", "", rows[0]).split("|")
+        # "", clause, claimed at, look at, ""
+        self.assertEqual(len(cells), 5, rows[0])
+        return [c.strip() for c in cells]
 
     def cell(self, body: str, key: str) -> str:
         """The `claimed at` cell of one clause's row, and only that.
@@ -983,15 +1087,16 @@ class Coverage(unittest.TestCase):
         itself, so a whole-row search would agree with a renderer that had lost
         the beat indices entirely.
         """
-        rows = [ln for ln in body.splitlines() if ln.startswith(f"| **{key}** ")]
-        self.assertEqual(len(rows), 1, f"no single row for {key}: {rows}")
-        # Escaped pipes out first, the way a markdown renderer reads them: an
-        # unescaped one in the clause text would otherwise split this row into
-        # more cells than the table has columns, which is the failure the
-        # escaping exists to prevent and is asserted below.
-        cells = re.sub(r"\\\|", "", rows[0]).split("|")
-        self.assertEqual(len(cells), 4, rows[0])  # "", clause, claimed at, ""
-        return cells[2].strip()
+        return self.row(body, key)[2]
+
+    def look_at(self, body: str, key: str) -> str:
+        """The `look at` cell of one clause's row, and only that.
+
+        Same narrowness, for the same reason: every still link in the comment
+        shares a prefix, so a whole-body search for one would be satisfied by
+        the row above it.
+        """
+        return self.row(body, key)[3]
 
     def swept(self, body: str, timeline: dict) -> str:
         """`body` with the spans the renderer quotes subtracted out of it.
@@ -1112,7 +1217,7 @@ class Coverage(unittest.TestCase):
         # before this section existed.
         body = self.body(TIMELINE)
         self.assertIn("| # | at | Caption |", body)  # control: still a comment
-        for absent in ("clause", "claimed at", "nothing claims this", "AC-"):
+        for absent in ("clause", "claimed at", "look at", "nothing claims this", "AC-"):
             self.assertNotIn(absent, body)
 
     def test_the_comment_no_longer_reports_the_binding_as_unwritten(self):
@@ -1137,6 +1242,135 @@ class Coverage(unittest.TestCase):
         )
         cells = self.cell(self.body(piped), "AC-1")
         self.assertEqual(cells, "beat 3")
+
+    # -- one picture per clause, and the clauses with none (#274) -----------
+
+    def test_a_claimed_still_is_linked_at_the_recorded_commit(self):
+        # The whole cell, not a substring of it: the reviewer clicks this, and
+        # a link to the right file at the wrong commit is an artifact that
+        # lies more convincingly than a missing one. Four things are pinned by
+        # this equality — the repository, the full sha, the demo directory the
+        # still belongs to, and the path the manifest recorded.
+        self.assertEqual(
+            self.look_at(self.body(TAGGED), "AC-1"),
+            f"[01-search-box.png]({self.REPO_URL}/raw/{self.SHA}"
+            f"/demos/x/images/01-search-box.png)",
+        )
+
+    def test_a_clause_links_its_own_still_and_not_another_clauses(self):
+        # The count of links is free to satisfy; which one lands in which row
+        # is the claim. AC-3's still is the second row of its own claim list,
+        # so a renderer reading `claimed` flat would put AC-1's here.
+        body = self.body(TAGGED)
+        self.assertIn("/demos/x/images/01-search-box.png)", self.look_at(body, "AC-1"))
+        self.assertIn("/demos/x/images/03-requester.png)", self.look_at(body, "AC-3"))
+
+    def test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture(self):
+        # #274's acceptance criterion: AC-1 claimed by a `shot()`, AC-2 by a
+        # `caption()` alone. Before this the two rendered identically.
+        body = self.body(CAPTION_ONLY)
+        line = self.no_still_headline(body)
+        self.assertIn("AC-2", line)
+        for illustrated in ("AC-1", "AC-3"):
+            self.assertNotIn(illustrated, line)
+        # And AC-4, which nothing claims at all: it is a different finding and
+        # it is already named by the sentence above this one.
+        self.assertNotIn("AC-4", line)
+        self.assertEqual(self.look_at(body, "AC-2"), "*no still*")
+        self.assertEqual(self.look_at(body, "AC-4"), "—")
+
+    def test_the_clauses_with_no_picture_are_named_before_the_claimed_table(self):
+        # Gap first, the same ordering claim as the unclaimed headline: a
+        # reader who meets the table of pictures first has already formed the
+        # impression this sentence exists to correct.
+        body = self.body(CAPTION_ONLY)
+        self.assertIn("| clause | claimed at | look at |", body)  # control
+        where = body.index(self.no_still_headline(body))
+        self.assertLess(where, body.index("| clause | claimed at | look at |"))
+        self.assertLess(where, body.index("**AC-1**"))
+        self.assertLess(where, body.index("| # | at | Caption |"))
+
+    def test_a_still_the_manifest_names_and_nothing_published_is_not_linked(self):
+        # The artifact-lies case: a `shot()` that raised, or a still the
+        # freshness filter held back as a previous recording's. Naming it as
+        # absent is the honest answer; linking it hands the reviewer last
+        # week's picture, and skipping it silently is a claim with no evidence
+        # that reads like a clause nobody illustrated.
+        body = self.body(ABSENT_STILL)
+        cell = self.look_at(body, "AC-2")
+        self.assertIn("09-never-written.png", cell)
+        self.assertNotIn("](http", cell)
+        # And it counts as a clause with nothing to open, so the two agree.
+        self.assertIn("AC-2", self.no_still_headline(body))
+        # The control: a still that *was* published, in the same table.
+        self.assertIn("](http", self.look_at(body, "AC-1"))
+
+    def test_a_still_outside_the_demo_directory_is_named_and_not_linked(self):
+        # `timeline.json` is committed, and a pull request may edit it. A still
+        # of `../../leaked.png` resolves on disk, so existence alone would let
+        # it through and the comment would link a picture belonging to another
+        # part of the repository as this demo's evidence.
+        escaping = dict(
+            TIMELINE,
+            coverage={
+                "criteria": {"AC-1": "A search box above the queue narrows it."},
+                "claimed": {"AC-1": [claim(3, "../../leaked.png")]},
+            },
+        )
+        self.assertTrue((self.root / "leaked.png").exists())  # control
+        cell = self.look_at(self.body(escaping), "AC-1")
+        self.assertIn("leaked.png", cell)
+        self.assertNotIn("](http", cell)
+
+    def test_a_still_is_looked_for_in_the_directory_this_take_published(self):
+        # The staging copy, not the working tree: `images/` is committed, so on
+        # any path where the take did not rewrite them the working tree still
+        # holds the previous recording's pictures. Rendering a demo whose
+        # staged directory holds nothing must not link the committed ones.
+        body = self.body(TAGGED, demo_root=str(self.root / "empty"))
+        self.assertNotIn("](http", self.look_at(body, "AC-1"))
+        self.assertIn("01-search-box.png", self.look_at(body, "AC-1"))
+
+    def test_a_space_in_a_still_path_is_encoded_so_the_link_survives(self):
+        # A markdown link ends at the first space. Unencoded, this renders as
+        # text with a stray `.png)` after it — a picture the reviewer cannot
+        # open, in the column that exists so they can.
+        (self.root / "demos/x/images/a b.png").write_bytes(b"\x89PNG")
+        spaced = dict(
+            TIMELINE,
+            coverage={
+                "criteria": {"AC-1": "A search box above the queue narrows it."},
+                "claimed": {"AC-1": [claim(3, "images/a b.png")]},
+            },
+        )
+        self.assertEqual(
+            self.look_at(self.body(spaced), "AC-1"),
+            f"[a b.png]({self.REPO_URL}/raw/{self.SHA}/demos/x/images/a%20b.png)",
+        )
+
+    def test_with_no_repository_url_a_published_still_is_named_not_linked(self):
+        # Run outside Actions there is nothing to build a URL from. Naming the
+        # file is the honest degradation; a relative link would resolve against
+        # the pull request's own page and 404.
+        body = self.body(TAGGED, repo_url=None)
+        self.assertEqual(self.look_at(body, "AC-1"), "`images/01-search-box.png`")
+        # It is still a still this take published, so it is not a gap.
+        self.assertNotIn("no still was published", body)
+
+    def test_a_take_whose_clauses_all_have_a_picture_prints_neither_gap(self):
+        body = self.body(ALL_ILLUSTRATED)
+        self.assertIn("| clause | claimed at | look at |", body)  # control
+        self.assertNotIn("no beat claiming", body)
+        self.assertNotIn("no still was published", body)
+        self.assertNotIn("*no still*", body)
+        self.assert_no_verdict(body, ALL_ILLUSTRATED)
+
+    def test_the_same_words_are_refused_where_a_clause_has_no_picture(self):
+        # A still beside a clause is exactly where a sentence that sounds like
+        # proof is tempting, and its absence is where a sentence that sounds
+        # like a failed check is. Both branches are swept.
+        for fixture in (CAPTION_ONLY, ABSENT_STILL):
+            self.assert_no_verdict(self.body(fixture), fixture)
 
     def test_a_claim_from_a_named_segment_says_which_segment(self):
         # A stitched demo renumbers beats, so "beat 6" alone points at the
@@ -1245,6 +1479,102 @@ class CommentCli(unittest.TestCase):
             body = out.read_text()
             self.assertIn("the take failed", body)
             self.assertIn("published no timeline.json", body)
+
+    def test_a_staged_still_is_linked_from_the_command_line_end_to_end(self):
+        # `render` is graded above with its arguments handed to it. This is the
+        # other half: that `main` finds the still beside the timeline it read
+        # and hands the reader a URL, which is where a `--demo-root` the
+        # existence check never saw would surface.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "stage"
+            (root / "demos/x/images").mkdir(parents=True)
+            (root / "demos/x/images/01-search-box.png").write_bytes(b"\x89PNG")
+            (root / "demos/x/timeline.json").write_text(
+                json.dumps(
+                    dict(
+                        TIMELINE,
+                        coverage={
+                            "criteria": {"AC-1": "A search box narrows the queue."},
+                            "claimed": {"AC-1": [claim(3, "images/01-search-box.png")]},
+                        },
+                    )
+                )
+            )
+            out = Path(tmp) / "body.md"
+            done = self._run(
+                "--demo",
+                "demos/x",
+                "--demo-root",
+                str(root),
+                "--repo-url",
+                "https://github.com/o/r",
+                "--sha",
+                "abcdef1234567890abcdef1234567890abcdef12",
+                "--retention-days",
+                "30",
+                "--out",
+                str(out),
+            )
+            self.assertEqual(done.returncode, 0, done.stderr)
+            body = out.read_text()
+            self.assertIn(
+                "[01-search-box.png](https://github.com/o/r/raw/"
+                "abcdef1234567890abcdef1234567890abcdef12"
+                "/demos/x/images/01-search-box.png)",
+                body,
+            )
+            self.assertNotIn(str(root), body)  # no runner path leaks to the reader
+
+    def test_the_repository_url_defaults_to_what_every_actions_step_is_given(self):
+        # So the workflow needs no new argument for the links to work. Both
+        # variables are set in every step; read rather than hardcoded, or a
+        # GitHub Enterprise host would have its blobs linked at github.com.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "stage"
+            (root / "demos/x/images").mkdir(parents=True)
+            (root / "demos/x/images/01-search-box.png").write_bytes(b"\x89PNG")
+            (root / "demos/x/timeline.json").write_text(
+                json.dumps(
+                    dict(
+                        TIMELINE,
+                        coverage={
+                            "criteria": {"AC-1": "A search box narrows the queue."},
+                            "claimed": {"AC-1": [claim(3, "images/01-search-box.png")]},
+                        },
+                    )
+                )
+            )
+            out = Path(tmp) / "body.md"
+            done = subprocess.run(
+                [
+                    sys.executable,
+                    str(_DIR / "demo-comment"),
+                    "--demo",
+                    "demos/x",
+                    "--demo-root",
+                    str(root),
+                    "--sha",
+                    "abcdef1234567890abcdef1234567890abcdef12",
+                    "--retention-days",
+                    "30",
+                    "--out",
+                    str(out),
+                ],
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "GITHUB_SERVER_URL": "https://ghe.example.com",
+                    "GITHUB_REPOSITORY": "o/r",
+                },
+            )
+            self.assertEqual(done.returncode, 0, done.stderr)
+            self.assertIn(
+                "[01-search-box.png](https://ghe.example.com/o/r/raw/"
+                "abcdef1234567890abcdef1234567890abcdef12"
+                "/demos/x/images/01-search-box.png)",
+                out.read_text(),
+            )
 
     def test_without_demo_root_the_demo_path_is_read_directly(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1420,7 +1750,10 @@ INJECTIONS = [
         "demo-comment",
         "    return gap + table + note",
         "    return table + gap + note",
-        ["Coverage.test_the_gap_is_stated_before_anything_that_was_claimed"],
+        [
+            "Coverage.test_the_gap_is_stated_before_anything_that_was_claimed",
+            "Coverage.test_the_clauses_with_no_picture_are_named_before_the_claimed_table",
+        ],
     ),
     (
         # The failure mode every coverage tool has: print the covered half and
@@ -1498,7 +1831,9 @@ INJECTIONS = [
         # be perfect and never be called.
         "render_demo stops rendering the coverage section",
         "demo-comment",
-        '    lines += render_coverage(timeline.get("coverage"))',
+        '    lines += render_coverage(\n        timeline.get("coverage"),\n'
+        "        demo=name,\n        directory=demo_dir(demo_root, name),\n"
+        "        repo_url=repo_url,\n        sha=sha,\n    )",
         "    lines += []",
         [
             "Coverage.test_the_gap_is_stated_before_anything_that_was_claimed",
@@ -1548,10 +1883,11 @@ INJECTIONS = [
     (
         "--demo-root is ignored, so the comment reads the working tree",
         "demo-comment",
-        "        directory = Path(args.demo_root) / name if args.demo_root else Path(name)",
-        "        directory = Path(name)",
+        "    return Path(demo_root) / name if demo_root else Path(name)",
+        "    return Path(name)",
         [
             "CommentCli.test_the_timeline_is_read_from_demo_root_and_named_by_demo",
+            "CommentCli.test_a_staged_still_is_linked_from_the_command_line_end_to_end",
         ],
     ),
     (
@@ -1670,6 +2006,156 @@ INJECTIONS = [
         [
             "Coverage.test_a_clause_whose_own_wording_is_a_verdict_does_not_trip_the_sweep"
         ],
+    ),
+    # -- one picture per clause (#274) --------------------------------------
+    (
+        # The link a reviewer clicks, pointed at a commit that is not the one
+        # this take was recorded from. Seven characters resolve today and are
+        # ambiguous later, which is the artifact lying slowly rather than
+        # loudly — and every count of links in the comment stays right.
+        "a still is linked at the abbreviated sha instead of the recorded one",
+        "demo-comment",
+        '    return f"{base}/raw/{quote(sha)}/{quote(path)}"',
+        '    return f"{base}/raw/{quote(sha[:7])}/{quote(path)}"',
+        [
+            "Coverage.test_a_claimed_still_is_linked_at_the_recorded_commit",
+            "CommentCli.test_a_staged_still_is_linked_from_the_command_line_end_to_end",
+        ],
+    ),
+    (
+        # A URL that 404s: the still is under the demo's directory, not the
+        # repository root. The cell still holds a link and still names the
+        # right file, so anything short of reading the whole href agrees.
+        "the still link drops the demo directory the picture lives in",
+        "demo-comment",
+        '        href = _still_href(repo_url, sha, f"{demo}/{rel}")',
+        "        href = _still_href(repo_url, sha, rel)",
+        [
+            "Coverage.test_a_claimed_still_is_linked_at_the_recorded_commit",
+            "CommentCli.test_a_staged_still_is_linked_from_the_command_line_end_to_end",
+        ],
+    ),
+    (
+        # The lookup rather than the link: the stills are searched for beside
+        # the *root* instead of inside this demo, so a repository with one demo
+        # in it would still be green if `images/` sat at the top level.
+        "a still is looked for outside the demo directory it belongs to",
+        "demo-comment",
+        "        directory=demo_dir(demo_root, name),",
+        "        directory=Path(demo_root),",
+        [
+            "Coverage.test_a_claimed_still_is_linked_at_the_recorded_commit",
+            "CommentCli.test_a_staged_still_is_linked_from_the_command_line_end_to_end",
+        ],
+    ),
+    (
+        # The count that stands in for the content, in the new column: every
+        # clause gets a picture, every picture resolves, and every row after
+        # the first points at the wrong one.
+        "every clause is pointed at the first still in the report",
+        "demo-comment",
+        "            claimed.get(key) or [],",
+        "            next((rows for rows in claimed.values() if rows), []),",
+        ["Coverage.test_a_clause_links_its_own_still_and_not_another_clauses"],
+    ),
+    (
+        # A still the manifest names and this take did not publish, handed to
+        # the reviewer as a link anyway — last week's picture under this
+        # week's clause, or a 404. The one the freshness filter exists for.
+        "a still nothing published is linked instead of reported absent",
+        "demo-comment",
+        "        if not (directory / rel).exists():\n            continue",
+        "        if False:\n            continue",
+        [
+            "Coverage.test_a_still_the_manifest_names_and_nothing_published_is_not_linked",
+            "Coverage.test_a_still_is_looked_for_in_the_directory_this_take_published",
+        ],
+    ),
+    (
+        # `timeline.json` is committed and a pull request may edit it, so the
+        # path in it is untrusted input pasted into a URL. Existence alone lets
+        # `../../leaked.png` through, because it does exist.
+        "a still pointing outside the demo is linked because it exists",
+        "demo-comment",
+        '    if not parts or ".." in parts:',
+        "    if not parts:",
+        ["Coverage.test_a_still_outside_the_demo_directory_is_named_and_not_linked"],
+    ),
+    (
+        # Without the encoding the markdown link ends at the first space and
+        # the reviewer gets text with a stray `.png)` after it.
+        "a still path is pasted into the link unencoded",
+        "demo-comment",
+        '    return f"{base}/raw/{quote(sha)}/{quote(path)}"\n',
+        '    return f"{base}/raw/{quote(sha)}/{path}"\n',
+        ["Coverage.test_a_space_in_a_still_path_is_encoded_so_the_link_survives"],
+    ),
+    (
+        # No repository to link under, and a root-relative href instead of the
+        # file's name: in a pull-request comment that resolves against the pull
+        # request's own page and 404s, while looking exactly like a link.
+        "a still is linked relatively when there is no repository to link under",
+        "demo-comment",
+        "    if not base or not sha:",
+        "    if not sha:",
+        ["Coverage.test_with_no_repository_url_a_published_still_is_named_not_linked"],
+    ),
+    (
+        # The finding itself, gone. The comment then reads exactly as it did
+        # before #274 on the take #274 is about: a clause claimed only by a
+        # caption is indistinguishable from a well-illustrated one.
+        "a clause with no picture is no longer named as one",
+        "demo-comment",
+        "    if unillustrated:",
+        "    if False:",
+        [
+            "Coverage.test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture",
+            "Coverage.test_the_clauses_with_no_picture_are_named_before_the_claimed_table",
+            "Coverage.test_a_still_the_manifest_names_and_nothing_published_is_not_linked",
+        ],
+    ),
+    (
+        # And the finding over-reporting, which is the failure that would get
+        # it switched off: every claimed clause named, including the ones with
+        # a picture right there in the row.
+        "the no-picture finding names every claimed clause",
+        "demo-comment",
+        "        key for key in criteria if key not in unclaimed "
+        + "and not pictures[key].found",
+        "        key for key in criteria if key not in unclaimed",
+        [
+            "Coverage.test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture",
+            "Coverage.test_a_take_whose_clauses_all_have_a_picture_prints_neither_gap",
+        ],
+    ),
+    (
+        # A clause nobody claimed described as one whose still is missing:
+        # same words, wrong cause, and the sentence above the table already
+        # said the true one.
+        "a clause nothing claims is reported as a claim with no still",
+        "demo-comment",
+        '        return _Picture("—", False)',
+        '        return _Picture("*no still*", False)',
+        [
+            "Coverage.test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture"
+        ],
+    ),
+    (
+        # The verdict sweep over the two sentences #274 adds. The disclaimer
+        # injections below cannot see these: `TAGGED` has a picture for every
+        # clause it claims, so neither sentence is rendered on that fixture.
+        "the no-picture sentence promotes the rest of the clauses",
+        "demo-comment",
+        '            f"here to open.**",',
+        '            f"here to open. The rest passed.**",',
+        ["Coverage.test_the_same_words_are_refused_where_a_clause_has_no_picture"],
+    ),
+    (
+        "the absent-still cell reads as a verdict on the clause",
+        "demo-comment",
+        '            f"no such file*",',
+        '            f"no such file, so nothing here is proved*",',
+        ["Coverage.test_the_same_words_are_refused_where_a_clause_has_no_picture"],
     ),
     (
         # What the eight per-word injections below are worth: a sentence that

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -851,6 +851,18 @@ ABSENT_STILL = dict(
     ),
 )
 
+# A still that resolves on disk and belongs to another part of the repository.
+# `timeline.json` is committed and a pull request may edit it, so this is the
+# untrusted-input branch — and its cell is a third sentence the renderer writes,
+# reached by no other fixture here.
+OUTSIDE_STILL = dict(
+    TIMELINE,
+    coverage={
+        "criteria": {"AC-1": "A search box above the queue narrows it."},
+        "claimed": {"AC-1": [claim(3, "../../leaked.png")]},
+    },
+)
+
 # The clean path: every clause claimed, every claim carrying a still that this
 # take published. Neither gap headline has anything to say about it, which is
 # the branch a coverage claim is most tempting to print into.
@@ -1334,15 +1346,8 @@ class Coverage(unittest.TestCase):
         # of `../../leaked.png` resolves on disk, so existence alone would let
         # it through and the comment would link a picture belonging to another
         # part of the repository as this demo's evidence.
-        escaping = dict(
-            TIMELINE,
-            coverage={
-                "criteria": {"AC-1": "A search box above the queue narrows it."},
-                "claimed": {"AC-1": [claim(3, "../../leaked.png")]},
-            },
-        )
         self.assertTrue((self.root / "leaked.png").exists())  # control
-        cell = self.look_at(self.body(escaping), "AC-1")
+        cell = self.look_at(self.body(OUTSIDE_STILL), "AC-1")
         self.assertIn("leaked.png", cell)
         self.assertNotIn("](http", cell)
 
@@ -1392,8 +1397,12 @@ class Coverage(unittest.TestCase):
     def test_the_same_words_are_refused_where_a_clause_has_no_picture(self):
         # A still beside a clause is exactly where a sentence that sounds like
         # proof is tempting, and its absence is where a sentence that sounds
-        # like a failed check is. Both branches are swept.
-        for fixture in (CAPTION_ONLY, ABSENT_STILL):
+        # like a failed check is. Every branch that writes one is swept, and
+        # the fixtures are listed rather than counted: `OUTSIDE_STILL` was left
+        # out of the first version of this loop, and the README then said "the
+        # two sentences" of a renderer that writes three — a boundary reported
+        # as guarded across text one branch of which nothing read.
+        for fixture in (CAPTION_ONLY, ABSENT_STILL, OUTSIDE_STILL):
             self.assert_no_verdict(self.body(fixture), fixture)
 
     def test_a_claim_from_a_named_segment_says_which_segment(self):
@@ -2241,6 +2250,16 @@ INJECTIONS = [
         "demo-comment",
         '            f"here to open.**",',
         '            f"here to open. The rest passed.**",',
+        ["Coverage.test_the_same_words_are_refused_where_a_clause_has_no_picture"],
+    ),
+    (
+        # The third sentence, and the one the first version of the sweep loop
+        # could not see: with only `CAPTION_ONLY` and `ABSENT_STILL` in it,
+        # this exact break left the whole suite green.
+        "the outside-the-demo cell reads as a verdict on the clause",
+        "demo-comment",
+        '            f"so it is not linked*",',
+        '            f"so nothing here is proved or verified*",',
         ["Coverage.test_the_same_words_are_refused_where_a_clause_has_no_picture"],
     ),
     (

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -432,6 +432,7 @@ GUARD_FACT_NOT_PASSED = {
 
 GUARD_STEP = "Refuse a target that could be production"
 RECORD_STEP = "Record"
+COMMENT_STEP = "Render the comment"
 _INPUT_RE = re.compile(r"^\$\{\{\s*inputs\.([a-z0-9-]+)\s*\}\}$")
 
 
@@ -681,6 +682,7 @@ class Render(unittest.TestCase):
             sha="abcdef1234567890",
             repo_url="https://github.com/o/r",
             demo_root="",
+            path_prefix="",
         )
         opts.update(kw)
         return comment.render([("demos/x", timeline or TIMELINE)], **opts)
@@ -1049,6 +1051,7 @@ class Coverage(unittest.TestCase):
             sha=self.SHA,
             repo_url=self.REPO_URL,
             demo_root=str(self.root),
+            path_prefix="",
         )
         opts.update(kw)
         return comment.render([("demos/x", timeline)], **opts)
@@ -1265,6 +1268,27 @@ class Coverage(unittest.TestCase):
         self.assertIn("/demos/x/images/01-search-box.png)", self.look_at(body, "AC-1"))
         self.assertIn("/demos/x/images/03-requester.png)", self.look_at(body, "AC-3"))
 
+    def test_a_demo_below_the_repository_root_is_linked_where_git_holds_it(self):
+        # `--demo` paths are relative to the workflow's working-directory; this
+        # repository's own reference call sets it to `examples/ticket-queue`.
+        # Both halves are asserted, because prefixing the *lookup* too is the
+        # tempting way to write this and it stops the still being found at all.
+        body = self.body(TAGGED, path_prefix="examples/ticket-queue")
+        self.assertEqual(
+            self.look_at(body, "AC-1"),
+            f"[01-search-box.png]({self.REPO_URL}/raw/{self.SHA}"
+            f"/examples/ticket-queue/demos/x/images/01-search-box.png)",
+        )
+
+    def test_the_default_working_directory_adds_nothing_to_the_link(self):
+        # `working-directory` defaults to `.`, which the workflow passes
+        # through as written. `/./demos/x/` resolves for a browser and is wrong
+        # in a link a human reads and compares against a path.
+        self.assertEqual(
+            self.look_at(self.body(TAGGED, path_prefix="."), "AC-1"),
+            self.look_at(self.body(TAGGED), "AC-1"),
+        )
+
     def test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture(self):
         # #274's acceptance criterion: AC-1 claimed by a `shot()`, AC-2 by a
         # `caption()` alone. Before this the two rendered identically.
@@ -1383,6 +1407,36 @@ class Coverage(unittest.TestCase):
             },
         )
         self.assertEqual(self.cell(self.body(stitched), "AC-1"), "beat 6 (`part2`)")
+
+
+class CommentStep(unittest.TestCase):
+    """The one fact about the repository only the workflow knows (#274).
+
+    A `--demo` path is relative to `working-directory`, and this repository's
+    own reference call sets that to `examples/ticket-queue`. `demo-comment`
+    cannot infer it and every default is wrong in the same direction — a link
+    at the repository root, rendered exactly like one that works. So the
+    coupling is the same shape as `WorkflowGates`: a fact the step is
+    configured with has to reach the script that needs it.
+    """
+
+    def setUp(self):
+        text = _WORKFLOW.read_text(encoding="utf-8")
+        steps = workflow_steps(text)
+        # The haystack first: a renamed or reindented step would otherwise make
+        # every assertion below hold over an empty list.
+        self.assertIn(COMMENT_STEP, steps, f"no {COMMENT_STEP!r} step")
+        self.lines = steps[COMMENT_STEP]
+        self.env = step_env(self.lines)
+        self.assertGreaterEqual(len(self.env), 5, self.env)
+
+    def test_the_working_directory_reaches_the_comment_as_a_path_prefix(self):
+        name = "WORKDIR"
+        self.assertEqual(self.env.get(name), "${{ inputs.working-directory }}")
+        # And is actually passed. The variable being exported says nothing:
+        # that is how the regression `WorkflowGates` was written for happened.
+        run = "\n".join(self.lines)
+        self.assertIn(f'--path-prefix "${name}"', run)
 
 
 class VerdictAlphabet(unittest.TestCase):
@@ -1832,7 +1886,8 @@ INJECTIONS = [
         "render_demo stops rendering the coverage section",
         "demo-comment",
         '    lines += render_coverage(\n        timeline.get("coverage"),\n'
-        "        demo=name,\n        directory=demo_dir(demo_root, name),\n"
+        "        demo=repo_path(path_prefix, name),\n"
+        "        directory=demo_dir(demo_root, name),\n"
         "        repo_url=repo_url,\n        sha=sha,\n    )",
         "    lines += []",
         [
@@ -2047,6 +2102,44 @@ INJECTIONS = [
             "Coverage.test_a_claimed_still_is_linked_at_the_recorded_commit",
             "CommentCli.test_a_staged_still_is_linked_from_the_command_line_end_to_end",
         ],
+    ),
+    (
+        # The 404 that looks like a working link: the demo is linked at the
+        # repository root, which is where it sits only when the caller left
+        # `working-directory` alone. This repository's own reference call does
+        # not, and every other assertion about the href passes.
+        "the still link forgets the directory the storyboards are rooted at",
+        "demo-comment",
+        "        demo=repo_path(path_prefix, name),",
+        "        demo=name,",
+        ["Coverage.test_a_demo_below_the_repository_root_is_linked_where_git_holds_it"],
+    ),
+    (
+        # The workflow's default, `.`, pasted into the URL as a path component.
+        "the path prefix stops being normalised, so `.` reaches the link",
+        "demo-comment",
+        '    parts = [p for p in f"{prefix}/{name}".split("/") if p not in ("", ".")]',
+        '    parts = [p for p in f"{prefix}/{name}".split("/") if p != ""]',
+        ["Coverage.test_the_default_working_directory_adds_nothing_to_the_link"],
+    ),
+    (
+        # The other half of the coupling, and the half no reading of
+        # `demo-comment` can see: the argument is never passed, so every still
+        # in a repository like this one is linked at the root and 404s.
+        "the comment step stops passing the working directory to the script",
+        "demo-video.yml",
+        '            --path-prefix "$WORKDIR" \\\n',
+        "",
+        ["CommentStep.test_the_working_directory_reaches_the_comment_as_a_path_prefix"],
+    ),
+    (
+        # And the variable exported but not used, which is the shape
+        # `WorkflowGates` exists for: it looks coupled.
+        "the comment step exports the working directory and drops it",
+        "demo-video.yml",
+        '            --path-prefix "$WORKDIR"',
+        '            --path-prefix ""',
+        ["CommentStep.test_the_working_directory_reaches_the_comment_as_a_path_prefix"],
     ),
     (
         # The count that stands in for the content, in the new column: every
@@ -2295,13 +2388,17 @@ def fault_inject() -> int:
 #   test of "updated in place", and it is done by hand on the reference pull
 #   request.
 #
-#   The **one** exception is `WorkflowGates` above, and it is deliberately
-#   narrow: that every fact the guard step classifies on is handed to the
-#   recorder that re-classifies it, from the same input. That is a property of
-#   the text, it is what broke, and no run of the workflow on an in-repo pull
-#   request would have caught it either — the regression only appears for a
-#   caller who sets `allow-private-network-target`, and this repository has
-#   none.
+#   The **two** exceptions are `WorkflowGates` and `CommentStep` above, and
+#   both are deliberately narrow: that every fact the guard step classifies on
+#   is handed to the recorder that re-classifies it, from the same input, and
+#   that the working directory the `--demo` paths are relative to reaches the
+#   script that pastes them into a URL. Both are properties of the text. The
+#   first is what broke, and no run of the workflow on an in-repo pull request
+#   would have caught it either — the regression only appears for a caller who
+#   sets `allow-private-network-target`, and this repository has none. The
+#   second is the reverse: it appears for *this* repository, whose reference
+#   call roots its storyboards at `examples/ticket-queue`, and the artifact it
+#   would produce is a link that 404s while looking like one that works.
 # - **The recorder.** `tests/smoke` owns that.
 # - **Egress.** The target guard is a static check on configuration and source
 #   text. A storyboard that computes a URL at run time is invisible to it, and


### PR DESCRIPTION
Slice B of #272. **This is the comment half of #274 only** — see *What is left
of #274* below, which is why this says `Refs` and not `Fixes`.

## What changed

#282 put the ticket's clauses in the pull-request comment, gap first. But a
clause whose only claim is a `caption(ac=…)` has no still, so "claimed" was a
word with nothing behind it, and it rendered exactly like a clause a `shot()`
had illustrated.

The table gains a `look at` column, and the clauses with no picture are named
above it with the unclaimed ones:

```
**`AC-4` has no beat claiming it.**

**`AC-2` and `AC-3` are claimed, but no still was published for them, so there is nothing here to open.**

4 clauses. 3 have a beat that claims them; whether the frames show what they
claim is the reviewer's call. Nothing in this comment graded a claim.

| clause | claimed at | look at |
|---|---|---|
| **AC-1** — A search box above the queue narrows the list as you type. | beat 3 | [01-search-box.png](https://github.com/o/r/raw/abcdef…f12/demos/x/images/01-search-box.png) |
| **AC-2** — Search and the status filter combine, and the heading agrees. | beat 5 | *no still* |
| **AC-3** — Search matches the requester as well as the title. | beat 7 | *`images/09-never-written.png` is named here, but this take published no such file* |
| **AC-4** — A search matching nothing shows the empty line. | *nothing claims this* | — |
```

`images/*.png` are committed, and they are the only piece of a take that has a
URL at all — `demo.mp4` and `frames/` are both inside Actions artifact zips and
`frames/` is gitignored. So the deliverable is a still, not a seek; #272
measured that and this change does not re-litigate it.

Four decisions worth naming:

- **Existence is checked in the directory the timeline was read from** — in CI
  the staging copy, which the freshness filter has already applied. A still
  left behind by a *previous* recording is therefore reported absent rather
  than linked as this take's.
- **A still the manifest names and nothing published is reported**, not
  skipped: skipping it silently would make a clause with a broken claim read
  like one nobody illustrated.
- **A `still` that is not a path inside the demo is named, not linked.**
  `timeline.json` is committed and a pull request may edit it, so its `still`
  is untrusted text being pasted into a URL, and `../../leaked.png` does exist
  on disk.
- **The link is built where git holds the file, not where the workflow ran.**
  A `--demo` path is relative to `working-directory`, and this repository's own
  reference call sets that to `examples/ticket-queue`; the first draft of this
  change linked every still at the repository root, which is a 404 that renders
  exactly like a working link. `--path-prefix` carries it and the workflow
  passes its `working-directory`. `--repo-url` needs no such wiring: it
  defaults to `$GITHUB_SERVER_URL/$GITHUB_REPOSITORY`, which every Actions step
  is given, read rather than hardcoded so an Enterprise host links its own
  blobs.

## What a linked still does and does not establish

**It establishes that a file exists, that it belongs to the beat that claimed
the clause, and that the URL points at it in this repository at the commit the
take was recorded from. It establishes nothing about what the picture shows.**

A still next to a clause is the most tempting place in this repo to write a
sentence that sounds like proof, so, explicitly: the column is called `look at`,
the sentence beside it says "what it is a picture of is the reviewer's call",
and the word "demonstrated" — with "verified", "shown", "proved", "passed",
"met", "✓" and the rest of #283's alphabet — appears nowhere the renderer
writes. `Coverage.test_no_sentence_promotes_a_claim_to_a_verdict` and
`…_where_a_clause_has_no_picture` sweep for all of them, on fixtures that
actually render the new sentences.

The two flat statements here are safe because neither takes judgement: nobody
asserted an unclaimed clause, and whether a file exists is a fact about a
filesystem.

## Stated limits (non-blocking, per `wip/verified-review/SKILL.md`)

- **Nothing opens the link.** The href is graded by equality against the one
  the arguments imply and the file is graded as present beside the timeline —
  neither is an HTTP request. A still this take rewrote and nobody committed at
  the head sha will be linked and will 404 for the reader; only a run of the
  workflow on a real pull request can see that. Recorded in `tests/README.md`'s
  **Known gaps**.
- **The comment derives its own finding.** Which clauses have no picture is
  computed from `claimed` and the same pass that fills the column, not read off
  a manifest key — the #282 rule, so the headline and the table cannot disagree
  about one take. It also means the comment's answer and a future
  `coverage.unillustrated` are answers to slightly different questions: the
  manifest's is structural, the comment's also counts a still that is named and
  absent.
- **One picture per clause**, the first published still among its claims. A
  clause claimed by four `shot()`s links one of them and says nothing about the
  other three.
- **A claim a failed take made still reads like a clean one** (slice F, #278):
  a `shot()` that raised now has its still reported absent, which is an
  improvement by accident, but the row is otherwise an ordinary claim.
- `tests/README.md` loses the sentence counting the acceptance section's
  injections. That number was already wrong (#295 item 4) and this change would
  have made it wronger; the rest of #295 is untouched.

## Round 2: a sentence the sweep could not see

Found in review, and it was real rather than theoretical. The renderer writes
**three** new sentences; the sweep loop had fixtures for two. Ending the
outside-the-demo cell with *"so nothing here is proved or verified"* left the
suite green:

```
--- two-fixture loop (as shipped in round 1): rc=0
    Ran 97 tests in 0.415s
    OK
--- three-fixture loop (this round): rc=1
    FAIL: test_the_same_words_are_refused_where_a_clause_has_no_picture (Coverage)
    Ran 97 tests in 0.416s
```

`OUTSIDE_STILL` is now a module-level fixture in that loop, with the injection
above. `tests/README.md` said "the two sentences #274 adds are swept" — a
boundary reported as guarded across text one branch of which nothing read — and
now lists the three sentences beside the fixture that reaches each, rather than
counting them. That is the same conclusion #264, #269, #292 and #295 reached.

## Rebased onto #297

Clean, tree `a8aca87`. Two things #297 landed were checked against this
rendering rather than assumed:

- **The new committed demo** `examples/ticket-queue/demos/2026-08-12-interlude-card`
  renders a working link and neither gap sentence, as expected: its one clause
  is claimed and illustrated. All five committed demos were rendered through
  the rebased script under this repository's own
  `working-directory: examples/ticket-queue`, and every link lands on a path
  that is in git.
- **`tests/README.md`.** #297 rewrote *What this deliberately does not grade*,
  whose first bullet is the same statement as the closing paragraph of my #274
  block 39 lines above it. The merge was clean and the result read as two
  drafts of one thought, so it is one statement now, in the place the section
  reserves for it, extended to name the picture the `look at` column links.

One observation from that render, which is #274's *the first published still is
often the pre-state*: this demo's AC-1 links `01-queue.png`, the queue before
anything is typed, while `03-invoice.png` is the frame that shows the clause.
The link resolves and belongs to a beat that claimed AC-1; which of a clause's
stills is the telling one is not something this change decides.

## Files outside the brief's scope

`.github/workflows/demo-video.yml` gains four lines. It was not in the slice's
file list, and the alternative was shipping a link that 404s in exactly the
configuration this repository uses — `demo-comment` cannot infer the working
directory and every default is wrong in the same direction. Nothing else in the
workflow is touched, and no other open branch is against that file.

## What is left of #274

Not in this change, and #274 stays open for them:

1. `coverage.py` gaining the `unillustrated` key, so `timeline.json` carries
   it. Its arithmetic is graded in `tests/unit`, which is outside this
   change's scope, and shipping a manifest key no assertion watches is the
   thing this repo refuses.
2. `timeline.md` reporting it (`timeline.py:_coverage_md`, likewise outside).
3. `SKILL.md`'s coverage guidance gaining *tag a `shot()` for every clause, not
   only a caption*. The rule is written down here in
   `skills/demo-video/reference/ci.md` instead.

## Fault injections

Eighteen added to `ci-unit`'s `INJECTIONS`, all caught; two existing entries
were repointed at code this change moved, and the harness's exactly-once abort
is what found both (`ABORT: injection '--demo-root is ignored…' matched 0
times`). One existing entry — *the acceptance section leads with what was
claimed instead of the gap* — gained the new ordering test, so a single break
reddens both orderings rather than the second riding on the first.

```
PASS  break: the outside-the-demo cell reads as a verdict on the clause
      in demo-comment: f"so it is not linked*",…
      FAIL: test_the_same_words_are_refused_where_a_clause_has_no_picture (Coverage)

PASS  break: the still link forgets the directory the storyboards are rooted at
      in demo-comment: demo=repo_path(path_prefix, name),…
      FAIL: test_a_demo_below_the_repository_root_is_linked_where_git_holds_it (Coverage)

PASS  break: the path prefix stops being normalised, so `.` reaches the link
      in demo-comment: parts = [p for p in f"{prefix}/{name}".split("/") if p not in ("", "."…
      FAIL: test_the_default_working_directory_adds_nothing_to_the_link (Coverage)

PASS  break: the comment step stops passing the working directory to the script
      in demo-video.yml: --path-prefix "$WORKDIR" \…
      FAIL: test_the_working_directory_reaches_the_comment_as_a_path_prefix (CommentStep)

PASS  break: the comment step exports the working directory and drops it
      in demo-video.yml: --path-prefix "$WORKDIR"…
      FAIL: test_the_working_directory_reaches_the_comment_as_a_path_prefix (CommentStep)

PASS  break: a still is linked at the abbreviated sha instead of the recorded one
      in demo-comment: return f"{base}/raw/{quote(sha)}/{quote(path)}"…
      FAIL: test_a_staged_still_is_linked_from_the_command_line_end_to_end (CommentCli)
      FAIL: test_the_repository_url_defaults_to_what_every_actions_step_is_given (CommentCli)
      FAIL: test_a_claimed_still_is_linked_at_the_recorded_commit (Coverage)
      FAIL: test_a_space_in_a_still_path_is_encoded_so_the_link_survives (Coverage)

PASS  break: the still link drops the demo directory the picture lives in
      in demo-comment: href = _still_href(repo_url, sha, f"{demo}/{rel}")…
      FAIL: test_a_staged_still_is_linked_from_the_command_line_end_to_end (CommentCli)
      FAIL: test_a_claimed_still_is_linked_at_the_recorded_commit (Coverage)
      FAIL: test_a_clause_links_its_own_still_and_not_another_clauses (Coverage)

PASS  break: a still is looked for outside the demo directory it belongs to
      in demo-comment: directory=demo_dir(demo_root, name),…
      FAIL: test_a_staged_still_is_linked_from_the_command_line_end_to_end (CommentCli)
      FAIL: test_a_claimed_still_is_linked_at_the_recorded_commit (Coverage)
      FAIL: test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture (Coverage)

PASS  break: every clause is pointed at the first still in the report
      in demo-comment: claimed.get(key) or [],…
      FAIL: test_a_clause_links_its_own_still_and_not_another_clauses (Coverage)
      FAIL: test_a_still_the_manifest_names_and_nothing_published_is_not_linked (Coverage)
      FAIL: test_the_clauses_with_no_picture_are_named_before_the_claimed_table (Coverage)

PASS  break: a still nothing published is linked instead of reported absent
      in demo-comment: if not (directory / rel).exists():…
      FAIL: test_a_still_is_looked_for_in_the_directory_this_take_published (Coverage)
      FAIL: test_a_still_the_manifest_names_and_nothing_published_is_not_linked (Coverage)

PASS  break: a still pointing outside the demo is linked because it exists
      in demo-comment: if not parts or ".." in parts:…
      FAIL: test_a_still_outside_the_demo_directory_is_named_and_not_linked (Coverage)

PASS  break: a still path is pasted into the link unencoded
      in demo-comment: return f"{base}/raw/{quote(sha)}/{quote(path)}"…
      FAIL: test_a_space_in_a_still_path_is_encoded_so_the_link_survives (Coverage)

PASS  break: a still is linked relatively when there is no repository to link under
      in demo-comment: if not base or not sha:…
      FAIL: test_with_no_repository_url_a_published_still_is_named_not_linked (Coverage)

PASS  break: a clause with no picture is no longer named as one
      in demo-comment: if unillustrated:…
      FAIL: test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture (Coverage)
      FAIL: test_a_still_the_manifest_names_and_nothing_published_is_not_linked (Coverage)
      FAIL: test_the_clauses_with_no_picture_are_named_before_the_claimed_table (Coverage)

PASS  break: the no-picture finding names every claimed clause
      in demo-comment: key for key in criteria if key not in unclaimed and not pictures[key].…
      FAIL: test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture (Coverage)
      FAIL: test_a_take_whose_clauses_all_have_a_picture_prints_neither_gap (Coverage)

PASS  break: a clause nothing claims is reported as a claim with no still
      in demo-comment: return _Picture("—", False)…
      FAIL: test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture (Coverage)

PASS  break: the no-picture sentence promotes the rest of the clauses
      in demo-comment: f"here to open.**",…
      FAIL: test_the_same_words_are_refused_on_a_take_that_claimed_everything (Coverage)
      FAIL: test_the_same_words_are_refused_where_a_clause_has_no_picture (Coverage)

PASS  break: the absent-still cell reads as a verdict on the clause
      in demo-comment: f"no such file*",…
      FAIL: test_the_same_words_are_refused_where_a_clause_has_no_picture (Coverage)

PASS  break: the acceptance section leads with what was claimed instead of the gap
      in demo-comment: return gap + table + note…
      FAIL: test_the_clauses_with_no_picture_are_named_before_the_claimed_table (Coverage)
      FAIL: test_the_gap_is_stated_before_anything_that_was_claimed (Coverage)

PASS  break: --demo-root is ignored, so the comment reads the working tree
      in demo-comment: return Path(demo_root) / name if demo_root else Path(name)…
      FAIL: test_the_timeline_is_read_from_demo_root_and_named_by_demo (CommentCli)
      FAIL: test_a_staged_still_is_linked_from_the_command_line_end_to_end (CommentCli)

All 65 injections were caught.
```

Three of them checked against the catalogue, since it says to:

- *every clause is pointed at the first still in the report* is the guard
  against **the count that stands in for the content** in the new column. It
  leaves the table its shape, gives every clause a picture, and every picture
  resolves. `Coverage.look_at()` reads that one cell for the same reason
  `cell()` reads only `claimed at`.
- *a still pointing outside the demo is linked because it exists* stages a
  **real** `leaked.png`, so the guard and not the file's absence has to be the
  reason it is refused.
- *the absent-still cell reads as a verdict* reddens exactly one test —
  `test_the_same_words_are_refused_where_a_clause_has_no_picture` — which is
  the measurement that says the new sweep fixture is carrying that sentence
  rather than **decorating** an existing one. Without it, the whole fixture
  would be dominated by the `TAGGED` sweep.

## Ran

`tests/ci-unit` (97, OK) · `tests/ci-unit --fault-inject` (65/65) ·
`tests/unit` (408, OK) · `tests/unit --fault-inject` (269/269) ·
`tests/unit --budget` · `tests/lint` · `tests/lint --self-test` ·
`tests/lint --issues` (1619 references across 51 files, against 218 issues) ·
`ruff@0.16.1 format --check .` (16 files) · `mypy 1.18.2` (13 files, no issues). All of it re-run on the rebased head.
`tests/smoke` not run — exclusive lock, and nothing here touches the recorder.

Not demoable, by CLAUDE.md's test: a pull-request comment is read, not watched.
#272 says the same about slices A–G.

Refs #274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

