### PR TITLE
Write down what this repo is for, and stop the backlog outgrowing the work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,14 @@
 This repo holds reusable agent skills, installed by the
 [`skills`](https://github.com/vercel-labs/skills) CLI (`npx skills add`).
 
+## Read `GOAL.md` first
+
+`GOAL.md` states what this repo is for — reducing the **cognitive debt** that
+agent-speed development pushes onto reviewers — and how success is measured
+(seconds of human attention per reviewed ticket). Every rule below serves that;
+where a rule and the goal appear to disagree, the goal wins and the rule is
+wrong. Plan work against `GOAL.md`, not against the backlog.
+
 ## Layout
 
 - `skills/` — **finished, shareable** skills. Everything here is discoverable and
@@ -64,6 +72,16 @@ never sees it. This is the whole mechanism:
 reach it.** There is no `TODO.md`, no backlog file, no list of open questions
 buried in `docs/`. If work is worth remembering, it is an issue.
 
+**A true observation is not automatically work.** This is the rule the repo
+spent its first year missing, and its absence cost more than any defect in it:
+every genuine finding became a durable ticket, the backlog grew faster than it
+closed, and the quality ratchet ran with no throughput term. File an issue only
+if the thing **makes the demo lie to its reader, or blocks the next phase of
+`GOAL.md`**. Everything else true-but-minor goes in the pull-request body as a
+stated limit, with its measurement, and dies there. A limit stated in the pull
+request is not a lesser outcome than an issue — it is the same information
+without a ticket nobody will pick up.
+
 - Start of a work session, or before picking up anything vague: `gh issue list`.
   Read the whole issue before acting on it — `gh issue view <n>`.
 - Spotted follow-up work that is out of scope for what you are doing? **File it
@@ -110,7 +128,18 @@ proving ground for anything about delivery.
 
 **Read `wip/verified-review/SKILL.md` before reviewing a change, and before
 writing or fixing any assertion that gates one.** It is the house discipline
-and it is not optional here. Two rules:
+and it is not optional here.
+
+**Where it applies, and where it does not.** It applies to **recorder
+behaviour** and to anything that changes what a viewer sees or what an artifact
+claims — that is where a wrong answer reaches a human as a false verdict. It
+does **not** apply to documentation sentences, prose, README tables, test
+counts, or the wording of a comment: those get an ordinary read, and a
+disagreement about them is settled in one round, in the pull request. Running
+an adversarial round on prose is how roughly half of a year's merged work ended
+up being about prose.
+
+Two rules:
 
 - **Authoring: an assertion you have not seen fail is not evidence.** Break the
   thing it watches, run it, show the failure output in the pull request, then

--- a/GOAL.md
+++ b/GOAL.md
@@ -1,0 +1,80 @@
+# What this repo is for
+
+Read this before planning work here. It is the thing every change is judged
+against, and it is deliberately short enough that there is no excuse for
+drifting from it.
+
+## The problem
+
+Agents now write code far faster than humans can review it. The cost has moved
+from writing to **understanding what an agent built and checking it against what
+was expected** — and it lands on reviewers who often had no say in the
+architecture, the planning, or the ticket. With no context to review against,
+line-by-line reading is the only tool they have left, and it does not scale with
+agent output.
+
+That is **cognitive debt**: the same shape as technical debt, accruing on
+people instead of code.
+
+## The answer this repo is a part of
+
+A layered set of **machine-checkable gates** — CI steps, tests, architectural
+fitness functions, guidelines, and tools like the skills here — each answering a
+review question before a human is involved, so human attention is spent only
+where it is genuinely required.
+
+No single gate answers everything. Each one owns a question, answers it well,
+and says plainly what it does not answer.
+
+## What `demo-video` owns
+
+**One question: did the change do what the ticket said?**
+
+Answered by watching rather than reading, and graded by an **independent agent**
+— one that sees the ticket's clauses and the recorded frames, and never sees the
+implementation, the diff, `record.py`, or the implementing session's reasoning.
+That isolation is the whole value: it is a genuinely fresh reader, which is
+exactly what a human reviewer is and what the implementing agent's self-report
+can never be.
+
+A human is pulled in only on `cannot tell`, or on disagreement.
+
+## What it explicitly does not own
+
+Watching a demo replaces reading the diff **for that one question only**.
+Anything else the change touches — a widened permission, a deleted check, a new
+dependency — is invisible to a demo and is still the diff's to answer. That
+sentence ships in the pull-request comment (`8bcd52e`) and must keep shipping.
+
+It also grades whether the frames show the clause, **not** whether the clause was
+the right thing to build.
+
+## Success
+
+> A developer opens a pull request and within **30 seconds** knows whether to
+> merge it, without reading the diff to answer "did it do what the ticket said."
+
+The metric is **seconds of human attention per reviewed ticket**, measured with
+a stopwatch on real tickets in `examples/ticket-queue`. Not "the artifacts are
+honest," not "every assertion is graded," not merged pull requests.
+
+Honesty of the artifacts is a *precondition* — necessary, already largely built,
+and not the product.
+
+## Rules that follow from this
+
+- **Never ask a human to judge a pixel, a colour, a duration or a count.** That
+  question goes to the harness. If a human is being asked to eyeball a number,
+  that is a bug in the harness.
+- **A true observation is not automatically work.** See `CLAUDE.md`.
+- **CI is a gate before merge, not the iteration loop.** If the loop is slow,
+  fix the loop rather than routing around it through a human.
+- **Ask a model one perceptual question at a time.** "Is this clause visible in
+  this frame" is stable; "is this pull request good" folds perception,
+  aggregation and a threshold into one answer and was measured unstable here
+  (#131 — the finding was stable, the ship/no-ship field was a coin flip). Any
+  roll-up is arithmetic over per-clause answers, done in code, with the rule
+  written down.
+- **Secrets: the skill has no masking, no scrubbing and no redaction, by
+  design.** `skills/demo-video/SKILL.md` states the constraint and the reasoning;
+  it is not a gap to be closed.

--- a/tests/README.md
+++ b/tests/README.md
@@ -2334,6 +2334,42 @@ exactly where `--strict-only` came from.
 Things a pass does **not** prove. They are listed because an assertion nobody
 knows is missing is worse than one that is openly absent.
 
+- **This suite's grading of itself is openly partial, by decision, since
+  2026-08-13.** Eighteen issues recording gaps in the harness's self-coverage
+  were closed that day as *recorded, not planned*, under `GOAL.md`: this repo's
+  product is a demo an independent agent can grade, and a harness that grades
+  its own assertions three times over is not that product. **Every measurement
+  survives in its issue body** — closed, not deleted — and each is listed here
+  so that a reader of this file does not have to know they exist to find them.
+
+  | what is ungraded | issues |
+  |---|---|
+  | Check functions reachable on an arm with no injection entry, so a pass proves only that they ran | [#233](https://github.com/rogvid/skills/issues/233), [#239](https://github.com/rogvid/skills/issues/239), [#240](https://github.com/rogvid/skills/issues/240), [#241](https://github.com/rogvid/skills/issues/241) |
+  | Assertions that can pass for the wrong reason, or grade less than the comment above them claims | [#288](https://github.com/rogvid/skills/issues/288), [#295](https://github.com/rogvid/skills/issues/295), [#296](https://github.com/rogvid/skills/issues/296), [#306](https://github.com/rogvid/skills/issues/306), [#321](https://github.com/rogvid/skills/issues/321) |
+  | Takes that never exercise the input the pass-through would be proved on | [#311](https://github.com/rogvid/skills/issues/311), [#318](https://github.com/rogvid/skills/issues/318) |
+  | Committed reference artifacts drifted from what the renderer or the manifest now produces | [#292](https://github.com/rogvid/skills/issues/292), [#302](https://github.com/rogvid/skills/issues/302), [#314](https://github.com/rogvid/skills/issues/314), [#317](https://github.com/rogvid/skills/issues/317), [#320](https://github.com/rogvid/skills/issues/320) |
+  | Arms that could not be built because Chromium's event timing defeated them | [#210](https://github.com/rogvid/skills/issues/210), [#228](https://github.com/rogvid/skills/issues/228) |
+
+  One of these deserves naming in prose rather than a table cell, because it
+  weakens what a green run means rather than merely leaving something unwatched.
+  **#320**: every `#24` regression check renders each committed `timeline.json`
+  on two revisions and diffs the outputs *against each other* — so a committed
+  `timeline.md` that no longer matches its own `timeline.json` is invisible to
+  it, and three of five have drifted. That is the *wrong-scope search* from
+  `wip/verified-review/SKILL.md`, and it is the scope every regression check in
+  this file uses.
+
+  A nineteenth, [#322](https://github.com/rogvid/skills/issues/322), was closed
+  the same way and reopened within the hour: `tests/lint`'s pointer check
+  decided from directories that happen to exist on the box it runs on, so an
+  untracked `.claude/` made the main checkout red and every worktree green. It
+  is fixed rather than listed — the triage bar is *does it block a phase of
+  `GOAL.md`*, and going red on the commit that closes it is that bar being met
+  out loud.
+
+  An honest gap beats a green check; eighteen tickets nobody picks up beats
+  neither.
+
 - **That the narration correction is right on a host whose clock really
   steps.** [#226](https://github.com/rogvid/skills/issues/226) puts each spoken
   clip at its own offset *plus the wall-clock steps its capture recorded before
@@ -3125,9 +3161,10 @@ knows is missing is worse than one that is openly absent.
   reviewer looking at a green pull request has not seen them pass. Five other
   check functions moved to merge-only with them; those five do have injections
   and are exercised nightly. Measured before the split rather than found after
-  it, and tracked in
-  [#233](https://github.com/rogvid/skills/issues/233), which is the entries
-  that would close it.
+  it, and recorded in
+  [#233](https://github.com/rogvid/skills/issues/233), which names the entries
+  that would have closed it and was itself closed as *recorded, not planned* in
+  the 2026-08-13 triage above.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.

--- a/tests/lint
+++ b/tests/lint
@@ -63,6 +63,7 @@ from __future__ import annotations
 
 import argparse
 import ast
+import functools
 import json
 import re
 import shutil
@@ -589,6 +590,39 @@ def resolve(rel: str, token: str) -> tuple[Path | None, Path]:
     return None, skill
 
 
+@functools.cache
+def tracked_dirs(skill: Path) -> frozenset[str]:
+    """Top-level directory names this repository actually contains.
+
+    Read off `git ls-files` rather than off the working tree, because the
+    working tree is not the same on two boxes and this decides a verdict. An
+    untracked `.claude/` — settings, worktrees, whatever a developer's tooling
+    left behind — used to make `.claude/skills` read `dead` locally and
+    `elsewhere` on a CI checkout, so the same document linted green on one box
+    and red on the other. A check that answers from the environment grades the
+    environment.
+
+    Tracked contents are the honest question anyway: `.claude/skills/` in a
+    shipped document names where *the reader's* installer puts a skill, not
+    anything in this repository, and git agrees because this repository does
+    not track it.
+
+    The other half of the same sensitivity is left standing and stated:
+    `resolve()` still asks the working tree whether a file exists, so a pointer
+    at a file that is present but uncommitted resolves here and dies on CI.
+    That direction fails closed — CI catches what the author forgot to commit —
+    which is the behaviour you want, so it is not worth removing.
+    """
+    tops = {p.split("/")[0] for p in tracked()}
+    within = {
+        p[len(prefix) :].split("/")[0]
+        for prefix in (f"{skill.relative_to(REPO).as_posix()}/",)
+        for p in tracked()
+        if p.startswith(prefix)
+    }
+    return frozenset(tops | within)
+
+
 def verdict(rel: str, token: str, sentence: str) -> tuple[str, str]:
     """(verdict, why) for one pointer. The whole rule, in one place.
 
@@ -615,7 +649,7 @@ def verdict(rel: str, token: str, sentence: str) -> tuple[str, str]:
             f"`npx skills add` has no such path"
         )
     head = token.split("/")[0]
-    if (REPO / head).is_dir() or (skill / head).is_dir():
+    if head in {".", ".."} or head in tracked_dirs(skill):
         return "dead", f"`{token}` does not exist, here or in the skill"
     return "elsewhere", ""
 


### PR DESCRIPTION
## Acceptance criterion

The repo has a written statement of its purpose that planning answers to, a rule that stops a true observation from automatically becoming a ticket, and an open-issue list that is a plan rather than a backlog.

## What changed

**`GOAL.md`** (new) — the cognitive-debt framing, the layered-gates answer, the one question `demo-video` owns, what it explicitly does not own, and success stated as *seconds of human attention per reviewed ticket*. `AGENTS.md` points at it first, and says the goal wins where a rule disagrees with it.

**`AGENTS.md`** — two rules the repo was missing:

- *A true observation is not automatically work.* File it only if it makes the demo lie to its reader or blocks a phase of `GOAL.md`; otherwise it is a stated limit in the pull request, with its measurement, and it dies there.
- *Where the review discipline applies*: recorder behaviour and anything a viewer sees. Not prose, tables, test counts or comment wording.

**Triage** — 36 open issues to 8, and nothing deleted:

| where it went | issues |
|---|---|
| `tests/README.md` Known gaps table | #210 #228 #233 #239 #240 #241 #288 #292 #295 #296 #302 #306 #311 #314 #317 #318 #320 #321 |
| #325's starting checklist | #301 #298 |
| folded into the issue they restate | #277 #284 → #300, #259 → #255, #274 → #279 |
| closed with their own reason | #312 #308 #70 #198 #78 |

Left open: #279 (Phase 1, the grader), #324 (Phase 2, the pixel loop), #325 (Phase 3, the recorder pass), #300 #276 #268 #255 (the four that make the demo untrustworthy), #272 (design record).

**`tests/lint` (#322)** — the pointer check decided `.claude/skills` was dead from directories that happen to exist on the box it runs on, so an untracked `.claude/` made the main checkout red and every worktree green. Fixed rather than parked because it went red on the commit that closed it, which is the triage bar being met out loud. It now reads tracked contents out of git; a token that spells its relativity out (`./scripts/mytool`) stays gradeable.

## Verification

This loosens a check, so both directions were exercised:

```
$ printf 'A pointer at `reference/nope-does-not-exist.md` …' >> skills/demo-video/README.md
pointers: skills/demo-video/README.md:192: `reference/nope-does-not-exist.md` does not exist, here or in the skill
lint: 1 pointer problem(s)

$ printf 'A pointer at `.claude/skills/elsewhere.md` …' >> skills/demo-video/README.md
pointers: 80 path(s) named across 25 shipped document(s); 9 named as this repository's, 1 waived
   (exit 0)
```

The waiver list's own staleness guard still fires — it caught `./scripts/mytool` the moment the first draft classified it `elsewhere`, which is what led to the `{".", ".."}` clause.

`tests/unit` OK · `tests/ci-unit` OK · `tests/lint` exit 0 · `--self-test` exit 0 · `--issues` exit 0 · `smoke-inject --self-test` exit 0 · **All 302 injections were caught** · **All 80 injections were caught**.

## Stated limits, deliberately not filed as issues

Per the rule this pull request adds:

- `resolve()` still asks the working tree whether a file exists, so a pointer at a present-but-uncommitted file resolves locally and dies on CI. That direction fails closed and is written down in the docstring.
- `examples/ticket-queue/tickets/` is empty and four of five demos have no committed `frames/` or `demo.mp4`, so the Phase 4 baseline — timing a human to a merge decision — cannot be run against today's artifacts yet. That is a Phase 1 input, not a defect here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)