### PR TITLE
A terminal take reads its own first frame and writes down what it was (#235)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/content.py
+++ b/skills/demo-video/helpers/demo_recording/content.py
@@ -379,7 +379,7 @@ def content_rect(rect: tuple[int, int, int, int]) -> tuple[int, int, int, int]:
 def _content_frames(
     mp4: Path,
     rect: tuple[int, int, int, int],
-    sample_fps: int,
+    sample_fps: int | None,
     limit_s: float | None = None,
 ) -> list[bytes]:
     """`mp4`'s content rect, sampled and reduced to grayscale frames.
@@ -387,11 +387,20 @@ def _content_frames(
     `limit_s` stops after that many seconds of video — the opening check looks
     at the first few seconds and decoding a whole 60 s take to answer a question
     about its first 400 ms is waste. None reads the file to the end.
+
+    `sample_fps` of None drops the `fps` filter and returns the file's own
+    frames, which is the only way to be sure of getting **frame zero**: the
+    filter quantises to its own output slots and hands back whichever source
+    frame lands nearest the middle of slot zero. That cost `tests/smoke`'s web
+    opening check a real defect once — at 1 fps it was reading a frame from
+    around 0.5 s and scoring a take whose first frame was flat white as
+    healthy. Pair it with a short `limit_s`.
     """
     x, y, w, h = rect
     chain = (
-        f"fps={sample_fps},crop={w}:{h}:{x}:{y},"
-        f"scale={_CONTENT_W}:{_CONTENT_H},format=gray"
+        (f"fps={sample_fps}," if sample_fps else "")
+        + f"crop={w}:{h}:{x}:{y},"
+        + f"scale={_CONTENT_W}:{_CONTENT_H},format=gray"
     )
     window = [] if limit_s is None else ["-t", f"{limit_s:.3f}"]
     proc = subprocess.run(
@@ -500,8 +509,138 @@ def opening_report(
     `held` is null for a recorder that does not cover its opening — see the
     section header for why the two numbers come from different passes over
     different files.
+
+    `card` is filled in afterwards by a recorder that can read its own opening
+    frame (`TerminalRecorder`, issue #235) and stays null for one that cannot.
+    Present and null rather than absent, so `opening` has the same shape on
+    every take — the same reason `held` is null rather than missing.
     """
-    return {"gap": gap, "held": held, "limit": limit, "note": note}
+    return {"gap": gap, "held": held, "limit": limit, "note": note, "card": None}
+
+
+# -- the frame a terminal segment opens on (issue #235) -----------------------
+#
+# The same 290 ms of bare terminal at a segment boundary has been reported by
+# three people watching a video ([#110], [#114]'s re-report, [#206]), and each
+# time it was a person who caught it, because nothing machine-readable ever saw
+# it. A demo directory commits `record.py`, `timeline.json`, `timeline.md` and
+# `images/`; it does not commit `demo.mp4` or the `.seg.mp4` parts, so no
+# committed artifact carries the frame the question is about. `tests/smoke`'s
+# `check_opening_card` sweeps this same corner and grades a take that suite
+# records itself, which is a claim about the *recorder* rather than about
+# anything anybody ships.
+#
+# So the recorder reads it, at the one moment the video exists: after the
+# segment is encoded, off that segment's own first frame, over a strip of the
+# background beside the terminal window. Outside the window on purpose —
+# inside it the card and the terminal are both dark and telling them apart
+# means reading text, which is not a robust thing to measure. Outside it the
+# two are an order of magnitude apart, and neither number is a threshold
+# anybody tuned; they are two constants in the recorder's own styling:
+#
+#   the card         a full-bleed #1c1a17 rectangle          luma ~26
+#   bare terminal    the _TERM_BG pastel gradient            luma ~226
+#
+# **Reported, never enforced**, and the measurement behind that decision is
+# [#128]: one CI run in nine read **128** and 0.00 s of cover on a loaded
+# runner — neither state. A refusal or a warning built on this bar would be
+# flaky on exactly the runner it most needs to be trusted on, and a bar retuned
+# until it was not would be grading the box it was tuned on. Nothing here
+# raises, warns, or fails a take. It writes down what the first frame was, in
+# the file a reviewer already reads.
+#
+# The band between the two bars is left deliberately empty, for the reason
+# `check_opening_card` leaves it empty: a frame that lands inside it is a card
+# still becoming opaque, and calling that "the card" or "bare" would be the
+# artifact claiming something it does not know. There are three answers here
+# and `"between"` is one of them.
+#
+# [#110]: https://github.com/rogvid/skills/issues/110
+# [#114]: https://github.com/rogvid/skills/issues/114
+# [#128]: https://github.com/rogvid/skills/issues/128
+# [#206]: https://github.com/rogvid/skills/issues/206
+OPENING_CARD_MAX_LUMA = 60.0
+OPENING_BARE_MIN_LUMA = 150.0
+
+# How much of the video is decoded to get its first frame. Shorter than one
+# frame at any rate this recorder encodes, so what comes back is frame zero and
+# at most one neighbour — and it is read with `-t` rather than with an `fps`
+# filter, because the filter answers with whatever frame lands nearest the
+# middle of its first slot rather than with the first frame. The question here
+# is *what did a viewer see when the segment started*, and that is frame zero
+# or it is nothing.
+OPENING_CARD_READ_S = 0.03
+
+
+def opening_card_state(luma: float | None) -> str | None:
+    """Which of the three states `luma` is, or None when there is no reading.
+
+    Not a boolean, and the third state is the point — see the section header.
+    """
+    if not isinstance(luma, (int, float)) or isinstance(luma, bool):
+        return None
+    if luma <= OPENING_CARD_MAX_LUMA:
+        return "card"
+    if luma >= OPENING_BARE_MIN_LUMA:
+        return "bare"
+    return "between"
+
+
+def opening_card_report(
+    mp4: Path | str,
+    rect: tuple[int, int, int, int] | None,
+    *,
+    raised: bool,
+    read_s: float = OPENING_CARD_READ_S,
+) -> dict:
+    """`content.opening.card`: what this segment's **first frame** showed.
+
+    `rect` is the strip beside the terminal window, in video pixels; `raised`
+    is whether this take asked the recorder for an opening card at all, which
+    is what tells a reader whether `"bare"` is the defect or the arrangement.
+
+    `state` is derived from the **rounded** `luma` this dict publishes, so the
+    number and the word can never disagree with each other.
+
+    Never raises, for the reason `content_report` does not: this runs inside
+    the encode path, and a measurement must never be able to cost somebody a
+    recording. A reading that could not be taken is a `note`, not an absence
+    and never a guess.
+    """
+    report: dict = {
+        "luma": None,
+        "state": None,
+        "raised": raised,
+        "rect": list(rect) if rect else None,
+        "card_max": OPENING_CARD_MAX_LUMA,
+        "bare_min": OPENING_BARE_MIN_LUMA,
+        "note": None,
+    }
+    try:
+        if rect is None:
+            report["note"] = (
+                "this recorder does not know where its window sits in the "
+                "frame, so the strip an opening card would cover could not be "
+                "read"
+            )
+            return report
+        mp4 = Path(mp4)
+        if not mp4.is_file():
+            report["note"] = f"there is no {mp4.name} to measure"
+            return report
+        frames = _content_frames(mp4, rect, None, limit_s=read_s)
+        if not frames:
+            report["note"] = (
+                f"no frame came back from the first {read_s:.2f}s of "
+                f"{mp4.name} over {tuple(rect)}, so nothing is claimed about "
+                f"the frame this segment opens on"
+            )
+            return report
+        report["luma"] = round(sum(frames[0]) / len(frames[0]), 1)
+        report["state"] = opening_card_state(report["luma"])
+    except Exception as exc:  # noqa: BLE001 - see the docstring
+        report["note"] = f"{type(exc).__name__}: {exc}"
+    return report
 
 
 def opening_warning(opening: dict | None) -> str | None:

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -950,6 +950,7 @@ class _DemoBase:
             "_evidence_payload",
             "_failure_screen",
             "_media_path",
+            "_opening_card",
             # extension points, each beside the sealed member it extends
             "_watch_extra",
             "_before_shot",
@@ -2315,6 +2316,23 @@ take with fewer beats than the last one would otherwise leave the
         if isinstance(up, list):
             self._overlay_note = overlay_warning([str(i) for i in up])
 
+    def _opening_card(self) -> dict | None:
+        """What this take's **first frame** showed, for a medium that can say.
+
+        A hook rather than an override (issue #235): `_measure_content` is
+        sealed, because it is what guarantees every take a `content` block —
+        and the medium seam's whole rule is that a medium extends by
+        implementing a hook it was offered.
+
+        Only `TerminalRecorder` answers. Its segments open on a card raised
+        before capture starts, and the strip of background beside its window
+        says in one number whether the card was up when the recording began.
+        A web take has neither the card nor the window, so None here is
+        "this medium has nothing to say" and lands in the artifact as
+        `content.opening.card: null`.
+        """
+        return None
+
     def _measure_content(self) -> None:
         """Fill in `self._content` off the mp4 this take just encoded.
 
@@ -2335,6 +2353,23 @@ take with fewer beats than the last one would otherwise leave the
                 f"frame ({type(exc).__name__}: {exc}), so nothing about the "
                 f"picture was measured"
             )
+            # The opening frame is *not* measured over the app rect — a medium
+            # that can read its own window still knows where to look — so a
+            # take that lost one measurement does not have to lose the other
+            # (issue #235). Without this the whole `opening` block was null on
+            # this path, which is an absence with no reason in it: a terminal
+            # take that could read `#__term_win` and not `#__term_host` said
+            # nothing at all about the frame it opened on, and nothing said
+            # why. `gap` genuinely could not be measured here, and the note is
+            # where that is written down.
+            self._content["opening"] = opening_report(
+                None,
+                "the app rect could not be worked out, so the opening gap was "
+                "not measured; `card` below is read off this medium's own "
+                "window and is unaffected",
+                self._opening_held,
+            )
+            self._content["opening"]["card"] = self._opening_card()
         else:
             # The beat log goes in, and it is what makes the held-picture arm
             # mean anything: without it a demo narrating over a rendered screen
@@ -2347,6 +2382,11 @@ take with fewer beats than the last one would otherwise leave the
             # silently did nothing leaves a non-zero gap right here (#119).
             gap, note = opening_gap(self._media_path(), rect)
             self._content["opening"] = opening_report(gap, note, self._opening_held)
+            # And what that first frame *was*, from the medium that can read
+            # its own (issue #235). Reported, never enforced: it appends no
+            # warning here, and see `opening_card_report` for the loaded-runner
+            # measurement that decided it.
+            self._content["opening"]["card"] = self._opening_card()
             warning = opening_warning(self._content["opening"])
             if warning:
                 self._content["warnings"].append(warning)

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -35,7 +35,7 @@ import time
 from collections import deque
 from pathlib import Path
 
-from .content import content_rect
+from .content import content_rect, opening_card_report
 from .core import INTERLUDE_ID, _beat_verb, _DemoBase, _env
 
 _ASSETS = Path(__file__).parent.parent / "assets" / "xterm"
@@ -197,6 +197,19 @@ _OPENING_CARD_JS = """
 # doing the same job.
 OPENING_CARD_HOLD_S = 2.8
 
+# Where the card is read back off the finished video (issue #235): a strip of
+# the background beside the terminal window, in the top corner opposite the
+# caption bar. See `_opening_card_rect`, and "the frame a terminal segment
+# opens on" in `content` for why it is outside the window rather than in it.
+#
+# The margin clears the window's rounded corner and the near side of its drop
+# shadow; the height keeps the strip well above the window's top inset (70 px),
+# so nothing but the background — or whatever is covering it — is in the read.
+# `_TERM_HOST_JS` insets the window by 74 px, so this is a 58x50 strip on the
+# stock geometry, and that is the rect `tests/smoke` has swept since #110.
+OPENING_CARD_MARGIN_PX = 8
+OPENING_CARD_STRIP_PX = 50
+
 # Named keys -> the bytes a terminal program expects. Ctrl-<letter> is
 # handled generically (C-a..C-z -> 0x01..0x1a).
 _KEYMAP = {
@@ -340,6 +353,10 @@ class TerminalRecorder(_DemoBase):
         # Where the xterm.js screen sits in the frame, read off the live
         # element once the terminal exists (issue #97). See `_content_rect`.
         self._host_box: tuple[int, int, int, int] | None = None
+        # Where the window's right edge is, which is what says where the
+        # background stops being the window (issue #235). See
+        # `_opening_card_rect`.
+        self._win_right: int | None = None
 
     # -- setup / teardown ---------------------------------------------------
 
@@ -428,6 +445,7 @@ class TerminalRecorder(_DemoBase):
         )
         self._set_winsize(int(dims["rows"]), int(dims["cols"]))
         self._read_host_box()
+        self._read_win_edge()
         # Just enough to catch the shell's first prompt. It used to be kept
         # short so a segment opening on a transition would not dwell on a bare
         # terminal; with `interlude=` that dwell happens behind the card, and
@@ -466,6 +484,87 @@ class TerminalRecorder(_DemoBase):
                 int(box["x"]), int(box["y"]),
                 int(box["width"]), int(box["height"]),
             )
+
+    def _read_win_edge(self) -> None:
+        """Remember where `#__term_win` ends, for the opening card (#235).
+
+        Read off the live element for the reason `_read_host_box` is: the
+        window's insets are in `_TERM_HOST_JS` and the strip beside it is
+        derived from them, so a hardcoded copy would go on describing a
+        geometry somebody had already changed. Read **once**, here, because
+        nothing after this moves the window and the page is gone by the time
+        there is an mp4 to measure.
+
+        **`int(x + width)`, not `int(x) + int(width)`.** Two truncations of a
+        fractional box land a column apart from one truncation of their sum,
+        and this rect is compared against `tests/smoke`'s own reading of the
+        same strip. One column out of 58 moves the mean by a fraction of a
+        luma level — not enough to change the answer, easily enough to be a
+        latent flake in an agreement check with a 1.0 bar. So the two derive
+        the edge the same way, and the harness's way is the truer one.
+
+        Not fatal and not silent, again like `_read_host_box`: without it the
+        card report says it could not be measured, which is a truthful
+        artifact. Losing a recording over a strip of background would be the
+        measurement costing somebody the thing it exists to describe.
+        """
+        try:
+            box = self.page.locator("#__term_win").bounding_box()
+        except Exception as exc:  # noqa: BLE001 - a measurement is not a take
+            print(
+                f"demo-video: WARNING — could not read the terminal window's "
+                f"box ({type(exc).__name__}: {exc}), so this take's timeline "
+                f"will say the opening frame was not measured.",
+                file=sys.stderr,
+            )
+            return
+        if box:
+            self._win_right = int(box["x"] + box["width"])
+
+    def _opening_card_rect(self) -> tuple[int, int, int, int] | None:
+        """The strip of background the opening card is read off (issue #235).
+
+        Beside the window, not inside it: an opening card and a bare terminal
+        are both dark inside the window and are told apart there by their text.
+        Outside it they are the card's flat `#1c1a17` against the pastel
+        `_TERM_BG`, which is an order of magnitude of luma and needs no
+        threshold anybody had to choose.
+
+        None when the window's edge was never read, or when the geometry
+        leaves no strip worth reading — a take whose window fills the frame has
+        no background to measure, and inventing a rect there would produce a
+        confident number about the wrong pixels.
+        """
+        if self._win_right is None:
+            return None
+        left = self._win_right + OPENING_CARD_MARGIN_PX
+        width = self._size["width"] - left - OPENING_CARD_MARGIN_PX
+        if left < 0 or width < OPENING_CARD_MARGIN_PX:
+            return None
+        return (left, 0, width, OPENING_CARD_STRIP_PX)
+
+    def _opening_card(self) -> dict | None:
+        """What this segment's first frame showed (issue #235).
+
+        The medium's half of `_DemoBase._opening_card`, and the reason the
+        hook exists here rather than in the base: the strip it reads is
+        defined by *this* recorder's window, and the card it looks for is this
+        recorder's own opening. A web take has neither.
+
+        Reported and not enforced — nothing here appends to `warnings`, raises
+        or refuses. See "the frame a terminal segment opens on" in `content`
+        for the loaded-runner reading that decided that.
+
+        Answered on **every** terminal take, not only one opened with
+        `interlude=`: a segment that opens on a bare prompt is exactly what
+        three people reported by watching, and `raised` is what tells a reader
+        whether `"bare"` is the defect or the arrangement.
+        """
+        return opening_card_report(
+            self._media_path(),
+            self._opening_card_rect(),
+            raised=self._opening is not None,
+        )
 
     def _content_rect(self) -> tuple[int, int, int, int] | None:
         """The xterm.js screen's region of the frame (issue #97).

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -181,6 +181,24 @@ from .markdown import _fmt_t, _md_cell
 #                          `held` means the frames at the start of the video
 #                          are not frames the recording captured; see "the
 #                          blank opening".
+#   content.opening.card
+#                 dict?  — what this segment's **first frame** actually showed,
+#                          for a medium that can read its own (today:
+#                          `TerminalRecorder`; **null** for the web recorder,
+#                          which has no window to read beside). `luma` is the
+#                          mean luma of a strip of background next to the
+#                          terminal window on frame zero, `state` is that
+#                          number as one of `"card"`, `"bare"` or `"between"`
+#                          — the band between the two bars is deliberately
+#                          empty, so a card still becoming opaque is called
+#                          neither — `card_max`/`bare_min` are the bars it was
+#                          classified against, `raised` says whether the take
+#                          asked for an opening card at all, and `note` says
+#                          why when `luma` is null. **Reported, never
+#                          enforced**: nothing warns or refuses on it (issue
+#                          #235, and #128 for why). On a merged demo it is the
+#                          first segment's, like the rest of `opening`; a
+#                          later part's own is under `segments`.
 #   narration     dict?  — **null** on a take that mixed no speech into
 #                          `media` — narration off, no lines, or no mp4
 #                          encoded. Otherwise, where each spoken line's audio

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -319,8 +319,21 @@ CI run read **128** and 0.00 s of cover — neither state, which is what a card
 still becoming opaque looks like. One failure in four observed CI runs, none in
 six local ones ([#128](https://github.com/rogvid/skills/issues/128)).
 
-What to do: use the constructor argument, and look at `frames/beat-00.png` of a
-terminal segment before shipping it.
+Neither residue is closed, but the second one is now *visible without
+watching*: every terminal take reads that same strip off its own first frame
+and writes the answer into `content.opening.card` in `timeline.json` —
+`state: "card"`, `"bare"` or `"between"`, beside the luma it was read from and
+whether the take asked for a card at all. It is reported and not enforced,
+precisely because of the 128 above: a take that lands in the empty band says so
+rather than failing ([#235](https://github.com/rogvid/skills/issues/235)). It
+also covers the *first* residue from the side nothing else does — a segment
+that opened with `interlude()` as its first statement records
+`raised: false` and `state: "bare"`, which is the flash, in the one file a demo
+directory commits.
+
+What to do: use the constructor argument, and read `content.opening.card` in
+the timeline of a terminal segment before shipping it. If it does not say
+`card`, look at `frames/beat-00.png`.
 
 ## Where the picture measurement goes quiet
 

--- a/skills/demo-video/reference/terminal.md
+++ b/skills/demo-video/reference/terminal.md
@@ -45,6 +45,15 @@ either way. `Recorder` (web) has no such argument and does not need one: its
 page is blank until `goto()`, so there is no "before" to flash — and a card
 painted before that first `goto()` would be destroyed by it.
 
+**Check it in the timeline rather than by watching.** Every terminal take reads
+its own first frame after the encode and writes the answer into
+`content.opening.card`: `state` is `"card"`, `"bare"` or `"between"`, beside
+the luma it came from and whether this take asked for a card. `demo.mp4` is not
+a file anybody commits, so this is the only account of that frame a demo
+directory carries — and the same flash has been reported three times by people
+watching. Nothing enforces it; read it. See *`opening.card`* in
+[timeline.md](timeline.md).
+
 ### Driving the four patterns
 
 - **Non-interactive CLI:** `run(cmd)` → `wait_for_prompt()`.

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -118,7 +118,8 @@ the encoded frame, and writes down what it found:
              "static_for": 21.5, "static_from": 3.5, "static_limit": 15.0,
              "static_beats": [{ "index": 6, "verb": "caption", "acting": false },
                               { "index": 7, "verb": "hold", "acting": false }],
-             "opening": { "gap": 0.0, "held": 0.4, "limit": 1.5, "note": null },
+             "opening": { "gap": 0.0, "held": 0.4, "limit": 1.5, "note": null,
+                          "card": null },
              "warnings": [] }
 ```
 
@@ -137,7 +138,9 @@ the encoded frame, and writes down what it found:
   `content` itself is `null` only when the take encoded no mp4.
 - `opening` says what the take opened on — and, on a web take, what the
   recorder did about it. Read the next section: `held` above zero means the
-  first frames of your video are not frames the recording captured.
+  first frames of your video are not frames the recording captured. On a
+  terminal take `opening.card` says whether the segment's first frame was its
+  title card or a bare terminal.
 
 **What the take says out loud, and on which stream.** Which line the take
 prints decides the stream: **anything wrong — a warning, or the note that the
@@ -191,6 +194,41 @@ covering seconds of it would be inventing a demo rather than repairing one.
 inside the page, so it has no equivalent gap; open a terminal segment on a title
 card if you want its first frame to be deliberate (see *Opening a terminal
 segment on a title card*).
+
+### `opening.card` — what a terminal segment's first frame showed
+
+A terminal take reads its own frame zero after the encode and writes down what
+was there:
+
+```json
+"card": { "luma": 25.8, "state": "card", "raised": true,
+          "rect": [1214, 0, 58, 50],
+          "card_max": 60.0, "bare_min": 150.0, "note": null }
+```
+
+- `luma` is the mean luma of a strip of background **beside** the terminal
+  window on the segment's first frame. Outside the window on purpose: inside
+  it a title card and a terminal are both dark and telling them apart means
+  reading text. Outside it the card (`#1c1a17`, full bleed) reads ~26 and the
+  recorder's pastel background reads ~226.
+- `state` is that number as a word: `"card"`, `"bare"`, or `"between"`. The gap
+  between the two bars is wide and deliberately empty — a frame that lands in
+  it is a card still becoming opaque, and calling that either thing would be
+  this file claiming something nobody measured.
+- `raised` says whether the take asked for an opening card
+  (`TerminalRecorder(interlude=…)`). It is what makes `"bare"` readable: on a
+  take that asked, `"bare"` is the flash issue #110 is about; on a take that
+  did not, it is simply what the segment opens on.
+- `note` says why when there is no reading. `luma` and `state` are then `null`
+  rather than a guess.
+- `card` itself is `null` on a web take — there is no window to read beside.
+
+**Nothing enforces it.** No warning, no refusal, no failed take: one CI run in
+nine has read a value in the empty band on a loaded runner, and a bar that
+refused there would be unreliable exactly where it would be trusted most. This
+is a number to read, and the reason it exists is that the mp4 is the one
+artifact a demo directory does not commit — so without it, "does part 2 open on
+its card" can only be answered by watching.
 
 ### An overlay the recorder left up is reported exactly
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -38,7 +38,7 @@ below for what it covers and what it does not.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~45 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~47 min, nightly)
 ├── unit               # the browser-free half (~0.07 s, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
@@ -183,7 +183,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~225 s)
-tests/smoke-inject                # all 60 entries, ~45 min
+tests/smoke-inject                # all 64 entries, ~47 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -451,7 +451,7 @@ argument for keeping them is cost per check function moved. Dropping one from
 | arm | seconds | check functions it would move | seconds per check moved |
 |---|---|---|---|
 | segments | 29 | 11 | 2.6 |
-| polish | 26 | 2 | 13 |
+| polish | 26 | 3 | 8.7 |
 | overlay | 31 | 1 | 31 |
 | failure | 48 | 1 | 48 |
 | the three expensive arms | 457 | 8 | 57 |
@@ -459,9 +459,11 @@ argument for keeping them is cost per check function moved. Dropping one from
 Every one of the four buys check coverage more cheaply than the arms the
 decision *did* move, so a second cut inside the cheap tier would be a worse
 trade than the first one, made on no measurement. Two specifics on top of the
-ratio: `--polish-only`'s two functions (`check_opening_card`,
+ratio: two of `--polish-only`'s three functions (`check_opening_card`,
 `check_spotlight_transitions`) have no injection anywhere, so the per-push run
-is their only exercise in the repo; and `--failure-only` is the only thing that
+is their only exercise in the repo — the third,
+`check_reported_opening_card`, is the arm's own four entries
+([#235](https://github.com/rogvid/skills/issues/235)); and `--failure-only` is the only thing that
 runs the recorder's exception paths, which is where the catalogue's
 *clean-path-only assertion* lives. `--failure-only` is nonetheless the one to
 revisit first if the per-push budget ever binds — it is 22% of `--cheap` for
@@ -1244,6 +1246,25 @@ to run unless the pattern matched exactly once:
 | the card raised 400 ms into the document instead of at document start | first frame is bare, and the prefix is 0.00 s |
 | the card built at `opacity: 0` like `interlude()` builds it | the same two, plus the content floor |
 | the card never cleared | "the corner never reaches 150 mean luma — the card is never taken down" |
+
+**The same frame, from the other side (issue #235).** Everything above grades
+the video, and no demo directory ships one. So the recorder reads its own first
+frame after the encode — the same strip, off the live `#__term_win` box, on the
+segment's own frame zero — and writes it into `content.opening.card`:
+`luma`, `state` (one of `card`, `bare`, `between`), `raised` (whether this take
+asked for a card at all), the two bars it was classified against, and a `note`
+when there was no reading. **Reported, never enforced**: nothing warns, refuses
+or raises on it, because [#128](https://github.com/rogvid/skills/issues/128) is
+one CI run in nine reading 128 on a loaded runner and a bar that refuses there
+would be flaky on the runner it most needs to be trusted on.
+
+`check_reported_opening_card` grades that field on the same take: it is there
+and complete, it says `card`, it says the card was asked for, and — the one
+that keeps the rest from being a document agreeing with itself — the number in
+it is within `OPENING_CARD_AGREEMENT` (1.0) of frame zero re-read here. Both
+readings came out at **25.8** on this box, which is [#207](https://github.com/rogvid/skills/issues/207)'s
+number for the fixed take. Four `tests/smoke-inject` entries, one per statement,
+and the third of them is the injection #235's acceptance criterion names.
 
 **What this does not catch**, and is a stated limit rather than an oversight: a
 card that *fades in* over 450 ms rather than being painted opaque is invisible
@@ -2076,7 +2097,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-60 entries, 12 arms, ~44.6 min of takes
+64 entries, 13 arms, ~46.8 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -2109,6 +2130,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
+| `--polish-only` | 4 | a terminal segment stops saying what it opened on ([#235](https://github.com/rogvid/skills/issues/235)), which is the one account of that frame a demo directory ships: the field gone entirely; the number a plausible constant instead of a reading, which every other statement about the field is happy with; the card raised 400 ms into the document, which is [#110](https://github.com/rogvid/skills/issues/110) itself and the injection that issue's acceptance criterion names; or the report forgetting that a card was asked for, without which `"bare"` cannot be told from a segment that never wanted one |
 | `--segments-only` | 14 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the sheet stops saying **which clock** it cut them on, so a reviewer cannot tell a corrected sheet from one cut on the raw beat log ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
@@ -2118,7 +2140,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **17 of `tests/smoke`'s 43 check functions have no entry**, and the harness
+- **17 of `tests/smoke`'s 44 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -2179,9 +2201,11 @@ paragraph whose job is to say what this manifest does not cover.
   - **`--determinism-only`, 19 s an entry** — `check_determinism`.
     [#239](https://github.com/rogvid/skills/issues/239).
   - **`--polish-only`, 26 s an entry** — `check_spotlight_transitions`,
-    `check_opening_card`, `_check_video`. The arm carries no entry at all
-    today, so it also pays one baseline.
-    [#240](https://github.com/rogvid/skills/issues/240).
+    `check_opening_card`, `_check_video`.
+    [#240](https://github.com/rogvid/skills/issues/240). The arm is no longer
+    free of entries — the opening-card *report* has four of them
+    ([#235](https://github.com/rogvid/skills/issues/235)) — so its baseline is
+    already paid and each of these three now costs 26 s and nothing else.
   - **`--segments-only`, 29 s an entry** — `check_caption`, `check_take`,
     `check_content_healthy`, `check_merge_offset`, `_check_frame_captions`,
     `_check_stale_frames`, `_check_segment_refusal`, `_check_scene_fallback`.
@@ -2457,18 +2481,42 @@ knows is missing is worse than one that is openly absent.
   costs. **The timeline gap does not stand in for it** — see the
   `terminal-opening/` section above, and
   [#207](https://github.com/rogvid/skills/issues/207) for the two takes it was
-  measured on. What would close it is the same corner strip read off the live
-  `#__term_win` box at *record* time, on the segment's own first frame, written
-  into the take's report where a reviewer reads a number instead of squinting
-  — card `<= 60` mean luma, bare `>= 150`, the constants `check_opening_card`
-  already uses. That is
-  [#235](https://github.com/rogvid/skills/issues/235). Separately, the sweep
-  itself has no `tests/smoke-inject` entry — it is in the ungraded roster
-  above, it was fault-injected by hand when it was written, and since
-  [#61](https://github.com/rogvid/skills/issues/61) the per-push
+  measured on.
+
+  **What [#235](https://github.com/rogvid/skills/issues/235) changed, and what
+  it did not.** A terminal take now reads that strip itself, off its own frame
+  zero, and writes `content.opening.card` into `timeline.json` — which *is*
+  committed, so a re-recorded demo carries a number saying what its segment
+  opened on. What is still true is everything about the takes already on disk:
+  no demo in this repository has been re-recorded since, so
+  `2026-07-26-status-filter`'s committed timeline has no such field and remains
+  graded by the person who watched it. The field arrives with the next
+  re-record, not with this paragraph. And the number is *reported* — nothing in
+  the recorder refuses, warns or fails a take over it
+  ([#128](https://github.com/rogvid/skills/issues/128) is why), so a demo whose
+  part 2 opens bare ships with the flash and a truthful line about it.
+
+  Separately, the sweep itself has no `tests/smoke-inject` entry — it is in the
+  ungraded roster above, it was fault-injected by hand when it was written, and
+  since [#61](https://github.com/rogvid/skills/issues/61) the per-push
   `--polish-only` run is its only exercise in the repo (see **Why the four
   middle arms stayed on the push**, which is the measurement that kept it
-  there).
+  there). The four entries that arm now carries are aimed at
+  `check_reported_opening_card`, not at it.
+
+- **Nothing grades that a reported opening `state` follows the `luma` beside
+  it.** Every take `--polish-only` records opens *on* the card, so the healthy
+  answer there is `"card"` — and a `state` pinned to `"card"` could only ever
+  fail together with the assertion that the take says `card`, which is the
+  catalogue's dominated assertion. An assertion for it was written and deleted
+  rather than shipped unfirable. What carries the claim instead: the word is
+  derived from the published number in one expression
+  (`opening_card_report`), and `tests/unit`'s `OpeningCard` grades that
+  mapping at both bars and either side of each. What would close it properly
+  is a second terminal take in that arm which opens *without* `interlude=` —
+  it would have to report `bare`, `raised: false`, and would be the control
+  this pair is missing. It costs another recording in a locked 10-minute
+  suite, which is why it is written down here instead.
 
 - **Nothing here grades whether a tagged beat's frames show its criterion.**
   `tests/unit` grades the coverage report's arithmetic, `tests/smoke

--- a/tests/smoke
+++ b/tests/smoke
@@ -1390,6 +1390,21 @@ MIN_OPENING_CARD_S = 1.0
 # sweep of three frames would satisfy every assertion below by accident.
 MIN_OPENING_FRAMES = 40
 
+# How far the recorder's own reading of its opening frame (issue #235) may sit
+# from this harness's reading of the same frame.
+#
+# Not a tolerance for the answer being roughly right. The two readings are the
+# same crop of the same frame of the same file, reduced the same way, and they
+# come out equal to the rounding the timeline publishes (0.05) — the strip is
+# computed twice, once by the recorder off `#__term_win` and once by
+# `record_terminal_opening` off the same live box, and both then read frame
+# zero with `-t` and no `fps` filter. What this has to be far under is the
+# thing it exists to catch: a number that describes something other than this
+# video, which is 200 luma levels away when the card is not up. An order of
+# magnitude either side, which is the shape to prefer over a comfortable
+# margin.
+OPENING_CARD_AGREEMENT = 1.0
+
 OPENING_DURATION_S = (5.0, 30.0)
 
 # -- per-beat evidence (issue #9) ---------------------------------------------
@@ -8496,6 +8511,136 @@ def check_opening_card(out_dir: Path, info: dict) -> list[str]:
     return failures
 
 
+def check_reported_opening_card(out_dir: Path, info: dict) -> list[str]:
+    """The take's **own** record of the frame it opened on (issue #235).
+
+    Everything above grades the video. This grades what the recorder wrote
+    down about it, and the difference is the whole of #235: a demo directory
+    commits `record.py`, `timeline.json`, `timeline.md` and `images/` and never
+    `demo.mp4` or its `.seg.mp4` parts, so the flash three separate people
+    reported by watching (#110, #114's re-report, #206) is in no committed
+    artifact. `check_opening_card` above sweeps a take *this suite* records, in
+    a directory nobody ships. The number in `content.opening.card` is the one a
+    reviewer of somebody else's demo can actually read.
+
+    Four statements, and each is broken by a different mistake:
+
+      * the field is **there and complete** — a recorder that measured nothing
+        and said nothing leaves a reviewer back at the video;
+      * the number **describes this video**, re-read here off frame zero of the
+        same mp4 over this harness's own strip. A plausible constant agrees
+        with itself forever otherwise, and 25.8 is a very plausible constant;
+      * on this take it says **card**, which is the acceptance criterion and is
+        what a card raised late breaks;
+      * and it says the card was **asked for**, without which `"bare"` cannot
+        be told from a segment that never wanted one.
+
+    The second is what keeps the rest from being a document agreeing with
+    itself, and its independence is deliberately narrow: the strip comes from
+    `record_terminal_opening`'s own reading of the live `#__term_win` box, and
+    the frame is decoded here rather than taken from the take's word for it.
+    What it cannot see is a recorder and a harness making the same mistake
+    about which corner to read; the sweep above, which reads the whole take
+    rather than one frame, is what makes that mistake visible.
+
+    **What is deliberately not asserted here**: that `state` follows the `luma`
+    beside it. Every take this arm records opens on the card, so a `state`
+    pinned to `"card"` would satisfy any such assertion — it could only fail
+    together with the "it says card" statement below, which the catalogue calls
+    a dominated assertion. What carries that claim instead is structural (one
+    expression in `opening_card_report` derives the word from the number it
+    publishes) plus `tests/unit`'s `OpeningCard`, which grades the mapping at
+    both bars. `tests/README.md`'s Known gaps has it with its measurement.
+    """
+    from demo_recording.content import (
+        OPENING_BARE_MIN_LUMA as PKG_BARE_MIN,
+    )
+    from demo_recording.content import (
+        OPENING_CARD_MAX_LUMA as PKG_CARD_MAX,
+    )
+
+    label = "terminal-opening"
+    failures: list[str] = []
+    # The recorder classifies at record time against the package's copy of
+    # these two bars; every statement below is written against this file's.
+    # A bar quietly widened on one side has to fail here rather than pass by
+    # agreeing with itself.
+    if (PKG_CARD_MAX, PKG_BARE_MIN) != (OPENING_CARD_MAX_LUMA, OPENING_BARE_MIN_LUMA):
+        failures.append(
+            f"{label}: the recorder classifies its opening frame against "
+            f"card <= {PKG_CARD_MAX}, bare >= {PKG_BARE_MIN}; this harness "
+            f"grades card <= {OPENING_CARD_MAX_LUMA}, bare >= "
+            f"{OPENING_BARE_MIN_LUMA} — one of them moved without the other"
+        )
+
+    doc = json.loads((out_dir / "timeline.json").read_text())
+    opening = ((doc.get("content") or {}).get("opening")) or {}
+    card = opening.get("card")
+    if not isinstance(card, dict):
+        return failures + [
+            f"{label}: this take wrote content.opening.card = {card!r}, so its "
+            f"timeline says nothing about the frame the segment opened on. "
+            f"That is the state issue #235 is about: the mp4 is not committed "
+            f"anywhere, so a reviewer with only this directory is back to "
+            f"taking somebody's word for it"
+        ]
+    luma, state = card.get("luma"), card.get("state")
+    if not isinstance(luma, (int, float)) or state not in ("card", "bare", "between"):
+        return failures + [
+            f"{label}: content.opening.card reports luma={luma!r} and "
+            f"state={state!r} over rect={card.get('rect')!r} — no reading, so "
+            f"nothing below can be graded. The take says: {card.get('note')!r}"
+        ]
+
+    # The number against the file. Read here, off frame zero, over the
+    # strip this harness worked out for itself — `-t` and no `fps` filter, for
+    # the reason check_opening() spells out.
+    try:
+        first = gray_frames(
+            out_dir / "demo.mp4", info["corner"], duration=OPENING_FIRST_FRAME_S
+        )
+    except RuntimeError as exc:
+        return failures + [f"{label}: {exc}"]
+    if not first:
+        return failures + [
+            f"{label}: nothing decoded from the first {OPENING_FIRST_FRAME_S}s "
+            f"of demo.mp4 over {info['corner']}, so the reported reading has "
+            f"nothing to be checked against"
+        ]
+    measured = sum(first[0]) / len(first[0])
+    if abs(measured - luma) > OPENING_CARD_AGREEMENT:
+        failures.append(
+            f"{label}: the take reports its first frame at {luma} mean luma "
+            f"over {card.get('rect')}, and frame zero of demo.mp4 reads "
+            f"{measured:.1f} over {info['corner']} — {abs(measured - luma):.1f} "
+            f"apart, over the {OPENING_CARD_AGREEMENT} these two readings of "
+            f"one frame are allowed. The number in the timeline is not a "
+            f"measurement of this video"
+        )
+
+    # The acceptance criterion, and the control beside it: this take asked for
+    # a card, so "bare" here is the defect rather than the arrangement.
+    if state != "card":
+        failures.append(
+            f"{label}: this take opened with TerminalRecorder(interlude=…) and "
+            f"reports its first frame as {state!r} at {luma} mean luma — the "
+            f"segment opens on the terminal and the card arrives afterwards "
+            f"(issue #110), and this time the take's own report says so"
+        )
+    if card.get("raised") is not True:
+        failures.append(
+            f"{label}: content.opening.card says raised={card.get('raised')!r} "
+            f"on a take constructed with interlude=… — without that flag "
+            f"'bare' cannot be told from a segment that never asked for a card"
+        )
+    if not failures:
+        print(
+            f"smoke: terminal-opening reports its own opening frame as "
+            f"{state} ({luma} mean luma, frame zero here reads {measured:.1f})"
+        )
+    return failures
+
+
 def evidence_docs(
     label: str, out_dir: Path, segment: str | None = None
 ) -> tuple[list[dict], list[dict], list[str]]:
@@ -8968,6 +9113,10 @@ def run_terminal_opening(out_root: Path) -> list[str]:
             "terminal-opening", mp4, OPENING_DURATION_S, keep_top(info["app"])
         )
         + check_opening_card(out_dir, info)
+        # The same frame, from the other side: what the *take* says it opened
+        # on, which is the only account of it a demo directory ever ships
+        # (issue #235).
+        + check_reported_opening_card(out_dir, info)
         + check_healthy("terminal-opening", out_dir)
     )
 

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -681,6 +681,78 @@ INJECTIONS = [
         sites=("check_issues",),
         must_contain=("failed is indistinguishable from one that worked",),
     ),
+    # -- what a terminal segment says it opened on (issue #235), 26 s an entry
+    #
+    # The same 290 ms of bare terminal was reported three times by three people
+    # watching (#110, #114's re-report, #206), and nothing machine-readable
+    # ever saw it: a demo directory commits `timeline.json` and never
+    # `demo.mp4`, so the frame in question is in no shipped artifact.
+    # `check_opening_card` sweeps the corner of a take *this suite* records,
+    # which is a claim about the recorder. These four are aimed at the number
+    # the recorder now writes into `content.opening.card` — the account of that
+    # frame a reviewer of somebody else's demo can actually read.
+    #
+    # The third is the acceptance criterion's own injection, and it is one of
+    # the nine `tests/README.md` records being performed by hand when the
+    # corner sweep was written. It is executed here instead.
+    Injection(
+        name="a terminal take says nothing about the frame it opened on",
+        module="terminal.py",
+        old=(
+            "        return opening_card_report(\n"
+            "            self._media_path(),\n"
+            "            self._opening_card_rect(),\n"
+            "            raised=self._opening is not None,\n"
+            "        )\n"
+        ),
+        new="        return None\n",
+        arm="--polish-only",
+        sites=("check_reported_opening_card",),
+        must_contain=("timeline says nothing about the frame the segment opened on",),
+    ),
+    Injection(
+        # A plausible constant, which is the shape this class of defect really
+        # takes: 40.0 is inside the card band, so the take still reports
+        # `state: "card"` and every other statement about this field passes.
+        # Only reading the frame again says the number is not a measurement.
+        name="the opening frame's luma is a constant rather than a reading",
+        module="content.py",
+        old='        report["luma"] = round(sum(frames[0]) / len(frames[0]), 1)',
+        new='        report["luma"] = 40.0',
+        arm="--polish-only",
+        sites=("check_reported_opening_card",),
+        must_contain=("The number in the timeline is not a ",),
+    ),
+    Injection(
+        # The defect itself, exactly as #110 measured it: the card raised from
+        # a timer instead of at document start, so capture begins on the bare
+        # terminal and the card arrives afterwards. `check_opening_card` fires
+        # too — it is the same frame — and the entry is aimed at the *report*,
+        # which is the only account of that frame anybody ships.
+        name="the opening card is raised 400 ms into the document",
+        module="terminal.py",
+        old=(
+            "  if (document.body) build();\n"
+            "  else addEventListener('DOMContentLoaded', build);\n"
+        ),
+        new="  setTimeout(build, 400);\n",
+        arm="--polish-only",
+        sites=("check_reported_opening_card",),
+        must_contain=("and this time the take's own report says so",),
+    ),
+    Injection(
+        # Without `raised`, "bare" is ambiguous: it is the defect on a segment
+        # opened with `interlude=` and the arrangement on one that never asked
+        # for a card. A flag that is always false makes every reading of this
+        # field unreadable, and no luma can notice.
+        name="the report forgets that the take asked for an opening card",
+        module="terminal.py",
+        old="            raised=self._opening is not None,\n",
+        new="            raised=False,\n",
+        arm="--polish-only",
+        sites=("check_reported_opening_card",),
+        must_contain=("cannot be told from a segment that never asked for a card",),
+    ),
     # -- the clock demo.mp4 is on (issues #18/#215), 29 s an entry ------------
     #
     # Chromium stamps every screencast frame with the host's *wall* clock and

--- a/tests/unit
+++ b/tests/unit
@@ -65,10 +65,14 @@ from demo_recording.content import (  # noqa: E402
     CONTENT_ACTING_VERBS,
     CONTENT_CAPTION_TRIM,
     CONTENT_PASSIVE_VERBS,
+    OPENING_BARE_MIN_LUMA,
+    OPENING_CARD_MAX_LUMA,
     OPENING_WARN_S,
     _beats_within,
     content_rect,
     merge_content,
+    opening_card_report,
+    opening_card_state,
     opening_report,
     opening_warning,
     overlay_warning,
@@ -1195,6 +1199,99 @@ class OpeningWarning(unittest.TestCase):
 
     def test_a_healthy_take_whose_hold_landed_is_silent(self):
         self.assertIsNone(opening_warning(opening_report(0.0, None, 0.42)))
+
+
+class OpeningCard(unittest.TestCase):
+    """issue #235 — the number that says what a terminal segment opened on.
+
+    Three people watching found the same flash of bare terminal, because the
+    only thing that ever graded it was `tests/smoke` sweeping a take the suite
+    records itself. The recorder now reads its own first frame and writes the
+    answer into `content.opening.card`.
+
+    The pixels are smoke's — this file grades nothing measured off real frames,
+    and says so at the bottom. What is here is the classifier and the shape of
+    the record: whether a reader can tell *the card was up* from *the card was
+    not* from *nobody could say*, which is the half that decides whether the
+    artifact can lie.
+    """
+
+    def test_the_two_states_the_recorder_paints(self):
+        # The measured readings, from #128 and #207: ~26 with the card up,
+        # ~226 bare. Neither is a tuned bar — they are the card's `#1c1a17`
+        # and the recorder's pastel gradient, an order of magnitude apart.
+        self.assertEqual(opening_card_state(25.8), "card")
+        self.assertEqual(opening_card_state(226.5), "bare")
+
+    def test_a_card_part_way_up_is_called_neither(self):
+        # 128.0 is a real reading, not a hypothetical: one CI run in nine, on
+        # a loaded runner (#128). It is the reason nothing here enforces, and
+        # calling it either state would be the artifact claiming something
+        # nobody measured.
+        self.assertEqual(opening_card_state(128.0), "between")
+
+    def test_both_bars_are_graded_at_their_boundary(self):
+        # The catalogue's "ungraded constant": either side of each bar rather
+        # than comfortably inside one of them.
+        self.assertEqual(opening_card_state(OPENING_CARD_MAX_LUMA), "card")
+        self.assertEqual(opening_card_state(OPENING_CARD_MAX_LUMA + 0.1), "between")
+        self.assertEqual(opening_card_state(OPENING_BARE_MIN_LUMA), "bare")
+        self.assertEqual(opening_card_state(OPENING_BARE_MIN_LUMA - 0.1), "between")
+
+    def test_the_band_between_the_bars_stays_wide_and_empty(self):
+        # If the two bars ever met, "between" would be unreachable and a card
+        # mid-fade would have to be reported as one of the other two — which
+        # is the whole thing this measurement refuses to do.
+        self.assertGreater(OPENING_BARE_MIN_LUMA - OPENING_CARD_MAX_LUMA, 50.0)
+
+    def test_no_reading_is_no_state(self):
+        # Not "bare". A frame nobody could read is not a frame that showed the
+        # terminal, and the difference is the whole of #128's third answer.
+        self.assertIsNone(opening_card_state(None))
+
+    def test_a_recorder_that_cannot_place_its_window_says_so(self):
+        card = opening_card_report("demo.mp4", None, raised=True)
+        self.assertIsNone(card["luma"])
+        self.assertIsNone(card["state"])
+        self.assertIn("does not know where its window sits", card["note"] or "")
+
+    def test_a_take_with_no_mp4_is_a_note_rather_than_an_exception(self):
+        # This runs inside `__exit__`, after the encode: an exception escaping
+        # it costs the take every artifact written after it.
+        card = opening_card_report(
+            Path(tempfile.gettempdir()) / "demo-video-no-such-take.mp4",
+            (0, 0, 8, 8),
+            raised=False,
+        )
+        self.assertIsNone(card["state"])
+        self.assertIn("demo-video-no-such-take.mp4", card["note"] or "")
+
+    def test_whether_a_card_was_asked_for_is_in_the_record(self):
+        # "bare" is the defect on a segment opened with `interlude=` and the
+        # arrangement on one that was not, and no luma can tell them apart.
+        self.assertIs(
+            opening_card_report("demo.mp4", None, raised=True)["raised"], True
+        )
+        self.assertIs(
+            opening_card_report("demo.mp4", None, raised=False)["raised"], False
+        )
+
+    def test_the_bars_the_reading_was_classified_against_are_published(self):
+        # A number is not a verdict unless the reader can see what it was
+        # compared with — and these two move (see the boundary test above),
+        # so a document carrying the number and not the bars ages into a
+        # number nobody can interpret.
+        card = opening_card_report("demo.mp4", None, raised=True)
+        self.assertEqual(card["card_max"], OPENING_CARD_MAX_LUMA)
+        self.assertEqual(card["bare_min"], OPENING_BARE_MIN_LUMA)
+
+    def test_the_opening_block_carries_the_key_on_every_take(self):
+        # Present and null on a recorder that cannot read its own first frame,
+        # rather than absent — the same reason `held` is null on a terminal
+        # take. A consumer that has to distinguish "no card" from "this key
+        # did not exist yet" is reading a shape that changes under it.
+        self.assertIn("card", opening_report(0.0, None, 0.4))
+        self.assertIsNone(opening_report(0.0, None, 0.4)["card"])
 
 
 class OverlayWarning(unittest.TestCase):
@@ -4672,6 +4769,85 @@ class TerminalStill(unittest.TestCase):
         self.assertEqual(
             [(b["verb"], b["selector"], b.get("ac")) for b in rec._beats],
             [("shot", "01-done", ["AC-2"])],
+        )
+
+
+class OpeningCardOnATake(unittest.TestCase):
+    """The take-level half of issue #235, without a browser or a frame.
+
+    `OpeningCard` above grades the classifier and the record. These two grade
+    the recorder around it: where the strip it reads comes from, and whether
+    the reading survives the *other* measurement failing. Both are arithmetic
+    and control flow — no ffmpeg runs here, because the mp4 these takes name
+    does not exist and every path below stops at "there is no demo.mp4".
+    """
+
+    class Boxes(FakePage):
+        """A page whose element boxes are the ones a test wrote down.
+
+        Keyed by selector, so a recorder reaching for `#__term_host` where it
+        means `#__term_win` reads `None` here rather than the other element's
+        box, and says it could not measure instead of measuring the wrong
+        thing.
+        """
+
+        def __init__(self, boxes: dict) -> None:
+            super().__init__()
+            self.boxes = boxes
+
+        def locator(self, selector: str):
+            box = self.boxes.get(selector)
+            return types.SimpleNamespace(bounding_box=lambda: box)
+
+    def test_the_strip_starts_from_the_windows_unrounded_right_edge(self):
+        # `int(x) + int(w)` and `int(x + w)` are a column apart on a
+        # fractional box: 100.6 + 57.6 is 158.2, so the edge is 158 and the
+        # strip starts at 166 — two truncations give 157 and start it at 165.
+        # One column out of 58 is a fraction of a luma level and would never
+        # change the verdict; what it can do is drift the recorder's number
+        # away from tests/smoke's independent reading of the same strip, which
+        # is graded with a 1.0 bar. The two derive the edge the same way.
+        rec = recorder(
+            self,
+            cls=TermRec,
+            page=self.Boxes(
+                {"#__term_win": {"x": 100.6, "y": 70.0, "width": 57.6, "height": 400.0}}
+            ),
+        )
+        rec._read_win_edge()
+        rect = rec._opening_card_rect()
+        self.assertIsNotNone(rect, "the window's box was read and gave no strip")
+        self.assertEqual(rect[0], 166)
+
+    def test_a_take_that_lost_its_app_rect_still_reports_its_opening_frame(self):
+        """The catalogue's clean-path-only assertion, on this field's guard.
+
+        `_content_rect` raising nulls the whole `content.opening` block — so a
+        terminal take that could read `#__term_win` and not `#__term_host`
+        used to say nothing whatsoever about the frame it opened on, with
+        nothing anywhere saying why. The opening card is not measured over the
+        app rect, so it has no reason to be lost with it.
+        """
+        rec = recorder(self, cls=TermRec, page=self.Boxes({}))
+        rec._converted = True
+
+        def no_host_box():
+            raise RuntimeError("#__term_host has no box")
+
+        rec._content_rect = no_host_box
+        rec._measure_content()
+        opening = (rec._content or {}).get("opening")
+        self.assertIsInstance(
+            opening, dict, "the whole opening block went null with the app rect"
+        )
+        self.assertIsInstance(opening["card"], dict)
+        self.assertIn("app rect could not be worked out", opening["note"] or "")
+        # And the absence inside it says why, rather than being a bare null:
+        # this take never read its window either, which is a different reason
+        # from the one above and has to be legible as one.
+        self.assertIsNone(opening["card"]["luma"])
+        self.assertIn(
+            "does not know where its window sits", opening["card"]["note"] or ""
         )
 
 
@@ -10984,6 +11160,94 @@ INJECTIONS = [
         [
             "OpeningWarning.test_the_warning_bar_is_graded_at_its_boundary",
             "OpeningWarning.test_a_healthy_take_whose_hold_landed_is_silent",
+        ],
+    ),
+    (
+        # Issue #235's classifier, at the bar rather than comfortably inside
+        # it. `<` for `<=` moves the card bar by nothing a take would notice
+        # and is exactly the edit no test inside the band can see.
+        "the card bar excludes the value it is written as including",
+        "content.py",
+        "    if luma <= OPENING_CARD_MAX_LUMA:",
+        "    if luma < OPENING_CARD_MAX_LUMA:",
+        ["OpeningCard.test_both_bars_are_graded_at_their_boundary"],
+    ),
+    (
+        # The band closed up. Every reading is then one of two states, and the
+        # 128 a loaded CI runner produced (#128) is reported as a bare
+        # terminal — a confident answer about a frame nobody could classify.
+        "the empty band between the two bars is closed",
+        "content.py",
+        "OPENING_BARE_MIN_LUMA = 150.0",
+        "OPENING_BARE_MIN_LUMA = 61.0",
+        [
+            "OpeningCard.test_a_card_part_way_up_is_called_neither",
+            "OpeningCard.test_the_band_between_the_bars_stays_wide_and_empty",
+        ],
+    ),
+    (
+        # A recorder that could not place its window reports on the frame
+        # anyway, off whatever `rect` it was handed. The note this replaces is
+        # the difference between "not measured" and a number.
+        "a take with no window box measures something regardless",
+        "content.py",
+        '        if rect is None:\n            report["note"] = (\n',
+        '        if False:\n            report["note"] = (\n',
+        ["OpeningCard.test_a_recorder_that_cannot_place_its_window_says_so"],
+    ),
+    (
+        # Without this flag "bare" is unreadable: it is #110's flash on a
+        # segment that asked for a card and the ordinary state of one that did
+        # not, and the luma is identical either way.
+        "the report claims every take asked for an opening card",
+        "content.py",
+        '        "raised": raised,',
+        '        "raised": True,',
+        ["OpeningCard.test_whether_a_card_was_asked_for_is_in_the_record"],
+    ),
+    (
+        # The key gone from the envelope rather than null. A consumer then
+        # cannot tell a medium that has nothing to say from a recorder that
+        # predates the field.
+        "the opening block stops carrying the card key at all",
+        "content.py",
+        '    return {"gap": gap, "held": held, "limit": limit, "note": note, "card": None}',
+        '    return {"gap": gap, "held": held, "limit": limit, "note": note}',
+        ["OpeningCard.test_the_opening_block_carries_the_key_on_every_take"],
+    ),
+    (
+        # The exception path as it shipped in the first draft of #235: the app
+        # rect could not be worked out, so the whole `opening` block went null
+        # and the frame the segment opened on went with it — a measurement
+        # that needs only `#__term_win`, lost because `#__term_host` was
+        # unreadable, with nothing saying so.
+        "a take that lost its app rect reports nothing about its opening",
+        "core.py",
+        '            self._content["opening"] = opening_report(\n'
+        "                None,\n"
+        '                "the app rect could not be worked out, so the opening gap was "\n'
+        '                "not measured; `card` below is read off this medium\'s own "\n'
+        '                "window and is unaffected",\n'
+        "                self._opening_held,\n"
+        "            )\n"
+        '            self._content["opening"]["card"] = self._opening_card()\n',
+        "            pass\n",
+        [
+            "OpeningCardOnATake."
+            "test_a_take_that_lost_its_app_rect_still_reports_its_opening_frame"
+        ],
+    ),
+    (
+        # Two truncations instead of one. Invisible on an integral box, a
+        # column adrift on a fractional one — and the column is on the side
+        # tests/smoke's agreement check reads.
+        "the strip is measured from a twice-rounded window edge",
+        "terminal.py",
+        '            self._win_right = int(box["x"] + box["width"])',
+        '            self._win_right = int(box["x"]) + int(box["width"])',
+        [
+            "OpeningCardOnATake."
+            "test_the_strip_starts_from_the_windows_unrounded_right_edge"
         ],
     ),
     (


### PR DESCRIPTION
Fixes #235.

At record time — the only moment the video exists — a terminal take reads the
corner strip off its own **first frame** and writes the number into the take's
report. A reviewer reads `content.opening.card` in `timeline.json`, which *is*
a committed artifact, instead of opening an mp4 that is not.

## The field

`content.opening.card`, on every terminal take (null on a web take, which has
no window to read beside):

```json
"card": { "luma": 25.8, "state": "card", "raised": true,
          "rect": [1214, 0, 58, 50],
          "card_max": 60.0, "bare_min": 150.0, "note": null }
```

- `luma` — mean luma of the strip of background beside the live `#__term_win`
  box, on frame zero, read with `-t` and **no** `fps` filter (the filter
  answers with whatever frame lands nearest the middle of its first slot; that
  cost `check_opening` a real defect once).
- `state` — `"card"`, `"bare"` or `"between"`, derived from the **rounded**
  `luma` this dict publishes, so the number and the word cannot disagree.
- `raised` — whether the take asked for a card. It is what makes `"bare"`
  readable: the defect on a segment opened with `interlude=`, the arrangement
  on one that never wanted a card. A take using the old `interlude()`-first
  shape (#114) therefore records `raised: false, state: "bare"` — the flash,
  in the one file a demo directory commits.
- `note` — why, when `luma` is null. Never a guess, never silently absent.

The two bars are `OPENING_CARD_MAX_LUMA = 60.0` / `OPENING_BARE_MIN_LUMA =
150.0`, moved into `content.py` so the recorder classifies against the same
pair `check_opening_card` grades against. `tests/smoke` keeps its own
hand-written copy and `check_reported_opening_card` asserts the two are equal —
one moved without the other is a failure, not an agreement.

## Report, not enforce — and this was decided, not defaulted

#235 left warn/refuse/report open. This is **report**: nothing warns, nothing
raises, no take fails. #128 measured one CI run in nine reading **128** luma and
0.00 s of cover on a loaded runner — neither state — so a refusal built on this
bar would be flaky on exactly the runner it most needs to be trusted on, and a
bar retuned until it was not would be the catalogue's *threshold tuned to this
box*. The band between 60 and 150 is left deliberately empty so a card mid-fade
is called `"between"` rather than either thing.

I found no strong reason report-only is wrong.

## The seam

`_measure_content` is sealed on `_DemoBase` (`__init_subclass__` refuses an
override at import — the #147 machinery caught my first attempt). So this lands
as a declared medium hook, `_opening_card`, added to `MEDIUM_HOOKS` beside
`_content_rect`. Core's change is four lines; everything medium-specific is in
`terminal.py`.

## What is graded, and every injection

### `tests/smoke --polish-only` → `check_reported_opening_card`, 4 entries

Registered in `tests/smoke-inject`, so they re-run rather than being a claim in
this PR body. The harness aborts unless the search string matches **exactly
once** — it did that to me once during this work, on a string that occurred
twice in `content.py`:

```
ABORT: injection 'a take with no window box measures something regardless' matched 2 times in
content.py, expected exactly 1. The injection did not land, so nothing it would have proven is proven.
```

```
smoke-inject: 4 injection(s) over 1 arm(s), plus 1 clean baseline(s)

BASE  --polish-only passes clean (28s)

PASS  break: a terminal take says nothing about the frame it opened on  [28s]
      --polish-only, in terminal.py: return opening_card_report(…
      caught: terminal-opening: this take wrote content.opening.card = None, so its timeline says
              nothing about the frame the segment opened on. That is the state i…

PASS  break: the opening frame's luma is a constant rather than a reading  [28s]
      --polish-only, in content.py: report["luma"] = round(sum(frames[0]) / len(frames[0]), 1)…
      caught: terminal-opening: the take reports its first frame at 40.0 mean luma over
              [1214, 0, 58, 50], and frame zero of demo.mp4 reads 25.8 over (1214, 0, 58,…

PASS  break: the opening card is raised 400 ms into the document  [29s]
      --polish-only, in terminal.py: if (document.body) build();
  else addEventListener('DOMContentL…
      caught: terminal-opening: this take opened with TerminalRecorder(interlude=…) and reports its
              first frame as 'bare' at 226.5 mean luma — the segment opens on…

PASS  break: the report forgets that the take asked for an opening card  [29s]
      --polish-only, in terminal.py: raised=self._opening is not None,…
      caught: terminal-opening: content.opening.card says raised=False on a take constructed with
              interlude=… — without that flag 'bare' cannot be told from a segme…

All 4 injections were caught. [2.4 min]
```

The third is the injection the acceptance criterion names. Run by hand as well,
in the working tree, to capture the whole failure list and the artifact it
leaves — `tests/smoke --polish-only`:

```
smoke: FAILED
  - terminal-opening: the recording's first frame reads 226.5 mean luma in the corner at
    (1214, 0, 58, 50), which is 'bare' and not the card (card <= 60.0, bare terminal >= 150.0).
    The segment opens on the terminal and the card arrives afterwards — issue #110.
  - terminal-opening: the card covers only the first 0.00s of the recording (0 frames at 20 fps),
    under the 1.0s bar for a card held 2.5s. Frame 0 reads 226.5 — the viewer sees the terminal
    before the card that is supposed to be covering it.
  - terminal-opening: this take opened with TerminalRecorder(interlude=…) and reports its first
    frame as 'bare' at 226.5 mean luma — the segment opens on the terminal and the card arrives
    afterwards (issue #110), and this time the take's own report says so
```

and the take's own report, which is the point of the change:

```json
"card": { "luma": 226.5, "state": "bare", "raised": true,
          "rect": [1214, 0, 58, 50], "card_max": 60.0, "bare_min": 150.0, "note": null }
```

226.5 → 25.8 is #207's pair of numbers for the same storyboard one line apart,
reproduced here by the recorder itself. On the healthy take the two independent
readings agree exactly:

```
smoke: terminal-opening card covers the first 2.85s (corner 26 -> 226), then clears
smoke: terminal-opening reports its own opening frame as card (25.8 mean luma, frame zero here reads 25.8)
```

### `tests/unit` → `OpeningCard`, 5 injections

0.2 s each, all caught (`tests/unit --fault-inject`: *All 274 injections were
caught*):

```
PASS  break: the card bar excludes the value it is written as including
      in content.py: if luma <= OPENING_CARD_MAX_LUMA:…
      FAIL: test_both_bars_are_graded_at_their_boundary

PASS  break: the empty band between the two bars is closed
      in content.py: OPENING_BARE_MIN_LUMA = 150.0…
      FAIL: test_a_card_part_way_up_is_called_neither
      FAIL: test_the_band_between_the_bars_stays_wide_and_empty

PASS  break: a take with no window box measures something regardless
      in content.py: if rect is None:…
      FAIL: test_a_recorder_that_cannot_place_its_window_says_so

PASS  break: the report claims every take asked for an opening card
      in content.py: "raised": raised,…
      FAIL: test_whether_a_card_was_asked_for_is_in_the_record

PASS  break: the opening block stops carrying the card key at all
      in content.py: return {"gap": gap, "held": held, "limit": limit, "note": note, "car…
      FAIL: test_the_opening_block_carries_the_key_on_every_take
```

### An assertion written and then deleted

`state` follows the `luma` beside it — deleted rather than shipped unfirable.
Every take `--polish-only` records opens **on** the card, so a `state` pinned to
`"card"` could only fail together with "it says card", which is the catalogue's
*dominated assertion*. Recorded in `tests/README.md`'s Known gaps with what
would close it (a second terminal take in that arm, opened without
`interlude=`, which would have to report `bare`/`raised: false`) and what that
costs.

## Stated limits

- **No demo in this repository has been re-recorded**, so
  `2026-07-26-status-filter`'s committed timeline carries no such field and is
  still graded by whoever watched it. The field arrives with the next
  re-record. Out of scope here on purpose.
- **The number is in `timeline.json` only.** It is not a clause of the healthy
  `shows a picture` line and not on stderr — the take prints exactly what it
  printed before. #235 asks for it where a reviewer reads without opening the
  video, and that is the committed file.
- **Reported means shippable.** A demo whose part 2 opens bare still ships, with
  a truthful line saying so. Enforcement is a second decision (#114 owns the
  constructor half).
- **The independence of the smoke check is narrow.** It re-reads frame zero
  itself, over a strip `record_terminal_opening` derives from the same live
  `#__term_win` box the recorder reads — so a recorder and a harness that made
  the same mistake about *which* corner to read would agree. What makes that
  visible is `check_opening_card` above it, which sweeps the whole take.
- **A card that fades in is still invisible here**, exactly as before: the
  recorder spends longer injecting xterm.js than a 450 ms fade takes, so frame
  zero is opaque either way. Unchanged by this, and already stated in
  `tests/README.md`.
- **`--polish-only` now carries entries**, which it did not before. #240 stays
  open for the arm's other three functions (`check_opening_card`,
  `check_spotlight_transitions`, `_check_video`) — this PR adds none for them,
  per #235's out-of-scope list. Their baseline is now already paid.
- **Manifest cost.** 60 → 64 entries, ~44.6 → ~46.8 min estimated. `--self-test`
  checks every figure in `tests/README.md` against the manifest, so those
  numbers are in the file and graded.

## Suites

`tests/lint`, `tests/unit` (418), `tests/unit --fault-inject` (274),
`tests/ci-unit` (99), `tests/smoke-inject --self-test`, mypy 1.18.2, and the
full `tests/smoke` — **PASSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
