### PR TITLE
tests/unit --fault-inject runs the tests each entry names, not the whole suite

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -81,6 +81,22 @@ tests/lint                        # ruff check + ruff format --check + doc fence
 tests/lint --self-test            # prove all three grade something
 ```
 
+**`tests/unit --fault-inject` runs only the tests each entry names, not the
+whole suite.** Every entry already declares which tests must fail, so that is
+what the inner run executes. It used to re-run all of `tests/unit` per entry,
+which made an injection cost `O(every test in this file)` — 302 entries × the
+whole suite — and the `unit (demo-video recorder)` job was cancelled twice, at
+10m17s and 15m16s. Measured on a 16-core developer box over the same 302
+entries: **557 s before, 63 s after**, all 302 caught either way.
+
+The reason that speed-up is not a hole: a targeted run that selects *nothing*
+runs no tests and exits 0, which reads exactly like "the injection was caught".
+So the driver reads the number of tests the inner run actually started and
+**aborts at exit 3** — the same refusal a search string that matched other than
+exactly once gets — unless it equals the number of tests the entry named. An
+entry naming a test that no longer exists aborts by name rather than arriving
+as a miss.
+
 **Lint with `tests/lint`, not with `uvx ruff`.** They are not the same command.
 `uvx ruff` resolves to whatever ruff is current, which on this tree sees a
 different set of files and disagrees about them — in the direction where you

--- a/tests/unit
+++ b/tests/unit
@@ -13475,6 +13475,56 @@ INJECTIONS = [
 ]
 
 
+# The two things the inner run has to be able to tell the driver, and neither
+# of them is "I exited non-zero". A selection that matched nothing runs no
+# tests and exits 0, which reads exactly like "the injection was caught" — so
+# the driver reads a count off the inner run and refuses anything else.
+INNER_ABORT = "INNER-ABORT: "
+INNER_RAN = "INNER-RAN: "
+
+
+def inner_run(names: list[str]) -> int:
+    """Run exactly the `Class.method` tests named, or refuse to run at all.
+
+    `--fault-inject` spawns this once per manifest entry. It used to spawn the
+    whole suite, which made an injection cost `O(every test in this file)` —
+    every test added anywhere slowed every injection everywhere, and the CI job
+    was cancelled twice at ten and fifteen minutes. The entries already declare
+    which tests must fail; this runs those.
+
+    Selection is done by hand rather than through `unittest`'s loader because
+    the loader turns an unresolvable name into a synthetic test that *errors*
+    with that name in its id — so an entry naming a test that no longer exists
+    would produce `ERROR: Gone.test_gone`, and the driver's "did the named test
+    fire" check would read it as the injection being caught. A manifest naming
+    nothing would then grade nothing while printing all green.
+    """
+    if not names:
+        print(f"{INNER_ABORT}no tests were named", file=sys.stderr)
+        return 3
+    module = sys.modules["__main__"]
+    loader = unittest.TestLoader()
+    suite = unittest.TestSuite()
+    missing = []
+    for name in names:
+        cls_name, _, method = name.partition(".")
+        cls = getattr(module, cls_name, None)
+        if not (isinstance(cls, type) and issubclass(cls, unittest.TestCase)):
+            missing.append(name)
+        elif method not in loader.getTestCaseNames(cls):
+            missing.append(name)
+        else:
+            suite.addTest(cls(method))
+    if missing:
+        print(f"{INNER_ABORT}no such test: {', '.join(missing)}", file=sys.stderr)
+        return 3
+    result = unittest.TextTestRunner(verbosity=1).run(suite)
+    # Printed last, and read by the driver: the number of tests that actually
+    # started, straight off the runner's own counter.
+    print(f"{INNER_RAN}{result.testsRun}", file=sys.stderr)
+    return 0 if result.wasSuccessful() else 1
+
+
 def fault_inject() -> int:
     """Break one thing at a time and require the named tests to notice."""
     failures = 0
@@ -13557,7 +13607,7 @@ def fault_inject() -> int:
             target.write_text(text.replace(old, new), encoding="utf-8")
 
             done = subprocess.run(
-                [sys.executable, str(unit), "--_inner"],
+                [sys.executable, str(unit), "--_inner", *must_fail],
                 capture_output=True,
                 text=True,
                 env={
@@ -13570,7 +13620,52 @@ def fault_inject() -> int:
                     "UNIT_EXAMPLES": str(examples),
                 },
             )
-            noticed = {t for t in must_fail if t in done.stderr}
+            # Before the verdict, and on the same footing as a pattern that did
+            # not match exactly once: an inner run that executed none of the
+            # tests it selected exits 0 and would be read as a catch. So the
+            # count is checked, not just the exit status, and a name the inner
+            # run could not resolve stops the whole thing rather than arriving
+            # as a green `ERROR:` line carrying its own name.
+            aborted = [
+                ln[len(INNER_ABORT) :]
+                for ln in done.stderr.splitlines()
+                if ln.startswith(INNER_ABORT)
+            ]
+            if aborted:
+                print(
+                    f"ABORT: injection {name!r} names a test the suite does "
+                    f"not have — {aborted[0]}. Nothing it would have proven "
+                    f"is proven.",
+                    file=sys.stderr,
+                )
+                return 3
+            ran = [
+                int(ln[len(INNER_RAN) :])
+                for ln in done.stderr.splitlines()
+                if ln.startswith(INNER_RAN)
+            ]
+            if ran != [len(must_fail)]:
+                print(
+                    f"ABORT: injection {name!r} selected {len(must_fail)} "
+                    f"test(s) but the inner run reported {ran or 'no count'}. "
+                    f"A run that executes nothing exits 0 and reads as a "
+                    f"catch, so this is a refusal, not a miss.",
+                    file=sys.stderr,
+                )
+                print(
+                    textwrap.indent(done.stderr[-1500:], "       | "), file=sys.stderr
+                )
+                return 3
+            # Scoped to the runner's own verdict lines: over a whole-suite run
+            # a name could only turn up there, but a targeted run also prints
+            # the names it selected, and a check that reads all of stderr would
+            # find them in its own bookkeeping.
+            verdicts = [
+                ln
+                for ln in done.stderr.splitlines()
+                if ln.startswith(("FAIL:", "ERROR:"))
+            ]
+            noticed = {t for t in must_fail if any(t in ln for ln in verdicts)}
             missed = set(must_fail) - noticed
             ok = done.returncode != 0 and not missed
             print(f"{'PASS' if ok else 'FAIL'}  break: {name}")
@@ -13692,6 +13787,8 @@ def main() -> int:
         return budget_report()
     if args.fault_inject:
         return fault_inject()
+    if args._inner:
+        return inner_run(rest)
     result = unittest.main(argv=[sys.argv[0], *rest], exit=False, verbosity=1)
     return 0 if result.result.wasSuccessful() else 1
 


### PR DESCRIPTION
## Acceptance criterion

`tests/unit --fault-inject` grades exactly what it graded before, in a fraction of the time, and **cannot report a catch for a run that executed nothing**.

## The defect

Each entry spawned a subprocess re-running the **entire suite**. The cost was `O(entries × whole suite)`, so every test added anywhere slowed every injection everywhere.

It went over a cliff on #327, which adds a script and 18 entries: the `unit (demo-video recorder)` job was cancelled twice, at **10m17s** and again at **15m16s** after the timeout was raised. Cutting the new entries would not have fixed it — 300 entries against the slower suite is still over budget. #327 did not break this; it was the first change big enough to expose a curve that was always there.

Each entry already declares the tests that must fail. Now only those run.

## Measured, same tree, run alone, 302 entries

| | before | after |
|---|---|---|
| whole run | **556.8 s** | **63.2 s** |
| per entry | 1.84 s | 0.21 s |

**8.8×.** Independently re-timed in a clean checkout at 65.9 s, `All 302 injections were caught.`

## The trap this had to avoid, which was worse than expected

A targeted run that selects **nothing** exits 0 and reads as "the injection was caught" — silently turning the whole harness into a green light that grades nothing.

Worse, the obvious implementation walks straight into it: **`unittest`'s loader turns a stale test name into a synthetic test that *errors carrying that name*** — so a renamed test would produce an `ERROR:` line matching the entry's expectation and be scored a catch. Names are therefore resolved by hand rather than through the loader.

Guards, all of them aborting at exit 3 like the existing match-count guard:

- an entry naming a test the suite does not have;
- a selection that resolves to nothing;
- the inner run reporting a test count that differs from the number the entry named (`INNER-RAN:`).

## Proofs — every guard seen to fail

```
Proof 1  302 PASS before, 302 PASS after, diff of verdict lines → IDENTICAL VERDICTS

