### PR TITLE
A clause already true at the open is not a disagreement, and the stated limit was wrong

### DIFF
--- a/skills/demo-video/scripts/demo-grade
+++ b/skills/demo-video/scripts/demo-grade
@@ -102,6 +102,15 @@ NO_READING = "no reading"
 AGREEMENT = "agreement"
 CLASS_ORDER = (DISAGREEMENT, CANNOT_TELL, NO_READING, NOT_DEMONSTRATED, AGREEMENT)
 
+# Where the reader's beat fell relative to the beats the storyboard claimed.
+# Three events, and the classes above collapse two of them: a reading before
+# the first claimed beat and a reading after the last are not the same finding
+# at all. `classify()` carries the argument; this is the vocabulary, printed
+# beside every agreement so the two kinds of agreement stay distinguishable.
+BEFORE_SPAN = "before the first claimed beat"
+INSIDE_SPAN = "inside the claimed span"
+AFTER_SPAN = "after the last claimed beat"
+
 # Where each status came from. **Never the storyboard**: a status that appears
 # beside the thing that derived it can be weighed, and one that appears alone
 # is taken for a fact. `coverage.claimed` names beats, and naming beats is all
@@ -130,9 +139,16 @@ BY_NOTHING_TO_COMPARE = (
 # The agreement rule, in one sentence, carried into every artifact that uses
 # it. See `agreement_rule()` for the argument and the weakness.
 SPAN_RULE = (
-    "A reading agrees when the beat of the frame the reader named lies within "
-    "the closed span [first claimed beat, last claimed beat] for that clause, "
-    "and disagrees when it falls outside that span entirely."
+    "The reader is asked for the *first* frame in which a clause is visible, "
+    "so its answer is a lower bound and not the only place the clause can be "
+    "seen. A reading inside the closed span [first claimed beat, last claimed "
+    "beat] agrees. A reading before the first claimed beat also agrees, and is "
+    "marked `before the first claimed beat`: a lower bound earlier than the "
+    "claim contradicts nothing the storyboard said, and it is what a clause "
+    "already true when the demo opens has to look like. A reading after the "
+    "last claimed beat disagrees, and that is the one direction that is "
+    "evidence: it says the clause was in no frame up to and including the last "
+    "beat that claimed it."
 )
 
 # The sentence #279 requires in the artifact, and the reason it cannot be
@@ -469,12 +485,32 @@ def agreement_rule() -> dict:
     reports a disagreement on a demo that is right. A cross-check whose false
     alarms outnumber its findings is one nobody reads.
 
+    **Why before the span is not the same event as after it.** Span
+    containment on its own reads `0 < 2` as a disagreement, and that is a false
+    alarm every clause that is already true when the demo opens will produce —
+    measured on the eval corpus, where a queue listing every ticket's id, title
+    and requester is true from the first painted frame, was claimed on beats
+    [2, 4, 5, 9], and was correctly read at beat 0. The reader is asked for the
+    *first* frame, so its beat is a **lower bound** on where the clause is
+    visible. A lower bound below the claim is consistent with the claim: the
+    clause was visible earlier and may well still be visible on every beat that
+    claimed it. A lower bound above the claim is a proof against it: the reader
+    found no earlier frame, so none of the claimed beats showed the clause.
+    Only the second direction is evidence, so only the second direction
+    disagrees.
+
     **Its weakness, which is the other half of stating a rule.** Agreement gets
     cheaper the wider the claimed span: a clause claimed on beats 2 and 30
     agrees with a reading anywhere between them, and a storyboard that tagged
     every beat with every clause would agree with everything. So agreement is
     weaker evidence the more beats a clause claims, and the span is printed
-    beside every row so a reader can see how much room the rule was given.
+    beside every row so a reader can see how much room the rule was given. The
+    before-the-span agreement adds a second, narrower gap for the same reason
+    it is not a disagreement: a lower bound says the clause was visible *then*
+    and not that it was still visible later, so a clause shown early and gone
+    by the beats that claimed it agrees here. That is why the position and the
+    distance in beats are printed on the row rather than folded into the word
+    `agreement`.
     """
     return {
         "rule": SPAN_RULE,
@@ -491,59 +527,125 @@ def agreement_rule() -> dict:
             "[4, 6, 8, 12, 13] and [18, 20, 25, 26, 31] were correctly read at "
             "beats 10 and 23 — inside both spans, in neither claimed set."
         ),
+        "before_the_span": (
+            "A reading before the first claimed beat agrees, and says so on its "
+            "row. The reader is asked for the first frame showing a clause, so "
+            "its beat is a lower bound: below the claim it contradicts nothing, "
+            "and it is what a clause already true when the demo opens has to "
+            "look like — measured on the eval corpus, a queue listing every "
+            "ticket's id, title and requester was true from the first painted "
+            "frame, claimed on beats [2, 4, 5, 9], and read at beat 0. Above "
+            "the claim the same lower bound is a proof against it: no earlier "
+            "frame showed the clause, so none of the claimed beats did. Only "
+            "that direction disagrees."
+        ),
         "weakness": (
             "Agreement is cheaper the wider the claimed span. A clause claimed "
             "on beats 2 and 30 agrees with a reading anywhere between them, so "
             "agreement is weaker evidence the more beats a clause claims. Every "
-            "row below prints its span for exactly this reason."
+            "row below prints its span for exactly this reason. A "
+            "before-the-span agreement is weaker again: a lower bound says the "
+            "clause was visible then, not that it was still visible on the "
+            "beats that claimed it, so a clause shown early and gone by its "
+            "claimed beats agrees here. Those rows print their position and how "
+            "many beats early, so the two kinds of agreement can be told apart "
+            "without reading the frames."
         ),
     }
 
 
-def classify(reading: dict | None, beats: list[int]) -> tuple[str, str]:
-    """(class, why) for one clause. The whole comparison, in one place."""
+def classify(reading: dict | None, beats: list[int]) -> tuple[str, str, str | None]:
+    """(class, why, position) for one clause. The whole comparison, in one place.
+
+    `position` is where the reader's beat fell relative to the claimed span,
+    and it is `None` for every clause where no such comparison happened. It
+    exists because the class alone cannot say which of the two agreements a
+    row is — see `agreement_rule()` for why a reading before the span agrees
+    at all, and for what that agreement does not prove.
+    """
     span = f"[{beats[0]}, {beats[-1]}]" if beats else "nothing"
     if reading is None:
-        return NO_READING, (
-            "The reading names no answer for this clause. Nothing derived a "
-            "status here — it is neither seen nor unseen, and it is recorded "
-            f"as unanswered rather than as either. The storyboard claimed {span}."
+        return (
+            NO_READING,
+            (
+                "The reading names no answer for this clause. Nothing derived a "
+                "status here — it is neither seen nor unseen, and it is recorded "
+                f"as unanswered rather than as either. The storyboard claimed "
+                f"{span}."
+            ),
+            None,
         )
     if reading["status"] == CANNOT_TELL:
-        return CANNOT_TELL, (
-            f"The reader could not tell from the frames; the storyboard claimed "
-            f"{span}. This is one of the two cases a human is pulled in for."
+        return (
+            CANNOT_TELL,
+            (
+                f"The reader could not tell from the frames; the storyboard "
+                f"claimed {span}. This is one of the two cases a human is "
+                f"pulled in for."
+            ),
+            None,
         )
     if reading["status"] == SEEN:
         if not beats:
-            return DISAGREEMENT, (
-                f"The reader located this clause at beat {reading['beat']} "
-                f"(`{reading['frame']}`) and the storyboard claimed no beat for "
-                f"it at all — it is in `unclaimed`."
+            return (
+                DISAGREEMENT,
+                (
+                    f"The reader located this clause at beat {reading['beat']} "
+                    f"(`{reading['frame']}`) and the storyboard claimed no beat "
+                    f"for it at all — it is in `unclaimed`."
+                ),
+                None,
             )
-        if beats[0] <= reading["beat"] <= beats[-1]:
-            return AGREEMENT, (
-                f"The reader located this clause at beat {reading['beat']} "
-                f"(`{reading['frame']}`), inside the claimed span {span}."
+        if reading["beat"] < beats[0]:
+            return (
+                AGREEMENT,
+                (
+                    f"The reader located this clause at beat {reading['beat']} "
+                    f"(`{reading['frame']}`), {beats[0] - reading['beat']} "
+                    f"beat(s) before the claimed span {span} — it was already "
+                    f"visible before anything claimed it. The reader was asked "
+                    f"for the *first* frame showing the clause, so this is a "
+                    f"lower bound and contradicts nothing the storyboard said. "
+                    f"It does not prove the clause was still visible on the "
+                    f"claimed beats."
+                ),
+                BEFORE_SPAN,
             )
-        outside = (
-            beats[0] - reading["beat"]
-            if reading["beat"] < beats[0]
-            else reading["beat"] - beats[-1]
-        )
-        return DISAGREEMENT, (
-            f"The reader located this clause at beat {reading['beat']} "
-            f"(`{reading['frame']}`), {outside} beat(s) outside the claimed "
-            f"span {span}."
+        if reading["beat"] <= beats[-1]:
+            return (
+                AGREEMENT,
+                (
+                    f"The reader located this clause at beat {reading['beat']} "
+                    f"(`{reading['frame']}`), inside the claimed span {span}."
+                ),
+                INSIDE_SPAN,
+            )
+        return (
+            DISAGREEMENT,
+            (
+                f"The reader located this clause at beat {reading['beat']} "
+                f"(`{reading['frame']}`), {reading['beat'] - beats[-1]} beat(s) "
+                f"after the claimed span {span}. No earlier frame showed it, so "
+                f"none of the beats the storyboard claimed did."
+            ),
+            AFTER_SPAN,
         )
     if beats:
-        return DISAGREEMENT, (
-            f"The storyboard claimed this clause on beats {beats} and the "
-            f"reader could not find it in any frame."
+        return (
+            DISAGREEMENT,
+            (
+                f"The storyboard claimed this clause on beats {beats} and the "
+                f"reader could not find it in any frame."
+            ),
+            None,
         )
-    return NOT_DEMONSTRATED, (
-        "Neither derivation locates this clause: nothing claimed it and the "
-        "reader did not find it."
+    return (
+        NOT_DEMONSTRATED,
+        (
+            "Neither derivation locates this clause: nothing claimed it and the "
+            "reader did not find it."
+        ),
+        None,
     )
 
 
@@ -558,7 +660,7 @@ def verdict_doc(
     for key, text in criteria.items():
         claimed = beats.get(key, [])
         reading = readings.get(key)
-        kind, why = classify(reading, claimed)
+        kind, why, position = classify(reading, claimed)
         clauses.append(
             {
                 "criterion": key,
@@ -577,6 +679,7 @@ def verdict_doc(
                 },
                 "agreement": {
                     "class": kind,
+                    "position": position,
                     "why": why,
                     "derivation": (
                         BY_NOTHING_TO_COMPARE if kind == NO_READING else BY_COMPARISON
@@ -595,6 +698,13 @@ def verdict_doc(
         "limit": LIMIT,
         "frames_read": len(frames),
         "counts": counts,
+        # Counted separately from `counts` rather than as a sixth class: it is
+        # not a class, it is which of two agreements a row is, and a reader who
+        # only ever looks at the headline should still be told how many of the
+        # agreements were read before the beats that claimed them.
+        "agreements_before_the_claim": sum(
+            1 for row in clauses if row["agreement"]["position"] == BEFORE_SPAN
+        ),
         "clauses": clauses,
     }
 
@@ -616,10 +726,15 @@ def _reader_line(reading: dict) -> str:
 def render_verdict_md(doc: dict) -> str:
     """The comparison as a page: what disagrees, then everything else."""
     counts = doc["counts"]
+    early = doc["agreements_before_the_claim"]
+    parts = [f"{counts[kind]} {kind}" for kind in CLASS_ORDER]
+    if early:
+        parts.append(f"{early} of them before the first claimed beat")
+    headline = " · ".join(parts)
     out = [
         "# Two derivations of where each clause is",
         "",
-        " · ".join(f"{counts[kind]} {kind}" for kind in CLASS_ORDER),
+        headline,
         "",
         "One derivation is the `ac=` tags the storyboard author typed. The "
         "other is a reader who was given the clause text and the frames and "
@@ -635,6 +750,9 @@ def render_verdict_md(doc: dict) -> str:
         "",
         f"*Why a span:* {doc['agreement_rule']['why']}",
         "",
+        f"*Why before the span is not after it:* "
+        f"{doc['agreement_rule']['before_the_span']}",
+        "",
         f"*What it gives up:* {doc['agreement_rule']['weakness']}",
         "",
     ]
@@ -648,10 +766,12 @@ def render_verdict_md(doc: dict) -> str:
             board = row["storyboard"]
             span = board["span"]
             claimed = board["claimed_beats"] or "none"
+            position = row["agreement"]["position"]
+            label = f"{kind}, {position}" if position else kind
             out += [
                 f"### {row['criterion']} — {row['text']}",
                 "",
-                f"- **{kind}** — {row['agreement']['why']}",
+                f"- **{label}** — {row['agreement']['why']}",
                 f"  *Derived by:* {row['agreement']['derivation']}.",
                 _reader_line(reading),
                 f"  *Derived by:* {reading['derivation']}.",

--- a/skills/demo-video/scripts/demo-grade
+++ b/skills/demo-video/scripts/demo-grade
@@ -33,7 +33,7 @@ same terms, and their ship/no-ship fields disagreed. The stable half is asked
 for; the unstable half stays with the human. Any roll-up is arithmetic over the
 per-clause answers, done in code, with the rule written into the artifact.
 
-## The limit that cannot be designed away
+## The limit that cannot be designed away, and the one that can
 
 The reader is blind to the storyboard, the `ac` ids, the coverage table and the
 diff. It **cannot** be blind to the storyboard author's prose: captions are
@@ -42,12 +42,33 @@ burned into the picture (`helpers/demo_recording/core.py`'s `_CAPTION_JS` sets
 string. So every frame the reader looks at carries the author's claim in its
 pixels.
 
+That was long written down here as the blind spot — a caption asserting a
+misread requirement over a screen that agrees with it — and it is not the
+binding constraint. **The reader is never asked to compare the screen against
+the caption. It is given the ticket's clause text.** So a caption that
+overclaims against that text is something it can disbelieve, and does: this
+repository's eval corpus (`tests/eval/grader/`) planted exactly that defect as
+its negative control and two independent runs caught it, one of them noting
+that the query typed was a word from a ticket *title* and that the requester
+match the caption asserted was never demonstrated. Twice caught is not always
+caught — that is two runs over one take, a measurement rather than a property —
+but telling a reader not to bother with something they demonstrably can do is
+the more expensive error.
+
+The real blind spot is one level up, and no reading of any frame reaches it:
+**a declared clause text that is itself the misreading.** If `criteria={"AC-3":
+<a wrong paraphrase of the ticket>}` and the demo faithfully satisfies the
+paraphrase, the reader agrees, the storyboard agrees, and the ticket is still
+unmet, because every input the reader has is downstream of the paraphrase.
+Comparing the declared clause against the ticket's own words is the only thing
+that closes it, and that is issue #276.
+
 Consequence, stated the same way in `brief.md` and `verdict.md`: this catches a
 clause tagged on the wrong beat, a clause whose evidence never arrives, a
-tagged beat showing an error page, and a clause the demo never reaches. It does
-**not** catch a storyboard derived from the diff whose caption asserts a misread
-requirement and whose screen agrees with the caption — both readers read that
-caption.
+tagged beat showing an error page, a clause the demo never reaches, and — twice
+measured, not guaranteed — a caption overclaiming against the clause it was
+handed. It does **not** catch a ticket that was misread before its clauses were
+written down.
 
 ## Exit status
 
@@ -158,11 +179,20 @@ LIMIT = (
     "Agreement is a cross-check, not a verification. Two readers can share a "
     "bias, and a plausible-looking screen can fool both — and here they are not "
     "even fully independent: the caption the storyboard author wrote is burned "
-    "into every frame both of them read. This catches a clause tagged on the "
-    "wrong beat, a clause whose evidence never arrives, a tagged beat showing "
-    "an error page, and a clause the demo never reaches. It does not catch a "
-    "storyboard whose caption asserts a misread requirement and whose screen "
-    "agrees with the caption."
+    "into every frame both of them read. The reader is not asked to compare the "
+    "screen with that caption, though. It is handed the ticket's clause text, "
+    "so a caption overclaiming against the clause is something it can and does "
+    "disbelieve — measured twice on a take built to defeat it, which is a "
+    "measurement and not a guarantee. This catches a clause tagged on the wrong "
+    "beat, a clause whose evidence never arrives, a tagged beat showing an "
+    "error page, a clause the demo never reaches, and — twice measured — a "
+    "caption asserting what the screen was never shown doing. What it cannot "
+    "catch is one level up: a declared clause text that is itself a misreading "
+    "of the ticket. If the clauses above paraphrase the ticket wrongly and the "
+    "demo satisfies the paraphrase, both derivations agree and the ticket is "
+    "still unmet, because every input the reader has is downstream of that "
+    "paraphrase. Comparing the declared clause with the ticket's own words is "
+    "the only thing that closes it (issue #276)."
 )
 
 
@@ -341,12 +371,27 @@ def render_brief_md(criteria: dict[str, str], frames: list[str]) -> str:
         "",
         "The captions on these frames were written by the storyboard's author, "
         "and they are burned into the pixels — there is no framing of this "
-        "request that removes them. So your reading catches a clause placed on "
-        "the wrong beat, a clause whose evidence never arrives, a beat showing "
-        "an error page, and a clause the demo never reaches. It does **not** "
-        "catch a storyboard whose caption asserts a misread requirement and "
-        "whose screen agrees with the caption — you and the author read the "
-        "same caption there.",
+        "request that removes them. **You are not being asked to check the "
+        "screen against the caption.** You have the ticket's clause text above, "
+        "and that is what to hold the pictures against: where a caption asserts "
+        "something you are not shown the software doing, that is exactly the "
+        "`cannot tell` above, and readers here demonstrably catch it — on this "
+        "tool's own corpus, two independent runs caught a caption claiming a "
+        "match the screen never performed. Two runs over one recording is a "
+        "measurement, not a promise, so do not assume it of yourself; read the "
+        "pictures.",
+        "",
+        "So your reading catches a clause placed on the wrong beat, a clause "
+        "whose evidence never arrives, a beat showing an error page, a clause "
+        "the demo never reaches, and a caption overclaiming against a clause "
+        "above. What no reading of any frame can catch is one level up: a "
+        "clause above that is **itself** a misreading of the ticket. If these "
+        "clauses paraphrase the ticket wrongly and the demo faithfully "
+        "satisfies the paraphrase, you will agree, the author will agree, and "
+        "the ticket is still unmet — every input you have is downstream of that "
+        "paraphrase. This check does **not** catch that, and nothing you can do "
+        "with these frames would; closing it means comparing the clauses with "
+        "the ticket's own words, which you have not been given.",
         "",
         "## The clauses",
         "",

--- a/tests/eval-grader
+++ b/tests/eval-grader
@@ -25,11 +25,23 @@ it runs in seconds, and no model's opinion is ever a committed file.
 
 `AGENTS.md`, under "Where an eval replaces the injections": *a corpus with no
 expected misses is not a measurement.* A corpus of defects the reader catches
-measures its own fixtures. So `caption-overclaims` plants the defect
-`demo-grade`'s own docstring says it cannot catch — a caption asserting a
-misread requirement over a screen that agrees with it — and the table below
-prints that clause as an **expected** miss rather than as a failure. If a run
-ever scores it caught, that is a finding to report, not an expectation to edit.
+measures its own fixtures. So `caption-overclaims` plants what `demo-grade`'s
+docstring named as its blind spot when this corpus was written — a caption
+asserting a misread requirement over a screen that agrees with it — and the
+table below prints that clause as an **expected** miss rather than as a failure.
+If a run ever scores it caught, that is a finding to report, not an expectation
+to edit.
+
+**It has been caught, twice, and the expectation still stands.** That is the
+rule working: the docstring's limit was wrong, because the reader is never
+asked to compare the screen with the caption — it is handed the ticket's clause
+text, and it disbelieves a caption that overclaims against it. `demo-grade` now
+states the real blind spot instead: a declared clause text that is itself the
+misreading, which no reading of any frame can reach. Rebuilding this take to
+plant *that* is issue #276, and until it is, the corpus's own negative control
+is not an instance of the blind spot it is standing in for. So the table below
+is honest about the reader and weaker than it looks about the boundary; see
+`tests/eval/grader/README.md`.
 
 ## The mechanic the corpus is built around
 

--- a/tests/eval/grader/README.md
+++ b/tests/eval/grader/README.md
@@ -44,16 +44,51 @@ a narrowed list, another's is a line of text where the rows used to be.
 
 **`caption-overclaims` is the negative control and it is not a joke.**
 `AGENTS.md`, under *Where an eval replaces the injections*: a corpus with no
-expected misses is not a measurement. `demo-grade`'s own docstring names this
-exact defect as the one it cannot catch — the storyboard author's caption is
-burned into every frame, so the blind reader and the author read the same
-sentence. The take types `webhook`, a word from TQ-104's **title** that appears
-in no requester in `data/tickets.json`, under a caption asserting that search
-matches the requester. The screen genuinely narrows; the caption genuinely
-overclaims.
+expected misses is not a measurement. When this corpus was written,
+`demo-grade`'s own docstring named this exact defect as the one it cannot catch
+— the storyboard author's caption is burned into every frame, so the blind
+reader and the author read the same sentence. The take types `webhook`, a word
+from TQ-104's **title** that appears in no requester in `data/tickets.json`,
+under a caption asserting that search matches the requester. The screen
+genuinely narrows; the caption genuinely overclaims.
 
 > If a run scores that clause as **caught**, that is a finding about the
 > reader. Report it. Do not edit `expected.json` to match the result.
+
+### The corpus's own stated limit: the negative control is not an instance of the blind spot
+
+That clause has now been caught **twice**, by independent readers, and the
+expectation has not been edited. The finding it produced is about the limit
+rather than about the reader: the reasoning behind it — "the caption is burned
+into the pixels, so both readers read it" — is true and is not the binding
+constraint, because **the reader is never asked to compare the screen against
+the caption. It is given the ticket's clause text.** A caption that overclaims
+against that text is therefore catchable, and one reader said so in as many
+words:
+
+> *"matching on a requester's name or address is asserted only by the burned-in
+> caption at beat-06 and is never demonstrated on screen; the later highlight of
+> `leo.fontaine@northwind.example` merely rings the requester column of a
+> title-matched row."*
+
+`demo-grade` now states the real blind spot: **a declared clause text that is
+itself the misreading.** If `criteria={"AC-3": <a wrong paraphrase of the
+ticket>}` and the demo faithfully satisfies the paraphrase, the reader agrees,
+the storyboard agrees, and the ticket is still unmet — every input the reader
+has is downstream of the paraphrase. Issue **#276** is what closes it, by
+comparing the declared clause with the ticket's own words.
+
+**So this corpus currently has no expected miss that is an instance of the
+blind spot it claims to hold.** `caption-overclaims` stays an `expected-miss`
+and stays reported as an `UNEXPECTED CATCH`, because the score has to keep
+saying out loud that the negative control does not do its job. Rebuilding it to
+plant a wrong paraphrase the demo faithfully satisfies is #276's work, not this
+corpus's. Until then, read the score as: honest about what the reader catches,
+and untested about what it cannot.
+
+Two runs on one take is also not a proof that a caption overclaim is *always*
+caught. It is two observations, and the corrected limit in `demo-grade` says so
+in those words.
 
 ## What "caught" means
 

--- a/tests/unit
+++ b/tests/unit
@@ -9817,15 +9817,35 @@ class BriefIsBlind(_GradeCase):
         self.assertIn("do not say whether it should ship", text.lower())
 
     def test_the_brief_states_the_limit_it_cannot_design_away(self):
-        # Required by #279 in the artifact itself: the caption is burned into
-        # every frame the reader reads, so a storyboard whose caption asserts a
-        # misread requirement and whose screen agrees with it survives this
-        # check. A cross-check that does not carry its own boundary gets read
-        # as one that has none.
+        """Required by #279 in the artifact itself, and #276 corrected which
+        limit that is.
+
+        The brief used to tell its reader that a caption asserting a misread
+        requirement over an agreeing screen survives this check. The eval
+        measured otherwise: the corpus planted that defect and two independent
+        runs caught it, because **the reader is not asked to compare the screen
+        with the caption — it is handed the ticket's clause text**. A stated
+        limit that is wrong in the conservative direction still costs a
+        reader's trust, and this one told them not to bother with the one thing
+        they demonstrably do.
+
+        So three things are asserted, and all three are load-bearing: that the
+        caption's presence is still stated (it is why the two derivations are
+        not fully independent), that what the reader *can* do is stated
+        plainly, and that the blind spot named is the real one — a clause text
+        that is itself the misreading, which no frame can show.
+        """
         text = grade.render_brief_md(GRADE_CRITERIA, ["beat-00.png"])
         self.assertIn("burned into the pixels", text)
+        self.assertIn("not being asked to check the screen against the caption", text)
         self.assertIn("does **not**", text)
-        self.assertIn("agrees with the caption", text)
+        self.assertIn("itself** a misreading of the ticket", text)
+        self.assertIn("downstream of that paraphrase", text)
+        # The hedge, in the other direction. Two runs on one take is not a
+        # property, and a brief that traded one overclaim for its opposite
+        # would pass every assertion above.
+        self.assertIn("measurement, not a promise", text)
+        self.assertNotIn("agrees with the caption", text)
 
 
 class BriefRefusals(_GradeCase):
@@ -10245,7 +10265,14 @@ class VerdictOutput(_GradeCase):
         doc = self.verdict(self.demo, [_grade_row(k, v) for k, v in GRADE_READ.items()])
         page = (self.demo / "review" / "verdict.md").read_text()
         self.assertIn("cross-check, not a verification", page)
-        self.assertIn("agrees with the caption", page)
+        # The corrected limit (#276): what the reader can do, said plainly,
+        # then the blind spot that is actually structural, then the hedge that
+        # keeps the correction from becoming the opposite overclaim.
+        self.assertIn("not asked to compare the screen with that caption", page)
+        self.assertIn("a declared clause text that is itself a misreading", page)
+        self.assertIn("issue #276", page)
+        self.assertIn("a measurement and not a guarantee", page)
+        self.assertNotIn("agrees with the caption", page)
         for row in doc["clauses"]:
             beats = GRADE_CLAIMED[row["criterion"]]
             self.assertEqual(row["storyboard"]["span"], [min(beats), max(beats)])
@@ -14453,15 +14480,42 @@ INJECTIONS = [
         ["VerdictOutput.test_disagreements_are_printed_before_agreements"],
     ),
     (
-        # The rule at its boundary, widened by one beat either side — the
-        # shape a tolerance grows by when somebody is looking at one noisy
-        # take. The span's ends are still inside, so only the two readings
-        # just outside it can tell.
-        "the agreement span grows a beat of tolerance at each end",
+        # The rule at the boundary that still carries evidence, widened by one
+        # beat — the shape a tolerance grows by when somebody is looking at one
+        # noisy take. The span's last beat is still inside, so only the reading
+        # just past it can tell.
+        "the agreement span grows a beat of tolerance past the last claim",
         "scripts/demo-grade",
-        '        if beats[0] <= reading["beat"] <= beats[-1]:',
-        '        if beats[0] - 1 <= reading["beat"] <= beats[-1] + 1:',
-        ["SpanRule.test_one_beat_outside_each_end_is_a_disagreement"],
+        '        if reading["beat"] <= beats[-1]:',
+        '        if reading["beat"] <= beats[-1] + 1:',
+        ["SpanRule.test_a_reading_after_the_last_claimed_beat_is_the_disagreement"],
+    ),
+    (
+        # **The way the false-alarm fix would actually be got wrong**: one
+        # branch for everything outside the span, so the reading that proves
+        # the claimed beats showed nothing becomes an agreement alongside the
+        # one that proves nothing at all. The class, the sentence and the count
+        # all keep working; the only thing lost is the finding.
+        "a reading past the last claim is swallowed by the before-the-span rule",
+        "scripts/demo-grade",
+        '        if reading["beat"] < beats[0]:',
+        '        if reading["beat"] < beats[0] or reading["beat"] > beats[-1]:',
+        ["SpanRule.test_a_reading_after_the_last_claimed_beat_is_the_disagreement"],
+    ),
+    (
+        # The distinction made and then not written down. `classify()` still
+        # returns it, the class is still right, and every row in both artifacts
+        # reads `inside the claimed span` — so an agreement located before
+        # anything claimed it is indistinguishable from an ordinary one in the
+        # only two files a human opens.
+        "every agreement is printed as though it were inside the claimed span",
+        "scripts/demo-grade",
+        '                    "position": position,',
+        '                    "position": INSIDE_SPAN,',
+        [
+            "VerdictOutput."
+            "test_an_agreement_read_before_the_claim_is_told_apart_in_both_files"
+        ],
     ),
     (
         # The one thing this command may never do. A grader that can redden a

--- a/tests/unit
+++ b/tests/unit
@@ -10000,18 +10000,43 @@ class ReadingValidation(_GradeCase):
 
 
 class SpanRule(unittest.TestCase):
-    """The comparison rule, graded at both ends of the span and outside it."""
+    """The comparison rule, graded at both ends of the span and outside it.
+
+    **The rule is three-way, not two-way**, and the eval is what said so. The
+    corpus's `never-demonstrated` take declares a clause — "the queue lists
+    every ticket with its id, title and requester" — that is true from the
+    first painted frame. The reader is asked for the *first* frame showing a
+    clause, so it correctly named `beat-00`; the storyboard claimed beats
+    [2, 4, 5, 9]; span containment read `0 < 2` as a disagreement and the
+    score counted a false alarm on a clean clause. Any clause already true
+    when the demo opens produces that, so it is structural and not a fixture
+    artifact.
+
+    What the reader's answer *is* settles the direction: a lower bound. Below
+    the claim, it contradicts nothing — the clause was visible earlier and may
+    still be visible on every claimed beat. Above the claim, the same lower
+    bound is a proof against it — no earlier frame showed the clause, so none
+    of the claimed beats did. Only the second direction is evidence, so only
+    the second direction disagrees, and the first is an agreement that says on
+    its own row which of the two agreements it is.
+    """
 
     CLAIMED = [4, 6, 8, 12, 13]
 
-    def kind(self, beat=None, status="seen", claimed=None):
+    def classify(self, beat=None, status="seen", claimed=None):
         reading = (
             None
             if status is None
             else {"status": status, "frame": f"beat-{beat}.png", "beat": beat}
         )
         claimed = self.CLAIMED if claimed is None else claimed
-        return grade.classify(reading, claimed)[0]
+        return grade.classify(reading, claimed)
+
+    def kind(self, beat=None, status="seen", claimed=None):
+        return self.classify(beat, status, claimed)[0]
+
+    def position(self, beat=None, status="seen", claimed=None):
+        return self.classify(beat, status, claimed)[2]
 
     def test_a_reading_inside_the_span_but_in_no_claimed_set_agrees(self):
         # The measured case, and the whole reason the rule is a span: beat 10
@@ -10019,19 +10044,48 @@ class SpanRule(unittest.TestCase):
         # evidence. Set membership, or one beat of tolerance, calls this a
         # disagreement on a demo that is right.
         self.assertEqual(self.kind(10), "agreement")
+        self.assertEqual(self.position(10), grade.INSIDE_SPAN)
 
     def test_the_two_ends_of_the_span_are_inside_it(self):
         self.assertEqual(self.kind(4), "agreement")
         self.assertEqual(self.kind(13), "agreement")
+        self.assertEqual(self.position(4), grade.INSIDE_SPAN)
+        self.assertEqual(self.position(13), grade.INSIDE_SPAN)
 
-    def test_one_beat_outside_each_end_is_a_disagreement(self):
-        # The boundary, from the other side. Without these two the rule could
-        # be any window at all and this class would not notice.
-        self.assertEqual(self.kind(3), "disagreement")
+    def test_a_reading_after_the_last_claimed_beat_is_the_disagreement(self):
+        # The boundary, from the side that carries evidence. The reader found
+        # no earlier frame, so no beat the storyboard claimed showed it.
         self.assertEqual(self.kind(14), "disagreement")
+        self.assertEqual(self.position(14), grade.AFTER_SPAN)
+
+    def test_a_reading_before_the_first_claimed_beat_agrees_and_says_so(self):
+        # The false alarm the eval found, and the fix. Beat 3 is one before the
+        # span and beat 0 is the arrival-true case the corpus actually hit;
+        # neither contradicts a claim, because the reader was asked for the
+        # first frame and not for the only one.
+        for beat in (3, 0):
+            self.assertEqual(self.kind(beat), "agreement", f"beat {beat}")
+            self.assertEqual(self.position(beat), grade.BEFORE_SPAN, f"beat {beat}")
+
+    def test_the_two_agreements_are_told_apart_by_more_than_the_class(self):
+        # Without this, "before the span agrees" is indistinguishable from the
+        # rule having no lower bound at all, and a genuine early reading would
+        # be swallowed into the same word as an ordinary one. The sentence has
+        # to carry the distance too — a reader who sees only `agreement` on a
+        # clause read 4 beats early has been told less than the run knows.
+        _, before_why, before_where = self.classify(0)
+        _, inside_why, inside_where = self.classify(10)
+        self.assertNotEqual(before_where, inside_where)
+        self.assertIn("before the claimed span [4, 13]", before_why)
+        self.assertIn("4 beat(s) before", before_why)
+        self.assertIn("does not prove the clause was still visible", before_why)
+        self.assertIn("inside the claimed span [4, 13]", inside_why)
 
     def test_a_clause_the_reader_found_that_nothing_claimed_disagrees(self):
+        # Nothing claimed it, so there is no span to be before or after: the
+        # before-the-span agreement must not reach a clause in `unclaimed`.
         self.assertEqual(self.kind(10, claimed=[]), "disagreement")
+        self.assertIsNone(self.position(10, claimed=[]))
 
     def test_a_claimed_clause_the_reader_could_not_find_disagrees(self):
         # The finding this whole check exists for: the storyboard says the
@@ -10046,15 +10100,27 @@ class SpanRule(unittest.TestCase):
     def test_cannot_tell_stays_cannot_tell_whatever_was_claimed(self):
         self.assertEqual(self.kind(10, status="cannot tell"), "cannot tell")
 
+    def test_a_class_with_no_comparison_has_no_position(self):
+        # `position` is where the reader's beat fell against the claim, so a
+        # clause where no such comparison happened must not carry one. A
+        # default of "inside the claimed span" would read as a measurement.
+        self.assertIsNone(self.position(None, status="not seen"))
+        self.assertIsNone(self.position(10, status="cannot tell"))
+        self.assertIsNone(self.position(None, status=None))
+
     def test_the_rule_and_its_weakness_are_written_down(self):
         # An agreement rule nobody can read is a number with no argument. The
         # weakness is stated with it: a wide claimed span makes agreement
-        # cheap, so agreement is weaker the more beats a clause claims.
+        # cheap, so agreement is weaker the more beats a clause claims — and
+        # the before-the-span agreement is weaker again, because a lower bound
+        # does not say the clause was still there when it was claimed.
         rule = grade.agreement_rule()
         self.assertIn("span", rule["rule"])
         self.assertIn("beats, not seconds", rule["unit"])
         self.assertIn("caption", rule["why"])
         self.assertIn("wider the claimed span", rule["weakness"])
+        self.assertIn("before-the-span agreement is weaker", rule["weakness"])
+        self.assertIn("lower bound", rule["before_the_span"])
 
 
 class VerdictOutput(_GradeCase):
@@ -10190,6 +10256,37 @@ class VerdictOutput(_GradeCase):
                 f"{row['criterion']}'s storyboard row does not print the span "
                 f"the rule was given",
             )
+
+    def test_an_agreement_read_before_the_claim_is_told_apart_in_both_files(self):
+        """The eval's false alarm, in the artifacts a human actually opens.
+
+        A reading before the first claimed beat agrees — see `SpanRule` for
+        why — and an agreement that does not say which of the two it is has
+        swallowed the distinction rather than settled it. So the position is a
+        field in `verdict.json`, a word on the row in `verdict.md`, and a
+        count in the headline, and this asserts all three: a run that dropped
+        any one of them would still be a run that folded an early reading into
+        an ordinary agreement somewhere a reader looks.
+        """
+        doc = self.verdict(
+            self.demo,
+            [
+                _grade_row("AC-1", GRADE_READ["AC-1"]),
+                _grade_row("AC-3", GRADE_READ["AC-3"]),
+                # AC-2 is claimed on [1, 2] and read at beat 0.
+                _grade_row("AC-2", "beat-00.png"),
+            ],
+        )
+        by_id = {row["criterion"]: row for row in doc["clauses"]}
+        self.assertEqual(by_id["AC-2"]["agreement"]["class"], "agreement")
+        self.assertEqual(by_id["AC-2"]["agreement"]["position"], grade.BEFORE_SPAN)
+        self.assertEqual(by_id["AC-1"]["agreement"]["position"], grade.INSIDE_SPAN)
+        self.assertEqual(doc["agreements_before_the_claim"], 1)
+        page = (self.demo / "review" / "verdict.md").read_text()
+        self.assertIn("1 of them before the first claimed beat", page)
+        self.assertIn(f"- **agreement, {grade.BEFORE_SPAN}** —", page)
+        self.assertIn(f"- **agreement, {grade.INSIDE_SPAN}** —", page)
+        self.assertIn(grade.agreement_rule()["before_the_span"], page)
 
     def test_a_refused_run_leaves_no_verdict_from_the_run_before_it(self):
         """A stale answer under a current mtime is the artifact lying.


