### PR TITLE
An agreement you cannot see is still homework (#337)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -485,8 +485,10 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
    the pass. Save the reply verbatim as `reading.json`; `verdict` writes
    `review/verdict.md`, the reading against the `ac=` tags the storyboard author
    typed. The result reaches the pull request in step 8, via `pr-block`:
-   disagreements and every `cannot tell` first, agreements collapsed to a
-   line — the first two classes are what a human is being pulled in for.
+   disagreements and every `cannot tell` first, agreements after them, every
+   clause with its text and its committed still — the first two classes are
+   what a human is being pulled in for, and the agreement rows are what lets
+   them confirm the rest without opening the diff.
 
    The reader is asked for one clause, one frame, and not for a verdict on the
    demo: that aggregate was measured unstable here

--- a/skills/demo-video/scripts/demo-grade
+++ b/skills/demo-video/scripts/demo-grade
@@ -85,7 +85,7 @@ of the working `frames/` sheet under the names the reader used, one sha256
 each. All of it stays local and gitignored, like the brief and the sheet.
 `pr-block` is what carries the result to a reviewer: it reads
 `review/verdict.json` and prints a markdown block for the pull-request
-description, with each finding pointed at a beat's *committed* still — the
+description, with every clause pointed at a beat's *committed* still — the
 `images/*.png` a take already commits — linked raw at the head commit. The
 exact frame the reader read stays in the local `review/frames/`, and the block
 says so. `basis_digest` is how `pr-block` tells a verdict that still describes
@@ -1242,16 +1242,38 @@ def _placement(row: dict) -> str:
     return f"{placed} {claims}"
 
 
-def _agrees_line(row: dict) -> str:
+def _agrees_sentence(row: dict) -> str:
     reading = row.get("reading") or {}
     early = (
         ", before the first claimed beat"
         if (row.get("agreement") or {}).get("position") == BEFORE_SPAN
         else ""
     )
+    return f"Reader placed it at beat {reading.get('beat')}{early}."
+
+
+def _still_lines(row: dict, stills: dict[int, str], url_for) -> tuple[list[str], bool]:
+    """The row's picture lines, and whether a picture was embedded.
+
+    A cited beat that wrote no committed still gets the honest line instead.
+    A plausible picture from another beat is worse evidence than none.
+    """
+    beat, still = cited_beat_still(row, stills)
+    if beat is None:
+        return (
+            ["No beat cites this clause, so there is no still to look at.", ""],
+            False,
+        )
+    if still is None:
+        return [f"No still exists for beat {beat}.", ""], False
     return (
-        f"{row.get('criterion')} — reader placed it at beat "
-        f"{reading.get('beat')}{early} (agrees)."
+        [
+            f"![{row.get('criterion')}]({url_for(still)})",
+            "",
+            f"The still is beat {beat}'s.",
+            "",
+        ],
+        True,
     )
 
 
@@ -1265,19 +1287,30 @@ def render_pr_block(doc: dict, stills: dict[int, str], url_for) -> str:
 
     Findings and `cannot tell` rows first, each with the clause text, the
     reader's placement, their one sentence, and the cited beat's committed
-    still. Agreements collapse to a line each. `url_for(still)` turns a
+    still. Agreements follow with the same clause text and still, minus the
+    quoted sentence. PR #337 measured the bare-line form on a reviewer, who
+    read the quiet lines and then went digging in the diff for the pictures.
+    When everything agrees, the summary line leads: it is the decision, and
+    the rows below it are the evidence. `url_for(still)` turns a
     take-relative still path into the URL a picture is embedded at.
     """
     rows = [row for row in doc.get("clauses") or [] if isinstance(row, dict)]
     findings = [row for row in rows if _row_class(row) != AGREEMENT]
     agreed = [row for row in rows if _row_class(row) == AGREEMENT]
     pictured = 0
+    total = len(rows)
     out = ["## Where a blind reader found each clause", ""]
     if findings:
-        n, total = len(findings), len(rows)
+        n = len(findings)
         out += [
             f"**{n} of {total} clause{'s' if total != 1 else ''} "
             f"need{'s' if n == 1 else ''} a person to look.**",
+            "",
+        ]
+    else:
+        out += [
+            f"The reader and the storyboard agree on all {total} "
+            f"clause{'s' if total != 1 else ''}.",
             "",
         ]
     for row in findings:
@@ -1290,30 +1323,19 @@ def render_pr_block(doc: dict, stills: dict[int, str], url_for) -> str:
         why = (row.get("reading") or {}).get("why")
         if isinstance(why, str) and why.strip():
             out += [f"> {why.strip()}", "", "<sub>— the reader.</sub>", ""]
-        beat, still = cited_beat_still(row, stills)
-        if beat is None:
-            out += ["No beat cites this clause, so there is no still to look at.", ""]
-        elif still is None:
-            out += [f"No still exists for beat {beat}.", ""]
-        else:
-            pictured += 1
-            out += [
-                f"![{row.get('criterion')}]({url_for(still)})",
-                "",
-                f"The still is beat {beat}'s.",
-                "",
-            ]
+        finding_lines, embedded = _still_lines(row, stills, url_for)
+        out += finding_lines
+        pictured += embedded
     for row in agreed:
-        out.append(_agrees_line(row))
-    if agreed:
-        out.append("")
-    if not findings:
-        total = len(rows)
         out += [
-            f"The reader and the storyboard agree on all {total} "
-            f"clause{'s' if total != 1 else ''}.",
+            f"**{row.get('criterion')} — {row.get('text')}**",
+            "",
+            _agrees_sentence(row),
             "",
         ]
+        agreed_lines, embedded = _still_lines(row, stills, url_for)
+        out += agreed_lines
+        pictured += embedded
     if pictured:
         out += [
             "Each picture above is the committed still of the beat named "

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -1143,7 +1143,8 @@ def reading(status: str, frame: str | None, beat: int | None, why: str) -> dict:
 #: The readings `PrBlock` hands the grader, one per clause, keyed by clause.
 #: AC-2 is a disagreement (the reader placed it where nothing claimed it),
 #: AC-3 a `cannot tell`, AC-4 a clause neither derivation located, and AC-1
-#: the one agreement — the class that collapses to a line.
+#: the one agreement — the class that renders below the findings, with its
+#: clause text and its still but without the reader's quoted sentence (#337).
 PR_READINGS = {
     "AC-2": reading("seen", "beat-07.png", 7, READER_WHY["AC-2"]),
     "AC-3": reading("cannot tell", None, None, READER_WHY["AC-3"]),
@@ -2147,29 +2148,41 @@ class PrBlock(unittest.TestCase):
         self.assertEqual(code, 0, err)
         return out
 
-    def test_the_findings_lead_and_the_agreement_is_a_line_below_them(self):
+    def test_the_findings_lead_and_the_agreement_is_a_row_below_them(self):
         # The routing decision, which is the whole product: three clauses need
         # a person and one does not, and the one that does not must not spend
         # the reviewer's first screen.
         self.take()
         body = self.block()
-        agree = body.index("AC-1 — reader placed it at beat 3 (agrees).")
+        agree = body.index(f"**AC-1 — {COVERAGE['criteria']['AC-1']}**")
         for key in ("AC-2", "AC-3", "AC-4"):
             self.assertLess(body.index(f"### {key} — "), agree, key)
         # A finding carries the ticket's own clause text, not just the id: the
         # text is what the person about to look judges the still against.
         self.assertIn(f"### AC-2 — {COVERAGE['criteria']['AC-2']}", body)
 
-    def test_an_agreement_is_one_line_and_gets_no_picture(self):
+    def test_an_agreement_shows_its_clause_and_its_still(self):
+        # PR #337, measured: bare agreement lines sent the reviewer into the
+        # diff to find the pictures. The agreement row carries the clause
+        # text, the reader's placement, and the beat's committed still.
         self.take()
         body = self.block()
-        self.assertIn("AC-1 — reader placed it at beat 3 (agrees).", body)
+        self.assertIn(f"**AC-1 — {COVERAGE['criteria']['AC-1']}**", body)
+        self.assertIn("Reader placed it at beat 3.", body)
+        self.assertIn(
+            "![AC-1](https://raw.githubusercontent.com/o/r/"
+            f"{self.sha}/demos/x/images/03-search.png)",
+            body,
+        )
+        # Not the finding treatment: no header, no quoted reader sentence.
         self.assertNotIn("### AC-1", body)
-        self.assertNotIn("![AC-1]", body)
+        self.assertNotIn(READER_WHY["AC-1"], body)
 
-    def test_a_take_where_everything_agrees_is_lines_and_one_summary(self):
-        # No callout asking for human attention: an all-agree block that still
-        # called for a person would train reviewers to stop reading callouts.
+    def test_a_take_where_everything_agrees_leads_with_the_summary(self):
+        # The summary is the decision, so it prints first. The rows below it
+        # are the evidence, one per clause (#337). No callout asking for human
+        # attention: an all-agree block that still called for a person would
+        # train reviewers to stop reading callouts.
         claimed = {"AC-1": [3], "AC-2": [7], "AC-3": [6], "AC-4": [8]}
         self.take(
             readings={
@@ -2184,11 +2197,21 @@ class PrBlock(unittest.TestCase):
             claimed=claimed,
         )
         body = self.block()
+        summary = body.index("The reader and the storyboard agree on all 4 clauses.")
         for key, beats in claimed.items():
-            self.assertIn(
-                f"{key} — reader placed it at beat {beats[0]} (agrees).", body
-            )
-        self.assertIn("The reader and the storyboard agree on all 4 clauses.", body)
+            row = body.index(f"**{key} — {COVERAGE['criteria'][key]}**")
+            self.assertLess(summary, row, key)
+            self.assertIn(f"Reader placed it at beat {beats[0]}.", body)
+        # Beat 3 wrote a committed still, so AC-1's row embeds it.
+        self.assertIn(
+            "![AC-1](https://raw.githubusercontent.com/o/r/"
+            f"{self.sha}/demos/x/images/03-search.png)",
+            body,
+        )
+        # Beat 7 wrote none, so AC-2's row says so instead of borrowing one.
+        self.assertIn("No still exists for beat 7.", body)
+        # Pictures were embedded, so the honest last line prints here too.
+        self.assertIn("not the frame the reader read", body)
         self.assertNotIn("need a person to look", body)
         self.assertNotIn("###", body)
 
@@ -3057,8 +3080,8 @@ INJECTIONS = [
         "    findings = [row for row in rows if _row_class(row) == AGREEMENT]\n"
         "    agreed = [row for row in rows if _row_class(row) != AGREEMENT]",
         [
-            "PrBlock.test_the_findings_lead_and_the_agreement_is_a_line_below_them",
-            "PrBlock.test_an_agreement_is_one_line_and_gets_no_picture",
+            "PrBlock.test_the_findings_lead_and_the_agreement_is_a_row_below_them",
+            "PrBlock.test_an_agreement_shows_its_clause_and_its_still",
         ],
     ),
     (
@@ -3069,8 +3092,22 @@ INJECTIONS = [
         "    findings = [row for row in rows if _row_class(row) != AGREEMENT]\n",
         "    findings = list(rows)\n",
         [
-            "PrBlock.test_a_take_where_everything_agrees_is_lines_and_one_summary",
-            "PrBlock.test_an_agreement_is_one_line_and_gets_no_picture",
+            "PrBlock.test_a_take_where_everything_agrees_leads_with_the_summary",
+            "PrBlock.test_an_agreement_shows_its_clause_and_its_still",
+        ],
+    ),
+    (
+        # #337 undone: the agreement row keeps its clause text and drops its
+        # still. The reviewer is back to digging in the diff for the picture,
+        # and an all-agree block with no pictures also loses the honest last
+        # line.
+        "the agreement row loses its still",
+        "scripts/demo-grade",
+        "        agreed_lines, embedded = _still_lines(row, stills, url_for)",
+        "        agreed_lines, embedded = [], False",
+        [
+            "PrBlock.test_an_agreement_shows_its_clause_and_its_still",
+            "PrBlock.test_a_take_where_everything_agrees_leads_with_the_summary",
         ],
     ),
     (
@@ -3096,8 +3133,8 @@ INJECTIONS = [
         # plausible wrong picture, worse evidence than none.
         "a beat with no still borrows another beat's picture",
         "scripts/demo-grade",
-        '            out += [f"No still exists for beat {beat}.", ""]',
-        '            out += [f"![x]({url_for(next(iter(stills.values())))})", ""]',
+        '        return [f"No still exists for beat {beat}.", ""], False',
+        '        return [f"![x]({url_for(next(iter(stills.values())))})", ""], True',
         ["PrBlock.test_a_cited_beat_with_no_still_says_so_instead_of_borrowing_one"],
     ),
     (


### PR DESCRIPTION
PR #337 put the all-agree block in front of a real reviewer. It failed. The three quiet lines said the reader agreed, but showed nothing, so the reviewer went into the diff to find the images. Two minutes; the target is thirty seconds.

Now every clause row shows its text and its still, agreements included. The summary line moves to the top — it is the decision, and the evidence follows it. Findings keep their fuller form and stay first. The honest footer prints whenever any picture is embedded.

## Evidence

- `tests/ci-unit`: 124 OK, all 89 injections caught (one new: "the agreement row loses its still"). Changed assertions were each seen red first — summary moved to bottom, clause text dropped, sentence reworded, reader quote added to an agreement — before restoring.
- `tests/unit` 499 OK, `tests/lint` green, ruff clean.
- Rendered by hand against the corpus: `clean-search` gives the new all-agree form, `caption-overclaims` keeps the finding-first form.

## Limits

- An agreement whose beat has no committed still shows a neighbouring claimed beat's still and says whose it is ("The still is beat 6's"). The footer covers the general case.
- "(agrees)" is gone; in a mixed block an agreement is told apart by its heading weight and the absence of a reader quote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)