Proof 2  harmless replacement (injection that should not be noticed):
         FAIL  break: each clip is corrected by the take's total…
               these tests did NOT fail: [...3 names...]
               the suite passed against broken code            EXIT=1

Proof 3  ABORT: injection '…' names a test the suite does not have — no such
         test: NarrationMix.test_…_RENAMED.                     EXIT=3

Proof 4  match-count guard untouched: 0 matches → EXIT=3; 4 matches → EXIT=3

Extra    the new count guard, which had never been seen fail:
         "selected 5 test(s) but the inner run reported [0]. A run that
          executes nothing exits 0 and reads as a catch…"       EXIT=3
```

Independently reproduced Proof 3 in a separate checkout by renaming a real test method:

```
ABORT: injection 'coverage accumulates criteria from the tags instead of the
declaration' names a test the suite does not have — no such test:
Coverage.test_a_criterion_no_beat_claims_is_reported_unclaimed.
Nothing it would have proven is proven.
```

## Manifest audit

All **452 test references across 302 entries** are `Class.method`, all resolve to one of 67 top-level `TestCase` classes, no duplicate class names, no doctests, no `load_tests`, no dynamically generated tests. Nothing needed normalising, so no entry's content changed.

## Verification

`tests/unit` 0 · `--fault-inject` 0 (**302 caught**) · `--budget` 0 · `tests/ci-unit` 0 · `--fault-inject` 0 (80 caught) · `tests/lint` 0 · `--self-test` 0 · `smoke-inject --self-test` 0.

## Stated limits, deliberately not filed as issues

- **`tests/ci-unit` has the identical structure** (80 entries × ~0.86 s = 69 s). Left alone on purpose — one change at a time to the thing that grades everything else. It is cheap today and the same fix applies when it stops being.
- Scoping the `noticed` check to the runner's `FAIL:`/`ERROR:` lines relies on Python ≥3.11's `FAIL: test_x (__main__.Cls.test_x)` id format. The pre-existing substring check already relied on it; the file's `requires-python = ">=3.10"` is wider than what any entry would match on 3.10.
- `tests/README.md:20,42` still carries a stale `~0.07 s` figure for `tests/unit` (actual 1.7 s). A different claim, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)