### PR TITLE
Repair two injections #309 left proving nothing, and name every stale entry at once

### DIFF
--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -317,8 +317,12 @@ INJECTIONS = [
     Injection(
         name="a claim points one beat past the beat that made it",
         module="coverage.py",
-        old='                        "index": beat.get("index"),',
-        new='                        "index": (beat.get("index") or 0) + 1,',
+        # #309 extracted `_claim_row` out of the comprehension that used to
+        # build this dict, so the line lost sixteen columns of indentation and
+        # this entry went STALE. `--self-test` caught it; CI's own
+        # `tests/smoke-inject --self-test` step did not run before the merge.
+        old='        "index": beat.get("index"),',
+        new='        "index": (beat.get("index") or 0) + 1,',
         arm="--coverage-only",
         sites=("check_coverage", "check_coverage_merge"),
         must_contain=(
@@ -332,8 +336,11 @@ INJECTIONS = [
         # asserted.
         name="a claimed beat forgets which segment it came from",
         module="coverage.py",
-        old='                        "segment": beat.get("segment"),',
-        new='                        "segment": None,',
+        # Stale for the same reason as the entry above — #309's `_claim_row`
+        # extraction. This one was hidden behind it: `--self-test` reports the
+        # first STALE entry it meets, so fixing one uncovers the next.
+        old='        "segment": beat.get("segment"),',
+        new='        "segment": None,',
         arm="--coverage-only",
         sites=("check_coverage_merge",),
         must_contain=("a reviewer handed a bare 'beat 5'",),
@@ -1931,12 +1938,26 @@ def self_test() -> int:
             print(f"WRONG    {what}: contended() said {contended(lines)}")
 
     # The real manifest, against the real tree.
-    try:
-        verify_manifest(INJECTIONS)
-        print(f"OK       all {len(INJECTIONS)} registered entries still match")
-    except Refused as exc:
+    #
+    # Entry at a time, so every stale entry is named in one run. `verify_manifest`
+    # raises on the first, which is right for the run path — a manifest with one
+    # rotten entry should not start recording — but wrong for a report. #309 left
+    # two entries stale by the same re-indentation and the second only became
+    # visible after the first was fixed, which is one round per rotten entry on
+    # exactly the check that exists to stop silent rot.
+    stale = []
+    for entry in INJECTIONS:
+        try:
+            verify_manifest([entry])
+        except Refused as exc:
+            stale.append(str(exc))
+    if stale:
         bad += 1
-        print(f"STALE    {exc}")
+        print(f"STALE    {len(stale)} registered entr(ies) no longer match the tree:")
+        for problem in stale:
+            print(f"         - {problem}")
+    else:
+        print(f"OK       all {len(INJECTIONS)} registered entries still match")
 
     # And what tests/README.md says this manifest covers, against what it
     # covers (#184). Read as text: the README is the claim, `INJECTIONS` and


### PR DESCRIPTION
`main` has been red since `ccd381c`. This makes it green and stops the next
occurrence costing one round per rotten entry.

## What was broken

#309 extracted `_claim_row` out of the comprehension that built the coverage
row. Two lines in `coverage.py` lost sixteen columns of indentation, and two
`tests/smoke-inject` entries went on searching for the old form. An injection
whose search string does not occur never lands — so both entries were
registered, green, and proving nothing:

| entry | grades |
|---|---|
| `a claim points one beat past the beat that made it` | that a coverage row's `index` is the beat that made the claim (#229's scrub-target family) |
| `a claimed beat forgets which segment it came from` | that a merged claim keeps its segment, so a reviewer is not handed a bare `beat 5` (#137) |

Both are in the honesty machinery #278 and #305 were about.

## Why nobody saw it

Nothing was missing. `tests/smoke-inject --self-test` caught it, and CI runs
that step on **every push** (`ci.yml:178`). #309 was merged on the strength of
an independent review's local suite runs — that review was asked for
`tests/unit`, `tests/ci-unit` and `tests/lint`, and was not asked for this
harness. The post-merge run on `main` was never opened.

The harness worked. The process around it did not.

## The second fix: report every stale entry, not the first

Repairing the first entry uncovered the second. `verify_manifest` raises on the
first bad entry, which is correct for the run path — a manifest with one rotten
entry should not start recording — and wrong for a report, where it costs one
round per rotten entry on the check whose whole job is catching silent rot.

`--self-test` now calls `verify_manifest` an entry at a time and collects. No
logic is duplicated and the run path is untouched; `verify_manifest`'s checks
are all per-entry, so the loop is equivalent.

## Evidence

Injection, both entries broken at once — the case the change is about, with each
anchor confirmed to match exactly once before the edit landed:

```
injected 2 stale entries, each anchor matched exactly once

STALE    2 registered entr(ies) no longer match the tree:
         - 'a claim points one beat past the beat that made it': its search string occurs 0 times in coverage.py, expected exactly 1 — the injection would not land, so nothing it claims to prove would be proven.
       looked for: '        "index": beat.get("INDEX"),'
         - 'a claimed beat forgets which segment it came from': its search string occurs 0 times in coverage.py, expected exactly 1 — the injection would not land, so nothing it claims to prove would be proven.
       looked for: '        "segment": beat.get("SEGMENT"),'
exit=1
```

Before the repair, on `2803a8e`, the same run named only the first of the two.

Repaired:

```
$ tests/smoke-inject --self-test
Every guard refused what it exists to refuse.                    exit 0

$ tests/smoke-inject --arm coverage
All 14 injections were caught. [3.8 min]
```

**The arm run is the load-bearing one.** `--self-test` proves a pattern matches
exactly once; only recording against the injected tree proves the entry is
evidence. Both repaired entries are `--coverage-only`, so that run exercises
them end to end.

## Stated limits

- `tests/lint` fails locally on this branch and on `main` alike, for a reason
  neither introduced: its pointer check reads the filesystem, and a developer's
  box has a `.claude/` that a CI checkout does not. Filed as #322 with its
  measurement; not touched here.
- Nothing here stops a future refactor from re-indenting another pattern. The
  self-test catching it on the next push is the design, and it works; what
  failed was reading the result.