### PR TITLE
A gallery of pictures the take never took (#305)

### DIFF
--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -1371,7 +1371,22 @@ def render_timeline_md(doc: dict) -> str:
         if total > len(issues):
             out.append(f"- …and {total - len(issues)} more, not recorded.")
         out.append("")
-    stills = [b for b in beats if b.get("still")]
+    # A beat whose verb raised contributes nothing here. `shot()` stamps the
+    # path on the beat *before* it takes the picture, so on a take that died
+    # there the path names a file this take never wrote — and the interesting
+    # case is not the missing file. `images/` is committed, so on a re-record
+    # after a crash the *previous* take's picture of that name is already
+    # sitting on disk, and the embed puts a real photograph under this take's
+    # heading, this take's timestamp and this take's caption, as evidence of a
+    # moment this take never reached. The acceptance table one section up
+    # withholds the same path for the same reason (issues #278, #305).
+    #
+    # Dropped rather than marked: this is a gallery of pictures, and a heading
+    # with no picture under it is not one. The beat table above already carries
+    # the row, marked **raised**.
+    stills = [
+        b for b in beats if b.get("still") and not isinstance(b.get("error"), dict)
+    ]
     if stills:
         out += ["", "## Stills", ""]
         for beat in stills:

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -317,6 +317,15 @@ A clause claimed by a beat that **returned** is untouched, even when the take
 died later somewhere else: that claim is as good as any other claim that take
 made.
 
+**The `## Stills` gallery at the foot of the same file drops that beat too**
+([#305](https://github.com/rogvid/skills/issues/305)). Withholding the path in
+the table above and embedding it as a picture twenty lines lower is the same
+lie twice, and the picture is the worse half: `images/` is committed, so on a
+re-record after a crash the *previous* take's file of that name is already on
+disk, and the embed puts a real photograph under this take's heading, this
+take's timestamp and this take's caption. The beat table is where that beat
+still appears, marked **raised**.
+
 ### Put the clause on screen: `criterion()`
 
 Everything above lives in files a viewer never opens. The video — the artifact

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -14,7 +14,11 @@ next to the media, whether or not the storyboard finished. No storyboard
 changes are needed; it is a byproduct of recording.
 
 `timeline.md` is the readable version: a table of every beat, then each still
-embedded under the caption it was taken during. Directly above that table it
+**the take actually wrote** embedded under the caption it was taken during — a
+`shot()` whose screenshot raised stamped its path on the beat before it took
+the picture, so that beat contributes no gallery entry at all
+([#305](https://github.com/rogvid/skills/issues/305)); the beat table above
+still carries its row, marked **raised**. Directly above that table it
 says when the host's wall clock **stepped** during the take, and by how much —
 the times in the table are `time.monotonic()` and `demo.mp4` is on the wall
 clock, so a step parts the two (`timeline.json`'s `capture_clock` carries every

--- a/tests/README.md
+++ b/tests/README.md
@@ -1516,13 +1516,56 @@ says so explicitly. The injection *the failure lead counts every clause, not
 the ones no beat returned on* is what holds that line; without it the sentence
 would read as a finding against every clause on any crashed take.
 
-**What this leaves alone, stated rather than implied.** `render_timeline_md`'s
-`## Stills` gallery still embeds `![02](images/02.png)` for a `shot` beat that
-raised — a broken image in the same file whose acceptance table now withholds
-that path ([#305](https://github.com/rogvid/skills/issues/305)). It is a
-different renderer, reading `beats` rather than `coverage`, and #278's scope is
-the coverage row and the acceptance section; the wiring test asserts the path
-is absent from the acceptance section and says which issue owns the rest.
+**The same lie one section down: the `## Stills` gallery**
+([#305](https://github.com/rogvid/skills/issues/305)). #278 stopped the
+acceptance table naming `images/02.png` for a `shot` beat that raised, and
+twenty lines lower in the same file `render_timeline_md` embedded it as a
+picture — a third renderer, selecting off `beats` rather than `coverage` with
+`[b for b in beats if b.get("still")]`. A beat whose verb raised now
+contributes no gallery entry at all: not the embed, not the `### 02-empty —
+5.40s` heading, not the caption quoted under it. The beat table is where that
+beat still appears, marked **raised**.
+
+**`StillsGallery` grades the file-present case, and that is the whole design of
+it.** A missing file renders a broken-image placeholder — visibly broken,
+self-announcing, and an injection built on it would grade the easy half. But
+`images/` is committed, so on a re-record after a crash the *previous* take's
+picture of that name is already sitting on disk, and the embed puts a real
+photograph under this take's heading, this take's timestamp and this take's
+caption. So `setUp` stages that file, the document is written into the
+directory holding it with `write_timeline` — the path is relative, and means
+nothing without a directory to resolve against — and the assertions are on
+**which files on disk a markdown viewer could open out of the rendered
+document**, parsed here rather than borrowed from the renderer.
+
+| claim | what would otherwise pass |
+|---|---|
+| the openable pictures are exactly the ones this take wrote | stated as an equality, because "the stale picture is gone" is also true of a gallery that lost the section |
+| the heading and timestamp go with the picture | an entry stripped of only its `![…]()` line is still this take's heading and second over last week's photograph — and the injection *a beat that raised keeps its gallery heading and loses only the image* reddens this and leaves the row above green |
+| a take whose every picture raised prints no `## Stills` at all | a heading decided before the filter rather than after it is a promise of evidence with nothing behind it |
+| a take that finished embeds every picture it took | the #24 direction: a filter off by one `not` empties a healthy demo's gallery and satisfies all three rows above |
+
+Verified against the five committed `examples/ticket-queue/demos/*/timeline.json`:
+rendered on `ccd381c` and on this change, all five come out byte for byte the
+same. None of them carries a beat that raised, which is the point.
+
+**Two graded-coverage gaps in #278's own tests, closed here.** Both were found
+reviewing the merged change rather than by anything in the suite:
+
+- `_coverage_failure_md`'s `beat is None` branch — the take that came out of the
+  `with` block with no verb running — was ungraded in `tests/unit` while the
+  comment's mirror of it was graded. Replacing *"between beats — no verb was
+  running, so no beat is blamed"* with *"beat None (`None`)"* left the suite at
+  `Ran 420 tests … OK`. `CoverageMd.test_a_take_that_died_between_beats_blames_no_beat`
+  and an injection now hold it.
+- `Coverage.test_a_clean_take_carries_none_of_this` and
+  `Coverage.test_the_same_words_are_refused_on_a_take_that_did_not_finish` in
+  `tests/ci-unit` were in no `INJECTIONS` entry. Neither was hollow, but an edit
+  that hollowed them would have been silent. They now have one each: the lead
+  printed on a take that *finished* (the #24 direction, which `tests/unit` had
+  and this side did not), and a verdict word appended to the lead — appended
+  rather than substituted, for the reason the per-word injections append to the
+  disclaimer.
 
 **The sweep grades the sentences the renderer writes, not the ones it quotes**
 ([#283](https://github.com/rogvid/skills/issues/283)). Clause text belongs to

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -2167,6 +2167,39 @@ INJECTIONS = [
         ],
     ),
     (
+        # The same condition inverted, which is the direction #24 is about and
+        # the one the injection above cannot reach: the lead printed on every
+        # take that *finished*. `tests/unit` has this pair; this side had only
+        # the deletion, so nothing here watched an ordinary comment stay
+        # ordinary and `test_a_clean_take_carries_none_of_this` was in no
+        # manifest entry at all.
+        "the failure lead is printed on a take that did not fail",
+        "demo-comment",
+        "    if isinstance(failure, dict):\n"
+        "        gap += _failure_lead(failure, criteria, claimed)",
+        "    if not isinstance(failure, dict):\n"
+        "        gap += _failure_lead(failure or {}, criteria, claimed)",
+        [
+            "Coverage.test_a_clean_take_carries_none_of_this",
+            "Coverage.test_a_failed_take_says_so_before_anything_it_claimed",
+        ],
+    ),
+    (
+        # The verdict sweep, on the two sentences only a crashed take reaches.
+        # Appended rather than substituted, the same way the per-word
+        # injections treat the disclaimer: the lead's opening words are what
+        # three assertions above locate it by, and replacing them would redden
+        # those instead — the green-to-red transition that makes a sweep look
+        # alive while it stays silent.
+        "the failure lead promotes what the take got through to a verdict",
+        "demo-comment",
+        '        f"`with` block at {where}.",',
+        '        f"`with` block at {where}. Everything before it was demonstrated.",',
+        [
+            "Coverage.test_the_same_words_are_refused_on_a_take_that_did_not_finish",
+        ],
+    ),
+    (
         # The count that would be inventing a finding. #278 says it explicitly:
         # a clause claimed by a beat that *returned* on a take that later died
         # elsewhere is as good as any other claim that take made.

--- a/tests/unit
+++ b/tests/unit
@@ -116,6 +116,7 @@ from demo_recording.timeline import (  # noqa: E402
     _coverage_md,
     render_timeline_md,
     timeline_paths,
+    write_timeline,
 )
 
 # --------------------------------------------------------------------------
@@ -584,6 +585,24 @@ class CoverageMd(unittest.TestCase):
         line = [ln for ln in text.splitlines() if "no claim from a beat" in ln][0]
         self.assertNotIn("AC-1", line)
 
+    def test_a_take_that_died_between_beats_blames_no_beat(self):
+        # `failure["beat"]` is null when the take came out of the `with` block
+        # with no verb running, and this branch was ungraded here: replacing
+        # its sentence with `beat None (`None`)` left the whole suite green.
+        # The comment's mirror of it *is* graded, so this was one-sided — and
+        # "beat None" is a confident wrong answer where the branch exists to
+        # say nobody may honestly be blamed.
+        lines = _coverage_md(
+            self.RAISED, {"type": "KeyboardInterrupt", "beat": None, "verb": None}
+        )
+        self.assertTrue(lines[2].startswith("**This take did not finish**"), lines[2])
+        self.assertIn("between beats", lines[2])
+        self.assertNotIn("beat None", lines[2])
+        # The control, on the same renderer: a failure that *does* name a beat
+        # still names it. Without it this passes on a lead that never blames
+        # anything.
+        self.assertIn("beat 2 (`shot`)", _coverage_md(self.RAISED, self.FAILURE)[2])
+
     def test_a_take_that_died_claiming_everything_says_that_instead(self):
         # The other branch, and the one a reader meets when the take crashed at
         # a beat that tagged nothing. Without it the count sentence would be
@@ -678,7 +697,13 @@ class TimelineMd(unittest.TestCase):
         )
         text = render_timeline_md(doc)
         start = text.index("## Acceptance criteria")
-        section = text[start : text.index("\n## ", start + 1)]
+        # To the next `## ` heading, **or to the end of the file**. This used
+        # to index unconditionally, and the heading it landed on was `##
+        # Stills` — which this document no longer has, because its one still
+        # belongs to the beat that raised (issue #305). The span is the same
+        # bytes either way: the gallery was the last thing in the file.
+        end = text.find("\n## ", start + 1)
+        section = text[start : len(text) if end < 0 else end]
         self.assertIn("**AC-2**", section)  # control: the section rendered
         # The lead line, not "did not finish" anywhere in the section. The
         # first version of this assertion searched for the phrase, and the
@@ -687,8 +712,8 @@ class TimelineMd(unittest.TestCase):
         # was not written about. Fault injection found that; reading did not.
         self.assertIn("\n**This take did not finish**", section)
         # And the still the beat never wrote is nowhere in the section. The
-        # `## Stills` gallery further down still embeds it — that is a
-        # different renderer and issue #305, not this one.
+        # `## Stills` gallery further down is a different renderer, reading
+        # `beats` rather than `coverage`; `StillsGallery` below grades it.
         self.assertNotIn("images/02.png", section)
 
     def test_a_null_duration_is_not_rendered_as_a_number(self):
@@ -799,6 +824,133 @@ class TimelineMd(unittest.TestCase):
             )
         )
         self.assertIn("204 more", text)
+
+
+class StillsGallery(unittest.TestCase):
+    """`## Stills` must embed only pictures this take actually wrote (#305).
+
+    The gallery selects off the beat log, and `shot()` stamps `still` on the
+    beat *before* it takes the picture — so a beat whose screenshot raised
+    carried the path and no file, and the gallery embedded it one section below
+    an acceptance table that withheld the same path for the stated reason that
+    it was never written (#278).
+
+    **The interesting case is the file being there, not missing.** A missing
+    file renders a broken-image placeholder: visibly broken, self-announcing.
+    But `images/` is committed, so on a re-record after a crash the *previous*
+    take's picture of that name is already sitting on disk, and the embed puts
+    a real photograph under this take's heading, this take's timestamp and this
+    take's caption — evidence of a moment this take never reached.
+
+    So these assertions are written from the reader's side rather than the
+    renderer's: the document is written to a directory where the stale picture
+    is staged, and what is graded is which files on disk a markdown viewer
+    could open out of it.
+    """
+
+    STALE = b"\x89PNG\r\n\x1a\nthe previous recording's 02-empty"
+
+    def setUp(self):
+        self.dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.dir, ignore_errors=True)
+        (self.dir / "images").mkdir()
+        (self.dir / "images" / "01-filtered.png").write_bytes(b"\x89PNG\r\n\x1a\nthis")
+        (self.dir / "images" / "02-empty.png").write_bytes(self.STALE)
+
+    KEPT = beat(
+        1,
+        "shot",
+        3.2,
+        caption="Filtering to one status.",
+        still="images/01-filtered.png",
+    )
+    RAISED = beat(
+        2,
+        "shot",
+        5.4,
+        caption="Nothing matches, and the queue says why.",
+        still="images/02-empty.png",
+        error={"type": "TimeoutError", "message": "no such locator"},
+    )
+    FAILURE = {
+        "type": "TimeoutError",
+        "beat": 2,
+        "verb": "shot",
+        "message": "no such locator",
+    }
+
+    def render(self, *beats: dict, failure: object = None) -> str:
+        """`timeline.md` as it lands beside the pictures, and read back.
+
+        Through `write_timeline` rather than `render_timeline_md` because the
+        claim is about a *relative* path: `images/02-empty.png` means nothing
+        until the document has a directory to resolve against, and that
+        directory is the one holding the previous recording's stills.
+        """
+        doc = envelope(duration=None, beats=list(beats))
+        if failure is not None:
+            doc["failure"] = failure
+        write_timeline(self.dir, doc)
+        return (self.dir / "timeline.md").read_text(encoding="utf-8")
+
+    def openable(self, text: str) -> list[str]:
+        """The embedded pictures a reader could actually open, resolved on disk.
+
+        The markdown is parsed here rather than in the renderer's terms — no
+        helper is shared with `timeline.py` — because the claim is about what a
+        viewer recovers from the artifact, and a check that borrowed the
+        producer's idea of an embed would be blind wherever the producer is.
+        """
+        return [
+            rel
+            for rel in re.findall(r"!\[[^\]]*\]\(([^)]*)\)", text)
+            if (self.dir / rel).is_file()
+        ]
+
+    def test_a_picture_this_take_never_wrote_is_not_embedded(self):
+        # The staging first: this grades the file-*present* case on purpose.
+        # With the file absent the same embed is a broken image, which fails
+        # safe, and an injection built on that would grade the easy half.
+        self.assertTrue((self.dir / "images" / "02-empty.png").is_file())
+        text = self.render(self.KEPT, self.RAISED, failure=self.FAILURE)
+        # Exactly the one this take wrote. Stated as an equality rather than as
+        # two membership checks so that a gallery which embedded nothing at all
+        # cannot satisfy it: "the stale picture is gone" is also true of a
+        # renderer that lost the section.
+        self.assertEqual(self.openable(text), ["images/01-filtered.png"], text)
+
+    def test_the_heading_and_timestamp_over_it_go_with_the_picture(self):
+        # The embed is not the whole of the lie. `### 02-empty — 5.40s` and the
+        # caption quoted under it are this take's heading and this take's
+        # second over last week's photograph, and an entry stripped of only its
+        # `![…]()` line would still be all three.
+        text = self.render(self.KEPT, self.RAISED, failure=self.FAILURE)
+        section = text[text.index("## Stills") :]
+        self.assertIn("### 01-filtered — 3.20s", section)  # control
+        self.assertNotIn("02-empty", section)
+        self.assertNotIn("5.40", section)
+
+    def test_a_take_whose_every_picture_raised_prints_no_gallery_at_all(self):
+        # An empty `## Stills` heading is a promise of evidence with none under
+        # it. The control is the same document with the beat's `error` dropped,
+        # which must still print one.
+        text = self.render(self.RAISED, failure=self.FAILURE)
+        self.assertIn("| # | start |", text)  # control: the document rendered
+        self.assertNotIn("## Stills", text)
+        kept = {k: v for k, v in self.RAISED.items() if k != "error"}
+        self.assertIn("## Stills", self.render(kept))
+
+    def test_a_take_that_finished_embeds_every_picture_it_took(self):
+        # The #24 direction, and the only thing here that watches an ordinary
+        # take stay ordinary: absent `error`, nothing is withheld. A filter
+        # inverted by one `not` empties the gallery of a healthy demo, and
+        # every assertion above is satisfied by exactly that.
+        text = self.render(
+            self.KEPT, {k: v for k, v in self.RAISED.items() if k != "error"}
+        )
+        self.assertEqual(
+            self.openable(text), ["images/01-filtered.png", "images/02-empty.png"], text
+        )
 
 
 class TimelinePaths(unittest.TestCase):
@@ -10401,6 +10553,111 @@ INJECTIONS = [
         '    out += _coverage_md(doc.get("coverage"), failure)',
         '    out += _coverage_md(doc.get("coverage"))',
         ["TimelineMd.test_the_acceptance_section_is_told_the_take_failed"],
+    ),
+    (
+        # The branch a take that came out of the `with` block with no verb
+        # running lands in. It was ungraded on this side while the comment's
+        # mirror of it was graded, so the sentence could be replaced with the
+        # confident wrong answer below and the suite stayed green. Eight spaces
+        # of indent, which is what tells this occurrence from the identical
+        # sentence in `render_timeline_md` twelve spaces in.
+        "the failure lead names beat None instead of saying no beat is blamed",
+        "timeline.py",
+        '\n        else "between beats — no verb was running, so no beat is blamed"',
+        "\n        else f\"beat {failure['beat']} (`{_md_cell(failure.get('verb'))}`)\"",
+        ["CoverageMd.test_a_take_that_died_between_beats_blames_no_beat"],
+    ),
+    (
+        # **The defect issue #305 is about**, restored exactly: the gallery
+        # selects off `still` alone, so a beat whose screenshot raised is
+        # embedded. `images/` is committed, so the file is usually *there* —
+        # the previous recording's — and the reader is shown a real photograph
+        # under this take's heading, timestamp and caption.
+        "the stills gallery embeds a picture the take never wrote",
+        "timeline.py",
+        "    stills = [\n"
+        '        b for b in beats if b.get("still") '
+        'and not isinstance(b.get("error"), dict)\n'
+        "    ]",
+        '    stills = [b for b in beats if b.get("still")]',
+        [
+            "StillsGallery.test_a_picture_this_take_never_wrote_is_not_embedded",
+            "StillsGallery.test_the_heading_and_timestamp_over_it_go_with_the_picture",
+            "StillsGallery."
+            "test_a_take_whose_every_picture_raised_prints_no_gallery_at_all",
+        ],
+    ),
+    (
+        # The heading decided before the filter rather than after it: a `##
+        # Stills` on a take with nothing left to show under it, which is a
+        # promise of evidence with none behind it. This is the break that
+        # reddens the empty-gallery assertion **alone**, which is what says it
+        # is measuring something the assertion above does not.
+        "the stills heading is printed for pictures the gallery then drops",
+        "timeline.py",
+        '    if stills:\n        out += ["", "## Stills", ""]',
+        '    if any(b.get("still") for b in beats):\n'
+        '        out += ["", "## Stills", ""]',
+        [
+            "StillsGallery."
+            "test_a_take_whose_every_picture_raised_prints_no_gallery_at_all"
+        ],
+    ),
+    (
+        # The half-fix, and the reason the heading assertion is not decoration:
+        # the entry is still built for a beat that raised — its `### 02-empty —
+        # 5.40s` and the caption quoted under it — and only the `![…]()` line
+        # is skipped. Nothing about the *picture* is wrong under this break, so
+        # the assertion above stays green and this one is the only thing that
+        # can see it. Two edits in one span, because a heading kept without its
+        # image cannot be expressed at either site alone.
+        "a beat that raised keeps its gallery heading and loses only the image",
+        "timeline.py",
+        "    stills = [\n"
+        '        b for b in beats if b.get("still") '
+        'and not isinstance(b.get("error"), dict)\n'
+        "    ]\n"
+        "    if stills:\n"
+        '        out += ["", "## Stills", ""]\n'
+        "        for beat in stills:\n"
+        '            rel = str(beat["still"])\n'
+        '            name = rel.rsplit("/", 1)[-1].removesuffix(".png")\n'
+        '            out += [f"### {name} — {_fmt_t(beat.get(\'t_start\'))}s", ""]\n'
+        '            if beat.get("caption"):\n'
+        '                out += [f"> {beat[\'caption\']}", ""]\n'
+        '            out += [f"![{name}]({rel})", ""]',
+        '    stills = [b for b in beats if b.get("still")]\n'
+        "    if stills:\n"
+        '        out += ["", "## Stills", ""]\n'
+        "        for beat in stills:\n"
+        '            rel = str(beat["still"])\n'
+        '            name = rel.rsplit("/", 1)[-1].removesuffix(".png")\n'
+        '            out += [f"### {name} — {_fmt_t(beat.get(\'t_start\'))}s", ""]\n'
+        '            if beat.get("caption"):\n'
+        '                out += [f"> {beat[\'caption\']}", ""]\n'
+        '            if not isinstance(beat.get("error"), dict):\n'
+        '                out += [f"![{name}]({rel})", ""]',
+        [
+            "StillsGallery.test_the_heading_and_timestamp_over_it_go_with_the_picture",
+            "StillsGallery."
+            "test_a_take_whose_every_picture_raised_prints_no_gallery_at_all",
+        ],
+    ),
+    (
+        # The same filter inverted, which is the #24 direction: the gallery of
+        # a healthy demo emptied of every picture it took. Only the clean-take
+        # assertion can see this one, and without it a filter off by one `not`
+        # satisfies everything else #305 added.
+        "the stills gallery keeps only the pictures no beat wrote",
+        "timeline.py",
+        '        b for b in beats if b.get("still") '
+        'and not isinstance(b.get("error"), dict)',
+        '        b for b in beats if b.get("still") '
+        'and isinstance(b.get("error"), dict)',
+        [
+            "StillsGallery.test_a_take_that_finished_embeds_every_picture_it_took",
+            "StillsGallery.test_a_picture_this_take_never_wrote_is_not_embedded",
+        ],
     ),
     (
         # Same words, wrong cause. The two reasons this sentence has always


### PR DESCRIPTION
Fixes #305. The other half of #278, which #309 (`ccd381c`) left one section down.

## What was wrong

`coverage.py` and `demo-comment` both refuse a still by the row's `error` now.
`render_timeline_md`'s gallery is a **third** renderer, and it reads `beats`
rather than `coverage`:

```python
stills = [b for b in beats if b.get("still")]     # timeline.py:1374
```

`shot()` stamps `still` on the beat *before* it takes the picture, so a beat
whose screenshot raised carries the path and no file.

### The reproduction, file-present

The issue's document — one `shot` beat, `ac=["AC-2"]`, `still="images/02-empty.png"`,
`error=TimeoutError`, take carrying `failure` — written with `write_timeline`
into a directory where the **previous** recording's `images/02-empty.png` is
sitting. On `ccd381c`:

```
| criterion | claimed by | at | still |
|---|---|---:|---|
| **AC-2** — A filter that matches nothing explains itself. | beat 2 **raised TimeoutError** | 5.40 | *not written* |

...

## Stills

### 02-empty — 5.40s

> the empty state

![02-empty](images/02-empty.png)

embedded paths: ['images/02-empty.png']
...which resolve to real files on disk: ['images/02-empty.png']
```

On this branch, the same document in the same directory:

```
| **AC-2** — A filter that matches nothing explains itself. | beat 2 **raised TimeoutError** | 5.40 | *not written* |

...
(no ## Stills section)

embedded paths: []
...which resolve to real files on disk: []
```

**The file-missing case is the harmless one** and is deliberately not what
anything here is built against: a missing file renders a broken-image
placeholder, which announces itself. `images/` is committed, so the case that
actually happens on a re-record after a crash is the one above — a real
photograph under this take's heading, this take's timestamp and this take's
caption, as evidence of a moment this take never reached.

## What it does

A beat whose verb raised contributes **no entry at all**: not the embed, not
the `### 02-empty — 5.40s` heading, not the caption quoted under it. Dropped
rather than marked, because this is a gallery of pictures and a heading with
no picture under it is not one — the beat table above still carries the row,
marked **raised**, and the acceptance table still says `*not written*`.

**Absent-otherwise, per #24.** All five committed
`examples/ticket-queue/demos/*/timeline.json` were rendered on `ccd381c` and on
this branch and diffed: identical, byte for byte. None of them carries a beat
that raised, which is the point.

`reference/timeline.md` and `reference/review.md` say so; `tests/README.md`
carries the measurement. `demo-comment` needed no change — it has no gallery,
and its `_picture` already refuses by the row's `error` before the existence
check.

## Also here: two graded-coverage gaps in #309's own tests

Both were found reviewing the merged change, both are in the code it just
landed, and both belong to this rendering path.

1. **`_coverage_failure_md`'s `beat is None` branch was ungraded in
   `tests/unit`.** Replacing *"between beats — no verb was running, so no beat
   is blamed"* with *"beat None (`None`)"* left the suite at `Ran 420 tests …
   OK`. The ci-unit mirror **is** graded, so this was one-sided.
2. **Two new ci-unit assertions were in no `INJECTIONS` entry** —
   `test_a_clean_take_carries_none_of_this` and
   `test_the_same_words_are_refused_on_a_take_that_did_not_finish`. Neither was
   hollow, but nothing recorded that, so a future edit could have hollowed them
   silently.

## Fault injection

Every assertion added here was watched failing. Both harnesses abort unless the
injection's search string matches **exactly once**.

- `tests/unit --fault-inject` — **All 285 injections were caught** (280 before).
- `tests/ci-unit --fault-inject` — **All 76 injections were caught** (74 before).

### `tests/unit` — the gallery

```
PASS  break: the stills gallery embeds a picture the take never wrote
      in timeline.py: stills = […
      FAIL: test_a_picture_this_take_never_wrote_is_not_embedded (__main__.StillsGallery.test_a_picture_this_take_never_wrote_is_not_embedded)
      FAIL: test_a_take_whose_every_picture_raised_prints_no_gallery_at_all (__main__.StillsGallery.test_a_take_whose_every_picture_raised_prints_no_gallery_at_all)
      FAIL: test_the_heading_and_timestamp_over_it_go_with_the_picture (__main__.StillsGallery.test_the_heading_and_timestamp_over_it_go_with_the_picture)

PASS  break: the stills gallery keeps only the pictures no beat wrote
      in timeline.py: b for b in beats if b.get("still") and not isinstance(b.get("error")…
      FAIL: test_a_picture_this_take_never_wrote_is_not_embedded (__main__.StillsGallery.test_a_picture_this_take_never_wrote_is_not_embedded)
      FAIL: test_a_take_that_finished_embeds_every_picture_it_took (__main__.StillsGallery.test_a_take_that_finished_embeds_every_picture_it_took)
      FAIL: test_a_take_whose_every_picture_raised_prints_no_gallery_at_all (__main__.StillsGallery.test_a_take_whose_every_picture_raised_prints_no_gallery_at_all)
      FAIL: test_the_heading_and_timestamp_over_it_go_with_the_picture (__main__.StillsGallery.test_the_heading_and_timestamp_over_it_go_with_the_picture)

PASS  break: the stills heading is printed for pictures the gallery then drops
      in timeline.py: if stills:…
      FAIL: test_a_take_whose_every_picture_raised_prints_no_gallery_at_all (__main__.StillsGallery.test_a_take_whose_every_picture_raised_prints_no_gallery_at_all)

PASS  break: a beat that raised keeps its gallery heading and loses only the image
      in timeline.py: stills = […
      FAIL: test_a_take_whose_every_picture_raised_prints_no_gallery_at_all (__main__.StillsGallery.test_a_take_whose_every_picture_raised_prints_no_gallery_at_all)
      FAIL: test_the_heading_and_timestamp_over_it_go_with_the_picture (__main__.StillsGallery.test_the_heading_and_timestamp_over_it_go_with_the_picture)
```

The first two are the defect and its #24 inverse — the second empties a healthy
demo's gallery, and it is the only thing that watches an ordinary take stay
ordinary. The last two are why there are four assertions rather than two:

- the **heading** injection reddens the empty-gallery assertion *alone*, so
  that assertion is measuring the guard being evaluated after the filter rather
  than before it;
- the **half-fix** injection keeps the entry and skips only its `![…]()` line.
  Nothing about the picture is wrong under it — `test_a_picture_this_take_never_wrote_is_not_embedded`
  stays green — and the heading assertion is the only thing that can see it.
  That is what says the heading assertion is not decoration. It is two edits in
  one span, because a heading kept without its image cannot be expressed at
  either site alone.

### `tests/unit` — gap 1

```
PASS  break: the failure lead names beat None instead of saying no beat is blamed
      in timeline.py: else "between beats — no verb was running, so no beat is blamed"…
      FAIL: test_a_take_that_died_between_beats_blames_no_beat (__main__.CoverageMd.test_a_take_that_died_between_beats_blames_no_beat)
```

The search string carries its eight spaces of indent, which is what tells it
from the byte-identical sentence in `render_timeline_md` twelve spaces in —
without them the harness aborts on two matches rather than grading the wrong
one.

### `tests/ci-unit` — gap 2

```
PASS  break: the failure lead is printed on a take that did not fail
      in demo-comment: if isinstance(failure, dict):…
      FAIL: test_a_clean_take_carries_none_of_this (__main__.Coverage.test_a_clean_take_carries_none_of_this)
      FAIL: test_a_failed_take_says_so_before_anything_it_claimed (__main__.Coverage.test_a_failed_take_says_so_before_anything_it_claimed)
      FAIL: test_a_take_that_died_claiming_everything_prints_no_count (__main__.Coverage.test_a_take_that_died_claiming_everything_prints_no_count)
      FAIL: test_the_lead_counts_the_clauses_no_returning_beat_claimed (__main__.Coverage.test_the_lead_counts_the_clauses_no_returning_beat_claimed)

PASS  break: the failure lead promotes what the take got through to a verdict
      in demo-comment: f"`with` block at {where}.",…
      FAIL: test_the_same_words_are_refused_on_a_take_that_did_not_finish (__main__.Coverage.test_the_same_words_are_refused_on_a_take_that_did_not_finish)
```

The second appends to the lead rather than replacing it, the same way the
per-word verdict injections treat the disclaimer: three assertions locate the
lead by its opening words, and replacing them would redden those instead — the
green-to-red transition that makes a sweep look alive while it stays silent.
It reddens the sweep **alone**.

### One assertion in #309 had to move, and it did not weaken

`TimelineMd.test_the_acceptance_section_is_told_the_take_failed` bounded the
acceptance section with `text.index("\n## ", start + 1)`, and the heading it
landed on was `## Stills`. That document's only still belongs to the beat that
raised, so the gallery is gone and the index raised `ValueError`. It now falls
back to the end of the file — **the same bytes**, because the gallery was the
last thing in the document.

## Other checks

- `tests/unit` — `Ran 425 tests … OK` (420 before)
- `tests/ci-unit` — `Ran 106 tests … OK` (unchanged; gap 2 adds injections, not tests)
- `tests/lint` — `All checks passed! / 16 files already formatted`
- `mypy 1.18.2` — `Success: no issues found in 13 source files`
- `tests/smoke` not run: no recorder, browser or ffmpeg path is touched.

## Stated limits

- **The entry is dropped silently.** An untagged `shot()` that raised leaves no
  trace in `## Stills` — the beat table's **raised** row is the only record in
  the file, and for a *tagged* one the acceptance table also says
  `*not written*`. #305's acceptance says "contributes no entry"; a
  `*not written*` placeholder in the gallery was considered and rejected,
  because a heading with no picture is not a gallery entry. If a reader wants
  the gallery to say what is missing, that is a new issue.
- **`tests/smoke` still does not look at the gallery on a crashed take.**
  `check_timeline` runs only on the clean web, terminal and stitch arms, and it
  already asserts every named still is on disk — so it structurally cannot
  reach a take that died at a `shot`. Unchanged by this PR, and the pure half
  is what `StillsGallery` grades.
- **A `shot()` that *returned* on a take that died later is untouched**, and
  its picture is still embedded. That file exists; #278 says explicitly that
  marking it would be inventing a finding.
- **`error` on a beat is trusted as the record of what happened.** Nothing here
  reads pixels or checks the file's mtime, so a beat that raised *after* the
  screenshot landed loses a picture that is genuinely this take's. The recorder
  stamps `still` before the capture precisely because that ordering cannot be
  known from the log, and losing a real picture is the safe direction.
- **The examples diff is a regression check, not coverage.** None of the five
  committed timelines carries a beat that raised, so it proves the change is
  inert on healthy documents and nothing more; the crash path is graded by
  `StillsGallery`.

## Coordination

Kept tightly scoped so a rebase over `ticket-names-the-source` (#310) stays
trivial: one filter in `render_timeline_md`'s gallery block, one new test class
in `tests/unit`, one new test in `CoverageMd`, five new `INJECTIONS` rows in
`tests/unit` and two in `tests/ci-unit`. Nothing in `coverage.py`, nothing in
the envelope, nothing in the acceptance-section header, and no refactoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
