### PR TITLE
Ask a second reader where each clause is, in a brief that cannot carry the answer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,13 @@ examples/*/demos/*/demo.mp4
 # to their demo folder, because `frames` is a plausible name for a directory of
 # real source; this repo has none, so a bare pattern is safe here.
 frames/
+# What `scripts/demo-grade` writes beside them: the brief handed to a blind
+# reader, and the comparison of that reader's answers with what the storyboard
+# claimed (issue #279). A sidecar and not part of timeline.json on purpose —
+# timeline.json is committed and diffed, and a model's reading of a picture
+# must not be carried in it forever. Anchored the way `frames/` is not, because
+# `review` is a likelier name for real source than `frames` is.
+examples/*/demos/*/review/
 # Left behind only when a take crashes before the recorder cleans up.
 .video/
 .frame.png

--- a/skills/demo-video/scripts/demo-grade
+++ b/skills/demo-video/scripts/demo-grade
@@ -1,0 +1,776 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Hand a blind reader the ticket's clauses and the frames; compare what they
+found with what the storyboard claimed.
+
+    <skill-dir>/scripts/demo-grade brief   <demo-dir>
+    <skill-dir>/scripts/demo-grade verdict <demo-dir> --reading reading.json
+
+**No model call happens in this file.** The reader is an *input*: `brief`
+writes the document you hand to an agent that has seen neither the storyboard
+nor the diff, and `verdict` reads that agent's answers back and compares them,
+in ordinary arithmetic, with what the storyboard claimed. Everything gradable
+here is a function of documents, so the comparison can be run — and tested —
+without a model, and a model's opinion never reaches a committed file.
+
+## Why there are two derivations at all
+
+Every timestamp in a take's coverage table comes from one source: an `ac=` tag
+the storyboard author typed. `helpers/demo_recording/coverage.py` says plainly
+that this is a claim and not evidence. A second derivation is available that
+does not read the tag — a reader who is given the clause text and the frames,
+and asked to *locate* each clause — and where two independent derivations of
+the same fact disagree, the disagreement is the finding.
+
+**Localisation, not a verdict.** The reader is asked, per clause, for the first
+frame in which they can see it. It is deliberately not asked whether the demo
+should ship: that question was measured unstable here — two readers over the
+same frames with the same instructions named the same beat, correctly, in the
+same terms, and their ship/no-ship fields disagreed. The stable half is asked
+for; the unstable half stays with the human. Any roll-up is arithmetic over the
+per-clause answers, done in code, with the rule written into the artifact.
+
+## The limit that cannot be designed away
+
+The reader is blind to the storyboard, the `ac` ids, the coverage table and the
+diff. It **cannot** be blind to the storyboard author's prose: captions are
+burned into the picture (`helpers/demo_recording/core.py`'s `_CAPTION_JS` sets
+`el.textContent` on a fixed lower third), and narration is speech of the same
+string. So every frame the reader looks at carries the author's claim in its
+pixels.
+
+Consequence, stated the same way in `brief.md` and `verdict.md`: this catches a
+clause tagged on the wrong beat, a clause whose evidence never arrives, a
+tagged beat showing an error page, and a clause the demo never reaches. It does
+**not** catch a storyboard derived from the diff whose caption asserts a misread
+requirement and whose screen agrees with the caption — both readers read that
+caption.
+
+## Exit status
+
+Two codes. 0 when the command produced its artifacts, and 2 both when it
+refuses and when the arguments do not parse — argparse's own code, which this
+does not override, so a caller cannot tell the two apart by status. The stderr
+line does: a refusal opens with `demo-grade: refusing`.
+
+`verdict` **never** fails a run for what it found: a clause nobody could see is
+a finding, not an error, and a grader that could redden a build would be turned
+off before it was believed.
+
+A refused run also **leaves no artifact of its own behind**. Both commands take
+the previous run's output off disk before they do anything else, so a reader
+who opens `review/` after a refusal finds nothing rather than the last run's
+answer sitting there reading as this one's — the same reason `frames.py`
+removes its stale sheet before writing a new one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "helpers"))
+
+from demo_recording.frames import frames_paths  # noqa: E402
+from demo_recording.timeline import timeline_paths  # noqa: E402
+
+REVIEW_DIRNAME = "review"
+BRIEF_SCHEMA = 1
+READING_SCHEMA = 1
+VERDICT_SCHEMA = 1
+
+# What a reading may say. Narrow on purpose: these become keys in a comparison
+# and headings in a document, and a fourth spelling of "seen" arriving from a
+# model would be counted as its own class rather than noticed.
+SEEN = "seen"
+NOT_SEEN = "not seen"
+CANNOT_TELL = "cannot tell"
+STATUSES = (SEEN, NOT_SEEN, CANNOT_TELL)
+CONFIDENCES = ("high", "medium", "low")
+
+# The classes a comparison can land in, in the order a human should read them.
+# Disagreements first: they are the thing worth the attention, and a document
+# that opens with its agreements has already spent the reader's first screen.
+DISAGREEMENT = "disagreement"
+NOT_DEMONSTRATED = "not demonstrated"
+NO_READING = "no reading"
+AGREEMENT = "agreement"
+CLASS_ORDER = (DISAGREEMENT, CANNOT_TELL, NO_READING, NOT_DEMONSTRATED, AGREEMENT)
+
+# Where each status came from. **Never the storyboard**: a status that appears
+# beside the thing that derived it can be weighed, and one that appears alone
+# is taken for a fact. `coverage.claimed` names beats, and naming beats is all
+# it is allowed to do here.
+BY_READER = (
+    "a reader given the clause text and the frame filenames, and neither the "
+    "storyboard, the ac tags, the coverage table nor the diff"
+)
+BY_STORYBOARD = (
+    "coverage.claimed in timeline.json — the ac= tags the storyboard author "
+    "typed, which are evidence of intent and nothing else"
+)
+BY_COMPARISON = (
+    "demo-grade, comparing the reader's answer with the beats the storyboard "
+    "claimed — the rule, including the span it uses when both derivations "
+    "locate the clause, is stated in this document"
+)
+# The one class where nothing was compared, and it says so rather than
+# borrowing the sentence above: a rule named beside a status it did not
+# produce is the artifact attributing a status to the wrong place.
+BY_NOTHING_TO_COMPARE = (
+    "demo-grade, from the absence of an answer for this clause — there was "
+    "nothing to compare the storyboard's claim with"
+)
+
+# The agreement rule, in one sentence, carried into every artifact that uses
+# it. See `agreement_rule()` for the argument and the weakness.
+SPAN_RULE = (
+    "A reading agrees when the beat of the frame the reader named lies within "
+    "the closed span [first claimed beat, last claimed beat] for that clause, "
+    "and disagrees when it falls outside that span entirely."
+)
+
+# The sentence #279 requires in the artifact, and the reason it cannot be
+# designed away. Printed in `verdict.md`, and said again in the reader's own
+# words in `brief.md`.
+LIMIT = (
+    "Agreement is a cross-check, not a verification. Two readers can share a "
+    "bias, and a plausible-looking screen can fool both — and here they are not "
+    "even fully independent: the caption the storyboard author wrote is burned "
+    "into every frame both of them read. This catches a clause tagged on the "
+    "wrong beat, a clause whose evidence never arrives, a tagged beat showing "
+    "an error page, and a clause the demo never reaches. It does not catch a "
+    "storyboard whose caption asserts a misread requirement and whose screen "
+    "agrees with the caption."
+)
+
+
+class Refused(Exception):
+    """The command cannot do its job on this input, and says why."""
+
+
+# --- reading the take's own documents ----------------------------------------
+
+
+def _load_json(path: Path, what: str) -> dict:
+    """One of the take's documents, or a refusal naming what is missing."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise Refused(f"there is no {what} at {path}") from None
+    except OSError as exc:
+        raise Refused(f"cannot read {what} at {path}: {exc}") from None
+    try:
+        doc = json.loads(text)
+    except ValueError as exc:
+        raise Refused(f"{path} is not readable JSON: {exc}") from None
+    if not isinstance(doc, dict):
+        raise Refused(f"{path} is not a JSON object")
+    return doc
+
+
+def declared_criteria(timeline: dict, where: Path) -> dict[str, str]:
+    """The clauses this take was recorded against, as the ticket words them.
+
+    Refuses when there are none. A take that declared no criteria has nothing
+    to grade — there is no question to put to a reader — and answering that
+    with an empty brief would produce a document whose emptiness reads like a
+    demo that showed nothing.
+    """
+    coverage = timeline.get("coverage")
+    if not isinstance(coverage, dict):
+        raise Refused(
+            f"{where} declares no acceptance criteria (`coverage` is absent or "
+            f"null), so there is nothing for a reader to locate. Record the "
+            f"take with criteria={{...}} to grade it against a ticket."
+        )
+    criteria = coverage.get("criteria")
+    if not isinstance(criteria, dict) or not criteria:
+        raise Refused(
+            f"{where}'s coverage names no criteria, so there is nothing for a "
+            f"reader to locate."
+        )
+    return {str(key): str(text) for key, text in criteria.items()}
+
+
+def frame_records(manifest: dict, where: Path) -> list[dict]:
+    """The manifest's frames, in the order they occur in **the video**.
+
+    Sorted on the manifest's own `t`, which is where the frame was cut out of
+    `demo.mp4`, rather than left in the order the records were planned. The two
+    are usually the same and are not always: `frames.py` writes `beat-NN.png`
+    plus up to three `beat-NN-scene-K.png` per beat, skips a beat whose
+    `t_start` is not a number, drops a record whose extraction failed, and cuts
+    a beat the host's clock deleted from the file at the last instant before
+    the gap. So the mapping from beat index to file is neither 1:1 nor
+    monotone in the filename, and it is read off the manifest here rather than
+    guessed from the pattern.
+    """
+    records = manifest.get("frames")
+    if not isinstance(records, list) or not records:
+        skipped = manifest.get("skipped")
+        raise Refused(
+            f"{where} lists no frames"
+            + (f": {skipped}" if skipped else "")
+            + ". There is nothing for a reader to look at; `beat_frames("
+            "out_dir)` regenerates the sheet from demo.mp4 and timeline.json."
+        )
+    for record in records:
+        if (
+            not isinstance(record, dict)
+            or not isinstance(record.get("file"), str)
+            or not isinstance(record.get("beat"), int)
+            or not isinstance(record.get("t"), (int, float))
+        ):
+            raise Refused(
+                f"{where} has a frame record without a file, a beat and a "
+                f"timestamp: {record!r}. The beat is what a reading is "
+                f"compared against, and it cannot be inferred from the name."
+            )
+    return sorted(records, key=lambda record: float(record["t"]))
+
+
+# --- the brief: what a blind reader is given ---------------------------------
+#
+# **The blindness is structural.** `brief_doc` and `render_brief_md` take the
+# criteria and the frame filenames and nothing else — not the coverage
+# document with the claims filtered out afterwards, which is a promise, but two
+# arguments that cannot carry a claim in the first place. `tests/unit` grades
+# it from the outside as well, by mutating `coverage.claimed` arbitrarily and
+# requiring both artifacts to come out byte-identical.
+
+
+def brief_doc(criteria: dict[str, str], frames: list[str]) -> dict:
+    """The brief, for a tool. A pure function of the clauses and the frames."""
+    return {
+        "schema": BRIEF_SCHEMA,
+        "generated_by": "demo-video",
+        "criteria": dict(criteria),
+        "frames": list(frames),
+        "reading_schema": READING_SCHEMA,
+        "statuses": list(STATUSES),
+        "confidences": list(CONFIDENCES),
+    }
+
+
+def _reading_template(criteria: dict[str, str]) -> str:
+    """The shape `demo-grade verdict --reading` accepts, one row per clause."""
+    rows = [
+        {
+            "criterion": key,
+            "frame": "beat-NN.png",
+            "status": "seen | not seen | cannot tell",
+            "why": "one sentence",
+            "confidence": "high | medium | low",
+        }
+        for key in criteria
+    ]
+    return json.dumps(
+        {"schema": READING_SCHEMA, "readings": rows}, indent=2, ensure_ascii=False
+    )
+
+
+def render_brief_md(criteria: dict[str, str], frames: list[str]) -> str:
+    """The document handed to the reader. Same two inputs, and no others."""
+    out = [
+        "# Locate each clause in the frames",
+        "",
+        "You are reading a recording of a change, frame by frame, against the "
+        "clauses of the ticket it was written for. You have not been shown the "
+        "storyboard, the code, the diff, or where anybody thinks each clause "
+        "is. That is deliberate: what makes your answer worth having is that "
+        "it is derived from the pictures alone.",
+        "",
+        "## What to do",
+        "",
+        "Read the frames in the order listed below — that is the order they "
+        "occur in the video. Then, **for each clause separately**, name the "
+        "**first** frame in which you can see that clause happening, or say it "
+        "is not seen.",
+        "",
+        "For every clause, answer with exactly these five things:",
+        "",
+        "- `criterion` — the clause id, exactly as written below;",
+        "- `frame` — the first frame filename in which you can see it "
+        "(`null` when you cannot);",
+        "- `status` — `seen`, `not seen`, or `cannot tell`;",
+        "- `why` — **one sentence** saying what in that frame shows it;",
+        "- `confidence` — `high`, `medium` or `low`.",
+        "",
+        "Answer every clause, including the ones you cannot find. Do **not** "
+        "give an overall judgement of the demo, and do not say whether it "
+        "should ship: that is not what you are being asked for, and it is not "
+        "yours to decide here. One clause, one frame, one sentence.",
+        "",
+        "**Answer `cannot tell` when the only thing showing the clause is the "
+        "caption text burned into the picture.** A caption is the storyboard "
+        "author asserting the clause, not the software doing it. If you cannot "
+        "see the software do the thing — only a line of text saying it does — "
+        "that is `cannot tell`, and say so in your sentence.",
+        "",
+        "Captions are written *before* the action they introduce, so a caption "
+        "normally leads the picture that evidences it by a frame or two. Name "
+        "the frame where you can **see** the clause, not the frame where a "
+        "line of text announces it.",
+        "",
+        "## What this check does and does not catch",
+        "",
+        "Stated here because you are half of it, and half of a cross-check that "
+        "does not know its own boundary is worse than no cross-check.",
+        "",
+        "The captions on these frames were written by the storyboard's author, "
+        "and they are burned into the pixels — there is no framing of this "
+        "request that removes them. So your reading catches a clause placed on "
+        "the wrong beat, a clause whose evidence never arrives, a beat showing "
+        "an error page, and a clause the demo never reaches. It does **not** "
+        "catch a storyboard whose caption asserts a misread requirement and "
+        "whose screen agrees with the caption — you and the author read the "
+        "same caption there.",
+        "",
+        "## The clauses",
+        "",
+    ]
+    for key, text in criteria.items():
+        out += [f"**{key}** — {text}", ""]
+    out += [
+        f"## The frames, in order ({len(frames)})",
+        "",
+    ]
+    out += [f"{n}. `{name}`" for n, name in enumerate(frames, 1)]
+    out += [
+        "",
+        "## Reply with exactly this shape",
+        "",
+        "```json",
+        _reading_template(criteria),
+        "```",
+        "",
+    ]
+    return "\n".join(out).rstrip() + "\n"
+
+
+# --- the verdict: the reader's answers against the storyboard's claims -------
+
+
+def claimed_beats(timeline: dict) -> dict[str, list[int]]:
+    """Which beats the storyboard claimed for each clause, by id.
+
+    The reader never saw any of this. It is read here and nowhere earlier.
+    """
+    coverage = timeline.get("coverage")
+    claimed = coverage.get("claimed") if isinstance(coverage, dict) else None
+    out: dict[str, list[int]] = {}
+    for key, rows in (claimed or {}).items():
+        beats = [
+            row.get("index")
+            for row in (rows or [])
+            if isinstance(row, dict) and isinstance(row.get("index"), int)
+        ]
+        out[str(key)] = sorted(beats)
+    return out
+
+
+def checked_readings(
+    doc: object, criteria: dict[str, str], beats_by_frame: dict[str, int]
+) -> dict[str, dict]:
+    """The reader's answers, validated strictly, keyed by criterion.
+
+    Strict because every one of these refusals is a document that would
+    otherwise be compared as though it said something it does not: an id
+    nobody declared, a frame nobody photographed, a status invented on the
+    spot. A comparison run over any of those is confidently wrong, which is
+    worse than absent.
+    """
+    if not isinstance(doc, dict):
+        raise Refused("the reading is not a JSON object")
+    if doc.get("schema") != READING_SCHEMA:
+        raise Refused(
+            f"the reading declares schema {doc.get('schema')!r}, and this "
+            f"command reads schema {READING_SCHEMA}"
+        )
+    rows = doc.get("readings")
+    if not isinstance(rows, list):
+        raise Refused("the reading has no `readings` list")
+    out: dict[str, dict] = {}
+    for n, row in enumerate(rows, 1):
+        if not isinstance(row, dict):
+            raise Refused(f"reading {n} is not an object: {row!r}")
+        key = row.get("criterion")
+        if not isinstance(key, str) or key not in criteria:
+            raise Refused(
+                f"reading {n} names criterion {key!r}, which this take did not "
+                f"declare. Declared: {', '.join(criteria) or 'none'}."
+            )
+        if key in out:
+            raise Refused(
+                f"reading {n} is a second answer for {key}. One clause, one "
+                f"frame — two answers have no single reading to compare."
+            )
+        status = row.get("status")
+        if status not in STATUSES:
+            raise Refused(
+                f"reading {n} ({key}) has status {status!r}; it must be one of "
+                f"{', '.join(repr(s) for s in STATUSES)}"
+            )
+        confidence = row.get("confidence")
+        if confidence not in CONFIDENCES:
+            raise Refused(
+                f"reading {n} ({key}) has confidence {confidence!r}; it must be "
+                f"one of {', '.join(repr(c) for c in CONFIDENCES)}"
+            )
+        why = row.get("why")
+        if not isinstance(why, str) or not why.strip():
+            raise Refused(
+                f"reading {n} ({key}) says nothing under `why`. The sentence is "
+                f"what tells a reviewer whether to trust the frame."
+            )
+        frame = row.get("frame")
+        if frame is not None and (
+            not isinstance(frame, str) or frame not in beats_by_frame
+        ):
+            raise Refused(
+                f"reading {n} ({key}) names frame {frame!r}, which is not in "
+                f"the frames manifest. A reading can only be of a frame the "
+                f"brief listed."
+            )
+        if status == SEEN and frame is None:
+            raise Refused(
+                f"reading {n} ({key}) is {SEEN!r} with no frame. The whole "
+                f"question is where — a status without one locates nothing."
+            )
+        out[key] = {
+            "status": status,
+            "frame": frame,
+            "beat": beats_by_frame[frame] if frame is not None else None,
+            "why": why.strip(),
+            "confidence": confidence,
+            "derivation": BY_READER,
+        }
+    return out
+
+
+def agreement_rule() -> dict:
+    """The comparison rule, written into the artifact rather than implied.
+
+    **Why a span and not a set.** A storyboard tags the beat where the caption
+    goes up, and SKILL.md's step 6 says captions are written before the action
+    they introduce — so the screen catches up a beat or two later, and the
+    reader, asked where the software visibly does the thing, names that later
+    beat. Measured on a real take of the criterion-card demo: AC-1 was claimed
+    on beats [4, 6, 8, 12, 13] and read at beat 10; AC-3 was claimed on
+    [18, 20, 25, 26, 31] and read at beat 23. Both readings are correct and
+    neither is in the claimed set, so "the reader's beat must be one of the
+    claimed beats" — and a naive one-beat tolerance either side of one —
+    reports a disagreement on a demo that is right. A cross-check whose false
+    alarms outnumber its findings is one nobody reads.
+
+    **Its weakness, which is the other half of stating a rule.** Agreement gets
+    cheaper the wider the claimed span: a clause claimed on beats 2 and 30
+    agrees with a reading anywhere between them, and a storyboard that tagged
+    every beat with every clause would agree with everything. So agreement is
+    weaker evidence the more beats a clause claims, and the span is printed
+    beside every row so a reader can see how much room the rule was given.
+    """
+    return {
+        "rule": SPAN_RULE,
+        "unit": (
+            "beats, not seconds: the beat log and the video run on different "
+            "clocks, so a tolerance in seconds would mean different things in "
+            "different takes"
+        ),
+        "why": (
+            "A storyboard tags the beat where the caption goes up, and captions "
+            "are written before the action they introduce, so the picture that "
+            "evidences a clause arrives a beat or two after the beat that "
+            "claims it. On a measured take, clauses claimed on beats "
+            "[4, 6, 8, 12, 13] and [18, 20, 25, 26, 31] were correctly read at "
+            "beats 10 and 23 — inside both spans, in neither claimed set."
+        ),
+        "weakness": (
+            "Agreement is cheaper the wider the claimed span. A clause claimed "
+            "on beats 2 and 30 agrees with a reading anywhere between them, so "
+            "agreement is weaker evidence the more beats a clause claims. Every "
+            "row below prints its span for exactly this reason."
+        ),
+    }
+
+
+def classify(reading: dict | None, beats: list[int]) -> tuple[str, str]:
+    """(class, why) for one clause. The whole comparison, in one place."""
+    span = f"[{beats[0]}, {beats[-1]}]" if beats else "nothing"
+    if reading is None:
+        return NO_READING, (
+            "The reading names no answer for this clause. Nothing derived a "
+            "status here — it is neither seen nor unseen, and it is recorded "
+            f"as unanswered rather than as either. The storyboard claimed {span}."
+        )
+    if reading["status"] == CANNOT_TELL:
+        return CANNOT_TELL, (
+            f"The reader could not tell from the frames; the storyboard claimed "
+            f"{span}. This is one of the two cases a human is pulled in for."
+        )
+    if reading["status"] == SEEN:
+        if not beats:
+            return DISAGREEMENT, (
+                f"The reader located this clause at beat {reading['beat']} "
+                f"(`{reading['frame']}`) and the storyboard claimed no beat for "
+                f"it at all — it is in `unclaimed`."
+            )
+        if beats[0] <= reading["beat"] <= beats[-1]:
+            return AGREEMENT, (
+                f"The reader located this clause at beat {reading['beat']} "
+                f"(`{reading['frame']}`), inside the claimed span {span}."
+            )
+        outside = (
+            beats[0] - reading["beat"]
+            if reading["beat"] < beats[0]
+            else reading["beat"] - beats[-1]
+        )
+        return DISAGREEMENT, (
+            f"The reader located this clause at beat {reading['beat']} "
+            f"(`{reading['frame']}`), {outside} beat(s) outside the claimed "
+            f"span {span}."
+        )
+    if beats:
+        return DISAGREEMENT, (
+            f"The storyboard claimed this clause on beats {beats} and the "
+            f"reader could not find it in any frame."
+        )
+    return NOT_DEMONSTRATED, (
+        "Neither derivation locates this clause: nothing claimed it and the "
+        "reader did not find it."
+    )
+
+
+def verdict_doc(
+    criteria: dict[str, str],
+    beats: dict[str, list[int]],
+    readings: dict[str, dict],
+    frames: list[str],
+) -> dict:
+    """The comparison, ordered so the disagreements are read first."""
+    clauses = []
+    for key, text in criteria.items():
+        claimed = beats.get(key, [])
+        reading = readings.get(key)
+        kind, why = classify(reading, claimed)
+        clauses.append(
+            {
+                "criterion": key,
+                "text": text,
+                "reading": reading
+                or {
+                    "status": NO_READING,
+                    "derivation": (
+                        "nothing — the reading file has no entry for this clause"
+                    ),
+                },
+                "storyboard": {
+                    "claimed_beats": claimed,
+                    "span": [claimed[0], claimed[-1]] if claimed else None,
+                    "derivation": BY_STORYBOARD,
+                },
+                "agreement": {
+                    "class": kind,
+                    "why": why,
+                    "derivation": (
+                        BY_NOTHING_TO_COMPARE if kind == NO_READING else BY_COMPARISON
+                    ),
+                },
+            }
+        )
+    clauses.sort(key=lambda row: CLASS_ORDER.index(row["agreement"]["class"]))
+    counts = {kind: 0 for kind in CLASS_ORDER}
+    for row in clauses:
+        counts[row["agreement"]["class"]] += 1
+    return {
+        "schema": VERDICT_SCHEMA,
+        "generated_by": "demo-video",
+        "agreement_rule": agreement_rule(),
+        "limit": LIMIT,
+        "frames_read": len(frames),
+        "counts": counts,
+        "clauses": clauses,
+    }
+
+
+def _reader_line(reading: dict) -> str:
+    """The reader's answer as one bullet: status, where, and their sentence."""
+    parts = [f"- **Reader:** {reading['status']}"]
+    if reading.get("frame"):
+        parts.append(f", `{reading['frame']}`")
+    if reading.get("beat") is not None:
+        parts.append(f" (beat {reading['beat']})")
+    if reading.get("confidence"):
+        parts.append(f", confidence {reading['confidence']}")
+    if reading.get("why"):
+        parts.append(f" — {reading['why']}")
+    return "".join(parts)
+
+
+def render_verdict_md(doc: dict) -> str:
+    """The comparison as a page: what disagrees, then everything else."""
+    counts = doc["counts"]
+    out = [
+        "# Two derivations of where each clause is",
+        "",
+        " · ".join(f"{counts[kind]} {kind}" for kind in CLASS_ORDER),
+        "",
+        "One derivation is the `ac=` tags the storyboard author typed. The "
+        "other is a reader who was given the clause text and the frames and "
+        "none of the rest — not the storyboard, not the tags, not this table. "
+        "Where they disagree, the disagreement is the finding, and it is "
+        "printed first.",
+        "",
+        f"**{LIMIT}**",
+        "",
+        "## The rule this page compares under",
+        "",
+        f"{doc['agreement_rule']['rule']} Measured in {doc['agreement_rule']['unit']}.",
+        "",
+        f"*Why a span:* {doc['agreement_rule']['why']}",
+        "",
+        f"*What it gives up:* {doc['agreement_rule']['weakness']}",
+        "",
+    ]
+    for kind in CLASS_ORDER:
+        rows = [row for row in doc["clauses"] if row["agreement"]["class"] == kind]
+        if not rows:
+            continue
+        out += [f"## {kind} ({len(rows)})", ""]
+        for row in rows:
+            reading = row["reading"]
+            board = row["storyboard"]
+            span = board["span"]
+            claimed = board["claimed_beats"] or "none"
+            out += [
+                f"### {row['criterion']} — {row['text']}",
+                "",
+                f"- **{kind}** — {row['agreement']['why']}",
+                f"  *Derived by:* {row['agreement']['derivation']}.",
+                _reader_line(reading),
+                f"  *Derived by:* {reading['derivation']}.",
+                f"- **Storyboard:** claimed beats {claimed}"
+                + (f", span [{span[0]}, {span[1]}]" if span else ""),
+                f"  *Derived by:* {board['derivation']}.",
+                "",
+            ]
+    return "\n".join(out).rstrip() + "\n"
+
+
+# --- the two commands --------------------------------------------------------
+
+
+def _write(demo: Path, name: str, text: str) -> Path:
+    """One artifact into `<demo-dir>/review/`, which is a working file."""
+    review = demo / REVIEW_DIRNAME
+    review.mkdir(parents=True, exist_ok=True)
+    path = review / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _clear_review(demo: Path, names: tuple[str, ...]) -> None:
+    """Take the previous run's answer off disk before this run starts.
+
+    **Before the refusals, not after the last one.** A refused run writes
+    nothing, so without this the file a reader opens afterwards is the previous
+    run's — a verdict about another reading, or a brief listing another
+    ticket's clauses, sitting under a current mtime with nothing on it saying
+    which run it belongs to. Exit 2 and a line on stderr are the only signals
+    that it is stale, and neither is in the file. That is the artifact lying,
+    which is the one failure this whole feature cannot afford.
+
+    Bounded to the names its command writes, never the directory — the same
+    rule, and the same reasoning, as `frames.py` taking its stale sheet off
+    disk before it cuts a new one.
+    """
+    for name in names:
+        try:
+            (demo / REVIEW_DIRNAME / name).unlink(missing_ok=True)
+        except OSError:  # noqa: PERF203 - a leftover is worth reporting, not fatal
+            print(
+                f"demo-grade: WARNING — could not remove the stale {name}, "
+                f"which is now a file about an earlier run",
+                file=sys.stderr,
+            )
+
+
+def cmd_brief(demo: Path) -> int:
+    _clear_review(demo, ("brief.md", "brief.json"))
+    timeline_json = timeline_paths(demo)[0]
+    frames_json = frames_paths(demo)[1]
+    timeline = _load_json(timeline_json, "timeline.json")
+    criteria = declared_criteria(timeline, timeline_json)
+    records = frame_records(_load_json(frames_json, "frames/frames.json"), frames_json)
+    frames = [str(record["file"]) for record in records]
+    # The two arguments below are the whole blindness of this feature. Nothing
+    # read out of `claimed` is in scope by the time they are built, and the two
+    # renderers cannot reach for it.
+    _write(demo, "brief.md", render_brief_md(criteria, frames))
+    _write(
+        demo,
+        "brief.json",
+        json.dumps(brief_doc(criteria, frames), indent=2, ensure_ascii=False) + "\n",
+    )
+    print(
+        f"wrote {demo / REVIEW_DIRNAME}/brief.md ({len(criteria)} clause(s), "
+        f"{len(frames)} frames). Hand it, and the frames, to an agent that has "
+        f"seen neither the storyboard nor the diff."
+    )
+    return 0
+
+
+def cmd_verdict(demo: Path, reading_path: Path) -> int:
+    _clear_review(demo, ("verdict.json", "verdict.md"))
+    timeline_json = timeline_paths(demo)[0]
+    timeline = _load_json(timeline_json, "timeline.json")
+    frames_json = frames_paths(demo)[1]
+    criteria = declared_criteria(timeline, timeline_json)
+    records = frame_records(_load_json(frames_json, "frames/frames.json"), frames_json)
+    frames = [str(record["file"]) for record in records]
+    beats_by_frame = {str(r["file"]): int(r["beat"]) for r in records}
+    readings = checked_readings(
+        _load_json(reading_path, "the reading"), criteria, beats_by_frame
+    )
+    doc = verdict_doc(criteria, claimed_beats(timeline), readings, frames)
+    _write(demo, "verdict.md", render_verdict_md(doc))
+    _write(demo, "verdict.json", json.dumps(doc, indent=2, ensure_ascii=False) + "\n")
+    counts = doc["counts"]
+    print(
+        f"wrote {demo / REVIEW_DIRNAME}/verdict.md — "
+        + ", ".join(f"{counts[kind]} {kind}" for kind in CLASS_ORDER)
+    )
+    # Exit 0 whatever it found. A clause nobody could see is a finding for a
+    # human, not a broken build, and a check that can redden one gets turned
+    # off long before it is believed.
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="command", required=True)
+    brief = sub.add_parser("brief", help="write the document a blind reader gets")
+    brief.add_argument("demo_dir", help="a take's output folder")
+    verdict = sub.add_parser("verdict", help="compare a reading with the claims")
+    verdict.add_argument("demo_dir", help="a take's output folder")
+    verdict.add_argument(
+        "--reading", required=True, help="the reader's answers, as JSON"
+    )
+    args = ap.parse_args(argv)
+    try:
+        if args.command == "brief":
+            return cmd_brief(Path(args.demo_dir))
+        return cmd_verdict(Path(args.demo_dir), Path(args.reading))
+    except Refused as refusal:
+        print(f"demo-grade: refusing — {refusal}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit
+++ b/tests/unit
@@ -9510,6 +9510,750 @@ class LogEarlyCause(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# A brief a second reader cannot see the claims through (issue #279)
+# --------------------------------------------------------------------------
+#
+# `scripts/demo-grade` has two halves and no model call in either. `brief`
+# writes what a blind reader is handed; `verdict` reads that reader's answers
+# back and compares them with `coverage.claimed`, which the reader never saw.
+# Both are functions of documents, which is what lets this suite grade the
+# whole thing without a model and without a browser.
+#
+# **The assertion this section exists for is `BriefIsBlind`.** The blindness is
+# structural — `render_brief_md(criteria, frames)` cannot be handed a claim —
+# but a structure is an argument, not a measurement. What is measured is the
+# artifact: `coverage.claimed` is mutated every way a storyboard could differ
+# (reordered, every timestamp changed, every still replaced, claimed nowhere,
+# claimed everywhere, the claims swapped between clauses, the key deleted
+# outright) and both brief files must come out **byte-identical**. Its control
+# is next to it, because a renderer that returned a constant would satisfy that
+# test perfectly: the same comparison is run over a changed clause and a
+# changed frame list, where the bytes must move.
+#
+# There are **three channels** a claim can leak through, and a mutation set
+# that closes two of them is a check with a hole in it. The claims can reach
+# the reader as *content* (a beat number, a timestamp, a still printed beside a
+# clause), as the *set* of frames listed, or as the *order* the clauses are
+# printed in. The last one leaves every byte of the text alone and still hands
+# the reader the storyboard's answer, and it survived the first version of this
+# section: every mutation preserved the two clauses' relative claim order, so a
+# `sorted(criteria, key=first_claimed_beat)` in `cmd_brief` was invisible. What
+# closes it is the fixture — see `GRADE_CRITERIA` — and the swap mutation, and
+# both are graded by an injection of exactly that shape.
+#
+# The fixture's numbers are not invented. They are a real take of
+# `examples/ticket-queue/demos/2026-08-11-criterion-card` graded by a blind
+# reader: AC-1 claimed on beats [4, 6, 8, 12, 13] and read at beat 10, AC-3
+# claimed on [18, 20, 25, 26, 31] and read at beat 23. Both readings are
+# correct and neither is in its claimed set — the caption goes up a beat or two
+# before the screen catches up — so a rule that asked for set membership, or
+# for one beat of tolerance, would report a disagreement on a demo that is
+# right. That is what the span rule is for and what `SpanRule` grades at its
+# boundary.
+
+GRADE_CLI = SKILL_DIR / "scripts" / "demo-grade"
+
+# The clauses, the claims and the readings of the measured take above, plus a
+# third clause whose **declaration order and claim order disagree**. That
+# disagreement is load-bearing and it is the fixture's job, not the shipped
+# code's: with two clauses declared in the order they are claimed, a leak that
+# reorders the brief *by* the claims produces the same file, and the
+# byte-identical check above never sees it. AC-2 is declared last and claimed
+# first, so any ordering derived from the claims — ascending or descending —
+# differs from the order the ticket declares.
+GRADE_CRITERIA = {
+    "AC-1": "A search box above the queue narrows the list as you type.",
+    "AC-3": "Search matches the requester as well as the title.",
+    "AC-2": "Search and the status filter combine, and the count agrees.",
+}
+GRADE_CLAIMED = {
+    "AC-1": [4, 6, 8, 12, 13],
+    "AC-3": [18, 20, 25, 26, 31],
+    "AC-2": [1, 2],
+}
+GRADE_READ = {
+    "AC-1": "beat-10.png",
+    "AC-3": "beat-23.png",
+    "AC-2": "beat-01.png",
+}
+
+
+def _grade_module():
+    """`scripts/demo-grade`, imported as a module.
+
+    Off `SKILL_DIR` rather than off the repository, so `--fault-inject` grades
+    the broken copy the way `OneClassifier` does for the target guard.
+    """
+    import importlib.machinery
+    import importlib.util
+
+    loader = importlib.machinery.SourceFileLoader("demo_grade", str(GRADE_CLI))
+    spec = importlib.util.spec_from_loader("demo_grade", loader)
+    module = importlib.util.module_from_spec(spec)
+    loader.exec_module(module)
+    return module
+
+
+grade = _grade_module()
+
+
+def _grade_claim_rows(beats: list[int]) -> list[dict]:
+    """`coverage.claimed[id]` rows, as `coverage.py` writes them."""
+    return [
+        {
+            "index": beat,
+            "segment": None,
+            "segment_index": beat,
+            "t_start": round(beat * 1.37, 3),
+            "still": f"images/{beat:02d}-x.png" if beat % 4 == 0 else None,
+        }
+        for beat in beats
+    ]
+
+
+def _grade_demo(
+    root,
+    criteria: dict | None = None,
+    claimed: dict | None = None,
+    frames: list[dict] | None = None,
+    coverage: object = ...,
+) -> Path:
+    """A take's output folder: a timeline, and a frames manifest beside it."""
+    demo = Path(root)
+    (demo / "frames").mkdir(parents=True, exist_ok=True)
+    criteria = GRADE_CRITERIA if criteria is None else criteria
+    claimed = GRADE_CLAIMED if claimed is None else claimed
+    if coverage is ...:
+        coverage = {
+            "criteria": criteria,
+            "claimed": {k: _grade_claim_rows(v) for k, v in claimed.items()},
+            "unclaimed": [k for k, v in claimed.items() if not v],
+            "tagged_beats": sum(len(v) for v in claimed.values()),
+            "untagged_beats": 3,
+        }
+    (demo / "timeline.json").write_text(
+        json.dumps({"schema": 1, "media": "demo.mp4", "coverage": coverage}),
+        encoding="utf-8",
+    )
+    if frames is None:
+        frames = [
+            {"file": f"beat-{i:02d}.png", "kind": "beat", "beat": i, "t": float(i)}
+            for i in range(35)
+        ]
+    (demo / "frames" / "frames.json").write_text(
+        json.dumps(
+            {
+                "schema": 1,
+                "media": "demo.mp4",
+                "duration": 35.0,
+                "frames": frames,
+                "skipped": None,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return demo
+
+
+def _grade_reading(rows: list[dict], schema: int = 1) -> dict:
+    return {"schema": schema, "readings": rows}
+
+
+def _grade_row(criterion, frame, status="seen", why="the list narrows", conf="high"):
+    return {
+        "criterion": criterion,
+        "frame": frame,
+        "status": status,
+        "why": why,
+        "confidence": conf,
+    }
+
+
+class _GradeCase(unittest.TestCase):
+    """Runs the shipped CLI, because the exit status is half the contract."""
+
+    def run_cli(self, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(GRADE_CLI), *args],
+            capture_output=True,
+            text=True,
+        )
+
+    def brief(self, demo: Path) -> tuple[bytes, bytes]:
+        done = self.run_cli("brief", str(demo))
+        self.assertEqual(done.returncode, 0, done.stderr)
+        review = demo / "review"
+        return (
+            (review / "brief.md").read_bytes(),
+            (review / "brief.json").read_bytes(),
+        )
+
+    def verdict(self, demo: Path, rows: list[dict], schema: int = 1) -> dict:
+        path = demo / "reading.json"
+        path.write_text(json.dumps(_grade_reading(rows, schema)), encoding="utf-8")
+        done = self.run_cli("verdict", str(demo), "--reading", str(path))
+        self.assertEqual(done.returncode, 0, done.stderr)
+        return json.loads((demo / "review" / "verdict.json").read_text())
+
+    def refused(self, *args: str) -> str:
+        """A refusal: exit 2, and the reason on stderr rather than a traceback."""
+        done = self.run_cli(*args)
+        self.assertEqual(done.returncode, 2, f"stdout={done.stdout} err={done.stderr}")
+        self.assertIn("refusing", done.stderr)
+        self.assertNotIn("Traceback", done.stderr)
+        return done.stderr
+
+
+class BriefIsBlind(_GradeCase):
+    """The brief is a pure function of the clauses and the frame manifest."""
+
+    # Every way a storyboard's claims can differ, applied to the same take.
+    # A brief that moved under any of them would be carrying the author's
+    # answer into the document written to keep it out.
+    def mutations(self, claimed: dict) -> list[tuple[str, object]]:
+        return [
+            (
+                "the claims are reordered",
+                {k: list(reversed(v)) for k, v in claimed.items()},
+            ),
+            (
+                "every timestamp is different",
+                {
+                    k: [{**row, "t_start": 99.9 - i} for i, row in enumerate(v)]
+                    for k, v in claimed.items()
+                },
+            ),
+            (
+                "every still is a different file",
+                {
+                    k: [{**row, "still": "images/99-elsewhere.png"} for row in v]
+                    for k, v in claimed.items()
+                },
+            ),
+            ("every clause is claimed nowhere", {k: [] for k in claimed}),
+            (
+                "every clause is claimed on every beat",
+                {k: _grade_claim_rows(list(range(35))) for k in claimed},
+            ),
+            # The ordering channel, and the only mutation that reaches it while
+            # every clause keeps a claim: each clause is given the next one's
+            # beats, so the rank the claims put the clauses in changes and not
+            # one byte of the text does. Without it, a brief ordered by the
+            # claims renders identically under every mutation above.
+            (
+                "the claims are swapped between the clauses",
+                {
+                    key: claimed[next_key]
+                    for key, next_key in zip(
+                        claimed,
+                        [*list(claimed)[1:], next(iter(claimed))],
+                        strict=True,
+                    )
+                },
+            ),
+            ("the claims are gone entirely", None),
+        ]
+
+    def test_the_brief_is_byte_identical_however_the_claims_are_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            demo = _grade_demo(tmp)
+            first = self.brief(demo)
+            doc = json.loads((demo / "timeline.json").read_text())
+            claimed = doc["coverage"]["claimed"]
+            for name, mutated in self.mutations(claimed):
+                with self.subTest(mutation=name):
+                    if mutated is None:
+                        doc["coverage"].pop("claimed", None)
+                    else:
+                        doc["coverage"]["claimed"] = mutated
+                    (demo / "timeline.json").write_text(
+                        json.dumps(doc), encoding="utf-8"
+                    )
+                    self.assertEqual(
+                        self.brief(demo),
+                        first,
+                        f"the brief changed when {name} — the reader is being "
+                        f"handed the storyboard's answer",
+                    )
+
+    def test_the_brief_does_move_when_a_clause_or_a_frame_moves(self):
+        # The control on the test above, and it is not optional: a renderer
+        # that returned a constant string would pass every mutation perfectly.
+        with tempfile.TemporaryDirectory() as tmp:
+            demo = _grade_demo(tmp)
+            first = self.brief(demo)
+            _grade_demo(tmp, criteria={**GRADE_CRITERIA, "AC-1": "Something else."})
+            self.assertNotEqual(self.brief(demo), first, "a reworded clause")
+            _grade_demo(
+                tmp,
+                frames=[
+                    {"file": "beat-00.png", "kind": "beat", "beat": 0, "t": 0.0},
+                    {"file": "beat-01.png", "kind": "beat", "beat": 1, "t": 1.0},
+                ],
+            )
+            self.assertNotEqual(self.brief(demo), first, "a different frame sheet")
+
+    def test_the_renderers_cannot_be_handed_a_claim_at_all(self):
+        # The structural half. `(criteria, frames)` and nothing else means a
+        # leak has to be written into the caller, where the test above sees it
+        # — rather than being one `doc.get("claimed")` away inside a renderer
+        # that was passed the whole coverage document.
+        for func in (grade.render_brief_md, grade.brief_doc):
+            with self.subTest(func=func.__name__):
+                self.assertEqual(
+                    list(inspect.signature(func).parameters),
+                    ["criteria", "frames"],
+                )
+
+    def test_the_brief_asks_for_localisation_and_not_for_a_verdict(self):
+        # #131 measured the aggregate answer unstable and the localisation
+        # stable, so the aggregate is not asked for. The words matter here:
+        # this is the whole instruction the reader acts on.
+        text = grade.render_brief_md(GRADE_CRITERIA, ["beat-00.png"])
+        self.assertIn("first", text)
+        self.assertIn("not seen", text)
+        self.assertIn("cannot tell", text)
+        self.assertIn("confidence", text)
+        self.assertIn("do not say whether it should ship", text.lower())
+
+    def test_the_brief_states_the_limit_it_cannot_design_away(self):
+        # Required by #279 in the artifact itself: the caption is burned into
+        # every frame the reader reads, so a storyboard whose caption asserts a
+        # misread requirement and whose screen agrees with it survives this
+        # check. A cross-check that does not carry its own boundary gets read
+        # as one that has none.
+        text = grade.render_brief_md(GRADE_CRITERIA, ["beat-00.png"])
+        self.assertIn("burned into the pixels", text)
+        self.assertIn("does **not**", text)
+        self.assertIn("agrees with the caption", text)
+
+
+class BriefRefusals(_GradeCase):
+    """Refusing is the correct answer to these, not an error path."""
+
+    def test_a_take_that_declared_no_criteria_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            demo = _grade_demo(tmp, coverage=None)
+            self.assertIn("no acceptance criteria", self.refused("brief", str(demo)))
+
+    def test_a_take_with_an_empty_criteria_map_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            demo = _grade_demo(tmp, coverage={"criteria": {}, "claimed": {}})
+            self.assertIn("no criteria", self.refused("brief", str(demo)))
+
+    def test_a_missing_frames_manifest_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            demo = _grade_demo(tmp)
+            (demo / "frames" / "frames.json").unlink()
+            self.assertIn("frames.json", self.refused("brief", str(demo)))
+
+    def test_an_empty_frames_manifest_is_refused(self):
+        # A take whose frames were skipped — a segment, or a crash before the
+        # encode — has nothing for a reader to look at, and the manifest says
+        # why. A brief listing no frames would be a question with no evidence.
+        with tempfile.TemporaryDirectory() as tmp:
+            demo = _grade_demo(tmp, frames=[])
+            self.assertIn("lists no frames", self.refused("brief", str(demo)))
+
+    def test_a_missing_timeline_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            demo = _grade_demo(tmp)
+            (demo / "timeline.json").unlink()
+            self.assertIn("timeline.json", self.refused("brief", str(demo)))
+
+    def test_the_ordinary_take_is_not_refused(self):
+        # The control: without it every assertion above is satisfied by a
+        # command that refuses everything.
+        with tempfile.TemporaryDirectory() as tmp:
+            demo = _grade_demo(tmp)
+            done = self.run_cli("brief", str(demo))
+            self.assertEqual(done.returncode, 0, done.stderr)
+            self.assertTrue((demo / "review" / "brief.md").is_file())
+
+
+class FrameOrder(_GradeCase):
+    """Beat index to frame file is not 1:1, and the manifest is what says so."""
+
+    # A scene frame inside a long beat, and a beat the host's clock deleted
+    # from the file — whose frame is cut at the last instant before the gap,
+    # so the sheet's name order and the video's order part company.
+    SHEET = [
+        {"file": "beat-00.png", "kind": "beat", "beat": 0, "t": 0.0},
+        {"file": "beat-01.png", "kind": "beat", "beat": 1, "t": 1.0},
+        {"file": "beat-01-scene-1.png", "kind": "scene", "beat": 1, "t": 2.5},
+        {"file": "beat-03.png", "kind": "beat", "beat": 3, "t": 9.0},
+        {"file": "beat-02.png", "kind": "beat", "beat": 2, "t": 4.0, "no_video": 1.2},
+    ]
+
+    def test_the_frames_are_listed_in_the_order_they_occur_in_the_video(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            demo = _grade_demo(tmp, frames=self.SHEET)
+            self.brief(demo)
+            listed = json.loads((demo / "review" / "brief.json").read_text())["frames"]
+            self.assertEqual(
+                listed,
+                [
+                    "beat-00.png",
+                    "beat-01.png",
+                    "beat-01-scene-1.png",
+                    "beat-02.png",
+                    "beat-03.png",
+                ],
+            )
+
+    def test_a_scene_frame_is_compared_against_the_beat_it_was_cut_from(self):
+        # The reading names `beat-01-scene-1.png`, which is beat 1 — a fact
+        # only the manifest holds. Read off the filename it would be beat 1 by
+        # luck; read off the sheet's position it would be the third frame.
+        with tempfile.TemporaryDirectory() as tmp:
+            demo = _grade_demo(
+                tmp, claimed={"AC-1": [1, 2], "AC-3": [3]}, frames=self.SHEET
+            )
+            doc = self.verdict(
+                demo,
+                [
+                    _grade_row("AC-1", "beat-01-scene-1.png"),
+                    _grade_row("AC-3", "beat-03.png"),
+                ],
+            )
+            rows = {c["criterion"]: c for c in doc["clauses"]}
+            self.assertEqual(rows["AC-1"]["reading"]["beat"], 1)
+            self.assertEqual(rows["AC-1"]["agreement"]["class"], "agreement")
+
+
+class ReadingValidation(_GradeCase):
+    """What a reading may say, and what is refused rather than compared."""
+
+    def refuse_reading(self, doc: object, demo: Path) -> str:
+        path = demo / "reading.json"
+        path.write_text(json.dumps(doc), encoding="utf-8")
+        return self.refused("verdict", str(demo), "--reading", str(path))
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.demo = _grade_demo(self._tmp.name)
+
+    def test_a_criterion_the_take_never_declared_is_refused(self):
+        said = self.refuse_reading(
+            _grade_reading([_grade_row("AC-9", "beat-10.png")]), self.demo
+        )
+        self.assertIn("AC-9", said)
+
+    def test_a_frame_that_is_not_in_the_manifest_is_refused(self):
+        # The reader can only have looked at the frames the brief listed, so a
+        # frame nobody photographed is a reading of something else.
+        said = self.refuse_reading(
+            _grade_reading([_grade_row("AC-1", "beat-99.png")]), self.demo
+        )
+        self.assertIn("beat-99.png", said)
+
+    def test_a_status_outside_the_three_is_refused(self):
+        said = self.refuse_reading(
+            _grade_reading([_grade_row("AC-1", "beat-10.png", status="met")]),
+            self.demo,
+        )
+        self.assertIn("met", said)
+
+    def test_a_confidence_outside_the_three_is_refused(self):
+        said = self.refuse_reading(
+            _grade_reading([_grade_row("AC-1", "beat-10.png", conf="pretty sure")]),
+            self.demo,
+        )
+        self.assertIn("pretty sure", said)
+
+    def test_a_seen_reading_with_no_frame_is_refused(self):
+        # `seen` without a frame answers the question the brief did not ask.
+        said = self.refuse_reading(
+            _grade_reading([_grade_row("AC-1", None)]), self.demo
+        )
+        self.assertIn("no frame", said)
+
+    def test_two_answers_for_one_clause_are_refused(self):
+        said = self.refuse_reading(
+            _grade_reading(
+                [_grade_row("AC-1", "beat-10.png"), _grade_row("AC-1", "beat-20.png")]
+            ),
+            self.demo,
+        )
+        self.assertIn("second answer", said)
+
+    def test_a_malformed_document_is_refused(self):
+        for name, doc in (
+            ("not an object", ["AC-1"]),
+            ("no readings list", {"schema": 1}),
+            ("another schema", _grade_reading([], schema=7)),
+            ("a row that is not an object", {"schema": 1, "readings": ["AC-1"]}),
+            (
+                "an empty why",
+                _grade_reading([_grade_row("AC-1", "beat-10.png", why="  ")]),
+            ),
+        ):
+            with self.subTest(document=name):
+                self.refuse_reading(doc, self.demo)
+
+    def test_the_measured_reading_is_accepted(self):
+        # The control. Every refusal above is satisfied by a command that
+        # refuses every document it is given.
+        doc = self.verdict(self.demo, [_grade_row(k, v) for k, v in GRADE_READ.items()])
+        self.assertEqual(doc["counts"]["agreement"], len(GRADE_CRITERIA))
+
+
+class SpanRule(unittest.TestCase):
+    """The comparison rule, graded at both ends of the span and outside it."""
+
+    CLAIMED = [4, 6, 8, 12, 13]
+
+    def kind(self, beat=None, status="seen", claimed=None):
+        reading = (
+            None
+            if status is None
+            else {"status": status, "frame": f"beat-{beat}.png", "beat": beat}
+        )
+        claimed = self.CLAIMED if claimed is None else claimed
+        return grade.classify(reading, claimed)[0]
+
+    def test_a_reading_inside_the_span_but_in_no_claimed_set_agrees(self):
+        # The measured case, and the whole reason the rule is a span: beat 10
+        # is between the claims at 8 and 12 because the caption led its
+        # evidence. Set membership, or one beat of tolerance, calls this a
+        # disagreement on a demo that is right.
+        self.assertEqual(self.kind(10), "agreement")
+
+    def test_the_two_ends_of_the_span_are_inside_it(self):
+        self.assertEqual(self.kind(4), "agreement")
+        self.assertEqual(self.kind(13), "agreement")
+
+    def test_one_beat_outside_each_end_is_a_disagreement(self):
+        # The boundary, from the other side. Without these two the rule could
+        # be any window at all and this class would not notice.
+        self.assertEqual(self.kind(3), "disagreement")
+        self.assertEqual(self.kind(14), "disagreement")
+
+    def test_a_clause_the_reader_found_that_nothing_claimed_disagrees(self):
+        self.assertEqual(self.kind(10, claimed=[]), "disagreement")
+
+    def test_a_claimed_clause_the_reader_could_not_find_disagrees(self):
+        # The finding this whole check exists for: the storyboard says the
+        # demo shows it and the frames do not.
+        self.assertEqual(self.kind(None, status="not seen"), "disagreement")
+
+    def test_neither_derivation_locating_it_is_not_demonstrated(self):
+        self.assertEqual(
+            self.kind(None, status="not seen", claimed=[]), "not demonstrated"
+        )
+
+    def test_cannot_tell_stays_cannot_tell_whatever_was_claimed(self):
+        self.assertEqual(self.kind(10, status="cannot tell"), "cannot tell")
+
+    def test_the_rule_and_its_weakness_are_written_down(self):
+        # An agreement rule nobody can read is a number with no argument. The
+        # weakness is stated with it: a wide claimed span makes agreement
+        # cheap, so agreement is weaker the more beats a clause claims.
+        rule = grade.agreement_rule()
+        self.assertIn("span", rule["rule"])
+        self.assertIn("beats, not seconds", rule["unit"])
+        self.assertIn("caption", rule["why"])
+        self.assertIn("wider the claimed span", rule["weakness"])
+
+
+class VerdictOutput(_GradeCase):
+    """What the comparison writes down, and what it refuses to leave out."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.demo = _grade_demo(self._tmp.name)
+
+    def test_a_clause_the_reader_did_not_see_still_exits_zero(self):
+        # The command may not fail a run for what it found. A grader that can
+        # redden a build is turned off long before it is believed, and "the
+        # demo does not show AC-3" is a finding for a human either way.
+        path = self.demo / "reading.json"
+        path.write_text(
+            json.dumps(
+                _grade_reading(
+                    [
+                        _grade_row("AC-1", GRADE_READ["AC-1"]),
+                        _grade_row("AC-3", None, status="not seen", why="never shown"),
+                    ]
+                )
+            ),
+            encoding="utf-8",
+        )
+        done = self.run_cli("verdict", str(self.demo), "--reading", str(path))
+        self.assertEqual(done.returncode, 0, done.stderr)
+        doc = json.loads((self.demo / "review" / "verdict.json").read_text())
+        self.assertEqual(doc["counts"]["disagreement"], 1)
+
+    def test_a_declared_clause_the_reader_skipped_is_recorded_as_no_reading(self):
+        # Never silently absent, and never a pass: nothing derived a status
+        # for it, and that is itself the thing to report.
+        doc = self.verdict(
+            self.demo,
+            [
+                _grade_row("AC-1", GRADE_READ["AC-1"]),
+                _grade_row("AC-2", GRADE_READ["AC-2"]),
+            ],
+        )
+        rows = {c["criterion"]: c for c in doc["clauses"]}
+        self.assertEqual(set(rows), set(GRADE_CRITERIA))
+        self.assertEqual(rows["AC-3"]["agreement"]["class"], "no reading")
+        self.assertEqual(rows["AC-3"]["reading"]["status"], "no reading")
+        self.assertEqual(doc["counts"]["no reading"], 1)
+        self.assertIn("no reading", (self.demo / "review" / "verdict.md").read_text())
+
+    def test_disagreements_are_printed_before_agreements(self):
+        # In both artifacts, and in declaration order that is the wrong way
+        # round: AC-1 agrees and is declared first.
+        doc = self.verdict(
+            self.demo,
+            [
+                _grade_row("AC-1", GRADE_READ["AC-1"]),
+                _grade_row("AC-3", "beat-33.png"),
+                _grade_row("AC-2", GRADE_READ["AC-2"]),
+            ],
+        )
+        self.assertEqual(
+            [c["agreement"]["class"] for c in doc["clauses"]],
+            ["disagreement", "agreement", "agreement"],
+        )
+        self.assertEqual(doc["clauses"][0]["criterion"], "AC-3")
+        page = (self.demo / "review" / "verdict.md").read_text()
+        self.assertLess(page.index("## disagreement"), page.index("## agreement"))
+
+    def test_no_status_is_written_down_without_what_derived_it(self):
+        """#279's acceptance, asserted over all three fields rather than one.
+
+        Nothing is pre-ticked by whatever wrote the label. Each of the three
+        rows names what produced it, and the claim is different for each — so
+        checking one field and describing three is how a hole gets left. The
+        two that carry a **status** (what the reader answered, and how the two
+        derivations compared) may never name the storyboard: it wrote the
+        claim being checked, and a status attributed to it is the artifact
+        agreeing with itself. The third row *is* the storyboard's, and it must
+        say so — `claimed_beats` presented without its source reads as a fact
+        about the demo rather than as the tags somebody typed.
+        """
+        doc = self.verdict(
+            self.demo,
+            [
+                _grade_row("AC-1", GRADE_READ["AC-1"]),
+                _grade_row("AC-3", "beat-33.png"),
+                _grade_row("AC-2", GRADE_READ["AC-2"]),
+            ],
+        )
+        page = (self.demo / "review" / "verdict.md").read_text()
+        for row in doc["clauses"]:
+            for part in ("reading", "storyboard", "agreement"):
+                self.assertTrue(
+                    row[part].get("derivation"),
+                    f"{row['criterion']}'s {part} has no derivation",
+                )
+                self.assertIn(row[part]["derivation"], page)
+            for part in ("reading", "agreement"):
+                self.assertNotEqual(
+                    row[part]["derivation"],
+                    grade.BY_STORYBOARD,
+                    f"the storyboard is named as what derived {row['criterion']}'s "
+                    f"{part} status",
+                )
+            self.assertEqual(
+                row["storyboard"]["derivation"],
+                grade.BY_STORYBOARD,
+                "the claimed beats are printed without naming the tags they are",
+            )
+
+    def test_the_verdict_carries_the_limit_and_the_span_it_compared(self):
+        """...on the **storyboard's own row**, which is what was promised.
+
+        `agreement_rule()["weakness"]` says every row prints its span so a
+        reader can see how much room the rule was given, and the storyboard row
+        is the one that keeps that promise. Asserting a bare `span [4, 13]`
+        anywhere on the page does not: `classify()` writes "inside the claimed
+        span [4, 13]" into the agreement sentence, so the storyboard row could
+        be deleted whole and the check would stay green on the other line.
+        That is the dominated assertion out of `wip/verified-review`, so the
+        whole line is anchored, for every clause.
+        """
+        doc = self.verdict(self.demo, [_grade_row(k, v) for k, v in GRADE_READ.items()])
+        page = (self.demo / "review" / "verdict.md").read_text()
+        self.assertIn("cross-check, not a verification", page)
+        self.assertIn("agrees with the caption", page)
+        for row in doc["clauses"]:
+            beats = GRADE_CLAIMED[row["criterion"]]
+            self.assertEqual(row["storyboard"]["span"], [min(beats), max(beats)])
+            self.assertIn(
+                f"- **Storyboard:** claimed beats {beats}, "
+                f"span [{min(beats)}, {max(beats)}]",
+                page,
+                f"{row['criterion']}'s storyboard row does not print the span "
+                f"the rule was given",
+            )
+
+    def test_a_refused_run_leaves_no_verdict_from_the_run_before_it(self):
+        """A stale answer under a current mtime is the artifact lying.
+
+        The refusal is on stderr and in the exit status, and neither of those
+        is in the file: a reader who opens `review/verdict.md` after a refused
+        run would otherwise find the *previous* reading's comparison, with
+        nothing on it saying which run it belongs to. `frames.py` takes its
+        stale sheet off disk before writing for the same reason.
+        """
+        self.verdict(self.demo, [_grade_row(k, v) for k, v in GRADE_READ.items()])
+        written = [self.demo / "review" / n for n in ("verdict.json", "verdict.md")]
+        self.assertTrue(all(p.is_file() for p in written), "nothing to go stale")
+        path = self.demo / "reading.json"
+        path.write_text(
+            json.dumps(_grade_reading([_grade_row("AC-9", "beat-10.png")])),
+            encoding="utf-8",
+        )
+        done = self.run_cli("verdict", str(self.demo), "--reading", str(path))
+        self.assertEqual(done.returncode, 2, done.stderr)
+        for path in written:
+            self.assertFalse(
+                path.exists(),
+                f"{path.name} survived a refused run and now reads as its output",
+            )
+
+    def test_a_refused_brief_leaves_no_brief_from_the_run_before_it(self):
+        # The same failure through the other command, and the worse of the
+        # two: a stale brief is a document handed to a reader, listing another
+        # take's clauses.
+        self.brief(self.demo)
+        written = [self.demo / "review" / n for n in ("brief.md", "brief.json")]
+        self.assertTrue(all(p.is_file() for p in written), "nothing to go stale")
+        _grade_demo(self._tmp.name, coverage=None)
+        self.assertIn("no acceptance criteria", self.refused("brief", str(self.demo)))
+        for path in written:
+            self.assertFalse(
+                path.exists(),
+                f"{path.name} survived a refused run and now reads as its output",
+            )
+
+
+class ExitStatus(_GradeCase):
+    """Two codes, and the docstring names the ones the script actually uses."""
+
+    def test_a_usage_error_exits_two_like_a_refusal_does(self):
+        # argparse's own code, not overridden. It is worth pinning because the
+        # obvious thing to write in a docstring is 1, and a caller reading that
+        # would treat a mistyped path as "refused" or the other way round.
+        for args in (("brief",), ("verdict", "/nowhere"), ("nonsense", "/nowhere")):
+            with self.subTest(args=args):
+                done = self.run_cli(*args)
+                self.assertEqual(done.returncode, 2, done.stderr)
+                self.assertNotIn("refusing", done.stderr)
+
+    def test_the_docstring_names_those_codes_and_no_others(self):
+        # The half that catches the drift: a paragraph promising an exit code
+        # the script cannot return is documentation that a caller's `if` is
+        # written against.
+        section = grade.__doc__.split("## Exit status")[1]
+        self.assertEqual(set(re.findall(r"\b([0-9])\b", section)), {"0", "2"})
+
+
+# --------------------------------------------------------------------------
 
 # Issue #203, as the overlay shipped before it was fixed and after it was.
 # Nothing below is rewritten by hand: the two are the same region of
@@ -13471,6 +14215,263 @@ INJECTIONS = [
         "(issue #278).\n"
         "    out += _ticket_md(doc)",
         ["TicketMd.test_the_ticket_is_named_above_the_table_of_clauses_quoted_from_it"],
+    ),
+    # -- scripts/demo-grade (issue #279) ------------------------------------
+    (
+        # **The defect the whole slice exists to prevent**, written the way
+        # somebody helpful would write it: the reader is told where to look, so
+        # that it "wastes less time". A reader handed the storyboard's answer
+        # is a reader agreeing with the storyboard, and the second derivation
+        # stops being a second derivation. Nothing else in this suite can see
+        # it — the brief still renders, still lists every clause and every
+        # frame, and still asks for a localisation.
+        "the brief tells the reader which beats the storyboard claimed",
+        "scripts/demo-grade",
+        "    # The two arguments below are the whole blindness of this feature."
+        " Nothing\n"
+        "    # read out of `claimed` is in scope by the time they are built, "
+        "and the two\n"
+        "    # renderers cannot reach for it.\n"
+        '    _write(demo, "brief.md", render_brief_md(criteria, frames))',
+        '    claimed = (timeline.get("coverage") or {}).get("claimed") or {}\n'
+        "    criteria = {\n"
+        '        key: f"{text} (claimed at beats "\n'
+        "        f\"{[row.get('index') for row in claimed.get(key, [])]})\"\n"
+        "        for key, text in criteria.items()\n"
+        "    }\n"
+        '    _write(demo, "brief.md", render_brief_md(criteria, frames))',
+        [
+            "BriefIsBlind."
+            "test_the_brief_is_byte_identical_however_the_claims_are_written"
+        ],
+    ),
+    (
+        # The same leak through the other file, carrying the other two fields.
+        # Without this entry the timestamp and still mutations above grade
+        # nothing: the beat-index leak leaves both of them byte-identical, and
+        # a mutation nothing can redden is decoration in a list that reads as
+        # coverage. It also grades that *both* artifacts are compared — this
+        # one leaves `brief.md` untouched.
+        "brief.json names the still and the time claimed for each clause",
+        "scripts/demo-grade",
+        "        json.dumps(brief_doc(criteria, frames), indent=2, "
+        'ensure_ascii=False) + "\\n",',
+        "        json.dumps(\n            brief_doc(\n                {\n"
+        '                    key: f"{text} "\n'
+        "                    f\"{[(r.get('t_start'), r.get('still')) for r in "
+        "((timeline.get('coverage') or {}).get('claimed') or {}).get(key, [])]}\"\n"
+        "                    for key, text in criteria.items()\n"
+        "                },\n                frames,\n            ),\n"
+        "            indent=2,\n            ensure_ascii=False,\n        )\n"
+        '        + "\\n",',
+        [
+            "BriefIsBlind."
+            "test_the_brief_is_byte_identical_however_the_claims_are_written"
+        ],
+    ),
+    (
+        # The frames are listed in the order they occur in the *video*, read
+        # off the manifest's own timestamps. Sorted by name they are almost
+        # always the same list, which is exactly why this needs an assertion:
+        # the cases that differ are a scene frame inside a long beat and a beat
+        # the host's clock deleted from the file.
+        "the brief lists the frames in filename order instead of video order",
+        "scripts/demo-grade",
+        '    return sorted(records, key=lambda record: float(record["t"]))',
+        '    return sorted(records, key=lambda record: str(record["file"]))',
+        ["FrameOrder.test_the_frames_are_listed_in_the_order_they_occur_in_the_video"],
+    ),
+    (
+        # A refusal reported as success. Both commands print the reason either
+        # way, so the only thing that changes is what a caller's `&&` does with
+        # it — which is the whole difference between a guard and a log line.
+        "a refusal exits 0",
+        "scripts/demo-grade",
+        '        print(f"demo-grade: refusing — {refusal}", file=sys.stderr)\n'
+        "        return 2",
+        '        print(f"demo-grade: refusing — {refusal}", file=sys.stderr)\n'
+        "        return 0",
+        [
+            "BriefRefusals.test_a_take_that_declared_no_criteria_is_refused",
+            "ReadingValidation.test_a_criterion_the_take_never_declared_is_refused",
+        ],
+    ),
+    (
+        # An empty sheet is what a segment take and a take that crashed before
+        # the encode both produce. A brief listing no frames is a question
+        # with no evidence attached, and it reads exactly like a brief for a
+        # demo that showed nothing.
+        "a frames manifest with no frames in it produces a brief anyway",
+        "scripts/demo-grade",
+        "    if not isinstance(records, list) or not records:",
+        "    if not isinstance(records, list):",
+        ["BriefRefusals.test_an_empty_frames_manifest_is_refused"],
+    ),
+    (
+        # A reading of a frame nobody photographed is a reading of something
+        # else. Accepted, it reaches the comparison as a beat that does not
+        # exist.
+        "a reading may name a frame that is not in the manifest",
+        "scripts/demo-grade",
+        "        if frame is not None and (\n"
+        "            not isinstance(frame, str) or frame not in beats_by_frame\n"
+        "        ):",
+        "        if frame is not None and not isinstance(frame, str):",
+        ["ReadingValidation.test_a_frame_that_is_not_in_the_manifest_is_refused"],
+    ),
+    (
+        # The status vocabulary, which is deliberately three words. A fourth
+        # spelling arriving from a model — "met", "demonstrated" — is not
+        # noticed by anything downstream: it falls through the comparison as
+        # though the reader had said `not seen`, which is a status the reader
+        # never gave.
+        "a status outside the three is compared instead of refused",
+        "scripts/demo-grade",
+        "        if status not in STATUSES:",
+        "        if status is None:",
+        ["ReadingValidation.test_a_status_outside_the_three_is_refused"],
+    ),
+    (
+        # The clause the reader skipped, dropped rather than recorded. The
+        # verdict then reads as a complete answer over a shorter ticket, and
+        # nobody counts the clauses.
+        "a clause with no reading disappears from the verdict",
+        "scripts/demo-grade",
+        "    clauses = []\n    for key, text in criteria.items():",
+        "    clauses = []\n"
+        "    for key, text in ((k, v) for k, v in criteria.items() if k in readings):",
+        [
+            "VerdictOutput."
+            "test_a_declared_clause_the_reader_skipped_is_recorded_as_no_reading"
+        ],
+    ),
+    (
+        # Ordering alone: every clause is still rendered, with the same class
+        # and the same derivations, and the disagreement is somewhere below
+        # the fold. Every presence assertion in this section passes on it.
+        "the verdict opens with the agreements",
+        "scripts/demo-grade",
+        '    clauses.sort(key=lambda row: CLASS_ORDER.index(row["agreement"]["class"]))',
+        '    clauses.sort(key=lambda row: row["criterion"])',
+        ["VerdictOutput.test_disagreements_are_printed_before_agreements"],
+    ),
+    (
+        # The rule at its boundary, widened by one beat either side — the
+        # shape a tolerance grows by when somebody is looking at one noisy
+        # take. The span's ends are still inside, so only the two readings
+        # just outside it can tell.
+        "the agreement span grows a beat of tolerance at each end",
+        "scripts/demo-grade",
+        '        if beats[0] <= reading["beat"] <= beats[-1]:',
+        '        if beats[0] - 1 <= reading["beat"] <= beats[-1] + 1:',
+        ["SpanRule.test_one_beat_outside_each_end_is_a_disagreement"],
+    ),
+    (
+        # The one thing this command may never do. A grader that can redden a
+        # build is turned off long before anybody believes it, and "the frames
+        # do not show AC-3" is a finding for a human either way.
+        "a disagreement fails the run",
+        "scripts/demo-grade",
+        "    # off long before it is believed.\n    return 0",
+        "    # off long before it is believed.\n"
+        "    return 2 if counts[DISAGREEMENT] else 0",
+        ["VerdictOutput.test_a_clause_the_reader_did_not_see_still_exits_zero"],
+    ),
+    (
+        # #279's acceptance, broken the way it would actually break: the
+        # agreement keeps its class and its sentence, and the thing named as
+        # having derived it becomes the storyboard — the one derivation that
+        # cannot produce a status, because it is the claim being checked.
+        "an agreement names the storyboard as what derived it",
+        "scripts/demo-grade",
+        "                        BY_NOTHING_TO_COMPARE if kind == NO_READING "
+        "else BY_COMPARISON",
+        "                        BY_STORYBOARD",
+        ["VerdictOutput.test_no_status_is_written_down_without_what_derived_it"],
+    ),
+    (
+        # **The third leak channel**, and the one the first version of this
+        # section could not see: the clauses are printed in the order the
+        # claims put them in. Not one byte of the text changes — same clauses,
+        # same wording, same frames — and the reader is handed the
+        # storyboard's ranking anyway. It is invisible to any mutation that
+        # leaves the clauses' relative claim order alone, which is why
+        # `GRADE_CRITERIA` declares AC-2 last and claims it first, and why the
+        # swap mutation exists.
+        "the brief orders the clauses by the beats that claim them",
+        "scripts/demo-grade",
+        '    timeline = _load_json(timeline_json, "timeline.json")\n'
+        "    criteria = declared_criteria(timeline, timeline_json)",
+        '    timeline = _load_json(timeline_json, "timeline.json")\n'
+        "    criteria = declared_criteria(timeline, timeline_json)\n"
+        '    _claimed = (timeline.get("coverage") or {}).get("claimed") or {}\n'
+        "    criteria = {\n"
+        "        key: criteria[key]\n"
+        "        for key in sorted(\n"
+        "            criteria,\n"
+        "            key=lambda k: min(\n"
+        '                [r.get("index", 99) for r in _claimed.get(k, [])] or [99]\n'
+        "            ),\n"
+        "        )\n"
+        "    }",
+        [
+            "BriefIsBlind."
+            "test_the_brief_is_byte_identical_however_the_claims_are_written"
+        ],
+    ),
+    (
+        # The reader's own row, attributed to the storyboard. The check that
+        # was supposed to catch this read one field of three and described
+        # three, so this exact line left the whole suite green.
+        "the reader's answer names the storyboard as what derived it",
+        "scripts/demo-grade",
+        '            "derivation": BY_READER,',
+        '            "derivation": BY_STORYBOARD,',
+        ["VerdictOutput.test_no_status_is_written_down_without_what_derived_it"],
+    ),
+    (
+        # The span dropped from the row that promised it. `classify()` still
+        # writes "inside the claimed span [4, 13]" into the agreement
+        # sentence, so a check for that substring anywhere on the page stays
+        # green while the storyboard row loses the number entirely — the
+        # dominated assertion, reproduced.
+        "the storyboard row stops printing the span the rule was given",
+        "scripts/demo-grade",
+        'f"- **Storyboard:** claimed beats {claimed}"\n'
+        '                + (f", span [{span[0]}, {span[1]}]" if span else ""),',
+        'f"- **Storyboard:** claimed beats {claimed}",',
+        ["VerdictOutput.test_the_verdict_carries_the_limit_and_the_span_it_compared"],
+    ),
+    (
+        # The docstring as it shipped, promising an exit code the script
+        # cannot return. A caller's `if status == 1` is written against this
+        # paragraph and nothing else.
+        "the exit-status paragraph goes back to claiming 1 for a usage error",
+        "scripts/demo-grade",
+        "refuses and when the arguments do not parse — argparse's own code, which this",
+        "refuses, and 1 for a usage error — argparse's own code, which this",
+        ["ExitStatus.test_the_docstring_names_those_codes_and_no_others"],
+    ),
+    (
+        # A refused run leaving the previous run's comparison on disk, under a
+        # current mtime, with nothing in the file saying which run it is. The
+        # refusal is on stderr and in the status; a reader who opens the file
+        # sees neither.
+        "a refused verdict leaves the previous run's verdict readable",
+        "scripts/demo-grade",
+        '    _clear_review(demo, ("verdict.json", "verdict.md"))',
+        "    _clear_review(demo, ())",
+        ["VerdictOutput.test_a_refused_run_leaves_no_verdict_from_the_run_before_it"],
+    ),
+    (
+        # The same failure through the other command, graded separately: one
+        # call site fixed and the other forgotten is exactly how this shape
+        # survives.
+        "a refused brief leaves the previous run's brief readable",
+        "scripts/demo-grade",
+        '    _clear_review(demo, ("brief.md", "brief.json"))',
+        "    _clear_review(demo, ())",
+        ["VerdictOutput.test_a_refused_brief_leaves_no_brief_from_the_run_before_it"],
     ),
 ]
 


### PR DESCRIPTION
Part of #279 — the first slice of Phase 1 in `GOAL.md`. Adds `skills/demo-video/scripts/demo-grade` with `brief` and `verdict`.

## Acceptance criterion

`brief` emits a packet carrying only the clause text and the ordered frame list, structurally incapable of carrying anything from `coverage.claimed`. `verdict` validates a reading strictly, records a declared clause with no reading as `no reading` rather than passing it silently, classifies agreement against a stated rule, prints disagreements first, names the derivation beside every status, and **never fails a run**.

## Why the model call is not in the script

There is no model infrastructure in this repo — no client, no CI secret. Rather than add one, the seam goes elsewhere: `brief` writes the blind packet, an **agent** reads it, `verdict` consumes the reading. Everything gradable is deterministic Python and the tests replay recorded readings, which is what #279's acceptance clause asks for. It also works today in Claude Code with no key.

## It was run for real, not only on fixtures

`examples/ticket-queue/demos/2026-08-11-criterion-card` re-recorded against the live app — 35 beats, 41 frames — and graded by **three independent blind reader agents** given the clause text and the frames and nothing else.

| | AC-1 | AC-3 |
|---|---|---|
| reader A | `beat-10` · high | `beat-23` · high |
| reader B | `beat-10` · high | `beat-23` · high |
| reader C (primed sceptical) | `beat-10` · medium | `beat-23` · high |
| storyboard claimed | 4, 6, 8, 12, 13 | 18, 20, 25, 26, 31 |

Six readings, six identical frame identifications; the only variance in the run is one confidence field. All three reached the same evidence independently — that lower-case `invoice` matching a capital-I title is the case-insensitivity half of AC-1, and that `mira` surviving only on TQ-103 can come only from the requester field.

**This settles the design fork that #131 is usually quoted for.** #131 measured a *ship/no-ship verdict over a whole take* and got a coin flip. Asked to localise one clause at a time, three readers agree exactly. The instability was in the aggregation, not the perception — so per-clause localisation is the unit, any roll-up is arithmetic in code, and `cannot tell` absorbs the rest.

**All three readings fall inside the claimed span and in neither claimed set** (10 between claims 8 and 12; 23 between 20 and 25). That is the caption-leads-its-evidence effect SKILL.md step 6 documents, and it is what the agreement rule had to be chosen against — a "must be in the claimed set" rule, or a naive ±1, would report disagreement on a demo that is correct.

## The agreement rule, and what it gives up

Span containment: agree iff `min(claimed) ≤ reader_beat ≤ max(claimed)`. Stated in both artifacts along with its reason and its weakness, quoted from the rendered page:

> *What it gives up:* Agreement is cheaper the wider the claimed span. A clause claimed on beats 2 and 30 agrees with a reading anywhere between them, so agreement is weaker evidence the more beats a clause claims. Every row below prints its span for exactly this reason.

Graded at `min`, `max`, `min-1`, `max+1`, and the boundary tests distinguish them.

## Verification

Independent verify round: **PASS, 0 blocking**, with a clean test audit (457 → 491 tests, nothing deleted or weakened). It verified rather than accepted three claims I flagged: frame ordering by `t` is load-bearing on real data (`beat-18.png` t=29.06 precedes `beat-18-scene-1.png` t=25.32 in the manifest); the filename's beat cannot disagree with the manifest's; six refusal guards individually disabled were all caught.

It then found three assertions that could not fail for the reason they claimed, which **block** under `AGENTS.md` even though it filed them as limits. All fixed and graded:

```
PASS  break: the brief orders the clauses by the beats that claim them
      FAIL: BriefIsBlind.test_the_brief_is_byte_identical… (mutation='the claims are swapped between the clauses')
PASS  break: the reader's answer names the storyboard as what derived it
      FAIL: VerdictOutput.test_no_status_is_written_down_without_what_derived_it
PASS  break: the storyboard row stops printing the span the rule was given
      FAIL: VerdictOutput.test_the_verdict_carries_the_limit_and_the_span_it_compared
PASS  break: a refused verdict leaves the previous run's verdict readable
      FAIL: VerdictOutput.test_a_refused_run_leaves_no_verdict_from_the_run_before_it
```

The clause-ordering leak is the one worth naming: all six original blindness mutations preserved the clauses' relative claim order, so a leak that reorders `criteria` by claimed beat passed green. The fixture now declares a third clause **last and claims it first**, so any claim-derived order differs from declaration order.

`tests/unit` 495 OK · `--fault-inject` **All 320 injections were caught** · `--budget` 600/600 · `tests/ci-unit` 115 OK · `--fault-inject` 80/80 · `tests/lint`, `--self-test`, `smoke-inject --self-test` all clean.

## Stated limits, deliberately not filed as issues

- `render_verdict_md`'s prose is largely ungraded — dropping the rule sentence or the counts line leaves the suite green. The rule *is* stated in both artifacts today; nothing holds it there.
- **Nothing invokes `demo-grade` yet.** Not SKILL.md, not the README, not CI. This slice is reachable only by hand; wiring is the next slice.
- Nothing here can enforce that the agent which produced a reading was genuinely blind. That is a process property, not a checkable one, and pretending otherwise would be the more dangerous artifact.
- `demo-grade` grades whether the frames show the clause — not whether the clause was the right thing to build, and not what else the diff touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)