### PR TITLE
A claim a failed take made must not read as a clean one (#278)

### DIFF
--- a/.github/scripts/demo-comment
+++ b/.github/scripts/demo-comment
@@ -24,8 +24,9 @@ today. Neither substitutes for the other.
 
 A take recorded against a ticket carries a third thing above the beat table:
 the ticket's clauses, the ones no beat claimed named first (issue #273), each
-claimed clause pointed at the committed still a reviewer can open (issue #274).
-It is a rendering of `timeline.json`'s `coverage` and it grades nothing — see
+claimed clause pointed at the committed still a reviewer can open (issue #274),
+and on a take that died, that fact ahead of all of them (issue #278). It is a
+rendering of `timeline.json`'s `coverage` and it grades nothing — see
 `render_coverage`. It also states, in `DIFF_LIMIT`, the one question watching
 the take answers and the many it does not (issue #303).
 
@@ -118,6 +119,12 @@ def _claim_label(rows: list[dict]) -> str:
         part = "an unnumbered beat" if index is None else str(index)
         if row.get("segment"):
             part += f" (`{_cell(str(row['segment']))}`)"
+        # A verb that threw did not do what its beat says it did, so a claim
+        # made by it is not a claim the take kept. Unmarked, this cell reads
+        # exactly like a claim from a beat that returned (issue #278).
+        error = row.get("error")
+        if isinstance(error, dict):
+            part += f" (raised {_cell(str(error.get('type') or 'an exception'))})"
         parts.append(part)
     return _plural(len(parts), "beat ", "beats ") + ", ".join(parts)
 
@@ -184,7 +191,16 @@ def _picture(
         return _Picture("—", False)
     named: list[str] = []
     outside: list[str] = []
+    raised: list[str] = []
     for row in rows:
+        # Before the existence check, and that order is the point: on a take
+        # that died, a still of this name left behind by a *previous* recording
+        # is sitting right there, and linking it would hand the reviewer last
+        # week's picture as evidence for a beat that threw (issue #278).
+        error = row.get("error")
+        if isinstance(error, dict):
+            raised.append(str(error.get("type") or "an exception"))
+            continue
         still = row.get("still")
         if not isinstance(still, str) or not still.strip():
             continue
@@ -201,6 +217,14 @@ def _picture(
         # and which demo, and the full path crowds a three-column table.
         label = _cell(rel.rsplit("/", 1)[-1])
         return _Picture(f"[{label}]({href})" if href else f"`{_cell(rel)}`", True)
+    if raised:
+        # First among the reasons there is nothing here, because it is a fact
+        # about the take rather than about a path: the beat threw, so whatever
+        # it was going to write was never written.
+        return _Picture(
+            f"*the beat claiming this raised {_cell(raised[0])}, so it wrote no still*",
+            False,
+        )
     if outside:
         return _Picture(
             f"*`{_cell(outside[0])}` is not a path inside this demo, "
@@ -216,6 +240,49 @@ def _picture(
     return _Picture("*no still*", False)
 
 
+def _failure_lead(failure: dict, criteria: dict, claimed: dict) -> list[str]:
+    """What the acceptance section leads with when the take crashed (#278).
+
+    Above the gap headlines, which are above the table, for the reason
+    `render_timeline_md` puts "## This take did not finish" above the beat
+    table: a reader who meets a table of claims first reads it as an ordinary
+    take's, and the heading alone is one line of a section they scroll past.
+
+    A clause is counted here when every claim it has came from a beat that
+    raised, and when it has no claim at all. Both mean nothing this take got
+    through asserted it; the two are not told apart, because the beats that
+    would say never ran.
+    """
+    beat = failure.get("beat")
+    where = f"beat {beat} (`{_cell(str(failure.get('verb') or '?'))}`)"
+    if beat is None:
+        where = "between beats"
+    unreached = [
+        key
+        for key in criteria
+        if not any(
+            not isinstance(row.get("error"), dict) for row in (claimed.get(key) or [])
+        )
+    ]
+    out = [
+        f"**This take did not finish**, so what is below is the part of the "
+        f"ticket it got through and not the whole of it. It came out of the "
+        f"`with` block at {where}.",
+        "",
+    ]
+    if unreached:
+        ids = _and_list([f"`{_cell(key)}`" for key in unreached])
+        out += [
+            f"**{len(unreached)} of the {len(criteria)} clauses "
+            f"{_plural(len(unreached), 'has', 'have')} no claim from a beat "
+            f"that returned: {ids}.** Each was either never tagged by this "
+            f"storyboard or sits after the beat the take died on, and this "
+            f"comment cannot tell those apart.",
+            "",
+        ]
+    return out
+
+
 def render_coverage(
     coverage: object,
     *,
@@ -223,6 +290,7 @@ def render_coverage(
     directory: Path,
     repo_url: str | None,
     sha: str | None,
+    failure: object = None,
 ) -> list[str]:
     """The ticket's clauses and what claimed them, **gap first** (issue #273).
 
@@ -251,6 +319,12 @@ def render_coverage(
     until issue #274 it looked exactly like a well-illustrated one. It is named
     with the other gaps, above the table: it is the second finding here that
     takes no judgement, being a fact about which files exist.
+
+    On a take that carries `failure` the section leads with that, before every
+    other gap (issue #278). A claim from a beat that raised says so in its own
+    row and is never given a picture — the verb that would have written one
+    threw, so a file of that name is a previous recording's. **A demo that
+    failed must never render a clean "AC-2 — shown at 0:12."**
     """
     doc = coverage if isinstance(coverage, dict) else {}
     criteria = doc.get("criteria")
@@ -277,6 +351,8 @@ def render_coverage(
     ]
 
     gap: list[str] = []
+    if isinstance(failure, dict):
+        gap += _failure_lead(failure, criteria, claimed)
     if unclaimed:
         ids = _and_list([f"`{_cell(key)}`" for key in unclaimed])
         gap += [
@@ -414,6 +490,10 @@ def render_demo(
         directory=demo_dir(demo_root, name),
         repo_url=repo_url,
         sha=sha,
+        # Without this the section renders a crashed take's claims exactly like
+        # a clean take's, five lines above a block that says the take failed
+        # (issue #278).
+        failure=failure,
     )
 
     if rows:

--- a/skills/demo-video/helpers/demo_recording/coverage.py
+++ b/skills/demo-video/helpers/demo_recording/coverage.py
@@ -41,6 +41,11 @@ import re
 #
 # `unclaimed` is the one machine-checkable finding here, and it is safe to
 # automate precisely because it needs no judgement: nobody even asserted it.
+#
+# A claim's `error` is the second, and it needs no judgement either: it is the
+# beat's own record of the verb raising. A claim made by a beat that threw is
+# not a claim the take kept, and rendering it like one is the artifact lying
+# (issue #278).
 
 # How a criterion id may be written. Deliberately narrow — these become table
 # rows, filenames in a reviewer's prompt and keys in a JSON object, and an id
@@ -89,6 +94,39 @@ def _ac_field(claims: list[str]) -> dict:
     return {"ac": claims} if claims else {}
 
 
+def _claim_row(beat: dict) -> dict:
+    """One row of `claimed[id]`: where the claim was made, and whether it held.
+
+    `error` is present **only** when the beat's verb raised, and absent
+    otherwise — the #24 rule, so a take recorded before this key existed reads
+    exactly like one whose beats all returned.
+
+    It is copied here rather than left for a consumer to look up in `beats`
+    because every renderer of this report reads the row and never the beat.
+    Without it a claim made by a beat that threw is indistinguishable from one
+    that worked, and a `shot("07-x", ac="AC-3")` whose screenshot raised
+    produces a row naming a still the take never wrote — an artifact reporting
+    success on failure, inside the feature whose whole purpose is honesty about
+    claims (issue #278).
+    """
+    row = {
+        "index": beat.get("index"),
+        "segment": beat.get("segment"),
+        "segment_index": beat.get("segment_index"),
+        "t_start": beat.get("t_start"),
+        "still": beat.get("still"),
+    }
+    error = beat.get("error")
+    if isinstance(error, dict):
+        # `type` and `message`, not the beat's dict by reference: a renderer
+        # that mutated this row would otherwise reach into `beats`.
+        row["error"] = {
+            "type": error.get("type"),
+            "message": error.get("message"),
+        }
+    return row
+
+
 def coverage_report(criteria: dict[str, str], beats: list[dict]) -> dict | None:
     """Which criteria the storyboard **claimed**, and which nothing claimed.
 
@@ -111,15 +149,7 @@ def coverage_report(criteria: dict[str, str], beats: list[dict]) -> dict | None:
         tagged += 1
         for key in ids:
             if key in claimed:
-                claimed[key].append(
-                    {
-                        "index": beat.get("index"),
-                        "segment": beat.get("segment"),
-                        "segment_index": beat.get("segment_index"),
-                        "t_start": beat.get("t_start"),
-                        "still": beat.get("still"),
-                    }
-                )
+                claimed[key].append(_claim_row(beat))
     return {
         "criteria": dict(criteria),
         # Every declared id is a key here, including the ones with an empty

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -218,6 +218,12 @@ from .markdown import _fmt_t, _md_cell
 #                          machine-checkable finding here), `tagged_beats`,
 #                          `untagged_beats`, and `conflicts` on a merged demo
 #                          whose segments used different text for one id.
+#                          A claimed row carries `error` — the raising beat's
+#                          `type` and `message` — **only** when that beat's
+#                          verb raised, absent otherwise (issue #24), because
+#                          a claim a beat threw out of is not a claim the take
+#                          kept and a `shot` that raised names a still nothing
+#                          wrote (issue #278).
 #                          On a stitched demo it is recomputed over the merged
 #                          beats, so its indices match this file. See
 #                          "acceptance criteria and coverage".
@@ -1022,7 +1028,64 @@ def _narration_md(narration: object) -> list[str]:
     ]
 
 
-def _coverage_md(coverage: object) -> list[str]:
+def _kept_claims(criteria: dict, claimed: dict) -> list[str]:
+    """The criteria no beat that *returned* claimed (issue #278).
+
+    A clause is here when every claim it has came from a beat that raised, and
+    when it has no claim at all. Both mean the same thing on a take that died:
+    nothing this take got through asserted it. The two are not told apart,
+    because they cannot be — the beats that would have said never ran.
+    """
+    return [
+        key
+        for key in criteria
+        if not any(
+            not isinstance(row.get("error"), dict) for row in (claimed.get(key) or [])
+        )
+    ]
+
+
+def _coverage_failure_md(failure: dict, criteria: dict, claimed: dict) -> list[str]:
+    """The first thing in the acceptance section on a take that crashed.
+
+    Above the table, for the same reason "## This take did not finish" is above
+    the beat table: a reader who opens this file after a crash is reading it
+    *because* something went wrong, and a coverage table met first is read as
+    an ordinary take's (issue #278).
+    """
+    where = (
+        f"beat {failure['beat']} (`{_md_cell(failure.get('verb'))}`)"
+        if failure.get("beat") is not None
+        else "between beats — no verb was running, so no beat is blamed"
+    )
+    out = [
+        f"**This take did not finish**, so the table below is the part of the "
+        f"ticket it got through and not the whole of it. It came out of the "
+        f"`with` block on a **{_md_cell(failure.get('type'))}**, at {where}.",
+        "",
+    ]
+    unreached = _kept_claims(criteria, claimed)
+    if unreached:
+        ids = ", ".join(f"`{_md_cell(k)}`" for k in unreached)
+        out += [
+            f"**{len(unreached)} of the {len(criteria)} criteria have no claim "
+            f"from a beat that returned: {ids}.** Each was either never tagged "
+            f"by this storyboard or sits after the beat the take died on, and "
+            f"this file cannot tell those apart — the beats that would say "
+            f"never ran.",
+            "",
+        ]
+    else:
+        out += [
+            f"Each of the {len(criteria)} criteria still has a claim from a "
+            f"beat that returned: the take died at a beat that tagged none of "
+            f"them.",
+            "",
+        ]
+    return out
+
+
+def _coverage_md(coverage: object, failure: object = None) -> list[str]:
     """The acceptance-criteria section of timeline.md, or nothing (issue #12).
 
     Every word here is chosen so a reader cannot come away thinking this file
@@ -1030,6 +1093,10 @@ def _coverage_md(coverage: object) -> list[str]:
     author's claim, and the only assertive sentence in the section is about
     the criteria nothing claimed — which needs no judgement, because nobody
     asserted them.
+
+    `failure` is the document's, and it changes what this section leads with
+    rather than what it concludes: a demo that failed must never render a clean
+    "AC-2 — shown at 0:12" (issue #278).
     """
     if not isinstance(coverage, dict):
         return []
@@ -1038,9 +1105,10 @@ def _coverage_md(coverage: object) -> list[str]:
         return []
     claimed = coverage.get("claimed") or {}
     unclaimed = coverage.get("unclaimed") or []
-    out = [
-        "## Acceptance criteria",
-        "",
+    out = ["## Acceptance criteria", ""]
+    if isinstance(failure, dict):
+        out += _coverage_failure_md(failure, criteria, claimed)
+    out += [
         "This take was recorded against a ticket. **The table below is what "
         "the storyboard *claimed*, not what it proved** — an `ac=` tag is a "
         "string its author typed, and whether the frames actually show the "
@@ -1065,18 +1133,35 @@ def _coverage_md(coverage: object) -> list[str]:
             if row.get("segment"):
                 beat += f" (`{_md_cell(row['segment'])}`)"
             still = row.get("still")
-            out.append(
-                f"| {label} | {beat} | {_fmt_t(row.get('t_start'))} | "
-                + (f"`{_md_cell(still)}`" if still else "")
-                + " |"
-            )
+            # Marked here and not only in the beat table below, and the still
+            # is withheld rather than printed: the verb that would have written
+            # it raised, so the path names a file this take never produced and
+            # the row would otherwise read exactly like one that worked
+            # (issue #278).
+            error = row.get("error")
+            if isinstance(error, dict):
+                beat += f" **raised {_md_cell(error.get('type'))}**"
+                cell = "*not written*" if still else ""
+            else:
+                cell = f"`{_md_cell(still)}`" if still else ""
+            out.append(f"| {label} | {beat} | {_fmt_t(row.get('t_start'))} | {cell} |")
     out.append("")
     if unclaimed:
+        # On a take that crashed the two reasons this sentence has always
+        # given are both wrong, and the third one is the reason: the take
+        # never got there. Same words, wrong cause (issue #278).
+        why = (
+            "Either the demo does not show them, the storyboard did not say "
+            "where, or — on this take, which did not finish — it died before "
+            "reaching them."
+            if isinstance(failure, dict)
+            else "Either the demo does not show them, or the storyboard did "
+            "not say where. Both are worth fixing before review."
+        )
         out += [
             f"**{len(unclaimed)} of {len(criteria)} criteria have no beat "
             f"claiming them: {', '.join(f'`{_md_cell(k)}`' for k in unclaimed)}.** "
-            f"Either the demo does not show them, or the storyboard did not say "
-            f"where. Both are worth fixing before review.",
+            f"{why}",
             "",
         ]
     else:
@@ -1193,7 +1278,10 @@ def render_timeline_md(doc: dict) -> str:
     # when the take was recorded against a ticket — and because a reviewer who
     # scrolls past 28 beats first has already formed the impression the
     # coverage report exists to test (issue #12).
-    out += _coverage_md(doc.get("coverage"))
+    # The failure goes in with it, not only into the section above: without it
+    # the acceptance table renders a crashed take's claims exactly like a clean
+    # take's, which is the artifact reporting success on failure (issue #278).
+    out += _coverage_md(doc.get("coverage"), failure)
     # Directly above the beat table, because it is a statement about the
     # numbers in it: a reader who has scrolled past the table has already read
     # the timestamps as the video's, which is the misreading this says out

--- a/skills/demo-video/reference/ci.md
+++ b/skills/demo-video/reference/ci.md
@@ -77,6 +77,23 @@ be looked at. Neither is evidence that the clause was demonstrated — a picture
 next to a clause is a frame the storyboard chose, and what it is a picture of
 is still the reviewer's call.
 
+**On a take that did not finish, that is the first thing the section says.**
+Above both gap headlines, which are themselves above the table: a reader who
+meets a table of claims first reads it as an ordinary take's. It names the beat
+the take came out of the `with` block at, and counts the clauses no beat that
+*returned* claimed — a clause claimed only by a beat that raised, and a clause
+nothing claimed at all, which on a crashed take mean the same thing and cannot
+be told apart, because the beats that would say never ran.
+
+A claim from a beat that raised says so in its own row and is **never given a
+picture**. `shot()` stamps the still's path on the beat before it takes the
+picture, so a take that died there names a file it did not write — and
+`images/` is committed, so the previous recording's still of that name is
+sitting in the directory waiting to be linked as this beat's evidence. A clause
+claimed by a beat that returned is left alone, on a crashed take as on any
+other: that claim is as good as any other claim the take made, and marking it
+would be inventing a finding.
+
 **It says "claimed", never "demonstrated", and it says out loud that it graded
 nothing.** An `ac=` tag is a string the storyboard author typed; whether the
 frames show the clause is the reviewer's call, and the comment is written so it

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -299,6 +299,24 @@ with Recorder(OUT, criteria={
 **1 of 3 criteria have no beat claiming them: `AC-3`.**
 ```
 
+### What a take that died renders instead
+
+A verb that raises is recorded on its beat (`error`), and the claim that beat
+made carries it too. So on a crashed take the acceptance section **leads with
+the failure**, before the table — the same ordering `timeline.md` already uses
+for "## This take did not finish" — and the row reads:
+
+```
+| **AC-3** — The CLI prints the same… | beat 17 **raised TimeoutError** | 31.80 | *not written* |
+```
+
+The still is withheld rather than printed. `shot()` stamps the path on the beat
+before it takes the picture, so on a take that died there the path names a file
+nothing wrote, and printing it sends a reviewer looking for last week's picture.
+A clause claimed by a beat that **returned** is untouched, even when the take
+died later somewhere else: that claim is as good as any other claim that take
+made.
+
 ### Put the clause on screen: `criterion()`
 
 Everything above lives in files a viewer never opens. The video — the artifact

--- a/tests/README.md
+++ b/tests/README.md
@@ -1472,6 +1472,58 @@ second and third rows each have an injection that reddens
 which is the measurement that says their fixtures are carrying those sentences
 rather than decorating an existing test.
 
+**A claim a failed take made must not read as a clean one**
+([#278](https://github.com/rogvid/skills/issues/278)). `coverage_report` copied
+`index`, `segment`, `segment_index`, `t_start` and `still` off the claiming
+beat and never its `error`, and every renderer downstream reads the row rather
+than the beat. So a `shot("07-x", ac="AC-3")` whose screenshot raised produced
+`**AC-3** — … | beat 17 | 31.8 | images/07-x.png` — a still the take never
+wrote, above a beat table that correctly said **raised**.
+
+Three things are graded, because they are three pieces of code: the report the
+row comes out of, the `timeline.md` rendering of it, and the pull-request
+comment's.
+
+| claim | where | what would otherwise pass |
+|---|---|---|
+| the row carries the beat's `error` | `Coverage`, in `tests/unit` | the row a renderer reads is the pre-#278 one, whatever either renderer does with it |
+| and only when it raised | `Coverage`, in `tests/unit` | a key on every row makes the assertion above pass on a report that copied a constant, and makes an old timeline read as one whose beats all raised |
+| the acceptance table marks the row | `CoverageMd`, in `tests/unit` | the beat table 40 lines lower still says **raised**, so a reader who scrolled far enough would find out |
+| and prints no still | `CoverageMd`, in `tests/unit` | the path names a file nothing wrote |
+| the section leads with the failure | `CoverageMd`, in `tests/unit` | a take that crashed opens its acceptance section exactly as a clean one does |
+| `render_timeline_md` hands it the failure | `TimelineMd`, in `tests/unit` | every assertion above holds on a perfect function nobody calls with the second argument |
+| the comment mirrors all of it | `Coverage`, in `tests/ci-unit` | the pull-request comment is the artifact a reviewer is guaranteed to read |
+
+**The comment's fixture stages the still on disk on purpose.** `RAISED` claims
+`images/01-search-box.png` from a beat that raised, and `setUp` writes that
+file — because `images/` is committed, so on a take that died the *previous*
+recording's picture of that name is sitting in the directory, and a renderer
+deciding by existence alone links last week's picture as this beat's evidence.
+`AC-1` claims the same file from a beat that returned and is linked in the same
+table, which is the control: a renderer that stopped linking anything satisfies
+neither.
+
+**One assertion was written and deleted** rather than kept: *the raised row is
+still four cells wide*. Every break that widens that row is caught one
+assertion earlier by the equality on the row's fourth cell, which indexes it
+and would read the wrong one or raise — the catalogue's dominated assertion,
+and it would have been a second row in the table above measuring nothing new.
+
+**What the count deliberately does not include.** A clause claimed by a beat
+that *returned*, on a take that died later somewhere else, is not marked and is
+not counted — that claim is as good as any other claim the take made, and #278
+says so explicitly. The injection *the failure lead counts every clause, not
+the ones no beat returned on* is what holds that line; without it the sentence
+would read as a finding against every clause on any crashed take.
+
+**What this leaves alone, stated rather than implied.** `render_timeline_md`'s
+`## Stills` gallery still embeds `![02](images/02.png)` for a `shot` beat that
+raised — a broken image in the same file whose acceptance table now withholds
+that path ([#305](https://github.com/rogvid/skills/issues/305)). It is a
+different renderer, reading `beats` rather than `coverage`, and #278's scope is
+the coverage row and the acceptance section; the wiring test asserts the path
+is absent from the acceptance section and says which issue owns the rest.
+
 **The sweep grades the sentences the renderer writes, not the ones it quotes**
 ([#283](https://github.com/rogvid/skills/issues/283)). Clause text belongs to
 whoever wrote the ticket and captions to whoever wrote the storyboard, and both

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -769,15 +769,29 @@ class Render(unittest.TestCase):
         self.assertEqual(unescaped.count("|"), 4, rows[0])  # 4 delimiters, 3 cells
 
 
-def claim(index: int, still: str | None = None, segment: str | None = None) -> dict:
-    """One row of `coverage.claimed[id]`, shaped as `coverage_report` writes it."""
-    return {
+def claim(
+    index: int,
+    still: str | None = None,
+    segment: str | None = None,
+    raised: str | None = None,
+) -> dict:
+    """One row of `coverage.claimed[id]`, shaped as `coverage_report` writes it.
+
+    `raised` adds the `error` key the recorder copies off a beat whose verb
+    threw (#278). Absent otherwise, exactly as the manifest has it — a fixture
+    that always carried the key would let a renderer reading it pass on a take
+    where nothing went wrong.
+    """
+    row = {
         "index": index,
         "segment": segment,
         "segment_index": index,
         "t_start": float(index),
         "still": still,
     }
+    if raised is not None:
+        row["error"] = {"type": raised, "message": "no such locator"}
+    return row
 
 
 # Four clauses, and the two nothing claims are **not** the last two: an
@@ -875,6 +889,51 @@ ALL_ILLUSTRATED = dict(
             "AC-2": [claim(5, "images/03-requester.png")],
             "AC-3": [claim(9, STILL)],
             "AC-4": [claim(11, "images/03-requester.png")],
+        },
+        unclaimed=[],
+    ),
+)
+
+# The take #278 is about: a `shot()` tagged AC-2 whose screenshot raised, on a
+# take that died right there.
+#
+# **AC-2's still is `STILL`, which `setUp` puts on disk.** That is the whole
+# point of the fixture and not an oversight: `images/` is committed, so a
+# previous recording's picture of that name is sitting in the directory, and a
+# renderer that decides by existence alone links last week's picture as this
+# beat's evidence. AC-1 claims the same file and *did* return, so the two rows
+# differ in exactly one field and the fixture cannot be satisfied by a renderer
+# that stopped linking anything.
+RAISED = dict(
+    TIMELINE,
+    failure={
+        "type": "TimeoutError",
+        "beat": 5,
+        "verb": "shot",
+        "message": "no such locator",
+    },
+    coverage=dict(
+        COVERAGE,
+        claimed={
+            "AC-1": [claim(3, STILL)],
+            "AC-2": [claim(5, STILL, raised="TimeoutError")],
+            "AC-3": [claim(9, "images/03-requester.png")],
+            "AC-4": [],
+        },
+        unclaimed=["AC-4"],
+    ),
+)
+
+# The other branch of the lead: the take died at a beat that tagged nothing, so
+# every clause still has a claim from a beat that returned. Without it the
+# count sentence would be the only thing the lead is ever seen writing.
+RAISED_NOWHERE = dict(
+    TIMELINE,
+    failure={"type": "RuntimeError", "beat": None, "verb": None, "message": "boom"},
+    coverage=dict(
+        COVERAGE,
+        claimed={
+            key: [claim(i + 1, STILL)] for i, key in enumerate(COVERAGE["criteria"])
         },
         unclaimed=[],
     ),
@@ -1276,10 +1335,11 @@ class Coverage(unittest.TestCase):
     def test_every_take_with_a_ticket_says_what_it_is_not_evidence_of(self):
         """The one sentence about the comment's own reach, on every branch.
 
-        Enumerated rather than counted, and the fixtures are the four shapes
-        the gap block takes: a clause nothing claims, a clause with no picture,
-        every clause claimed and illustrated, and nothing claimed at all. The
-        third is the one that matters most and is the easiest to lose — a
+        Enumerated rather than counted, and the fixtures are the shapes the
+        gap block takes: a clause nothing claims, a clause with no picture,
+        every clause claimed and illustrated, nothing claimed at all, and a
+        take that did not finish (#278, whose lead sits above this sentence).
+        The third is the one that matters most and is the easiest to lose — a
         rendering that printed this only where it already had a gap to report
         would say nothing on the take a reviewer is likeliest to trust.
 
@@ -1298,7 +1358,7 @@ class Coverage(unittest.TestCase):
                 unclaimed=list(COVERAGE["criteria"]),
             ),
         )
-        for fixture in (TAGGED, CAPTION_ONLY, ALL_ILLUSTRATED, none_claimed):
+        for fixture in (TAGGED, CAPTION_ONLY, ALL_ILLUSTRATED, none_claimed, RAISED):
             body = self.body(fixture)
             # The haystack: without this, a renderer that stopped printing the
             # acceptance section entirely would fail here for a reason this
@@ -1466,6 +1526,84 @@ class Coverage(unittest.TestCase):
         # two sentences" of a renderer that writes three — a boundary reported
         # as guarded across text one branch of which nothing read.
         for fixture in (CAPTION_ONLY, ABSENT_STILL, OUTSIDE_STILL):
+            self.assert_no_verdict(self.body(fixture), fixture)
+
+    # -- a claim a failed take made must not read as a clean one (#278) -----
+
+    def lead(self, body: str) -> str:
+        """The one sentence saying the take crashed, in the acceptance section.
+
+        Matched from the start of the line, not by "did not finish" anywhere:
+        `render_demo`'s own heading carries those words too, and a search that
+        found it would place the lead by the heading's position — above every
+        assertion below, whatever `render_coverage` did.
+        """
+        found = [ln for ln in body.splitlines() if ln.startswith("**This take did not")]
+        self.assertEqual(len(found), 1, f"no single failure lead in:\n{body}")
+        return found[0]
+
+    def test_a_failed_take_says_so_before_anything_it_claimed(self):
+        body = self.body(RAISED)
+        self.assertIn("| clause | claimed at | look at |", body)  # control
+        where = body.index(self.lead(body))
+        self.assertLess(where, body.index("| clause | claimed at | look at |"))
+        self.assertLess(where, body.index("**AC-1**"))
+        # And before the two gap headlines, which are themselves above the
+        # table: on a take that died, the failure is the reason for both.
+        self.assertLess(where, body.index(self.headline(body)))
+        self.assertIn("beat 5 (`shot`)", self.lead(body))
+
+    def test_the_lead_counts_the_clauses_no_returning_beat_claimed(self):
+        # AC-2's only claim raised and nothing claims AC-4, so two of the four
+        # have no claim from a beat that returned. AC-1 and AC-3 do, and
+        # counting them would be inventing a finding on claims as good as any
+        # other this take made.
+        body = self.body(RAISED)
+        line = [ln for ln in body.splitlines() if "no claim from a beat" in ln]
+        self.assertEqual(len(line), 1, body)
+        self.assertIn("2 of the 4 clauses", line[0])
+        self.assertIn("AC-2", line[0])
+        self.assertIn("AC-4", line[0])
+        self.assertNotIn("AC-1", line[0])
+        self.assertNotIn("AC-3", line[0])
+
+    def test_a_take_that_died_claiming_everything_prints_no_count(self):
+        body = self.body(RAISED_NOWHERE)
+        self.assertIn("between beats", self.lead(body))
+        self.assertNotIn("no claim from a beat", body)
+
+    def test_a_clause_claimed_by_a_beat_that_raised_says_so_in_its_row(self):
+        # The `claimed at` cell, read narrowly: unmarked it says "beat 5" and
+        # is indistinguishable from AC-1's, which is a claim the take kept.
+        body = self.body(RAISED)
+        self.assertEqual(self.cell(body, "AC-2"), "beat 5 (raised TimeoutError)")
+        self.assertEqual(self.cell(body, "AC-1"), "beat 3")
+
+    def test_a_still_a_beat_that_raised_would_have_written_is_not_linked(self):
+        # The artifact-lies case this slice exists for. The file is on disk —
+        # `images/` is committed, so a previous recording's picture of that
+        # name is right there — and AC-1 links it from the same table, so the
+        # renderer is demonstrably able to find it.
+        self.assertTrue((self.root / "demos/x/images/01-search-box.png").exists())
+        body = self.body(RAISED)
+        self.assertIn("](http", self.look_at(body, "AC-1"))  # control
+        cell = self.look_at(body, "AC-2")
+        self.assertNotIn("](http", cell)
+        self.assertNotIn("01-search-box.png", cell)
+        self.assertIn("raised TimeoutError", cell)
+
+    def test_a_clean_take_carries_none_of_this(self):
+        # The #24 rule at the comment's edge: a document with no failure and no
+        # raised claim must read exactly as it did before this slice.
+        body = self.body(ALL_ILLUSTRATED)
+        for added in ("did not finish", "raised", "no claim from a beat"):
+            self.assertNotIn(added, body)
+        self.assertIn("](http", self.look_at(body, "AC-1"))  # control
+
+    def test_the_same_words_are_refused_on_a_take_that_did_not_finish(self):
+        # The lead and the raised cell are two more sentences the renderer
+        # writes, in a branch every fixture above reaches by not having.
+        for fixture in (RAISED, RAISED_NOWHERE):
             self.assert_no_verdict(self.body(fixture), fixture)
 
     def test_a_claim_from_a_named_segment_says_which_segment(self):
@@ -1960,11 +2098,92 @@ INJECTIONS = [
         '    lines += render_coverage(\n        timeline.get("coverage"),\n'
         "        demo=repo_path(path_prefix, name),\n"
         "        directory=demo_dir(demo_root, name),\n"
-        "        repo_url=repo_url,\n        sha=sha,\n    )",
+        "        repo_url=repo_url,\n        sha=sha,\n"
+        "        # Without this the section renders a crashed take's claims "
+        "exactly like\n"
+        "        # a clean take's, five lines above a block that says the take "
+        "failed\n"
+        "        # (issue #278).\n"
+        "        failure=failure,\n    )",
         "    lines += []",
         [
             "Coverage.test_the_gap_is_stated_before_anything_that_was_claimed",
             "Coverage.test_every_declared_clause_reaches_the_comment_with_its_own_text",
+        ],
+    ),
+    (
+        # The wiring #278 adds, and the one the injection above cannot see: the
+        # call still happens, the section still renders, and it is never told
+        # the take died — so a crashed take's clauses come out exactly like a
+        # clean take's, five lines above a block saying the take failed.
+        "the coverage section is not told the take failed",
+        "demo-comment",
+        "        failure=failure,\n    )",
+        "    )",
+        [
+            "Coverage.test_a_failed_take_says_so_before_anything_it_claimed",
+            "Coverage.test_the_lead_counts_the_clauses_no_returning_beat_claimed",
+            "Coverage.test_a_take_that_died_claiming_everything_prints_no_count",
+        ],
+    ),
+    (
+        # **The defect #278 is about**, in the artifact a reviewer actually
+        # reads: the row's `error` ignored, so a claim a beat threw out of
+        # names the same beat in the same words as one that returned.
+        "a claim whose beat raised is labelled like one that returned",
+        "demo-comment",
+        "            part += f\" (raised {_cell(str(error.get('type') or 'an exception'))})\"",
+        "            pass",
+        ["Coverage.test_a_clause_claimed_by_a_beat_that_raised_says_so_in_its_row"],
+    ),
+    (
+        # And the picture. `images/` is committed, so on a take that died the
+        # previous recording's still of that name is sitting in the directory
+        # and existence alone links it — last week's picture, beside a clause
+        # whose beat threw.
+        "a still is linked for a beat that raised, because the file exists",
+        "demo-comment",
+        '        error = row.get("error")\n        if isinstance(error, dict):\n'
+        '            raised.append(str(error.get("type") or "an exception"))\n'
+        "            continue",
+        '        error = row.get("error")\n        if False:\n'
+        '            raised.append(str(error.get("type") or "an exception"))\n'
+        "            continue",
+        [
+            "Coverage.test_a_still_a_beat_that_raised_would_have_written_is_not_linked",
+        ],
+    ),
+    (
+        # The lead deleted. The gap headline then opens the section on a
+        # crashed take exactly as it does on one that finished.
+        "the acceptance section stops leading with the failure",
+        "demo-comment",
+        "    if isinstance(failure, dict):\n        gap += _failure_lead(failure, criteria, claimed)",
+        "    if False:\n        gap += _failure_lead(failure, criteria, claimed)",
+        [
+            "Coverage.test_a_failed_take_says_so_before_anything_it_claimed",
+            "Coverage.test_the_lead_counts_the_clauses_no_returning_beat_claimed",
+            "Coverage.test_a_take_that_died_claiming_everything_prints_no_count",
+        ],
+    ),
+    (
+        # The count that would be inventing a finding. #278 says it explicitly:
+        # a clause claimed by a beat that *returned* on a take that later died
+        # elsewhere is as good as any other claim that take made.
+        "the failure lead counts every clause, not the ones no beat returned on",
+        "demo-comment",
+        "    unreached = [\n"
+        "        key\n"
+        "        for key in criteria\n"
+        "        if not any(\n"
+        '            not isinstance(row.get("error"), dict) '
+        "for row in (claimed.get(key) or [])\n"
+        "        )\n"
+        "    ]",
+        "    unreached = list(criteria)",
+        [
+            "Coverage.test_the_lead_counts_the_clauses_no_returning_beat_claimed",
+            "Coverage.test_a_take_that_died_claiming_everything_prints_no_count",
         ],
     ),
     (

--- a/tests/unit
+++ b/tests/unit
@@ -310,6 +310,48 @@ class Coverage(unittest.TestCase):
             ],
         )
 
+    def test_a_claim_from_a_beat_that_raised_carries_that_beats_error(self):
+        # Issue #278. Without this the row is `index`/`segment`/`t_start`/
+        # `still` and nothing else, so a `shot()` whose screenshot threw is
+        # indistinguishable in the report from one that wrote its file.
+        report = coverage_report(
+            self.CRITERIA,
+            [
+                beat(
+                    17,
+                    "shot",
+                    31.8,
+                    ac=["AC-3"],
+                    still="images/07-x.png",
+                    error={"type": "TimeoutError", "message": "locator not found"},
+                )
+            ],
+        )
+        self.assertEqual(
+            report["claimed"]["AC-3"][0]["error"],
+            {"type": "TimeoutError", "message": "locator not found"},
+        )
+
+    def test_a_claim_from_a_beat_that_returned_carries_no_error_key(self):
+        # The control, and the #24 rule: absent, not null. A key present on
+        # every row would satisfy the assertion above on a report that copied
+        # a constant, and a timeline recorded before this key existed has to
+        # read exactly like one whose beats all returned.
+        report = coverage_report(
+            self.CRITERIA, [beat(4, "shot", 9.0, ac=["AC-1"], still="images/01.png")]
+        )
+        self.assertNotIn("error", report["claimed"]["AC-1"][0])
+
+    def test_a_takes_error_is_copied_and_not_shared_with_the_beat(self):
+        # The row is handed to renderers; the beat is the recorder's record of
+        # what happened. A renderer that edited the row must not be able to
+        # rewrite the beat log underneath it.
+        raised = {"type": "TimeoutError", "message": "locator not found"}
+        beats = [beat(2, "shot", 1.0, ac=["AC-1"], error=raised)]
+        report = coverage_report(self.CRITERIA, beats)
+        report["claimed"]["AC-1"][0]["error"]["type"] = "Rewritten"
+        self.assertEqual(beats[0]["error"]["type"], "TimeoutError")
+
     def test_a_take_recorded_outside_a_ticket_has_no_report(self):
         # None, not {}. An empty report would read as a take that covered
         # nothing, which is a different and false statement.
@@ -449,10 +491,141 @@ class CoverageMd(unittest.TestCase):
         "untagged_beats": 4,
     }
 
+    # The take issue #278 is about. Identical to REPORT in every field but the
+    # `error` on AC-2's claim — that is the whole difference the rendering has
+    # to make visible, and holding everything else equal is what stops these
+    # assertions passing off some other change to the fixture.
+    RAISED = {
+        "criteria": dict(REPORT["criteria"]),
+        "claimed": {
+            "AC-1": [{"index": 1, "t_start": 3.2, "still": None, "segment": None}],
+            "AC-2": [
+                {
+                    "index": 2,
+                    "t_start": 5.4,
+                    "still": "images/02.png",
+                    "segment": None,
+                    "error": {"type": "TimeoutError", "message": "no such locator"},
+                }
+            ],
+            "AC-3": [],
+        },
+        "unclaimed": ["AC-3"],
+        "tagged_beats": 2,
+        "untagged_beats": 4,
+    }
+    FAILURE = {
+        "type": "TimeoutError",
+        "beat": 2,
+        "verb": "shot",
+        "message": "no such locator",
+    }
+
     def test_the_unclaimed_sentence_names_every_unclaimed_id(self):
         text = "\n".join(_coverage_md(self.REPORT))
         self.assertIn("`AC-3`", text)
         self.assertIn("1 of 3 criteria have no beat claiming them", text)
+
+    # -- a claim a failed take made must not read as a clean one (#278) -----
+
+    def test_a_row_whose_beat_raised_says_so_in_the_table(self):
+        # In the acceptance table itself, not only in the beat table further
+        # down the file. A reviewer reading top-down meets this row first.
+        text = "\n".join(_coverage_md(self.RAISED))
+        row = [ln for ln in text.splitlines() if ln.startswith("| **AC-2**")]
+        self.assertEqual(len(row), 1, text)
+        self.assertIn("**raised TimeoutError**", row[0])
+
+    def test_a_row_whose_beat_raised_names_no_still(self):
+        # The still is the lie: `shot()` stamps the path on the beat before it
+        # takes the picture, so a take that died there names a file it never
+        # wrote. Searched over the whole section, not the row, because a path
+        # printed anywhere in it is a path a reviewer will go looking for.
+        text = "\n".join(_coverage_md(self.RAISED))
+        self.assertNotIn("images/02.png", text)
+        # The control: the same still, on the same claim, without the error.
+        # Without it this assertion passes on a renderer that lost the column.
+        self.assertIn("images/02.png", "\n".join(_coverage_md(self.REPORT)))
+
+    def test_a_row_whose_beat_raised_does_not_read_as_a_row_with_no_still(self):
+        # A blank cell is what a `caption(ac=)` claim renders as, and "nobody
+        # took a picture" is a different statement from "the picture this beat
+        # was taking was never written".
+        row = [ln for ln in _coverage_md(self.RAISED) if ln.startswith("| **AC-2**")][0]
+        self.assertEqual(split_row(row)[3], "*not written*")
+        # AC-1's claim carries no still at all, and stays blank.
+        blank = [ln for ln in _coverage_md(self.RAISED) if ln.startswith("| **AC-1**")]
+        self.assertEqual(split_row(blank[0])[3], "")
+
+    def test_a_failed_take_says_so_before_anything_it_claimed(self):
+        # "Leads with", read strictly: the first line of the section after its
+        # heading. "Somewhere above the table" would be satisfied by a sentence
+        # under the paragraph about what a tag means, which is where a reader
+        # scrolling to the table would never meet it.
+        lines = _coverage_md(self.RAISED, self.FAILURE)
+        self.assertEqual(lines[:2], ["## Acceptance criteria", ""])
+        self.assertTrue(lines[2].startswith("**This take did not finish**"), lines[2])
+        self.assertIn("beat 2 (`shot`)", lines[2])
+        text = "\n".join(lines)
+        self.assertIn("| criterion | claimed by |", text)  # control: a table ran
+        self.assertLess(text.index("did not finish"), text.index("| criterion |"))
+        self.assertLess(text.index("did not finish"), text.index("**AC-1**"))
+
+    def test_the_lead_counts_the_clauses_no_returning_beat_claimed(self):
+        # AC-2's only claim raised and nothing claims AC-3, so two of the three
+        # have no claim from a beat that returned. AC-1 does, and counting it
+        # here would be inventing a finding on a claim as good as any other.
+        text = "\n".join(_coverage_md(self.RAISED, self.FAILURE))
+        self.assertIn(
+            "2 of the 3 criteria have no claim from a beat that returned", text
+        )
+        self.assertIn("`AC-2`", text)
+        self.assertIn("`AC-3`", text)
+        line = [ln for ln in text.splitlines() if "no claim from a beat" in ln][0]
+        self.assertNotIn("AC-1", line)
+
+    def test_a_take_that_died_claiming_everything_says_that_instead(self):
+        # The other branch, and the one a reader meets when the take crashed at
+        # a beat that tagged nothing. Without it the count sentence would be
+        # the only thing this section ever says about a failure.
+        report = dict(
+            self.REPORT,
+            claimed={
+                key: [{"index": i, "t_start": 1.0, "still": None, "segment": None}]
+                for i, key in enumerate(self.REPORT["criteria"])
+            },
+            unclaimed=[],
+        )
+        text = "\n".join(_coverage_md(report, self.FAILURE))
+        self.assertIn("did not finish", text)
+        self.assertIn("still has a claim from a beat that returned", text)
+        self.assertNotIn("no claim from a beat that returned", text)
+
+    def test_a_take_that_finished_renders_exactly_what_it_did_before(self):
+        # The #24 rule, as a whole-section equality: a document with no failure
+        # and no raised claim must come out byte-for-byte as it always has.
+        # Nothing below this line is allowed to leak into an ordinary take.
+        text = "\n".join(_coverage_md(self.REPORT, None))
+        for added in ("did not finish", "raised", "not written", "died before"):
+            self.assertNotIn(added, text)
+        self.assertEqual(text, "\n".join(_coverage_md(self.REPORT)))
+
+    def test_the_unclaimed_sentence_offers_the_third_reason_only_on_a_failure(self):
+        # Same words, wrong cause: "either the demo does not show them, or the
+        # storyboard did not say where" is a complete list on a take that
+        # finished and is missing the reason that matters on one that did not.
+        crashed = "\n".join(_coverage_md(self.RAISED, self.FAILURE))
+        self.assertIn("died before reaching them", crashed)
+        clean = "\n".join(_coverage_md(self.RAISED))
+        self.assertNotIn("died before reaching them", clean)
+        self.assertIn("Both are worth fixing before review", clean)
+
+    # A "the raised row is still four cells wide" test stood here and was
+    # deleted rather than kept: every break that widens that row is caught one
+    # assertion earlier by `split_row(row)[3] == "*not written*"` above, which
+    # indexes the cell and would read the wrong one or raise. The catalogue
+    # calls that the dominated assertion, and a check that cannot fire for the
+    # reason it claims is worse than no check.
 
     def test_the_section_says_claimed_and_never_says_demonstrated(self):
         # The whole honesty of issue #12. If this file said "demonstrated",
@@ -479,6 +652,45 @@ class CoverageMd(unittest.TestCase):
 
 
 class TimelineMd(unittest.TestCase):
+    def test_the_acceptance_section_is_told_the_take_failed(self):
+        """The wiring, which no assertion on `_coverage_md` can reach.
+
+        `_coverage_md` can be perfect about a failure it is never handed:
+        `render_timeline_md` reads `failure` for the section above the beat
+        table and could pass the coverage report on its own, leaving a crashed
+        take's clauses rendered exactly like a clean take's a few lines below
+        a heading that says the take died (issue #278).
+        """
+        doc = envelope(
+            duration=None,
+            beats=[
+                beat(
+                    2,
+                    "shot",
+                    5.4,
+                    ac=["AC-2"],
+                    still="images/02.png",
+                    error={"type": "TimeoutError", "message": "no such locator"},
+                )
+            ],
+            coverage=CoverageMd.RAISED,
+            failure=CoverageMd.FAILURE,
+        )
+        text = render_timeline_md(doc)
+        start = text.index("## Acceptance criteria")
+        section = text[start : text.index("\n## ", start + 1)]
+        self.assertIn("**AC-2**", section)  # control: the section rendered
+        # The lead line, not "did not finish" anywhere in the section. The
+        # first version of this assertion searched for the phrase, and the
+        # unclaimed sentence three paragraphs lower carries it too — so with
+        # the lead deleted it stayed green, and it was grading a sentence it
+        # was not written about. Fault injection found that; reading did not.
+        self.assertIn("\n**This take did not finish**", section)
+        # And the still the beat never wrote is nowhere in the section. The
+        # `## Stills` gallery further down still embeds it — that is a
+        # different renderer and issue #305, not this one.
+        self.assertNotIn("images/02.png", section)
+
     def test_a_null_duration_is_not_rendered_as_a_number(self):
         # issue #20: a take that encoded no mp4 reports duration null, even
         # when a previous run's demo.mp4 is sitting right there. Rendering
@@ -10040,9 +10252,168 @@ INJECTIONS = [
     (
         "a claim records only the beat index, losing the frame it points at",
         "coverage.py",
-        '                        "still": beat.get("still"),',
-        '                        "still": None,',
+        '        "still": beat.get("still"),',
+        '        "still": None,',
         ["Coverage.test_a_claim_carries_the_beat_that_made_it"],
+    ),
+    (
+        # **The defect issue #278 is about**, restored exactly: the row copies
+        # index, segment, t_start and still off the claiming beat and never its
+        # `error`. Every renderer downstream reads the row, so a claim made by
+        # a beat that threw then reads as an ordinary one — and a `shot()` that
+        # raised names a still the take never wrote.
+        "a claim does not record that the beat making it raised",
+        "coverage.py",
+        '    error = beat.get("error")\n    if isinstance(error, dict):',
+        '    error = beat.get("error")\n    if False:',
+        [
+            "Coverage.test_a_claim_from_a_beat_that_raised_carries_that_beats_error",
+            "Coverage.test_a_takes_error_is_copied_and_not_shared_with_the_beat",
+        ],
+    ),
+    (
+        # The other direction, and the #24 rule: a key present on every row
+        # makes the assertion above pass on a report that copied a constant,
+        # and makes a take recorded before this key existed read as one whose
+        # beats all raised.
+        "every claim carries an error key, present or not",
+        "coverage.py",
+        '        row["error"] = {\n'
+        '            "type": error.get("type"),\n'
+        '            "message": error.get("message"),\n'
+        "        }",
+        "        pass\n"
+        '    row["error"] = {\n'
+        '        "type": (error or {}).get("type"),\n'
+        '        "message": (error or {}).get("message"),\n'
+        "    }",
+        [
+            "Coverage.test_a_claim_from_a_beat_that_returned_carries_no_error_key",
+            "Coverage.test_a_claim_carries_the_beat_that_made_it",
+        ],
+    ),
+    (
+        # The beat's own dict handed through by reference. Nothing downstream
+        # mutates a row today, which is exactly why the assertion needs its own
+        # injection: without this it would only ever be seen failing alongside
+        # the one above, and it would be decorating that measurement.
+        "the claim shares the beat's error dict instead of copying it",
+        "coverage.py",
+        '        row["error"] = {\n'
+        '            "type": error.get("type"),\n'
+        '            "message": error.get("message"),\n'
+        "        }",
+        '        row["error"] = error',
+        ["Coverage.test_a_takes_error_is_copied_and_not_shared_with_the_beat"],
+    ),
+    (
+        # The mark, gone from the acceptance table while the beat table 40
+        # lines lower still carries it. A reviewer reading top-down meets the
+        # clean row first, and that ordering is the whole of #278.
+        "the acceptance table stops marking a claim whose beat raised",
+        "timeline.py",
+        "                beat += f\" **raised {_md_cell(error.get('type'))}**\"",
+        "                pass",
+        ["CoverageMd.test_a_row_whose_beat_raised_says_so_in_the_table"],
+    ),
+    (
+        # The still printed anyway. `shot()` stamps the path on the beat before
+        # it takes the picture, so on a take that died there the path names a
+        # file nothing wrote — the artifact-lies case, in the one feature whose
+        # purpose is honesty about claims.
+        "a claim whose beat raised prints the still it never wrote",
+        "timeline.py",
+        '                cell = "*not written*" if still else ""',
+        '                cell = f"`{_md_cell(still)}`" if still else ""',
+        [
+            "CoverageMd.test_a_row_whose_beat_raised_names_no_still",
+            "CoverageMd.test_a_row_whose_beat_raised_does_not_read_as_a_row_with_no_still",
+            "TimelineMd.test_the_acceptance_section_is_told_the_take_failed",
+        ],
+    ),
+    (
+        # The lead, deleted. The table then opens the section on a crashed take
+        # exactly as it does on a clean one.
+        "the acceptance section stops leading with the failure",
+        "timeline.py",
+        "    if isinstance(failure, dict):\n"
+        "        out += _coverage_failure_md(failure, criteria, claimed)",
+        "    if False:\n"
+        "        out += _coverage_failure_md(failure, criteria, claimed)",
+        [
+            "CoverageMd.test_a_failed_take_says_so_before_anything_it_claimed",
+            "CoverageMd.test_the_lead_counts_the_clauses_no_returning_beat_claimed",
+            "CoverageMd.test_a_take_that_died_claiming_everything_says_that_instead",
+            "TimelineMd.test_the_acceptance_section_is_told_the_take_failed",
+        ],
+    ),
+    (
+        # The same condition inverted, which is the direction #24 is about: the
+        # lead printed on every take that *finished*. The injection above can
+        # only be seen by a document carrying a failure; this one is the only
+        # thing in the suite that watches an ordinary take stay ordinary.
+        "the failure lead is printed on a take that did not fail",
+        "timeline.py",
+        "    if isinstance(failure, dict):\n"
+        "        out += _coverage_failure_md(failure, criteria, claimed)",
+        "    if not isinstance(failure, dict):\n"
+        "        out += _coverage_failure_md(failure or {}, criteria, claimed)",
+        [
+            "CoverageMd.test_a_take_that_finished_renders_exactly_what_it_did_before",
+            "CoverageMd.test_a_failed_take_says_so_before_anything_it_claimed",
+        ],
+    ),
+    (
+        # And the third-reason sentence printed on every take, which is the
+        # same #24 direction one paragraph lower. Same search string as the
+        # injection below it and the opposite break, because the boundary has
+        # two sides and only one of them has ever been watched.
+        "the unclaimed sentence blames the crash on a take that finished",
+        "timeline.py",
+        "            if isinstance(failure, dict)\n"
+        '            else "Either the demo does not show them, or the storyboard did "',
+        "            if True\n"
+        '            else "Either the demo does not show them, or the storyboard did "',
+        [
+            "CoverageMd."
+            "test_the_unclaimed_sentence_offers_the_third_reason_only_on_a_failure",
+            "CoverageMd.test_a_take_that_finished_renders_exactly_what_it_did_before",
+        ],
+    ),
+    (
+        # The count that would be inventing a finding: a clause claimed by a
+        # beat that *returned* on a take that later died elsewhere is as good
+        # as any other claim on that take, and #278 says so explicitly.
+        "the failure lead counts every clause, not the ones no beat returned on",
+        "timeline.py",
+        "    unreached = _kept_claims(criteria, claimed)",
+        "    unreached = list(criteria)",
+        [
+            "CoverageMd.test_the_lead_counts_the_clauses_no_returning_beat_claimed",
+            "CoverageMd.test_a_take_that_died_claiming_everything_says_that_instead",
+        ],
+    ),
+    (
+        # The wiring, which no injection above touches: `_coverage_md` can be
+        # perfect about a failure `render_timeline_md` never hands it.
+        "the timeline renderer stops telling the acceptance section it failed",
+        "timeline.py",
+        '    out += _coverage_md(doc.get("coverage"), failure)',
+        '    out += _coverage_md(doc.get("coverage"))',
+        ["TimelineMd.test_the_acceptance_section_is_told_the_take_failed"],
+    ),
+    (
+        # Same words, wrong cause. The two reasons this sentence has always
+        # given are a complete list on a take that finished and are both wrong
+        # on one that did not.
+        "the unclaimed sentence blames the storyboard on a take that crashed",
+        "timeline.py",
+        '            if isinstance(failure, dict)\n            else "Either the demo does not show them, or the storyboard did "',
+        '            if False\n            else "Either the demo does not show them, or the storyboard did "',
+        [
+            "CoverageMd."
+            "test_the_unclaimed_sentence_offers_the_third_reason_only_on_a_failure"
+        ],
     ),
     (
         "segments disagreeing about a criterion's wording are silently resolved",


### PR DESCRIPTION
Slice F of #272.

## What was wrong

`coverage_report` copied `index`, `segment`, `segment_index`, `t_start` and
`still` off each claiming beat and never `error`, and **every renderer
downstream reads the row rather than the beat**. So a
`shot("07-x", ac="AC-3")` whose screenshot raised produced

```
| **AC-3** — The CLI prints the same filtered list. | beat 17 | 31.80 | `images/07-x.png` |
```

— naming a still the take never wrote, above a beat table that correctly said
**raised**. A reviewer reading top-down met a satisfied criterion on a crashed
take, inside the one feature whose entire purpose is honesty about claims.

## What it renders now

`timeline.md`, on that same document:

```
## Acceptance criteria

**This take did not finish**, so the table below is the part of the ticket it got through and not the whole of it. It came out of the `with` block on a **TimeoutError**, at beat 17 (`shot`).

**2 of the 3 criteria have no claim from a beat that returned: `AC-2`, `AC-3`.** Each was either never tagged by this storyboard or sits after the beat the take died on, and this file cannot tell those apart — the beats that would say never ran.

This take was recorded against a ticket. **The table below is what the storyboard *claimed*, not what it proved** — …

| criterion | claimed by | at | still |
|---|---|---:|---|
| **AC-1** — The queue can be filtered to one status. | beat 4 | 4.00 | `images/01-filtered.png` |
| **AC-2** — A filter that matches nothing explains itself. | *nothing claims this* | | |
| **AC-3** — The CLI prints the same filtered list. | beat 17 **raised TimeoutError** | 17.00 | *not written* |

**1 of 3 criteria have no beat claiming them: `AC-2`.** Either the demo does not show them, the storyboard did not say where, or — on this take, which did not finish — it died before reaching them.
```

- The claimed row carries the raising beat's `error` (`type` and `message`),
  **absent otherwise** — the #24 rule, so an old timeline reads byte-for-byte
  as it always has.
- The still is withheld: `shot()` stamps the path on the beat *before* it takes
  the picture, so on a take that died there the path names a file nothing
  wrote. `*not written*` rather than blank, because blank is what a
  `caption(ac=)` claim renders as, and "nobody took a picture" is a different
  statement from "the picture this beat was taking was never written".
- The section leads with the failure, above the table, for the reason
  `render_timeline_md` puts `## This take did not finish` above the beat table.
- The unclaimed sentence gains the third reason it was missing.

The pull-request comment mirrors all of it, and **refuses the still by the
row's `error` rather than by whether the file is on disk**: `images/` is
committed, so on a take that died the previous recording's picture of that name
is sitting in the directory waiting to be linked as this beat's evidence. The
fixture that grades it stages exactly that file, and links it from the row
above, which returned.

```
**This take did not finish**, so what is below is the part of the ticket it got through and not the whole of it. It came out of the `with` block at beat 5 (`shot`).

**2 of the 4 clauses have no claim from a beat that returned: `AC-2` and `AC-4`.** …

| clause | claimed at | look at |
|---|---|---|
| **AC-1** — A search box above the queue narrows the list as you type. | beat 3 | [01-search-box.png](…/raw/<sha>/demos/x/images/01-search-box.png) |
| **AC-2** — Search and the status filter combine, and the heading agrees. | beat 5 (raised TimeoutError) | *the beat claiming this raised TimeoutError, so it wrote no still* |
```

**What it deliberately does not mark**, per #278: a clause claimed by a beat
that *returned* on a take that died later somewhere else. That claim is as good
as any other claim the take made, and marking it would be inventing a finding.

## Fault injection

Every assertion added here was watched failing. Both harnesses abort unless the
injection's search string matches **exactly once**.

- `tests/unit --fault-inject` — **All 280 injections were caught.**
- `tests/ci-unit --fault-inject` — **All 74 injections were caught.**

### One injection found a defect in an assertion I had read and believed

`TimelineMd.test_the_acceptance_section_is_told_the_take_failed` grades the
wiring: `render_timeline_md` must hand `_coverage_md` the document's `failure`.
Its first version searched the acceptance section for `"did not finish"` — and
with the **lead deleted** it stayed green, because the unclaimed sentence three
paragraphs lower carries the same phrase. It was grading a sentence it was not
written about:

```
FAIL  break: the acceptance section stops leading with the failure
      in timeline.py: if isinstance(failure, dict):…
      these tests did NOT fail: ['TimelineMd.test_the_acceptance_section_is_told_the_take_failed']
```

It now matches the lead from the start of a line, and that injection reddens
it. Reading the assertion did not find this; running it against broken code
did.

### `tests/unit` — the report and `timeline.md`

```
PASS  break: a claim does not record that the beat making it raised
      in coverage.py: error = beat.get("error")…
      ERROR: test_a_claim_from_a_beat_that_raised_carries_that_beats_error (__main__.Coverage.test_a_claim_from_a_beat_that_raised_carries_that_beats_error)
      ERROR: test_a_takes_error_is_copied_and_not_shared_with_the_beat (__main__.Coverage.test_a_takes_error_is_copied_and_not_shared_with_the_beat)

PASS  break: every claim carries an error key, present or not
      in coverage.py: row["error"] = {…
      FAIL: test_a_claim_carries_the_beat_that_made_it (__main__.Coverage.test_a_claim_carries_the_beat_that_made_it)
      FAIL: test_a_claim_from_a_beat_that_returned_carries_no_error_key (__main__.Coverage.test_a_claim_from_a_beat_that_returned_carries_no_error_key)

PASS  break: the claim shares the beat's error dict instead of copying it
      in coverage.py: row["error"] = {…
      FAIL: test_a_takes_error_is_copied_and_not_shared_with_the_beat (__main__.Coverage.test_a_takes_error_is_copied_and_not_shared_with_the_beat)

PASS  break: a claim records only the beat index, losing the frame it points at
      in coverage.py: "still": beat.get("still"),…
      FAIL: test_a_claim_carries_the_beat_that_made_it (__main__.Coverage.test_a_claim_carries_the_beat_that_made_it)

PASS  break: the acceptance table stops marking a claim whose beat raised
      in timeline.py: beat += f" **raised {_md_cell(error.get('type'))}**"…
      FAIL: test_a_row_whose_beat_raised_says_so_in_the_table (__main__.CoverageMd.test_a_row_whose_beat_raised_says_so_in_the_table)

PASS  break: a claim whose beat raised prints the still it never wrote
      in timeline.py: cell = "*not written*" if still else ""…
      FAIL: test_a_row_whose_beat_raised_does_not_read_as_a_row_with_no_still (__main__.CoverageMd.test_a_row_whose_beat_raised_does_not_read_as_a_row_with_no_still)
      FAIL: test_a_row_whose_beat_raised_names_no_still (__main__.CoverageMd.test_a_row_whose_beat_raised_names_no_still)
      FAIL: test_the_acceptance_section_is_told_the_take_failed (__main__.TimelineMd.test_the_acceptance_section_is_told_the_take_failed)

PASS  break: the acceptance section stops leading with the failure
      in timeline.py: if isinstance(failure, dict):…
      FAIL: test_a_failed_take_says_so_before_anything_it_claimed (__main__.CoverageMd.test_a_failed_take_says_so_before_anything_it_claimed)
      FAIL: test_a_take_that_died_claiming_everything_says_that_instead (__main__.CoverageMd.test_a_take_that_died_claiming_everything_says_that_instead)
      FAIL: test_the_lead_counts_the_clauses_no_returning_beat_claimed (__main__.CoverageMd.test_the_lead_counts_the_clauses_no_returning_beat_claimed)
      FAIL: test_the_acceptance_section_is_told_the_take_failed (__main__.TimelineMd.test_the_acceptance_section_is_told_the_take_failed)

PASS  break: the failure lead is printed on a take that did not fail
      in timeline.py: if isinstance(failure, dict):…
      FAIL: test_a_failed_take_says_so_before_anything_it_claimed (__main__.CoverageMd.test_a_failed_take_says_so_before_anything_it_claimed)
      FAIL: test_a_take_that_died_claiming_everything_says_that_instead (__main__.CoverageMd.test_a_take_that_died_claiming_everything_says_that_instead)
      FAIL: test_a_take_that_finished_renders_exactly_what_it_did_before (__main__.CoverageMd.test_a_take_that_finished_renders_exactly_what_it_did_before)
      FAIL: test_the_lead_counts_the_clauses_no_returning_beat_claimed (__main__.CoverageMd.test_the_lead_counts_the_clauses_no_returning_beat_claimed)

PASS  break: the failure lead counts every clause, not the ones no beat returned on
      in timeline.py: unreached = _kept_claims(criteria, claimed)…
      FAIL: test_a_take_that_died_claiming_everything_says_that_instead (__main__.CoverageMd.test_a_take_that_died_claiming_everything_says_that_instead)
      FAIL: test_the_lead_counts_the_clauses_no_returning_beat_claimed (__main__.CoverageMd.test_the_lead_counts_the_clauses_no_returning_beat_claimed)

PASS  break: the unclaimed sentence blames the storyboard on a take that crashed
      in timeline.py: if isinstance(failure, dict)…
      FAIL: test_the_unclaimed_sentence_offers_the_third_reason_only_on_a_failure (__main__.CoverageMd.test_the_unclaimed_sentence_offers_the_third_reason_only_on_a_failure)

PASS  break: the unclaimed sentence blames the crash on a take that finished
      in timeline.py: if isinstance(failure, dict)…
      FAIL: test_a_take_that_finished_renders_exactly_what_it_did_before (__main__.CoverageMd.test_a_take_that_finished_renders_exactly_what_it_did_before)
      FAIL: test_the_unclaimed_sentence_offers_the_third_reason_only_on_a_failure (__main__.CoverageMd.test_the_unclaimed_sentence_offers_the_third_reason_only_on_a_failure)

PASS  break: the timeline renderer stops telling the acceptance section it failed
      in timeline.py: out += _coverage_md(doc.get("coverage"), failure)…
      FAIL: test_the_acceptance_section_is_told_the_take_failed (__main__.TimelineMd.test_the_acceptance_section_is_told_the_take_failed)
```

The last four are the pairs that matter. Two conditions are broken in **both**
directions — the lead and the third-reason sentence, each `if False` and each
`if True` — because #24's rule has two sides and only the "present when it
should be" side is ever tested by accident. The `if True` breaks are the only
thing in the suite that watches an ordinary take stay ordinary.

### `tests/ci-unit` — the pull-request comment

```
PASS  break: the coverage section is not told the take failed
      in demo-comment: failure=failure,…
      FAIL: test_a_failed_take_says_so_before_anything_it_claimed (__main__.Coverage.test_a_failed_take_says_so_before_anything_it_claimed)
      FAIL: test_a_take_that_died_claiming_everything_prints_no_count (__main__.Coverage.test_a_take_that_died_claiming_everything_prints_no_count)
      FAIL: test_the_lead_counts_the_clauses_no_returning_beat_claimed (__main__.Coverage.test_the_lead_counts_the_clauses_no_returning_beat_claimed)

PASS  break: a claim whose beat raised is labelled like one that returned
      in demo-comment: part += f" (raised {_cell(str(error.get('type') or 'an exception'))})"…
      FAIL: test_a_clause_claimed_by_a_beat_that_raised_says_so_in_its_row (__main__.Coverage.test_a_clause_claimed_by_a_beat_that_raised_says_so_in_its_row)

PASS  break: a still is linked for a beat that raised, because the file exists
      in demo-comment: error = row.get("error")…
      FAIL: test_a_still_a_beat_that_raised_would_have_written_is_not_linked (__main__.Coverage.test_a_still_a_beat_that_raised_would_have_written_is_not_linked)

PASS  break: the acceptance section stops leading with the failure
      in demo-comment: if isinstance(failure, dict):…
      FAIL: test_a_failed_take_says_so_before_anything_it_claimed (__main__.Coverage.test_a_failed_take_says_so_before_anything_it_claimed)
      FAIL: test_a_take_that_died_claiming_everything_prints_no_count (__main__.Coverage.test_a_take_that_died_claiming_everything_prints_no_count)
      FAIL: test_the_lead_counts_the_clauses_no_returning_beat_claimed (__main__.Coverage.test_the_lead_counts_the_clauses_no_returning_beat_claimed)

PASS  break: the failure lead counts every clause, not the ones no beat returned on
      in demo-comment: unreached = […
      FAIL: test_a_take_that_died_claiming_everything_prints_no_count (__main__.Coverage.test_a_take_that_died_claiming_everything_prints_no_count)
      FAIL: test_the_lead_counts_the_clauses_no_returning_beat_claimed (__main__.Coverage.test_the_lead_counts_the_clauses_no_returning_beat_claimed)

PASS  break: render_demo stops rendering the coverage section
      in demo-comment: lines += render_coverage(…
      FAIL: test_a_staged_still_is_linked_from_the_command_line_end_to_end (__main__.CommentCli.test_a_staged_still_is_linked_from_the_command_line_end_to_end)
      FAIL: test_the_repository_url_defaults_to_what_every_actions_step_is_given (__main__.CommentCli.test_the_repository_url_defaults_to_what_every_actions_step_is_given)
      FAIL: test_a_claim_from_a_named_segment_says_which_segment (__main__.Coverage.test_a_claim_from_a_named_segment_says_which_segment)
      FAIL: test_a_claimed_clause_names_its_own_beats_and_not_another_clauses (__main__.Coverage.test_a_claimed_clause_names_its_own_beats_and_not_another_clauses)
```

*a still is linked for a beat that raised, because the file exists* is the one
worth pausing on. Its fixture stages `images/01-search-box.png` on disk and
claims it from a beat that **raised**, so the pre-#278 renderer finds the file
and links it — last week's picture as this beat's evidence, and the row above
links the same file from a beat that returned, so a renderer that simply
stopped linking satisfies neither.

### An assertion written and then deleted

*The raised row is still four cells wide* was written, then deleted rather than
kept: every break that widens that row is caught one assertion earlier by the
equality on the row's fourth cell, which indexes it and would read the wrong
one or raise. That is the catalogue's *dominated assertion*, and a check that
cannot fire for the reason it claims is worse than no check. Recorded in
`tests/README.md` beside the table of what is graded.

## Stated limits

- **`timeline.md`'s `## Stills` gallery still embeds a raised `shot`'s
  picture.** `timeline.py:1376` selects it off `beats` alone —
  `stills = [b for b in beats if b.get("still")]` — so the same file whose
  acceptance table now says *not written* renders `![02](images/02.png)`
  twenty lines lower. Filed as **#305** with the reproduction. It is a
  different renderer, reading `beats` rather than `coverage`, and outside
  #278's scope; the wiring test asserts the path is absent from the
  **acceptance section** and names the issue that owns the rest.
- **`unillustrated` still names a clause claimed only by a raised beat.** In
  the comment such a clause is named both by the failure lead and by "*no still
  was published for it, so there is nothing here to open*". Both are true, and
  the row itself says which beat raised — the wrong-cause problem #278 raises
  about the *unclaimed* sentence does not apply here, because "no still was
  published" is exactly what happened.
- **The "N have a beat that claims them" count is unchanged.** It counts a
  clause claimed only by a raised beat as claimed, which is literally true — a
  beat did tag it — and the lead above it states how many have no claim from a
  beat that returned. Changing that count would change the clean-take rendering
  and is not in #278's *What to build*.
- **No retry, no partial re-record, no salvage**, and slice E's `no_video` case
  is untouched — both per #278's *What this deliberately leaves out*.
- **Nothing here grades whether a tagged beat's frames show its criterion.**
  Unchanged by this slice and stated in `tests/README.md`; the artifact still
  says `claimed`, never `demonstrated`, and the comment's verdict sweep now
  runs over the two crashed-take fixtures as well.

## Checks run

`tests/unit`, `tests/unit --fault-inject`, `tests/ci-unit`,
`tests/ci-unit --fault-inject`, `tests/lint` — all green. `tests/smoke` is
untouched: its coverage take is a clean take, and #278 records that the crash
path is already exercised end to end there, so the pure half needs no browser.

No demo video. By CLAUDE.md's test this is artifact integrity — verifiable by
reading a rendering, not by watching one.

Fixes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
