### PR TITLE
Scope the review discipline to what an eval cannot measure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,34 @@ The skill's catalogue of *measurements that grade nothing* is the reviewer's
 checklist. Every entry in it came from a change in this repo that had green CI
 and an honest author.
 
+### Where an eval replaces the injections
+
+**Code whose correctness is measured by an eval does not also owe injections.**
+The discipline above exists because a recorder defect is invisible until an
+assertion catches it. That reasoning does not carry to code that is graded by
+running it against a corpus with known answers — there, the corpus *is* the
+evidence, and it is better evidence, because it measures the thing the code is
+for rather than the code's own internals.
+
+This applies today to the grader (`skills/demo-video/scripts/demo-grade` and
+whatever reads its brief). Its question — *does a blind reader find the clause
+in the frames* — is answered by the eval corpus: takes with known defects
+planted, scored on what was caught and what was falsely flagged. Injections
+there are optional. Write them where they are cheap and skip them where they
+are not.
+
+The number that made this rule: a five-item assertion-hygiene round on the
+grader's own tests cost **85 minutes**, against an eval that answers the product
+question in **four**. Each item was individually defensible under the rules
+above, which is exactly why the scope had to be written down rather than left
+to judgement.
+
+An eval carries its own honesty requirement, and it is the same one: **a corpus
+with no expected misses is not a measurement.** It must contain at least one
+defect the reader is expected *not* to catch — the caption the screen agrees
+with is this repo's known blind spot — and the score must show it uncaught. A
+corpus that catches everything is measuring its own fixtures.
+
 ## Housekeeping
 
 - Never commit `node_modules/`, `dist/`, `build/`, `__pycache__/`, `.tts/`, or


### PR DESCRIPTION
## Acceptance criterion

`AGENTS.md` says where the `verified-review` discipline applies and where an eval replaces it, and states the honesty requirement an eval carries in exchange.

## Why

`verified-review` says an assertion you have not seen fail is not evidence. That is right for the recorder, where a defect is invisible until an assertion catches it. It is wrong for code that can be graded by running it against known answers — and applying it there is what has been eating the days.

The measurement that forced it: the grader slice (#327) took a five-item assertion-hygiene round costing **85 minutes**, against a **four-minute** eval — three blind readers over 41 real frames — which was the only thing in that slice that said whether the product works. Every one of the five was defensible under the rules as written. That is the point: the rules had no scope, so judgement had nowhere to stand.

## What it now says

Code whose correctness is measured by an eval does not also owe injections. The corpus is the evidence, and it is the better evidence, because it measures what the code is for rather than the code's own internals. Today that means the grader; **the recorder keeps the full discipline**.

With one requirement attached, because an eval can lie in a way injections cannot:

> **A corpus with no expected misses is not a measurement.** It must contain at least one defect the reader is expected *not* to catch, and the score must show it uncaught. A corpus that catches everything is measuring its own fixtures.

That is the eval's version of "an assertion you have not seen fail is not evidence."

## A note on how fast this rule got tested

The corpus built under it (next PR) planted exactly such an expected miss — and **the reader caught it**. The eval reported `UNEXPECTED CATCH` rather than quietly flipping the expectation to match the result, which is the behaviour this clause exists to produce.

Documentation only; no code changes. Per the scope this very change adds, it does not get an adversarial round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)