### PR TITLE
Say what the demo is evidence of, and what it leaves to the diff (#303)

### DIFF
--- a/.github/scripts/demo-comment
+++ b/.github/scripts/demo-comment
@@ -26,7 +26,8 @@ A take recorded against a ticket carries a third thing above the beat table:
 the ticket's clauses, the ones no beat claimed named first (issue #273), each
 claimed clause pointed at the committed still a reviewer can open (issue #274).
 It is a rendering of `timeline.json`'s `coverage` and it grades nothing — see
-`render_coverage`.
+`render_coverage`. It also states, in `DIFF_LIMIT`, the one question watching
+the take answers and the many it does not (issue #303).
 
 The body opens with an HTML marker so the workflow can find and rewrite this
 comment rather than appending a new one on every push.
@@ -42,6 +43,28 @@ from typing import NamedTuple
 from urllib.parse import quote
 
 MARKER = "<!-- demo-video-ci: one comment per pull request, rewritten on every push -->"
+
+#: What this comment is evidence of, and what it leaves to the diff (issue
+#: #303). Everything else here defends against the artifact *lying* — a still
+#: that does not exist, a claim promoted to a verdict. This defends against it
+#: implying more coverage than it has, which is the likelier harm: a demo can
+#: show a ticket's clauses; it cannot show the change does only that. The same
+#: pull request can delete a rate limiter, widen a permission or add a
+#: dependency, and the recording is silent about all three.
+#:
+#: Fixed text rather than anything computed. A count of files changed against
+#: paths the take exercised would be a number standing in for content, and it
+#: would invite exactly the confidence this sentence exists to withhold.
+#:
+#: It carries no word from `tests/ci-unit`'s `VERDICT_WORDS`, and is not
+#: exempted from that sweep — it is a sentence this script writes, so the sweep
+#: reads it like every other.
+DIFF_LIMIT = (
+    "**Watching this replaces reading the diff for one question only: whether "
+    "the take shows the clauses below.** Anything else the change touches — a "
+    "widened permission, a deleted check, a new dependency — is invisible to a "
+    "demo, and is still the diff's to answer."
+)
 
 
 def _cell(text: str) -> str:
@@ -285,6 +308,11 @@ def render_coverage(
             f"comment graded a claim."
         )
     gap.append("")
+    # Unconditional, and assembled apart from `gap` so that where it goes is
+    # one line rather than a position inside a block that varies with the take:
+    # it is printed on the take where every clause is claimed and illustrated
+    # too, which is the one it is most needed on.
+    limit = [DIFF_LIMIT, ""]
 
     table = ["| clause | claimed at | look at |", "|---|---|---|"]
     for key, text in criteria.items():
@@ -309,8 +337,9 @@ def render_coverage(
     ]
     # The gap first, and the order is the whole point rather than a layout
     # choice: a rendering that opened with the claimed table would *be* a
-    # coverage claim, whatever the words under it said.
-    return gap + table + note
+    # coverage claim, whatever the words under it said. `limit` follows for the
+    # same reason: below it, a reader has already started judging the clauses.
+    return gap + limit + table + note
 
 
 def _human_size(n: int | None) -> str:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
-# Design docs — kept local while the repo's home is still being decided
+# Design docs — kept local while the repo's home is still being decided.
+# CLAUDE.md's Layout section says `docs/` is gitignored; until now it was not,
+# so a `git add -A` would have committed every local design doc.
 .scratch/
+docs/
 
 # Node / TypeScript build artifacts (bundled skill CLIs)
 node_modules/

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -388,6 +388,42 @@ automate precisely because it takes no judgement: nobody even asserted those.
 Everything else is the reviewer's call, and the artifact's job is to put them in
 front of the right frames.
 
+### What a take is evidence about, and what stays the diff's to answer
+
+Everything above defends against one failure: the artifact **claiming** more
+than it earned. This is the other one, and it is the likelier way this skill
+hurts somebody — the artifact **implying** more than it covers.
+
+A demo can show that a ticket's clauses were met. It cannot show that the
+change does *only* that. Every criterion can be declared, claimed, illustrated
+and watched, and the same pull request can delete a rate limiter, widen a
+permission, drop an authorisation check or add a dependency: the recording is
+silent about all four. Not because the recorder missed them — because they are
+not things a screen does. There is no frame in which a removed guard is
+visible, and no storyboard that could film one.
+
+So watching a take replaces reading the diff for exactly one question: *were
+the declared clauses shown?* It is a real substitution and a narrow one, and
+the danger is a reviewer who has generalised it — "the demo is green, so the
+ticket is done" is half of a review being skipped by somebody who was never
+told which half. The pull-request comment this repository's workflow renders
+therefore says so above the clause table, in a sentence, on every take recorded
+against a ticket.
+
+**There is deliberately no number beside it.** Files changed against paths the
+take exercised, criteria against lines of diff, a percentage of anything — each
+is a count standing in for content, and each would be read as a bound on what
+got past. A demo that touched 90 % of the changed files is not 90 % reviewed.
+Worse, the number is the part people remember: it would manufacture exactly the
+confidence the sentence exists to withhold, and it would do it with a figure
+nobody could argue with. The honest artifact here is a sentence, not a
+measurement.
+
+Stated the way the security absence at the top of [SKILL.md](../SKILL.md) is
+stated, and for the same reason: this is a scope limit, not a gap waiting to be
+filled. A demo that graded the whole change would have to be trusted. This one
+only has to be watched.
+
 ### Rules that follow
 
 - **Derive the storyboard from the ticket, the ADR or the RFC — not from the

--- a/tests/README.md
+++ b/tests/README.md
@@ -1497,6 +1497,44 @@ writes are swept. Clause **ids** are not exempted either — they are too short
 to subtract safely, so a ticket with a clause called `verified` would redden
 this suite.
 
+**What the comment says about its own reach**
+([#303](https://github.com/rogvid/skills/issues/303)). Everything above stops
+the artifact *claiming* more than it earned; this is the complement — one fixed
+sentence, above the clause table on every take that declared a ticket, saying
+that watching replaces reading the diff for whether the clauses were shown and
+for nothing else. Two assertions hold it: that it reaches every branch of the
+gap block — a clause nothing claims, a clause with no picture, every clause
+claimed and illustrated, nothing claimed at all — and that it is read *with*
+the clauses rather than under the twenty captions past them. The fixtures are
+enumerated for the same reason the sweep's are: the branch that matters is the
+clean take, and a sentence printed only where the comment already has a gap to
+report would be missing from exactly the take a reviewer trusts most. That is
+an injection, and it reddens the first assertion alone.
+
+**The sentence sits inside the verdict sweep rather than beside it.** `_quoted`
+subtracts the ticket's clauses and the storyboard's captions and nothing else,
+and this is neither — it is text `demo-comment` writes, so
+`test_no_sentence_promotes_a_claim_to_a_verdict` reads it like every other
+sentence in the section. Which is why it carries none of `VERDICT_WORDS`:
+`shown` and `demonstrat*` are both on the list, and the wording works around
+the sweep rather than the sweep being taught to skip the wording. There is no
+separate assertion that the sentence is verdict-free, because the sweep already
+guarantees it and a second one would be the catalogue's dominated assertion.
+What exists instead is the injection *the limit sentence promotes the clauses
+it disclaims*, which appends "The clauses below were demonstrated." to it and
+reddens the sweep — the measurement that says the sweep can see it at all. It
+appends rather than replaces, so the two assertions above stay green and the
+sweep is the only thing that notices.
+
+**Where #303 stopped, stated rather than implied:** a take recorded without
+`criteria=` renders no acceptance section, and so carries no sentence. The demo
+whose storyboard declared no ticket says nothing about its own reach. That
+boundary is graded only in the negative — by
+`test_a_take_recorded_without_criteria_prints_no_acceptance_section`, which
+refuses the word `clause` anywhere in that body, and which is therefore also
+what would redden if the sentence were later printed unconditionally without
+being reworded.
+
 The injections that cover the acceptance section are enumerated in `ci-unit`'s
 `INJECTIONS`, and the number they add up to is deliberately not written here:
 it went stale the first time somebody added one, which is

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -1019,6 +1019,19 @@ QUOTED_VERDICT = dict(
 )
 
 
+#: The sentence #303 adds, hand-written here rather than imported from
+#: `comment`. Importing it would make this pair of tests agree with the script
+#: by construction: any rewording, including one that dropped the second half,
+#: would still be "present". Copied text goes stale loudly, which is the
+#: direction to be wrong in.
+DIFF_LIMIT = (
+    "**Watching this replaces reading the diff for one question only: whether "
+    "the take shows the clauses below.** Anything else the change touches — a "
+    "widened permission, a deleted check, a new dependency — is invisible to a "
+    "demo, and is still the diff's to answer."
+)
+
+
 class Coverage(unittest.TestCase):
     """The ticket's clauses in the pull-request comment, gap first (#273).
 
@@ -1257,6 +1270,56 @@ class Coverage(unittest.TestCase):
         )
         cells = self.cell(self.body(piped), "AC-1")
         self.assertEqual(cells, "beat 3")
+
+    # -- what watching answers, and what it leaves to the diff (#303) -------
+
+    def test_every_take_with_a_ticket_says_what_it_is_not_evidence_of(self):
+        """The one sentence about the comment's own reach, on every branch.
+
+        Enumerated rather than counted, and the fixtures are the four shapes
+        the gap block takes: a clause nothing claims, a clause with no picture,
+        every clause claimed and illustrated, and nothing claimed at all. The
+        third is the one that matters most and is the easiest to lose — a
+        rendering that printed this only where it already had a gap to report
+        would say nothing on the take a reviewer is likeliest to trust.
+
+        The boundary in the other direction — a take that declared no
+        `criteria=` prints no acceptance section and so no sentence — is
+        already graded by
+        `test_a_take_recorded_without_criteria_prints_no_acceptance_section`,
+        which refuses the word `clause` anywhere in that body. Asserting it
+        again here would be a check an earlier one already guarantees.
+        """
+        none_claimed = dict(
+            TIMELINE,
+            coverage=dict(
+                COVERAGE,
+                claimed={key: [] for key in COVERAGE["criteria"]},
+                unclaimed=list(COVERAGE["criteria"]),
+            ),
+        )
+        for fixture in (TAGGED, CAPTION_ONLY, ALL_ILLUSTRATED, none_claimed):
+            body = self.body(fixture)
+            # The haystack: without this, a renderer that stopped printing the
+            # acceptance section entirely would fail here for a reason this
+            # test would report as the sentence going missing.
+            self.assertIn("| clause | claimed at | look at |", body)
+            self.assertEqual(body.count(DIFF_LIMIT), 1, body)
+
+    def test_the_limit_is_read_with_the_clauses_and_not_after_the_captions(self):
+        # Placement is the claim: a sentence about what the comment covers is
+        # worth nothing below the twenty captions a reviewer scrolled past to
+        # reach it. It sits under the gaps and above the table — after the
+        # findings that need no judgement, before the reader starts working
+        # through the clauses and has decided what this comment is for.
+        body = self.body(TAGGED)
+        self.assertIn("| clause | claimed at | look at |", body)  # control
+        self.assertIn(DIFF_LIMIT, body)  # so a missing sentence reads as one
+        where = body.index(DIFF_LIMIT)
+        self.assertGreater(where, body.index(self.headline(body)))
+        self.assertLess(where, body.index("| clause | claimed at | look at |"))
+        self.assertLess(where, body.index("**AC-1**"))
+        self.assertLess(where, body.index("| # | at | Caption |"))
 
     # -- one picture per clause, and the clauses with none (#274) -----------
 
@@ -1811,8 +1874,8 @@ INJECTIONS = [
         # *is* a coverage claim, whatever the sentence under it says.
         "the acceptance section leads with what was claimed instead of the gap",
         "demo-comment",
-        "    return gap + table + note",
-        "    return table + gap + note",
+        "    return gap + limit + table + note",
+        "    return table + gap + limit + note",
         [
             "Coverage.test_the_gap_is_stated_before_anything_that_was_claimed",
             "Coverage.test_the_clauses_with_no_picture_are_named_before_the_claimed_table",
@@ -2280,6 +2343,55 @@ INJECTIONS = [
         [
             "VerdictAlphabet.test_each_injected_sentence_is_refused_for_exactly_its_own_word"
         ],
+    ),
+    # -- what the comment is evidence of (#303) -----------------------------
+    (
+        # The sentence gone. The comment then reads as it did before #303: a
+        # coverage table a reviewer can take for the whole of review, with
+        # nothing in it saying which half it is.
+        "the comment stops saying what the demo is not evidence of",
+        "demo-comment",
+        '    limit = [DIFF_LIMIT, ""]',
+        "    limit = []",
+        [
+            "Coverage.test_every_take_with_a_ticket_says_what_it_is_not_evidence_of",
+            "Coverage.test_the_limit_is_read_with_the_clauses_and_not_after_the_captions",
+        ],
+    ),
+    (
+        # Printed only where the comment already had a gap to report — so it is
+        # present on every fixture that names a missing clause, and absent from
+        # the clean take, which is the one a reviewer is likeliest to trust.
+        # The ordering assertion runs on `TAGGED` and stays green throughout.
+        "the limit is printed only on takes that already report a gap",
+        "demo-comment",
+        '    limit = [DIFF_LIMIT, ""]',
+        '    limit = [DIFF_LIMIT, ""] if unclaimed else []',
+        ["Coverage.test_every_take_with_a_ticket_says_what_it_is_not_evidence_of"],
+    ),
+    (
+        # Below the clauses instead of above them. Every count of it is still
+        # one and the acceptance section is otherwise untouched — a sentence
+        # about what the comment covers, printed after the reader worked
+        # through what it covers.
+        "the limit is printed under the clause table rather than over it",
+        "demo-comment",
+        "    return gap + limit + table + note",
+        "    return gap + table + limit + note",
+        ["Coverage.test_the_limit_is_read_with_the_clauses_and_not_after_the_captions"],
+    ),
+    (
+        # The one that says #303's sentence is *inside* the verdict sweep
+        # rather than exempted from it. It is text `demo-comment` writes, so
+        # `_quoted` never subtracts it; appending to it leaves the literal the
+        # two tests above look for intact, so the sweep is the only thing that
+        # can notice — which is the same shape the per-word injections use.
+        "the limit sentence promotes the clauses it disclaims",
+        "demo-comment",
+        '    "demo, and is still the diff\'s to answer."',
+        "    \"demo, and is still the diff's to answer. "
+        + 'The clauses below were demonstrated."',
+        ["Coverage.test_no_sentence_promotes_a_claim_to_a_verdict"],
     ),
 ]
 


### PR DESCRIPTION
Fixes #303

## What changed

Everything the acceptance section does so far defends against the artifact
**lying** — a still that does not exist, a claim promoted to a verdict. This is
the complement, and it guards the likelier harm: the artifact **implying** more
coverage than it has. A demo can show a ticket's clauses. It cannot show the
change does only that, and the same pull request can delete a rate limiter,
widen a permission or add a dependency with the recording silent about all
three.

1. **`.github/scripts/demo-comment`** grows one fixed sentence, `DIFF_LIMIT`,
   printed above the clause table on every take that declared a ticket:

   > **Watching this replaces reading the diff for one question only: whether
   > the take shows the clauses below.** Anything else the change touches — a
   > widened permission, a deleted check, a new dependency — is invisible to a
   > demo, and is still the diff's to answer.

   It sits under the gap headlines and over the table: below that, the reader
   has already started judging the clauses and has decided what the comment is
   for. It is unconditional — including on the take where every clause is
   claimed and illustrated, which is the one it is most needed on.

2. **`skills/demo-video/reference/review.md`** carries the fuller statement as
   a stated limit, in the register of SKILL.md's security absence: a scope
   limit, not a gap waiting to be filled. A demo that graded the whole change
   would have to be trusted; this one only has to be watched.

3. **No number**, deliberately. Files changed against paths exercised, criteria
   against lines of diff, a percentage of anything — each is the catalogue's
   *count that stands in for the content*, and the number is the part people
   remember. That reasoning is written into the constant's own comment so the
   next author does not add one.

4. **`.gitignore` now ignores `docs/`.** `CLAUDE.md`'s Layout section has
   asserted that since it was written and it was not true — a `git add -A`
   would have committed every local design doc. One line, folded in here.

## How the verdict sweep was handled

The new sentence is **inside** `VERDICT_WORDS`' scope, not exempted from it.
`_quoted()` subtracts only the ticket's clause text and the storyboard's
captions; `DIFF_LIMIT` is neither — it is text `demo-comment` writes, so
`test_no_sentence_promotes_a_claim_to_a_verdict` reads it along with every
other sentence in the section.

That is why the wording carries no swept word. `shown` and `demonstrat*` are
both on the list, so the sentence says *"whether the take **shows** the clauses
below"* — the wording works around the sweep rather than the sweep being taught
to skip the wording. Widening `_quoted` to exempt it would have punched a hole
in the one check that stops this comment claiming a verdict.

I did **not** add an assertion that `DIFF_LIMIT` is verdict-free. Eight
existing tests render it and sweep it, so such an assertion could not fail for
a reason one of them had not already caught — the catalogue's *dominated
assertion*. What stands in its place is injection 4 below, which is the
measurement that says the sweep can see the new sentence at all.

## Assertions added, and each one seen failing

Two, both in `Coverage`:

- `test_every_take_with_a_ticket_says_what_it_is_not_evidence_of` — the
  sentence appears exactly once on each of the four shapes the gap block takes
  (a clause nothing claims, a clause with no picture, every clause claimed and
  illustrated, nothing claimed at all), with the table header asserted first as
  the haystack.
- `test_the_limit_is_read_with_the_clauses_and_not_after_the_captions` — it is
  after the gap headline and before the clause table, the `**AC-1**` row and
  the beat table.

The boundary in the other direction needed no new assertion: a take with no
`criteria=` renders no acceptance section, and the existing
`test_a_take_recorded_without_criteria_prints_no_acceptance_section` refuses
the word `clause` anywhere in that body, which `DIFF_LIMIT` contains.

Four injections were added; all 69 in the manifest are caught
(`tests/ci-unit --fault-inject`, exit 0). Each was confirmed to match **exactly
once** in `demo-comment` — the harness aborts otherwise, and it did abort once
during this change, on the pre-existing *"the acceptance section leads with
what was claimed instead of the gap"* entry whose anchor line
`return gap + table + note` I had edited. Its anchor is updated in this PR.

### 1. `limit = [DIFF_LIMIT, ""]` → `limit = []`

The sentence gone; the comment reads as it did before #303.

```
FAIL: test_every_take_with_a_ticket_says_what_it_is_not_evidence_of
  File ".../ci-unit", line 1307, in test_every_take_with_a_ticket_says_what_it_is_not_evidence_of
    self.assertEqual(body.count(DIFF_LIMIT), 1, body)
AssertionError: 0 != 1 : <!-- demo-video-ci: one comment per pull request, rewritten on every push -->
...
**`AC-2` and `AC-4` have no beat claiming them.**

4 clauses. 2 have a beat that claims them; whether the frames show what they claim is the reviewer's call. Nothing in this comment graded a claim.

| clause | claimed at | look at |
```

(and `test_the_limit_is_read_with_the_clauses_and_not_after_the_captions`.)

### 2. `limit = [DIFF_LIMIT, ""] if unclaimed else []`

Printed only where the comment already reports a gap — so it is absent from
exactly the take a reviewer trusts most. The ordering test runs on `TAGGED` and
stays green throughout, so this reddens the branch test alone.

```
FAIL: test_every_take_with_a_ticket_says_what_it_is_not_evidence_of
    self.assertEqual(body.count(DIFF_LIMIT), 1, body)
AssertionError: 0 != 1 : ...
4 clauses. 4 have a beat that claims them; whether the frames show what they claim is the reviewer's call. Nothing in this comment graded a claim.

| clause | claimed at | look at |
```

### 3. `return gap + limit + table + note` → `return gap + table + limit + note`

Below the clauses instead of above them. Every count of it is still one and the
section is otherwise untouched.

```
FAIL: test_the_limit_is_read_with_the_clauses_and_not_after_the_captions
    self.assertLess(where, body.index("| clause | claimed at | look at |"))
AssertionError: 1001 not less than 348
```

### 4. `"…is still the diff's to answer."` → `"…is still the diff's to answer. The clauses below were demonstrated."`

The sweep interaction, proven rather than asserted. It **appends**, so the
literal both new tests look for is still present and they stay green — the
sweep is the only thing that can notice, which is the same shape the per-word
injections use.

```
FAIL: test_no_sentence_promotes_a_claim_to_a_verdict
    self.assert_no_verdict(self.body(TAGGED), TAGGED)
    self.assertEqual(hits, [], f"{hits} read as a verdict in:\n{swept}")
AssertionError: Lists differ: ['demonstrat*'] != []
...
**Watching this replaces reading the diff for one question only: whether the take shows the clauses below.** Anything else the change touches — a widened permission, a deleted check, a new dependency — is invisible to a demo, and is still the diff's to answer. The clauses below were demonstrated.
```

It also reddens `test_a_clause_whose_own_wording_is_a_verdict_does_not_trip_the_sweep`,
`test_a_take_where_no_beat_tagged_anything_still_names_every_clause` and
`test_a_take_whose_clauses_all_have_a_picture_prints_neither_gap` — every sweep
fixture renders the sentence, which is itself the evidence that the sentence is
not exempted anywhere.

## Stated limits

- **A take recorded without `criteria=` carries no statement.** It renders no
  acceptance section, and the sentence is scoped to clauses it would have none
  of. The most naive demo — no ticket declared — therefore says nothing about
  its own reach. That is where #303 stopped; it is written into
  `tests/README.md` rather than left to be noticed, and the negative is graded
  by the existing no-criteria test.
- **Nothing grades that a reviewer reads it.** A sentence above a table is a
  sentence somebody can skip, and this repo has no way to measure that. It is
  two lines and it leads with bold for that reason, which is a judgement and
  not a measurement.
- **The prose in `review.md` is not pinned to the sentence in the script.**
  They are deliberately not the same text — the reference paraphrases rather
  than quoting, so there is no verbatim duplicate to drift. Nothing checks that
  the two stay in agreement about substance.
- **No coverage metric, now or later.** Stated as a limit rather than a
  to-do: the absence is the point, and a future version should not fill it.

## Verification

```
tests/unit            408 tests, OK          (SKILL.md 600/600 lines, budget unchanged)
tests/ci-unit          99 tests, OK
tests/ci-unit --fault-inject   All 69 injections were caught.
tests/lint            All checks passed! · 16 files already formatted
```

No demo video: this is CI, tests and documentation, which `CLAUDE.md`'s table
puts squarely in the not-demoable column — the change is a sentence in a
rendered artifact, verifiable by reading it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
