### PR TITLE
The manifest names the ticket its clauses were copied out of (#275)

### DIFF
--- a/.github/scripts/demo-comment
+++ b/.github/scripts/demo-comment
@@ -28,7 +28,10 @@ claimed clause pointed at the committed still a reviewer can open (issue #274),
 and on a take that died, that fact ahead of all of them (issue #278). It is a
 rendering of `timeline.json`'s `coverage` and it grades nothing — see
 `render_coverage`. It also states, in `DIFF_LIMIT`, the one question watching
-the take answers and the many it does not (issue #303).
+the take answers and the many it does not (issue #303). The take's own line
+says **which** ticket those clauses were copied out of, linked when the string
+can be turned into a URL without guessing (issue #275); nothing here reads
+that ticket.
 
 The body opens with an HTML marker so the workflow can find and rewrite this
 comment rather than appending a new one on every push.
@@ -39,6 +42,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 from pathlib import Path
 from typing import NamedTuple
 from urllib.parse import quote
@@ -103,6 +107,53 @@ def _and_list(items: list[str]) -> str:
     if len(items) < 3:
         return " and ".join(items)
     return ", ".join(items[:-1]) + " and " + items[-1]
+
+
+#: `owner/repo#N`, the one ticket spelling that can be turned into a URL
+#: without guessing a host. Deliberately narrow: the string is free text a
+#: storyboard author typed, it is pasted into a link below, and anything this
+#: does not recognise is printed rather than linked.
+_TICKET_REF = re.compile(r"^([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)#([0-9]+)$")
+
+#: A URL safe to put in a markdown link target: http(s) only, and none of the
+#: characters that would end the target early or turn it into something else.
+_TICKET_URL = re.compile(r"^https?://[^\s<>()\[\]`\"']+$")
+
+
+def ticket_link(ticket: object) -> str | None:
+    """The ticket a take names, as one clickable thing — or as plain text.
+
+    `owner/repo#N` is linked at github.com and a URL is linked as itself.
+    Anything else is printed **verbatim**, in code, because a private
+    tracker's id is not this script's business to have opinions about and a
+    guessed link is worse than a name: it resolves somewhere, and a reviewer
+    who follows it reads the wrong requirement.
+
+    None when the timeline names no ticket, which is the ordinary take.
+    """
+    if not isinstance(ticket, str) or not ticket.strip():
+        return None
+    text = " ".join(ticket.split())
+    ref = _TICKET_REF.match(text)
+    if ref:
+        where = f"https://github.com/{ref.group(1)}/issues/{ref.group(2)}"
+        return f"[{_cell(text)}]({where})"
+    if _TICKET_URL.match(text):
+        return f"[{_cell(text)}]({text})"
+    return f"`{_cell(text)}`"
+
+
+def ticket_refs(timeline: dict) -> list[str]:
+    """Every ticket this timeline names, rendered. Usually one, sometimes none.
+
+    More than one only on a stitched demo whose segments disagree, which
+    `stitch()` records as `ticket_conflicts` and refuses to resolve. This
+    prints all of them for the same reason: the reviewer decides which of two
+    tickets a demo is about, not this script.
+    """
+    conflicts = timeline.get("ticket_conflicts")
+    named = conflicts if isinstance(conflicts, list) else [timeline.get("ticket")]
+    return [link for link in (ticket_link(t) for t in named) if link]
 
 
 def _claim_label(rows: list[dict]) -> str:
@@ -475,9 +526,20 @@ def render_demo(
     status = " — **the take did not finish**" if failure else ""
     lines.append(f"### `{name}`{status}")
     lines.append("")
-    lines.append(
-        f"{len(rows)} beats · {_duration(timeline)} · recorded by `{timeline.get('recorder', '?')}`"
+    meta = (
+        f"{len(rows)} beats · {_duration(timeline)} · recorded by "
+        f"`{timeline.get('recorder', '?')}`"
     )
+    # Where a reviewer can go and read the requirement, on the line that says
+    # what this take is (issue #275). Not inside the acceptance section: that
+    # section leads with the gap, and it is not rendered at all for a take that
+    # named a ticket without declaring clauses.
+    refs = ticket_refs(timeline)
+    if len(refs) == 1:
+        meta += f" · against {refs[0]}"
+    elif refs:
+        meta += f" · **its segments name different tickets**: {_and_list(refs)}"
+    lines.append(meta)
     lines.append("")
 
     # Above the beat table, because on a take recorded against a ticket it is

--- a/examples/ticket-queue/demos/2026-07-28-queue-search/record.py
+++ b/examples/ticket-queue/demos/2026-07-28-queue-search/record.py
@@ -11,7 +11,9 @@ Run the app first:
 
 The storyboard is written from ticket #129 and declares its four acceptance
 criteria on the recorder, so `timeline.md` carries a coverage table naming the
-beat and the still that claims each one.
+beat and the still that claims each one. It names the ticket to the recorder
+too — `ticket=TICKET` below — so the manifest says where those four sentences
+were copied from instead of leaving it here in prose nothing can read.
 
 The `wait_for()` calls are assertions, not decoration: `.ticket` after typing
 `invoice` fails the take if the search left nothing listed, and `.queue-empty`
@@ -38,6 +40,10 @@ from demo_recording import Recorder  # noqa: E402
 
 BASE_URL = os.environ.get("TICKET_QUEUE_URL", "http://127.0.0.1:8901")
 SEARCH = "#queue-search"
+# The ticket the four clauses below are quoted from. Written down, never
+# fetched: re-running this file has to produce the same manifest in six months,
+# whatever has happened to the issue since.
+TICKET = "rogvid/skills#129"
 
 CRITERIA = {
     "AC-1": (
@@ -66,7 +72,7 @@ def clear_search(rec):
     rec.page.keyboard.press("Backspace")
 
 
-with Recorder(HERE, base_url=BASE_URL, criteria=CRITERIA) as rec:
+with Recorder(HERE, base_url=BASE_URL, criteria=CRITERIA, ticket=TICKET) as rec:
     rec.goto("/")
     rec.wait_for(".ticket")
 

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -245,9 +245,9 @@ three it is not the variable lowercased, so do not infer it:
 
 `DEMO_VIDEO_BASE_URL` applies to the web `Recorder` only; the terminal
 `*` variables to `TerminalRecorder`. All the rest apply to both. The
-parameters with **no** env var are per-storyboard by nature: `segment`
-and `criteria` on both recorders, plus `TerminalRecorder`'s `interlude`,
-`interlude_hold` and `type_delay_ms`.
+parameters with **no** env var are per-storyboard by nature: `segment`,
+`criteria` and `ticket` on both recorders, plus `TerminalRecorder`'s
+`interlude`, `interlude_hold` and `type_delay_ms`.
 
 ## Recorder API (storyboard verbs)
 

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -48,7 +48,13 @@ from .content import (
     overlay_warning,
     print_content_summary,
 )
-from .coverage import _ac_field, _checked_criteria, coverage_report
+from .coverage import (
+    _ac_field,
+    _checked_criteria,
+    _checked_ticket,
+    _ticket_field,
+    coverage_report,
+)
 from .failure import (
     FAILURE_DIR,
     FAILURE_MARKER,
@@ -1005,6 +1011,7 @@ class _DemoBase:
         locale: str | None = None,
         evidence: bool | None = None,
         criteria: dict[str, str] | None = None,
+        ticket: str | None = None,
         allow_private: bool | None = None,
     ) -> None:
         # Every setting resolves explicit parameter > DEMO_VIDEO_* env var
@@ -1043,6 +1050,10 @@ class _DemoBase:
         # the criteria **nothing** claimed — and that is underivable from the
         # tags alone. Absent here, `coverage` is null and `ac=` is refused.
         self._criteria = _checked_criteria(criteria)
+        # Which ticket those clauses were copied out of (issue #275), as the
+        # author wrote it. Stored and written down; never fetched, never
+        # resolved — see `coverage.py`.
+        self._ticket = _checked_ticket(ticket)
         self.images_dir = self.out_dir / "images"
         self._video_dir = self.out_dir / ".video"
         if accent_rgb is None:
@@ -2396,6 +2407,11 @@ take with fewer beats than the last one would otherwise leave the
             "generated_by": "demo-video",
             "recorder": type(self).__name__,
             "segment": self.segment,
+            # The ticket this take was recorded against, exactly as the
+            # storyboard wrote it (issue #275). Absent on a take recorded
+            # outside one, so a timeline written before this key existed reads
+            # as it always did. Nothing here fetched or resolved it.
+            **_ticket_field(self._ticket),
             "media": mp4.name,
             "duration": duration,
             # Which clock produced this take. Without it a still committed to a

--- a/skills/demo-video/helpers/demo_recording/coverage.py
+++ b/skills/demo-video/helpers/demo_recording/coverage.py
@@ -1,4 +1,5 @@
-"""Acceptance criteria, and what a storyboard claimed against them.
+"""Acceptance criteria, what a storyboard claimed against them, and whose
+ticket they were copied out of.
 
 A pure function of the declared criteria and the beat list, so a stitched demo
 merges the same way a single take builds it, and a consumer can re-run the
@@ -81,6 +82,86 @@ def _checked_criteria(criteria: dict[str, str] | None) -> dict[str, str]:
             )
         checked[key] = text.strip()
     return checked
+
+
+# -- the ticket the clauses came out of (issue #275) --------------------------
+#
+# `criteria={...}` declares four sentences and, until this existed, nothing
+# anywhere recorded which ticket they were copied out of — in the reference
+# storyboard it lived in a Python docstring. A manifest that quotes four
+# clauses but cannot name their source cannot be checked against that source by
+# anything, and a reviewer cannot click through from the demo to the
+# requirement.
+#
+# **Never fetched and never resolved.** The recorder refuses a public target at
+# construction, before a browser opens; a call to a tracker inside a take is
+# exactly the coupling that machinery exists to avoid. It would also put a
+# network dependency and a credential inside a take, and make re-running a
+# committed storyboard produce a *different* manifest whenever somebody edited
+# the issue — the artifact would stop being a function of the file in git.
+# Whether the quoted clauses actually appear in the named ticket is a separate,
+# non-fatal step with a network and a token, and it is not this file's.
+
+
+def _checked_ticket(ticket: str | None) -> str | None:
+    """The ticket this take was recorded against, or None when there is none.
+
+    Checked for exactly one thing: that it is a non-empty string. A private
+    tracker's id is not this recorder's business to have opinions about, and a
+    shape rule here would refuse takes rather than catch mistakes — the
+    consumers that *can* use a shape (linking `owner/repo#N`) try it and print
+    the string verbatim when it does not fit.
+    """
+    if ticket is None:
+        return None
+    if not isinstance(ticket, str):
+        raise TypeError(
+            f"ticket must be a string — the ticket this take demonstrates, as "
+            f"you write it ('rogvid/skills#129', or a URL) — got "
+            f"{type(ticket).__name__}"
+        )
+    stripped = ticket.strip()
+    if not stripped:
+        raise ValueError(
+            "ticket is empty. Name the ticket this take was recorded against, "
+            "or leave the parameter off — a blank string is a take that "
+            "claims to have a source and cannot say what it is."
+        )
+    return stripped
+
+
+def _ticket_field(ticket: object) -> dict:
+    """`{"ticket": ...}` when there is one, `{}` when there is not.
+
+    Absent-rather-than-null for the reason `error` is absent on a beat that
+    returned (issue #24): a take recorded before this key existed then reads
+    exactly like a take recorded outside a ticket, which is what it is.
+    """
+    return {"ticket": ticket} if ticket else {}
+
+
+def _merged_ticket_fields(docs: list[dict]) -> dict:
+    """What a stitched demo says about the ticket(s) its segments named.
+
+    Every distinct ticket, in the order the segments named them. One of them —
+    including the case where only some segments named one, since silence is not
+    disagreement — is the merged demo's `ticket`.
+
+    Two or more is a **conflict**, and it is named rather than resolved, the
+    same treatment `coverage.conflicts` gives segments that disagree about a
+    clause's wording. `ticket` is then absent: a merged demo half of which
+    demonstrates another ticket has no single honest answer, and writing one of
+    them there would be the artifact stating something no segment said.
+    """
+    named: list[str] = []
+    for doc in docs:
+        ticket = doc.get("ticket")
+        if isinstance(ticket, str) and ticket.strip():
+            if ticket.strip() not in named:
+                named.append(ticket.strip())
+    if len(named) > 1:
+        return {"ticket_conflicts": named}
+    return _ticket_field(named[0] if named else None)
 
 
 def _ac_field(claims: list[str]) -> dict:

--- a/skills/demo-video/helpers/demo_recording/stitching.py
+++ b/skills/demo-video/helpers/demo_recording/stitching.py
@@ -14,7 +14,7 @@ import subprocess
 from pathlib import Path
 
 from .content import _common, media_duration, merge_content, print_content_summary
-from .coverage import _merged_coverage
+from .coverage import _merged_coverage, _merged_ticket_fields, _ticket_field
 from .frames import write_beat_frames
 from .timeline import (
     MAX_ISSUES,
@@ -505,6 +505,11 @@ def _merged_timeline(
                 "duration": duration,
                 "offset": round(offset, 3),
                 "beats": len(doc.get("beats") or []),
+                # This part's own ticket, absent when it named none — so a
+                # merged demo whose parts disagree can be read back to the
+                # segment that said each thing, rather than only to the list of
+                # what was said (issue #275).
+                **_ticket_field(doc.get("ticket")),
                 "recorder": doc.get("recorder"),
                 "determinism": doc.get("determinism"),
                 # Carried through rather than recomputed: the segment measured
@@ -535,6 +540,12 @@ def _merged_timeline(
         "generated_by": "demo-video",
         "recorder": _common([r["recorder"] for r in records], "mixed"),
         "segment": None,  # this document is the whole demo, not a part of one
+        # The ticket the parts were recorded against, when they agree on one.
+        # When they do not, `ticket_conflicts` names every one of them and
+        # `ticket` is absent — named rather than resolved, the treatment
+        # `coverage.conflicts` already gives a disagreement about wording
+        # (issue #275).
+        **_merged_ticket_fields(docs),
         "media": demo.name,
         "duration": total,
         "determinism": _merge_determinism([r["determinism"] for r in records]),

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -289,6 +289,7 @@ class TerminalRecorder(_DemoBase):
         locale: str | None = None,
         evidence: bool | None = None,
         criteria: dict[str, str] | None = None,
+        ticket: str | None = None,
         allow_private: bool | None = None,
         type_delay_ms: int = 45,
         interlude: str | None = None,
@@ -304,7 +305,7 @@ class TerminalRecorder(_DemoBase):
             speech_model=speech_model, strict=strict,
             deterministic=deterministic, clock=clock,
             timezone_id=timezone_id, locale=locale, evidence=evidence,
-            criteria=criteria, allow_private=allow_private,
+            criteria=criteria, ticket=ticket, allow_private=allow_private,
         )
         # Match the web recorder's effective caption height. Web composites
         # its page into a scaled, centered window, lifting its bottom:44px

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -40,6 +40,28 @@ from .markdown import _fmt_t, _md_cell
 #   recorder      str    — "Recorder" | "TerminalRecorder" (which medium), or
 #                          "mixed" on a merged demo whose segments differ
 #   segment       str?   — the segment name, or null for a whole demo
+#   ticket        str?   — the ticket this take was recorded against, as its
+#                          author wrote it ("rogvid/skills#129", or a URL).
+#                          **Absent** on a take recorded outside a ticket, so a
+#                          timeline written before this key existed reads as it
+#                          always did (issue #24's rule). **Never fetched and
+#                          never resolved by the recorder** — see `coverage.py`
+#                          for why a call to a tracker inside a take is the one
+#                          thing this must not become. Nothing in this document
+#                          has compared the `coverage.criteria` below with what
+#                          that ticket says; a take can name any ticket.
+#                          On a merged demo (`stitch`) it is the ticket every
+#                          part that named one agreed on, and is absent when
+#                          they disagreed — see `ticket_conflicts`.
+#   ticket_conflicts
+#                 list?  — merged demos only, and **absent unless the segments
+#                          named different tickets**: every distinct ticket
+#                          they named, in order. `ticket` is absent whenever
+#                          this is present, because a demo half of which
+#                          demonstrates another ticket has no single honest
+#                          answer and picking one would be this document
+#                          stating something no segment said. Each part's own
+#                          is in `segments` either way.
 #   media         str    — the mp4 this timeline describes, e.g. "demo.mp4"
 #   duration      float? — that mp4's real duration (ffprobe), null if absent
 #   determinism   dict   — the conditions the take was recorded under:
@@ -131,7 +153,8 @@ from .markdown import _fmt_t, _md_cell
 #                          (ffprobe), `offset` (where it starts in `media`),
 #                          `beats`, `recorder`, `determinism`, `content`,
 #                          `narration` and that part's own `capture_clock`,
-#                          the last two on its own clock.
+#                          the last two on its own clock; plus that part's own
+#                          `ticket`, absent when it named none.
 #                          Absent from a timeline a single take wrote.
 #   content       dict?  — what the *picture* turned out to be, measured off
 #                          the encoded mp4 over the region the app occupies:
@@ -1085,6 +1108,39 @@ def _coverage_failure_md(failure: dict, criteria: dict, claimed: dict) -> list[s
     return out
 
 
+def _ticket_md(doc: dict) -> list[str]:
+    """Which ticket this take was recorded against (issue #275), or nothing.
+
+    Rendered whether or not the take declared `criteria=`, and immediately
+    above the coverage table when there is one: the clauses in that table are
+    quoted from *this* ticket, and a reader who has to take the storyboard's
+    word for where four sentences came from cannot check them against anything.
+
+    It says the recorder never fetched it, because that is the load-bearing
+    half. The sentence "recorded against #129" invites a reader to assume
+    something compared the two, and nothing here has.
+    """
+    conflicts = doc.get("ticket_conflicts")
+    if isinstance(conflicts, list) and conflicts:
+        return [
+            f"**The segments name different tickets: "
+            f"{', '.join(f'`{_md_cell(str(t))}`' for t in conflicts)}.** All of "
+            f"them are listed rather than one of them chosen — a demo half of "
+            f"which was recorded against another ticket has no single answer. "
+            f"Each part's own is in its `segments` record.",
+            "",
+        ]
+    ticket = doc.get("ticket")
+    if not isinstance(ticket, str) or not ticket.strip():
+        return []
+    return [
+        f"Recorded against **{_md_cell(ticket)}**, as the storyboard names it. "
+        f"The recorder never fetched it: nothing here has compared anything in "
+        f"this file with what that ticket says.",
+        "",
+    ]
+
+
 def _coverage_md(coverage: object, failure: object = None) -> list[str]:
     """The acceptance-criteria section of timeline.md, or nothing (issue #12).
 
@@ -1278,6 +1334,12 @@ def render_timeline_md(doc: dict) -> str:
     # when the take was recorded against a ticket — and because a reviewer who
     # scrolls past 28 beats first has already formed the impression the
     # coverage report exists to test (issue #12).
+    #
+    # The ticket first, because the clauses in the table are quoted from it and
+    # a reader who meets four sentences before their source has already read
+    # them as the ticket's own words (issue #275). It sits above the section's
+    # own heading, so the section still opens on the failure below.
+    out += _ticket_md(doc)
     # The failure goes in with it, not only into the section above: without it
     # the acceptance table renders a crashed take's claims exactly like a clean
     # take's, which is the artifact reporting success on failure (issue #278).

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -492,6 +492,7 @@ class Recorder(_DemoBase):
         locale: str | None = None,
         evidence: bool | None = None,
         criteria: dict[str, str] | None = None,
+        ticket: str | None = None,
         allow_private: bool | None = None,
     ) -> None:
         super().__init__(
@@ -501,7 +502,7 @@ class Recorder(_DemoBase):
             speech_model=speech_model, strict=strict,
             deterministic=deterministic, clock=clock,
             timezone_id=timezone_id, locale=locale, evidence=evidence,
-            criteria=criteria, allow_private=allow_private,
+            criteria=criteria, ticket=ticket, allow_private=allow_private,
         )
         self.base_url = (
             base_url or _env("BASE_URL", "http://localhost:8000")

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -271,10 +271,11 @@ review in step 6 answers *"is this story clear?"*; a review gate has to answer
 *"does this show what the ticket asked for?"*, which is a different question
 with a different answer.
 
-Declare the criteria on the recorder and tag the beats that demonstrate them:
+Declare the criteria on the recorder, name the ticket they came out of, and tag
+the beats that demonstrate them:
 
 ```python
-with Recorder(OUT, criteria={
+with Recorder(OUT, ticket="rogvid/skills#129", criteria={
     "AC-1": "The queue can be filtered to one status.",
     "AC-2": "A filter that matches nothing explains itself.",
     "AC-3": "The CLI prints the same filtered list.",
@@ -287,9 +288,13 @@ with Recorder(OUT, criteria={
 ```
 
 `timeline.md` then carries a table above the beats, and `timeline.json` a
-`coverage` object:
+`coverage` object, with the ticket named above both:
 
 ```
+Recorded against **rogvid/skills#129**, as the storyboard names it. The
+recorder never fetched it: nothing here has compared anything in this file
+with what that ticket says.
+
 | criterion                                   | claimed by | at   | still                 |
 | **AC-1** — The queue can be filtered…       | beat 1     | 3.20 |                       |
 |                                             | beat 2     | 5.46 | `images/01-filtered…` |
@@ -325,6 +330,33 @@ re-record after a crash the *previous* take's file of that name is already on
 disk, and the embed puts a real photograph under this take's heading, this
 take's timestamp and this take's caption. The beat table is where that beat
 still appears, marked **raised**.
+
+### Name the ticket: `ticket=`
+
+`criteria={...}` quotes four sentences; `ticket=` is what says whose they are.
+Without it the source lives in a comment or a docstring, nothing machine-readable
+knows it, and a manifest quoting four clauses cannot be checked against the
+ticket they were copied from by anything — nor can a reviewer click through from
+the demo to the requirement.
+
+- **A free string**, checked only for being non-empty. `"rogvid/skills#129"`, a
+  URL, `"JIRA-4412"` — a private tracker's id is not this recorder's business to
+  have opinions about. The pull-request comment links `owner/repo#N` and URLs,
+  and prints anything else verbatim rather than guessing a link that would
+  resolve somewhere wrong.
+- **Never fetched and never resolved.** The recorder refuses a public target
+  before a browser opens; a call to a tracker inside a take is exactly the
+  coupling that machinery exists to avoid, and it would make re-running a
+  committed storyboard produce a *different* manifest whenever somebody edited
+  the issue. The artifact stays a function of the file in git.
+- **It lands in `timeline.json` as `ticket`**, absent on a take recorded outside
+  one, and `timeline.md` names it above the coverage table.
+- **`stitch()` carries it, and reports a conflict rather than choosing.**
+  Segments naming different tickets produce `ticket_conflicts` listing all of
+  them and *no* `ticket` — the same treatment a disagreement about a clause's
+  wording gets.
+- **Nothing has compared the clauses with the ticket.** Naming it makes that
+  check possible; it is not that check, and no artifact here implies otherwise.
 
 ### Put the clause on screen: `criterion()`
 

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -352,6 +352,13 @@ at the top level carry the value every segment agrees on — `"mixed"`, and
 `null` per key, where they do not; the per-segment truth is in `segments`. A
 timeline a single take wrote has no `segments` key at all.
 
+`ticket` is the exception to that pattern, and deliberately: parts that agree
+carry it at the top level, and parts that **disagree** produce
+`ticket_conflicts` naming every one of them with no top-level `ticket` at all.
+A demo half of which demonstrates another ticket has no single honest answer,
+so this one is named rather than resolved — the treatment a disagreement about
+a clause's wording already gets ([review.md](review.md)).
+
 `stitch()` refuses before it encodes anything if the parts cannot honestly be
 joined: a missing or unreadable `.seg.mp4`, a beat log of the wrong schema or
 one written for a *different recording* of that segment, or parts that

--- a/tests/README.md
+++ b/tests/README.md
@@ -1630,6 +1630,57 @@ refuses the word `clause` anywhere in that body, and which is therefore also
 what would redden if the sentence were later printed unconditionally without
 being reworded.
 
+**Which ticket the clauses were copied out of**
+([#275](https://github.com/rogvid/skills/issues/275)). `criteria={...}` quotes
+four sentences and, until #275, nothing machine-readable said whose they were —
+in the reference storyboard the ticket lived in a Python docstring. `ticket=` is
+a free string, stored and written into the envelope, and the shape of what is
+graded follows from what it is *not*: it is never fetched and never resolved, so
+no assertion anywhere compares a clause with the ticket it names.
+
+| grader | what it grades |
+|---|---|
+| `tests/unit`'s `CheckedTicket` | the one rule: a non-empty string, stripped. Its control is that three unrelated spellings — `owner/repo#N`, a URL, a bare tracker id — all pass, without which the two refusals hold over a function that refuses everything |
+| `tests/unit`'s `BeatLog` | the envelope carries the string the storyboard handed it, **by equality**, **on each recorder separately**, and a take recorded outside a ticket carries no `ticket` key at all (#24's rule, and the control on the equality) |
+| `tests/unit`'s `MergedTicket` | driven through `_merged_timeline`, not through the merge helper: parts agreeing carry the ticket, parts **disagreeing produce `ticket_conflicts` naming both and no `ticket`**, a silent part is not a disagreement, and each part keeps its own |
+| `tests/unit`'s `TicketMd` | `timeline.md` names it, names it **above** the clauses quoted from it, says nothing compared the two, and says nothing at all on a take that named none |
+| `tests/ci-unit`'s `Ticket` | the comment links `owner/repo#N` and a URL **by equality on the whole rendering**, prints anything else verbatim, and refuses a target that markdown would not survive — `timeline.json` is committed and a pull request may edit it |
+
+The ordering claim has an injection of its own that reorders the two renderings
+and changes nothing else, because every presence assertion above passes on a
+`timeline.md` that names the ticket underneath the four sentences it sourced.
+The comment's ticket line is swept for verdict words on `TICKETED`, with an
+injection that appends *verified* **after** the link — so the assertion about
+the link's own text stays green and the sweep is the only thing that can see it.
+
+**Two of these were added because a hand review broke what the manifest did
+not.** Both were the same shape — *one of a pair is graded and its twin is
+not* — and both are worth stating because the shape recurs:
+
+- **The parameter is forwarded by hand from each recorder** ([#313](https://github.com/rogvid/skills/issues/313)).
+  `ticket=` is declared on `_DemoBase`, so `Recorder` and `TerminalRecorder`
+  each pass it up separately and there are two things to break. The first
+  version of this suite read the envelope of the web recorder only; deleting
+  `ticket=ticket` from the terminal one left all 427 tests green. There is now
+  an assertion per recorder and **an injection per recorder**, the second of
+  which exists only because the honest answer to "is the twin graded?" is a
+  measurement rather than an assurance.
+- **`_ticket_md` escapes in two branches** ([#315](https://github.com/rogvid/skills/issues/315)).
+  A single ticket and a merged demo's conflicting ones are rendered by
+  different lines, and the pipe check read one of them. The escaping rule was
+  reported as held across text half of which nothing opened. The check now
+  loops over both branches and asserts the raw form is **absent** as well as
+  the escaped form present, and each branch has its own injection.
+
+**What none of it grades, and cannot:** that the ticket exists, that it is
+readable, or that the clauses appear in it. That needs a network and a token,
+it is [#276](https://github.com/rogvid/skills/issues/276), and it belongs in CI
+rather than in a take. Nor does anything grade that the recorder *did not*
+fetch: the assertion is that the envelope holds the constructor's own string,
+which a recorder that fetched and got the same answer would satisfy too. What
+stands behind that is the code — nothing in `coverage.py` or `core.py` opens a
+connection — and not a measurement.
+
 The injections that cover the acceptance section are enumerated in `ci-unit`'s
 `INJECTIONS`, and the number they add up to is deliberately not written here:
 it went stale the first time somebody added one, which is

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -817,6 +817,11 @@ COVERAGE = {
 }
 TAGGED = dict(TIMELINE, coverage=COVERAGE)
 
+# The same take, saying which ticket those four clauses were copied out of
+# (#275). A line that points at a requirement is exactly where a sentence
+# claiming the two were compared is tempting, so it is swept like every other.
+TICKETED = dict(TAGGED, ticket="rogvid/skills#129")
+
 # Every clause claimed. Same criteria, so the two documents differ in exactly
 # the thing the headline is a statement about. No claim carries a still, so
 # every clause is also one a reviewer has nothing to open for (#274).
@@ -1606,6 +1611,12 @@ class Coverage(unittest.TestCase):
         for fixture in (RAISED, RAISED_NOWHERE):
             self.assert_no_verdict(self.body(fixture), fixture)
 
+    def test_naming_the_ticket_promotes_no_claim_to_a_verdict(self):
+        # The branch #275 adds, swept where the helpers for it live. "verified
+        # against rogvid/skills#129" is the sentence this refuses, and nothing
+        # in the comment has read that ticket.
+        self.assert_no_verdict(self.body(TICKETED), TICKETED)
+
     def test_a_claim_from_a_named_segment_says_which_segment(self):
         # A stitched demo renumbers beats, so "beat 6" alone points at the
         # wrong picture when the reader goes back to a segment's own timeline.
@@ -1617,6 +1628,99 @@ class Coverage(unittest.TestCase):
             },
         )
         self.assertEqual(self.cell(self.body(stitched), "AC-1"), "beat 6 (`part2`)")
+
+
+class Ticket(unittest.TestCase):
+    """Which ticket the clauses were copied out of, in the comment (#275).
+
+    **What none of this grades:** whether the ticket exists, whether it is
+    readable, or whether the clauses above it appear in it. Nothing in this
+    script opens a network connection, and the comment says so rather than
+    letting the link imply otherwise.
+    """
+
+    SHA = "abcdef1234567890abcdef1234567890abcdef12"
+    REPO_URL = "https://github.com/o/r"
+
+    def body(self, timeline, **kw):
+        opts = dict(
+            artifact_url=None,
+            artifact_bytes=None,
+            retention_days=30,
+            evidence_retention_days=None,
+            failure_artifact_url=None,
+            run_url=None,
+            sha=self.SHA,
+            repo_url=self.REPO_URL,
+            demo_root="",
+            path_prefix="",
+        )
+        opts.update(kw)
+        return comment.render([("demos/x", timeline)], **opts)
+
+    def test_an_owner_repo_reference_is_linked_at_its_own_tracker(self):
+        # The whole rendering by equality, not "the number is in there": a link
+        # to the wrong issue resolves and reads exactly like the right one.
+        self.assertEqual(
+            comment.ticket_link("rogvid/skills#129"),
+            "[rogvid/skills#129](https://github.com/rogvid/skills/issues/129)",
+        )
+
+    def test_a_url_is_linked_as_itself(self):
+        url = "https://example.invalid/browse/QUEUE-4412"
+        self.assertEqual(comment.ticket_link(url), f"[{url}]({url})")
+
+    def test_anything_else_is_printed_verbatim_rather_than_guessed_at(self):
+        # A private tracker's id is not this script's business, and a guessed
+        # link is worse than a name: it resolves somewhere, and a reviewer who
+        # follows it reads the wrong requirement. `#129` alone is the tempting
+        # one — there is no host in it.
+        for named in ("QUEUE-4412", "#129", "the ticket in my head"):
+            rendered = comment.ticket_link(named)
+            self.assertNotIn("](", rendered, named)
+            self.assertIn(named, rendered)
+
+    def test_a_link_target_that_would_not_survive_markdown_is_not_linked(self):
+        # `timeline.json` is committed and a pull request may edit it, so the
+        # ticket is untrusted text pasted into a link target. A `)` ends that
+        # target early and the rest of the line becomes prose.
+        rendered = comment.ticket_link("https://example.invalid/a)(b")
+        self.assertNotIn("](", rendered)
+
+    def test_a_take_that_names_no_ticket_is_rendered_as_it_always_was(self):
+        # The control on everything below: a comment that always carried the
+        # word would satisfy the assertions above on every take.
+        self.assertIsNone(comment.ticket_link(None))
+        body = self.body(TIMELINE)
+        self.assertIn("recorded by `Recorder`", body)  # control: the line ran
+        self.assertNotIn("against", body)
+
+    def test_the_comment_says_which_ticket_the_clauses_came_out_of(self):
+        # The reviewer's route from the demo to the requirement, in the one
+        # artifact they are guaranteed to open.
+        body = self.body(TICKETED)
+        self.assertIn(
+            "· against [rogvid/skills#129](https://github.com/rogvid/skills/issues/129)",
+            body,
+        )
+
+    def test_naming_the_ticket_does_not_displace_the_gap(self):
+        # #273's ordering claim, retested on the branch this adds: the clauses
+        # nothing claimed are still stated before the table of what was.
+        body = self.body(TICKETED)
+        headline = [ln for ln in body.splitlines() if "no beat claiming" in ln]
+        self.assertEqual(len(headline), 1, body)
+        self.assertLess(body.index(headline[0]), body.index("| clause | claimed at |"))
+
+    def test_a_stitched_demo_whose_parts_disagree_names_every_ticket(self):
+        # `stitch()` names them rather than choosing, and so does this: which
+        # of two tickets a demo is about is the reviewer's call.
+        body = self.body(
+            dict(TAGGED, ticket_conflicts=["rogvid/skills#129", "acme/app#7"])
+        )
+        self.assertIn("its segments name different tickets", body)
+        self.assertIn("https://github.com/rogvid/skills/issues/129", body)
+        self.assertIn("https://github.com/acme/app/issues/7", body)
 
 
 class CommentStep(unittest.TestCase):
@@ -2666,6 +2770,58 @@ INJECTIONS += [
         ["Coverage.test_no_sentence_promotes_a_claim_to_a_verdict"],
     )
     for word, sentence in VERDICT_SENTENCES.items()
+]
+
+INJECTIONS += [
+    (
+        # A guessed link, which is the failure mode a verbatim fallback exists
+        # to prevent: it resolves, it renders exactly like a working one, and
+        # a reviewer who follows it reads somebody else's requirement. `#129`
+        # and `QUEUE-4412` name no host, and this invents one for them.
+        "a ticket this script cannot resolve is linked at a guessed host",
+        "demo-comment",
+        '    return f"`{_cell(text)}`"',
+        '    return f"[{_cell(text)}](https://github.com/{text})"',
+        [
+            "Ticket.test_anything_else_is_printed_verbatim_rather_than_guessed_at",
+            "Ticket.test_a_link_target_that_would_not_survive_markdown_is_not_linked",
+        ],
+    ),
+    (
+        # The comment stops saying which ticket a take was recorded against.
+        # The clause table is untouched, so the reviewer still gets four
+        # sentences with nothing to check them against — #275's problem, in
+        # the artifact a human is guaranteed to open.
+        "the comment stops naming the ticket a take was recorded against",
+        "demo-comment",
+        "    if len(refs) == 1:",
+        "    if len(refs) > 90:",
+        ["Ticket.test_the_comment_says_which_ticket_the_clauses_came_out_of"],
+    ),
+    (
+        # The sentence a ticket link invites, and the reason the ticketed
+        # fixture is swept rather than assumed to be covered by the others:
+        # nothing here has opened that ticket. Appended after the link rather
+        # than rewritten around it, so the assertion about the link's own text
+        # stays green and the sweep is the only thing that can notice — the
+        # measurement that says `TICKETED` carries this branch instead of
+        # decorating an existing test.
+        "the comment says the take was verified against the ticket it names",
+        "demo-comment",
+        '        meta += f" · against {refs[0]}"',
+        '        meta += f" · against {refs[0]}, verified"',
+        ["Coverage.test_naming_the_ticket_promotes_no_claim_to_a_verdict"],
+    ),
+    (
+        # A stitched demo whose parts disagree, rendered as though they had
+        # not. The other ticket disappears from the one artifact a reviewer
+        # reads, while `timeline.json` still names both.
+        "a demo whose segments name two tickets names neither in the comment",
+        "demo-comment",
+        "    elif refs:",
+        "    elif not refs:",
+        ["Ticket.test_a_stitched_demo_whose_parts_disagree_names_every_ticket"],
+    ),
 ]
 
 

--- a/tests/unit
+++ b/tests/unit
@@ -76,6 +76,7 @@ from demo_recording.content import (  # noqa: E402
 )
 from demo_recording.coverage import (  # noqa: E402
     _checked_criteria,
+    _checked_ticket,
     _declared_criteria,
     _merged_coverage,
     coverage_report,
@@ -114,6 +115,7 @@ from demo_recording.timeline import (  # noqa: E402
     STRICT_KINDS,
     TIMELINE_SCHEMA,
     _coverage_md,
+    _ticket_md,
     render_timeline_md,
     timeline_paths,
     write_timeline,
@@ -444,6 +446,133 @@ class MergedCoverage(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# coverage.py — which ticket the clauses were copied out of (issue #275)
+# --------------------------------------------------------------------------
+
+
+class CheckedTicket(unittest.TestCase):
+    """A free string, checked for one thing, and never resolved."""
+
+    def test_no_ticket_is_none_not_an_error(self):
+        # The ordinary take: recorded outside a ticket, and nothing about that
+        # is a mistake.
+        self.assertIsNone(_checked_ticket(None))
+
+    def test_any_non_empty_string_is_kept_whatever_tracker_it_names(self):
+        # The control on the two refusals below: without it they are satisfied
+        # by a function that refuses everything. Three spellings, because the
+        # stated rule is that a private tracker's id is not this recorder's
+        # business — a shape rule here would refuse takes rather than catch
+        # mistakes.
+        for named in (
+            "rogvid/skills#129",
+            "https://example.invalid/browse/QUEUE-4412",
+            "QUEUE-4412",
+        ):
+            self.assertEqual(_checked_ticket(named), named)
+
+    def test_a_blank_ticket_is_refused_rather_than_written_down_empty(self):
+        # A take that claims to have a source and cannot say what it is. The
+        # honest spelling of "no ticket" is the parameter left off.
+        for blank in ("", "   ", "\n\t"):
+            with self.assertRaises(ValueError):
+                _checked_ticket(blank)
+
+    def test_a_ticket_that_is_not_a_string_is_refused(self):
+        # `ticket=129` is the plausible mistake, and it reaches the envelope as
+        # a JSON number that no consumer's link-or-print rule knows what to do
+        # with.
+        for wrong in (129, ["rogvid/skills#129"], {"id": 129}):
+            with self.assertRaises(TypeError):
+                _checked_ticket(wrong)
+
+    def test_surrounding_whitespace_never_reaches_the_manifest(self):
+        # It is pasted into a URL by the pull-request comment, where a trailing
+        # newline is a link that 404s and looks exactly like one that works.
+        self.assertEqual(_checked_ticket("  rogvid/skills#129\n"), "rogvid/skills#129")
+
+
+class MergedTicket(unittest.TestCase):
+    """What a stitched demo says about the tickets its parts named (#275).
+
+    Driven through `_merged_timeline` rather than through the merge helper
+    alone: the claim is about the document `stitch()` writes, and a helper that
+    returned the right answer to a caller that dropped it on the floor would
+    satisfy an assertion made one level down.
+    """
+
+    def stitched(self, *tickets: str | None) -> dict:
+        names = [f"part{n + 1}" for n in range(len(tickets))]
+        docs = [
+            {
+                "recorder": "Recorder",
+                "segment": name,
+                "beats": [beat(0, "caption", 0.5, segment=name)],
+                **({"ticket": ticket} if ticket else {}),
+            }
+            for name, ticket in zip(names, tickets, strict=True)
+        ]
+        return _merged_timeline(
+            names,
+            [Path(f"{name}.seg.mp4") for name in names],
+            docs,
+            [4.0] * len(names),
+            # Never created: `_merged_timeline` probes it only for `duration`.
+            Path("demo.mp4"),
+        )
+
+    def test_parts_recorded_against_one_ticket_carry_it_into_the_merge(self):
+        # `stitch()` deletes the segment timelines, so whatever the merged
+        # envelope does not carry is gone.
+        doc = self.stitched("rogvid/skills#129", "rogvid/skills#129")
+        self.assertEqual(doc["ticket"], "rogvid/skills#129")
+        self.assertNotIn("ticket_conflicts", doc)
+
+    def test_parts_naming_different_tickets_report_both_and_choose_neither(self):
+        # The acceptance criterion of #275's merge half. Picking one would be
+        # the merged document stating something no segment said, about a demo
+        # half of which demonstrates the other ticket.
+        doc = self.stitched("rogvid/skills#129", "acme/app#7")
+        self.assertEqual(doc["ticket_conflicts"], ["rogvid/skills#129", "acme/app#7"])
+        self.assertNotIn("ticket", doc)
+
+    def test_a_part_that_named_none_does_not_conflict_with_one_that_did(self):
+        # Silence is not disagreement — the same reading `_declared_criteria`
+        # gives a segment that declared no criteria. Without this a demo whose
+        # terminal half was recorded without a ticket would report a conflict
+        # between one ticket and nothing.
+        doc = self.stitched("rogvid/skills#129", None)
+        self.assertEqual(doc["ticket"], "rogvid/skills#129")
+        self.assertNotIn("ticket_conflicts", doc)
+
+    def test_a_demo_no_part_of_which_named_a_ticket_carries_neither_key(self):
+        # The control on all three above, and the #24 rule at the merge: a
+        # stitched timeline from before this key existed reads as it always
+        # did.
+        doc = self.stitched(None, None)
+        self.assertNotIn("ticket", doc)
+        self.assertNotIn("ticket_conflicts", doc)
+
+    def test_each_part_keeps_the_ticket_it_was_recorded_against(self):
+        # Which part said what, not only that two things were said: on a
+        # conflict the merged envelope names both and the reader's next
+        # question is which half of the video belongs to which.
+        doc = self.stitched("rogvid/skills#129", "acme/app#7")
+        self.assertEqual(
+            [(s["segment"], s["ticket"]) for s in doc["segments"]],
+            [("part1", "rogvid/skills#129"), ("part2", "acme/app#7")],
+        )
+
+    def test_a_part_recorded_outside_a_ticket_has_no_ticket_in_its_record(self):
+        # The control on the assertion above: `"ticket": null` on every
+        # segment of every ticketless stitch is the noise the absent-key rule
+        # exists to keep out of a file this skill tells people to commit.
+        doc = self.stitched(None, "acme/app#7")
+        self.assertNotIn("ticket", doc["segments"][0])
+        self.assertEqual(doc["segments"][1]["ticket"], "acme/app#7")
+
+
+# --------------------------------------------------------------------------
 # timeline.py — the beat log's two renderings
 # --------------------------------------------------------------------------
 
@@ -668,6 +797,80 @@ class CoverageMd(unittest.TestCase):
         self.assertGreater(len(rows), 3)  # header + one row per claim
         widths = {len(split_row(r)) for r in rows}
         self.assertEqual(widths, {4})
+
+
+class TicketMd(unittest.TestCase):
+    """`timeline.md` names the ticket its clauses came out of (issue #275)."""
+
+    TICKET = "rogvid/skills#129"
+
+    def rendered(self, **over: object) -> str:
+        return render_timeline_md(
+            envelope(beats=[beat(0, "goto", 0.1)], coverage=CoverageMd.REPORT, **over)
+        )
+
+    def test_the_ticket_is_named_in_the_file_the_clauses_are_quoted_in(self):
+        self.assertIn(self.TICKET, self.rendered(ticket=self.TICKET))
+
+    def test_a_take_recorded_outside_a_ticket_says_nothing_about_one(self):
+        # The control on the assertion above, and the #24 rule at this end: a
+        # timeline written before this key existed has to read as it always
+        # did, and a document that always carried a sentence about tickets
+        # would satisfy every other assertion here.
+        text = self.rendered()
+        self.assertIn("## Acceptance criteria", text)  # control: a section ran
+        self.assertNotIn("Recorded against", text)
+        self.assertNotIn("never fetched", text)
+        self.assertEqual(_ticket_md({}), [])
+
+    def test_the_ticket_is_named_above_the_table_of_clauses_quoted_from_it(self):
+        # Ordering, not presence: a reader who meets four sentences before
+        # their source has already read them as the ticket's own words. Both
+        # positions are read off the rendered file rather than assumed.
+        text = self.rendered(ticket=self.TICKET)
+        self.assertLess(text.index(self.TICKET), text.index("| criterion |"))
+        self.assertLess(text.index(self.TICKET), text.index("**AC-1**"))
+
+    def test_the_file_says_nothing_compared_the_clauses_with_the_ticket(self):
+        # The sentence "recorded against #129" invites a reader to assume
+        # something checked the two against each other. Nothing has, and the
+        # artifact that named the ticket is the one that has to say so.
+        said = " ".join(_ticket_md({"ticket": self.TICKET}))
+        self.assertIn("never fetched", said)
+        self.assertIn("compared", said)
+
+    def test_a_stitched_demo_whose_parts_disagree_names_every_ticket(self):
+        # Both, and neither chosen. A merged demo half of which demonstrates
+        # another ticket has no single honest answer, and a file naming one of
+        # them would be stating something no segment said.
+        text = self.rendered(ticket_conflicts=["rogvid/skills#129", "acme/app#7"])
+        self.assertIn("rogvid/skills#129", text)
+        self.assertIn("acme/app#7", text)
+        self.assertIn("different tickets", text)
+
+    def test_a_pipe_in_a_ticket_does_not_add_a_column_to_the_table_below(self):
+        """Both branches of the renderer, not only the one a take reaches.
+
+        A free string an author typed, rendered a few lines above a markdown
+        table. Read from the renderer's side, like every other cell check
+        here.
+
+        The conflict branch is here because it was not (issue #315): the
+        single-ticket branch was graded and its twin was not, so unescaping
+        the merged rendering alone left all 427 tests green. Two branches
+        writing the same untrusted string are two places to escape it, and a
+        check that reads one of them reports the rule as held across text half
+        of which nothing opened.
+        """
+        for doc in (
+            {"ticket": "QUEUE-1|4"},
+            {"ticket_conflicts": ["QUEUE-1|4", "acme/app#7"]},
+        ):
+            said = " ".join(_ticket_md(doc))
+            self.assertIn("QUEUE-1\\|4", said, doc)
+            # The raw form absent, not only the escaped form present: a
+            # renderer that printed both would satisfy the line above.
+            self.assertNotIn("QUEUE-1|4", said, doc)
 
 
 class TimelineMd(unittest.TestCase):
@@ -5846,6 +6049,40 @@ class BeatLog(unittest.TestCase):
         # Issue #20 at this end: a take that wrote no mp4 must not probe a
         # previous run's file and report its length beside these beats.
         self.assertIsNone(self.envelope_of(self.storyboard())["duration"])
+
+    def test_the_envelope_names_the_ticket_the_storyboard_recorded_against(self):
+        # Issue #275: the storyboard quotes its clauses out of a ticket, and
+        # until this key nothing machine-readable said which one. Equality
+        # against the string the constructor was handed, because the whole
+        # point is that the recorder wrote down what it was told rather than
+        # resolving it into something else.
+        rec = recorder(self, page=NoisyPage(), ticket="rogvid/skills#129")
+        rec.pause(0)
+        self.assertEqual(self.envelope_of(rec)["ticket"], "rogvid/skills#129")
+
+    def test_the_terminal_recorder_carries_the_ticket_to_its_own_envelope(self):
+        """The other recorder's pass-through, graded (issue #313).
+
+        `ticket=` is declared on `_DemoBase` and forwarded by hand from each
+        subclass's `__init__`, so there are two of them and the assertion
+        above only travels one. Deleting `ticket=ticket` from
+        `TerminalRecorder`'s `super()` call left all 427 tests green: half the
+        feature could be removed with nothing to notice, on the medium whose
+        storyboards this repo runs least.
+
+        Read off the envelope rather than off `_ticket`, so it grades the same
+        thing for this recorder that the web assertion grades for that one —
+        the key a consumer reads, not the attribute behind it.
+        """
+        rec = recorder(self, cls=TermRec, ticket="rogvid/skills#129")
+        self.assertEqual(self.envelope_of(rec)["ticket"], "rogvid/skills#129")
+
+    def test_a_take_recorded_outside_a_ticket_writes_no_ticket_key(self):
+        # Absent, not null (issue #24): a timeline written before this key
+        # existed reads exactly like a take recorded outside a ticket, which is
+        # what it is. This is also the control on the assertion above — a key
+        # that was always present would satisfy it on every take.
+        self.assertNotIn("ticket", self.envelope_of(self.storyboard()))
 
     def test_the_envelope_carries_every_problem_and_the_count_that_saw_them_all(self):
         rec = self.watching_storyboard()
@@ -12825,6 +13062,151 @@ INJECTIONS = [
             "InterludePalette."
             "test_both_cards_are_opaque_and_cover_the_frame_above_the_caption",
         ],
+    ),
+    (
+        # The take never writes down the ticket it was handed — the state
+        # issue #275 is about, restored: four clauses in the manifest and
+        # nothing anywhere saying whose they are. The parameter still exists
+        # and is still validated, so a storyboard passing it sees no
+        # difference at all.
+        "the ticket a storyboard named never reaches the manifest",
+        "core.py",
+        "            **_ticket_field(self._ticket),",
+        "            **_ticket_field(None),",
+        [
+            "BeatLog.test_the_envelope_names_the_ticket_the_storyboard_recorded_against",
+            "BeatLog.test_the_terminal_recorder_carries_the_ticket_to_its_own_envelope",
+        ],
+    ),
+    (
+        # One recorder's pass-through, not the shared key: the parameter is
+        # declared on `_DemoBase` and forwarded by hand from each subclass, so
+        # there are two of these and each has to be watched separately. The
+        # review of this pull request removed exactly this and found all 427
+        # tests green (#313) — half the feature gone, on the medium whose
+        # storyboards this repo runs least.
+        "TerminalRecorder drops the ticket on the way to its base class",
+        "terminal.py",
+        "            criteria=criteria, ticket=ticket, allow_private=allow_private,",
+        "            criteria=criteria, allow_private=allow_private,",
+        ["BeatLog.test_the_terminal_recorder_carries_the_ticket_to_its_own_envelope"],
+    ),
+    (
+        # The web recorder's half of the same forwarding, broken on its own.
+        # It is here because #313 was found by asking "is the twin graded?" of
+        # a check that read one branch, and the honest answer to that question
+        # is a second injection rather than an assurance.
+        "Recorder drops the ticket on the way to its base class",
+        "web.py",
+        "            criteria=criteria, ticket=ticket, allow_private=allow_private,",
+        "            criteria=criteria, allow_private=allow_private,",
+        ["BeatLog.test_the_envelope_names_the_ticket_the_storyboard_recorded_against"],
+    ),
+    (
+        # The other direction, and the #24 rule: `ticket: null` on every take
+        # ever recorded. A timeline written before the key existed stops
+        # reading like the take it describes, and every consumer that asks
+        # "was this recorded against a ticket" gets a key to check instead of
+        # an absence.
+        "a take recorded outside a ticket says it has one and it is null",
+        "coverage.py",
+        '    return {"ticket": ticket} if ticket else {}',
+        '    return {"ticket": ticket}',
+        [
+            "BeatLog.test_a_take_recorded_outside_a_ticket_writes_no_ticket_key",
+            "MergedTicket.test_a_demo_no_part_of_which_named_a_ticket_carries_neither_key",
+            "MergedTicket.test_a_part_recorded_outside_a_ticket_has_no_ticket_in_its_record",
+        ],
+    ),
+    (
+        # A conflict resolved instead of named: the merged demo published
+        # against whichever ticket the first segment happened to name, while
+        # the other half of the video demonstrates something else. Everything
+        # about the document stays plausible — one ticket, linked, rendered —
+        # which is why nothing but this assertion can see it.
+        "a stitched demo whose parts disagree is published against the first",
+        "coverage.py",
+        "    if len(named) > 1:",
+        "    if len(named) > 99:",
+        [
+            "MergedTicket."
+            "test_parts_naming_different_tickets_report_both_and_choose_neither"
+        ],
+    ),
+    (
+        # The strip goes, so a ticket of spaces is a ticket. The manifest then
+        # carries a whitespace string that reads as "recorded against a
+        # ticket" to every consumer and names nothing, and a value with a
+        # trailing newline is pasted into a link that 404s.
+        "a blank ticket is written down as a ticket",
+        "coverage.py",
+        "    stripped = ticket.strip()",
+        "    stripped = ticket",
+        [
+            "CheckedTicket.test_a_blank_ticket_is_refused_rather_than_written_down_empty",
+            "CheckedTicket.test_surrounding_whitespace_never_reaches_the_manifest",
+        ],
+    ),
+    (
+        # `timeline.md` stops naming the ticket. The coverage table is
+        # untouched and still says "This take was recorded against a ticket",
+        # so the file reads as complete while the one fact that says *which*
+        # is gone — which is the whole of #275 in the human-readable artifact.
+        "timeline.md stops naming the ticket its clauses were quoted from",
+        "timeline.py",
+        "    out += _ticket_md(doc)",
+        "    out += _ticket_md({})",
+        [
+            "TicketMd.test_the_ticket_is_named_in_the_file_the_clauses_are_quoted_in",
+            "TicketMd.test_the_ticket_is_named_above_the_table_of_clauses_quoted_from_it",
+            "TicketMd.test_a_stitched_demo_whose_parts_disagree_names_every_ticket",
+        ],
+    ),
+    (
+        # The escaping on the **merged** rendering, which is the branch #315
+        # found unwatched: the identical removal in the single-ticket branch
+        # below was already caught, and this one left all 427 tests green. A
+        # `|` in a ticket a pull request edited shifts every column of the
+        # table three lines under it.
+        "a conflicting ticket reaches the reader unescaped",
+        "timeline.py",
+        "            f\"{', '.join(f'`{_md_cell(str(t))}`' for t in conflicts)}.**"
+        ' All of "',
+        "            f\"{', '.join(f'`{str(t)}`' for t in conflicts)}.** All of \"",
+        ["TicketMd.test_a_pipe_in_a_ticket_does_not_add_a_column_to_the_table_below"],
+    ),
+    (
+        # And its twin, broken on its own — the control that says the loop
+        # over the two branches reads both rather than passing on one.
+        "a single ticket reaches the reader unescaped",
+        "timeline.py",
+        '        f"Recorded against **{_md_cell(ticket)}**, as the storyboard names it. "',
+        '        f"Recorded against **{ticket}**, as the storyboard names it. "',
+        ["TicketMd.test_a_pipe_in_a_ticket_does_not_add_a_column_to_the_table_below"],
+    ),
+    (
+        # The ordering alone: everything is still rendered, and the source of
+        # the four sentences arrives after them. Nothing else in this suite
+        # can see it — every presence assertion above passes on this.
+        "timeline.md names the ticket below the clauses quoted from it",
+        "timeline.py",
+        "    out += _ticket_md(doc)\n"
+        "    # The failure goes in with it, not only into the section above: "
+        "without it\n"
+        "    # the acceptance table renders a crashed take's claims exactly "
+        "like a clean\n"
+        "    # take's, which is the artifact reporting success on failure "
+        "(issue #278).\n"
+        '    out += _coverage_md(doc.get("coverage"), failure)',
+        '    out += _coverage_md(doc.get("coverage"), failure)\n'
+        "    # The failure goes in with it, not only into the section above: "
+        "without it\n"
+        "    # the acceptance table renders a crashed take's claims exactly "
+        "like a clean\n"
+        "    # take's, which is the artifact reporting success on failure "
+        "(issue #278).\n"
+        "    out += _ticket_md(doc)",
+        ["TicketMd.test_the_ticket_is_named_above_the_table_of_clauses_quoted_from_it"],
     ),
 ]
 


### PR DESCRIPTION
Slice C of #272. Fixes #275, and closes #313 and #315 — two holes a hand
review found in this change's own assertions.

Rebased onto `ccd381c` (`--onto`, never a merge). Conflicts in
`demo-comment`, `timeline.py`, `reference/review.md`, `tests/README.md` and
`tests/ci-unit` were all keep-both; the one that needed a decision is
`render_timeline_md`, where #278 added a `failure` argument to `_coverage_md`
and this adds `_ticket_md` above it. The ticket line sits **above the section's
own `## Acceptance criteria` heading**, so the section still opens on #278's
failure sentence and both orderings hold.

## What this does

`Recorder(..., ticket="rogvid/skills#129")` — a free string, stored and written
into the timeline envelope as `ticket`.

- **Absent** on a take recorded outside a ticket, so an old `timeline.json`
  reads exactly as it does now (#24's rule).
- **Never fetched, never resolved.** Nothing in `coverage.py` or `core.py`
  opens a connection. Re-running a committed storyboard produces the same
  manifest however the issue has been edited since.
- `timeline.md` names it **above** the coverage table — the clauses in that
  table are quoted from it, and a reader who meets four sentences before their
  source has already read them as the ticket's own words.
- The pull-request comment links `owner/repo#N` and URLs on the take's own line
  and prints anything else verbatim. A guessed link is worse than a name: it
  resolves somewhere, and a reviewer who follows it reads the wrong requirement.
- `stitch()` carries it and reports a **conflict**: segments naming different
  tickets produce `ticket_conflicts` listing all of them and **no** `ticket`.
  Named rather than resolved, same as `coverage.conflicts`.
- `examples/ticket-queue/demos/2026-07-28-queue-search/record.py` passes it, so
  the reference take stops keeping this in a docstring.

Validation is exactly "a non-empty string, stripped". A private tracker's id is
not this recorder's business to have opinions about.

## What it deliberately leaves out

No check that the ticket exists, that it is readable, or that the quoted
clauses appear in it. That is #276 — it needs a network and a token, and it
belongs in CI rather than in a take.

## SKILL.md

Still **600/600 lines**, and nothing was cut to buy the room. Measured against
the merge base the whole delta is **+1 word and +10 characters**
(39,865 → 39,875 bytes; an earlier version of this section said +13, which was
wrong). The only change is the Configuration paragraph's list of parameters
with no env var, which was factually wrong once `ticket` existed: `segment` and
`criteria` → `segment`, `criteria` and `ticket`. The three-line paragraph was
re-wrapped across its own three lines to hold one extra word. Everything else
about the parameter is in `reference/review.md`, which SKILL.md already links
at the point of use — a new **Name the ticket: `ticket=`** section there, plus
the merge rule in `reference/timeline.md`.

## The two review findings, closed

Both were the same shape: **one of a pair is graded and its twin is not.**

- **#313 — the terminal recorder's pass-through was ungraded.** `ticket=` is
  declared on `_DemoBase` and forwarded by hand from each subclass, so there
  are two things to break. Deleting `ticket=ticket` from `TerminalRecorder`'s
  `super()` call left all 427 tests green: half the feature could be removed
  silently, on the medium this repo runs least. There is now an assertion per
  recorder, read off the **envelope** rather than off `_ticket` so it grades
  what a consumer reads, and **an injection per recorder** — the second exists
  because the honest answer to "is the twin graded?" is a measurement.
- **#315 — one branch of `_ticket_md` escaped unwatched.** A single ticket and
  a merged demo's conflicting ones are rendered by different lines; the pipe
  check read one. The escaping rule was reported as held across text half of
  which nothing opened. The check now loops over both branches and asserts the
  **raw form is absent** as well as the escaped form present, and each branch
  has its own injection.

## Fault injections

Ten in `tests/unit`, four in `tests/ci-unit`. Every one was watched failing the
named tests and nothing else. Full runs after the rebase:
`All 290 injections were caught.` / `All 78 injections were caught.`

```
PASS  break: the ticket a storyboard named never reaches the manifest
      in core.py: **_ticket_field(self._ticket),…
      ERROR: test_the_envelope_names_the_ticket_the_storyboard_recorded_against (__main__.BeatLog.test_the_envelope_names_the_ticket_the_storyboard_recorded_against)
      ERROR: test_the_terminal_recorder_carries_the_ticket_to_its_own_envelope (__main__.BeatLog.test_the_terminal_recorder_carries_the_ticket_to_its_own_envelope)

PASS  break: TerminalRecorder drops the ticket on the way to its base class
      in terminal.py: criteria=criteria, ticket=ticket, allow_private=allow_private,…
      ERROR: test_the_terminal_recorder_carries_the_ticket_to_its_own_envelope (__main__.BeatLog.test_the_terminal_recorder_carries_the_ticket_to_its_own_envelope)

PASS  break: Recorder drops the ticket on the way to its base class
      in web.py: criteria=criteria, ticket=ticket, allow_private=allow_private,…
      ERROR: test_the_envelope_names_the_ticket_the_storyboard_recorded_against (__main__.BeatLog.test_the_envelope_names_the_ticket_the_storyboard_recorded_against)

PASS  break: a take recorded outside a ticket says it has one and it is null
      in coverage.py: return {"ticket": ticket} if ticket else {}…
      FAIL: test_a_take_recorded_outside_a_ticket_writes_no_ticket_key (__main__.BeatLog.test_a_take_recorded_outside_a_ticket_writes_no_ticket_key)
      FAIL: test_a_demo_no_part_of_which_named_a_ticket_carries_neither_key (__main__.MergedTicket.test_a_demo_no_part_of_which_named_a_ticket_carries_neither_key)
      FAIL: test_a_part_recorded_outside_a_ticket_has_no_ticket_in_its_record (__main__.MergedTicket.test_a_part_recorded_outside_a_ticket_has_no_ticket_in_its_record)

PASS  break: a stitched demo whose parts disagree is published against the first
      in coverage.py: if len(named) > 1:…
      ERROR: test_parts_naming_different_tickets_report_both_and_choose_neither (__main__.MergedTicket.test_parts_naming_different_tickets_report_both_and_choose_neither)

PASS  break: a blank ticket is written down as a ticket
      in coverage.py: stripped = ticket.strip()…
      FAIL: test_a_blank_ticket_is_refused_rather_than_written_down_empty (__main__.CheckedTicket.test_a_blank_ticket_is_refused_rather_than_written_down_empty)
      FAIL: test_surrounding_whitespace_never_reaches_the_manifest (__main__.CheckedTicket.test_surrounding_whitespace_never_reaches_the_manifest)

PASS  break: timeline.md stops naming the ticket its clauses were quoted from
      in timeline.py: out += _ticket_md(doc)…
      ERROR: test_the_ticket_is_named_above_the_table_of_clauses_quoted_from_it (__main__.TicketMd.test_the_ticket_is_named_above_the_table_of_clauses_quoted_from_it)
      FAIL: test_a_stitched_demo_whose_parts_disagree_names_every_ticket (__main__.TicketMd.test_a_stitched_demo_whose_parts_disagree_names_every_ticket)
      FAIL: test_the_ticket_is_named_in_the_file_the_clauses_are_quoted_in (__main__.TicketMd.test_the_ticket_is_named_in_the_file_the_clauses_are_quoted_in)

PASS  break: a conflicting ticket reaches the reader unescaped
      in timeline.py: f"{', '.join(f'`{_md_cell(str(t))}`' for t in conflicts)}.** All of …
      FAIL: test_a_pipe_in_a_ticket_does_not_add_a_column_to_the_table_below (__main__.TicketMd.test_a_pipe_in_a_ticket_does_not_add_a_column_to_the_table_below)

PASS  break: a single ticket reaches the reader unescaped
      in timeline.py: f"Recorded against **{_md_cell(ticket)}**, as the storyboard names i…
      FAIL: test_a_pipe_in_a_ticket_does_not_add_a_column_to_the_table_below (__main__.TicketMd.test_a_pipe_in_a_ticket_does_not_add_a_column_to_the_table_below)

PASS  break: timeline.md names the ticket below the clauses quoted from it
      in timeline.py: out += _ticket_md(doc)…
      FAIL: test_the_ticket_is_named_above_the_table_of_clauses_quoted_from_it (__main__.TicketMd.test_the_ticket_is_named_above_the_table_of_clauses_quoted_from_it)

All 290 injections were caught.
```

Three pairs there are worth reading together, because each pair is what says a
check reads both halves of something rather than one: the two recorders'
`super()` calls, the two escaping branches, and the last two entries — the
first deletes the `timeline.md` rendering, the second only **reorders** it,
everything is still on the page, and the single ordering assertion is the only
thing in either suite that can see it.

```
PASS  break: a ticket this script cannot resolve is linked at a guessed host
      in demo-comment: return f"`{_cell(text)}`"…
      FAIL: test_a_link_target_that_would_not_survive_markdown_is_not_linked (__main__.Ticket.test_a_link_target_that_would_not_survive_markdown_is_not_linked)
      FAIL: test_anything_else_is_printed_verbatim_rather_than_guessed_at (__main__.Ticket.test_anything_else_is_printed_verbatim_rather_than_guessed_at)

PASS  break: the comment stops naming the ticket a take was recorded against
      in demo-comment: if len(refs) == 1:…
      FAIL: test_the_comment_says_which_ticket_the_clauses_came_out_of (__main__.Ticket.test_the_comment_says_which_ticket_the_clauses_came_out_of)

PASS  break: the comment says the take was verified against the ticket it names
      in demo-comment: meta += f" · against {refs[0]}"…
      FAIL: test_naming_the_ticket_promotes_no_claim_to_a_verdict (__main__.Coverage.test_naming_the_ticket_promotes_no_claim_to_a_verdict)

PASS  break: a demo whose segments name two tickets names neither in the comment
      in demo-comment: elif refs:…
      FAIL: test_a_stitched_demo_whose_parts_disagree_names_every_ticket (__main__.Ticket.test_a_stitched_demo_whose_parts_disagree_names_every_ticket)

All 78 injections were caught.
```

The third of those is the measurement that says the new `TICKETED` fixture
carries a branch of its own rather than decorating an existing test: *verified*
is appended **after** the link, so the assertion about the link's own text
stays green and the verdict sweep is the only thing that reddens.

### The harness refuses a pattern that does not land

Confirmed on this branch rather than assumed. One of the new patterns was
deliberately mistyped and the run stopped at exit 3 without reporting a pass:

```
ABORT: injection 'TerminalRecorder drops the ticket on the way to its base class' matched 0 times in terminal.py, expected exactly 1. The injection did not land, so nothing it would have proven is proven.
       looked for: '            criteria=criteria, ticket=ticket, allow_private=allow_privateX,'
```

This is also what the rebase surfaced: #309 moved the `_coverage_md` call site
the ordering injection pins, `--fault-inject` exited 3, and the fix was to
re-target the pattern at `_coverage_md(doc.get("coverage"), failure)` rather
than to loosen it.

## Stated limits

- **Nothing grades that the recorder did not fetch.** The assertion is that the
  envelope holds the constructor's own string; a recorder that fetched and got
  the same answer would satisfy it too. What stands behind the claim is the
  code — no connection is opened anywhere on this path — and not a measurement.
  Recorded in `tests/README.md` beside what *is* graded.
- **Nothing compares a clause with the ticket it names.** Naming it makes that
  possible; this is not it (#276). Every artifact says so in its own words, and
  the comment's ticket line is swept for verdict words for exactly that reason.
- **The committed reference artifacts are one recording behind** (#314).
  `timeline.json` and `timeline.md` in the reference demo were recorded before
  the parameter existed, so they carry no `ticket` key yet; `record.py` now
  passes one and the next real take writes it. Nothing was hand-edited into a
  recorded artifact — a fabricated timeline inside the feature about provenance
  would be self-defeating.
- **`tests/smoke` gains nothing** (#311). #275 says the envelope and the merge
  are graded in `tests/unit`, and both are functions of documents. The smoke
  coverage take does not pass `ticket=`, so the pass-through from a real
  recorder to a real `timeline.json` on disk is not exercised end to end.
- **A ticket string with a verdict word in it** (`PROVED-12`) would redden
  `tests/ci-unit`'s verdict sweep, the same way a clause **id** already does.
  Clause *text* and captions are exempted; the ticket is not, because it is
  usually too short to subtract from the body unambiguously.
- **`segments[*].ticket` is written through unvalidated** from each part's own
  timeline. Those are written by this recorder and `_segment_timeline` already
  refuses a foreign schema, so a non-string there is not reachable from the
  shipped path.

## Checks

`tests/unit` 440 OK · `tests/ci-unit` 115 OK · `tests/lint` clean ·
`tests/unit --budget` 600/600, exit 0 · `tests/unit --fault-inject` 290/290 ·
`tests/ci-unit --fault-inject` 78/78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