### PR DESCRIPTION
Two commits, two acceptance criteria. **Both findings came from the eval, not from anyone's opinion**, and the first one's acceptance criterion is a predicted movement in a measured table.

## Change 1 — `6706f7d` — a clause already true when the demo opens

`never-demonstrated`'s AC-1 is true from the first painted frame, so the reader correctly named `beat-00`; the storyboard claims it on beats 2–9; span containment called `0 < 2` a disagreement. Structural, not a fixture artifact: **any clause already true at the open does this**, and a false alarm spends exactly what `GOAL.md` measures.

Before and after span are now different events. The classification chosen — `agreement` carrying a `position`, rather than a new quiet class — with the reasoning:

> `agreement` is the only class that closes a clause without a human, and a second quiet class would have moved the eval's number by editing the scorer rather than the product. And a before-span reading carries no evidence against the claim: the reader is asked for the *first* frame, so its beat is a **lower bound** — below the claim it contradicts nothing; above the claim it proves no claimed beat showed the clause. Only the second direction disagrees, so nothing is being swallowed.

Visible as a `position` field per clause in `verdict.json`, a word on the row in `verdict.md` (`- **agreement, before the first claimed beat** — … 2 beat(s) before the claimed span [2, 9]`), and a headline count. The new rule's *new* weakness is stated as the old one's was: a lower bound does not prove the clause was still visible when claimed.

