### PR TITLE
Anchor the docs/ ignore so a skill can ship its own docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # Design docs — kept local while the repo's home is still being decided.
 # CLAUDE.md's Layout section says `docs/` is gitignored; until now it was not,
 # so a `git add -A` would have committed every local design doc.
+# Anchored: an unanchored `docs/` also ignores `skills/<name>/docs/`, and a
+# shipped doc that git cannot see is a doc `npx skills add` cannot install.
 .scratch/
-docs/
+/docs/
 
 # Node / TypeScript build artifacts (bundled skill CLIs)
 node_modules/


### PR DESCRIPTION
Follow-up to #304 (`8bcd52e`), which added `docs/` to `.gitignore` so
`CLAUDE.md`'s Layout section stopped asserting something false. The pattern was
unanchored, so it also matched `skills/<name>/docs/` at any depth.

Nothing is tracked under a nested `docs/` today, so this regresses nothing — it
closes a trap. A skill that grew a `docs/` directory would have had it silently
untracked, and a shipped doc git cannot see is a doc `npx skills add` cannot
install. The failure would have surfaced as a broken pointer in someone else's
checkout, not here.

Verified both directions rather than by reading the pattern:

```
$ git check-ignore -v docs/x.md
.gitignore:7:/docs/	docs/x.md

$ git check-ignore -v skills/demo-video/docs/x.md
(no match — correct)
```

`.scratch/` is deliberately left unanchored: scratch space at any depth should
be ignored, which is the opposite of what is wanted for docs.

## Stated limits

No assertion guards this. A `tests/lint` check that every shipped path under
`skills/` is visible to git would be the graded version; it is not worth its
weight against a single anchored pattern whose behaviour is shown above, and
inventing one here would be a check written to make a one-line PR look
rigorous. Recorded here rather than as an issue.