### The measured acceptance criterion

| | before | after |
|---|---|---|
| clean clauses falsely flagged | **1/6** | **0/6** |
| planted defects caught | 1/1 | 1/1 |
| `caption-overclaims` AC-3 | UNEXPECTED CATCH | UNEXPECTED CATCH |
| exact status+class | 6/8 | **7/8** |

Four fresh blind readers before, four *different* fresh blind readers after. The table moved exactly where it was predicted to and nowhere else — it could have failed in three independent directions (fix doesn't work, fix works by breaking the catch, fix works by burying the finding) and did not.

## Change 2 — `1382e53` — the stated limit was wrong, in three places

`demo-grade`'s docstring, the text rendered into **every brief**, and #279 all said the tool cannot catch a caption asserting a misread requirement over a screen that agrees. The corpus planted that as its negative control; **four independent runs have now caught it.**

The reasoning was "the caption is burned into the pixels, so both readers read it" — true, and not the binding constraint:

> **The reader is never asked to compare the screen against the caption. It is given the ticket's clause text.** … The real blind spot is one level up, and no reading of any frame reaches it: **a declared clause text that is itself the misreading.** If `criteria={"AC-3": <a wrong paraphrase>}` and the demo faithfully satisfies the paraphrase, the reader agrees, the storyboard agrees, and the ticket is still unmet, because every input the reader has is downstream of the paraphrase. … that is issue #276.

The hedge is kept deliberately, because correcting a limit is where overclaiming is tempting:

> Twice caught is not always caught — that is two runs over one take, a measurement rather than a property — but telling a reader not to bother with something they demonstrably can do is the more expensive error.

The shipped text says "two", the conservative claim matching what #276's comment recorded, even though four runs have now caught it.

`caption-overclaims`' `expected.json` is **not** edited. It stays an `expected-miss` and stays reported as an unexpected catch; rebuilding the negative control to plant the real blind spot is #276's work. The corpus README now states this as its own limit: its negative control is not currently an instance of the blind spot it was built for.

## Under the new rule

`AGENTS.md`'s "Where an eval replaces the injections" governs this — the eval is the evidence for change 1. Injections went 320 → 322 (three new or replaced grader entries where they were cheap), not a harness around the corpus.

`tests/unit` 0 · **All 322 injections caught** · `--budget` 0 · `tests/ci-unit` 0 · `tests/lint` 0 · `--self-test` 0 · `smoke-inject --self-test` 0.

## Stated limits, deliberately not filed

- `tests/lint`'s `shipped_prose()` scans `skills/**/*.md` and `*.py`, so `scripts/demo-grade` is extensionless and **its docstring is never pointer-checked**, even though it ships to every installer.
- `caption-overclaims`' `record.py` and `expected.json` still quote the now-corrected docstring wording. Left for #276, which rebuilds that take.

🤖 Generated with [Claude Code](https://claude.com/claude-code)