### PR TITLE
Show every claimed still, not the first one found (#337)

### DIFF
--- a/skills/demo-video/scripts/demo-grade
+++ b/skills/demo-video/scripts/demo-grade
@@ -1184,15 +1184,10 @@ def _take_relative(still: str) -> str | None:
     return "/".join(parts)
 
 
-def cited_beat_still(
-    row: dict, stills: dict[int, str]
-) -> tuple[int | None, str | None]:
-    """The beat this row's picture is of, and that beat's still, if any.
+def cited_beats(row: dict) -> list[int]:
+    """The beats this row cites: the reader's beat, then the claimed beats.
 
-    The reader's beat first — it is where they say the clause is — then the
-    storyboard's claimed beats, in order. The first cited beat that wrote a
-    still wins. When no cited beat wrote one, the first cited beat comes back
-    with no still, and the row says so instead of borrowing a picture.
+    The reader's beat leads because it is where they say the clause is.
     """
     reading = row.get("reading") or {}
     cited: list[int] = []
@@ -1202,12 +1197,7 @@ def cited_beat_still(
     for beat in board.get("claimed_beats") or []:
         if isinstance(beat, int) and beat not in cited:
             cited.append(beat)
-    if not cited:
-        return None, None
-    for beat in cited:
-        if beat in stills:
-            return beat, stills[beat]
-    return cited[0], None
+    return cited
 
 
 def _beats_phrase(beats: list[int]) -> str:
@@ -1255,26 +1245,36 @@ def _agrees_sentence(row: dict) -> str:
 def _still_lines(row: dict, stills: dict[int, str], url_for) -> tuple[list[str], bool]:
     """The row's picture lines, and whether a picture was embedded.
 
-    A cited beat that wrote no committed still gets the honest line instead.
-    A plausible picture from another beat is worse evidence than none.
+    Every committed still among the cited beats renders, in beat order,
+    each with its own label line. PR #337 measured the first-match rule:
+    it picked one half of a two-sided clause and withheld the other, and
+    the reviewer said DON'T MERGE to evidence that existed. Dedup is by
+    image path, labelled with the first beat that wrote it. A cited beat
+    that wrote no committed still gets the honest line instead. A
+    plausible picture from another beat is worse evidence than none.
     """
-    beat, still = cited_beat_still(row, stills)
-    if beat is None:
+    cited = cited_beats(row)
+    if not cited:
         return (
             ["No beat cites this clause, so there is no still to look at.", ""],
             False,
         )
-    if still is None:
-        return [f"No still exists for beat {beat}.", ""], False
-    return (
-        [
+    lines: list[str] = []
+    shown: set[str] = set()
+    for beat in sorted(set(cited)):
+        still = stills.get(beat)
+        if still is None or still in shown:
+            continue
+        shown.add(still)
+        lines += [
             f"![{row.get('criterion')}]({url_for(still)})",
             "",
             f"The still is beat {beat}'s.",
             "",
-        ],
-        True,
-    )
+        ]
+    if not lines:
+        return [f"No still exists for beat {cited[0]}.", ""], False
+    return lines, True
 
 
 def _row_class(row: dict) -> str:
@@ -1286,8 +1286,8 @@ def render_pr_block(doc: dict, stills: dict[int, str], url_for) -> str:
     """The verdict as markdown for a pull-request description.
 
     Findings and `cannot tell` rows first, each with the clause text, the
-    reader's placement, their one sentence, and the cited beat's committed
-    still. Agreements follow with the same clause text and still, minus the
+    reader's placement, their one sentence, and every cited beat's committed
+    still. Agreements follow with the same clause text and stills, minus the
     quoted sentence. PR #337 measured the bare-line form on a reviewer, who
     read the quiet lines and then went digging in the diff for the pictures.
     When everything agrees, the summary line leads: it is the decision, and

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -1157,14 +1157,19 @@ PR_READINGS = {
     "AC-1": reading("seen", "beat-03.png", 3, READER_WHY["AC-1"]),
 }
 
-#: Which beats the storyboard claims in `PrBlock`'s take. AC-3's first claimed
-#: beat (6) is the one with a committed still, so its finding gets a picture;
-#: AC-2's reader beat (7) wrote none, so its row must say so instead.
+#: Which beats the storyboard claims in `PrBlock`'s take. AC-3 claims beats 6
+#: and 9, both wrote committed stills, and its finding must show both — PR
+#: #337 is what a first-match rule withholds. AC-2's reader beat (7) wrote
+#: none, so its row must say so instead.
 PR_CLAIMED = {"AC-1": [3], "AC-2": [], "AC-3": [6, 9], "AC-4": []}
 
 #: Which beats wrote a committed still, by index — the `still` column of the
 #: beat log, as `record.py` leaves it.
-PR_STILLS = {3: "images/03-search.png", 6: "images/06-requester.png"}
+PR_STILLS = {
+    3: "images/03-search.png",
+    6: "images/06-requester.png",
+    9: "images/09-highlight.png",
+}
 
 
 #: The sentence #303 adds, hand-written here rather than imported from
@@ -2218,8 +2223,8 @@ class PrBlock(unittest.TestCase):
     def test_the_picture_is_the_committed_still_raw_at_head(self):
         # The whole URL by equality: a picture of the right name at the wrong
         # commit, or under the wrong path, resolves to other bytes or to a 404
-        # that reads exactly like evidence. AC-3's first claimed beat (6) is
-        # the cited beat that wrote a still.
+        # that reads exactly like evidence. AC-3 claims beats 6 and 9, both
+        # wrote stills, and each URL must be exact.
         self.take()
         body = self.block()
         self.assertIn(
@@ -2227,7 +2232,58 @@ class PrBlock(unittest.TestCase):
             f"{self.sha}/demos/x/images/06-requester.png)",
             body,
         )
+        self.assertIn(
+            "![AC-3](https://raw.githubusercontent.com/o/r/"
+            f"{self.sha}/demos/x/images/09-highlight.png)",
+            body,
+        )
         self.assertIn("The still is beat 6's.", body)
+
+    def test_a_clause_with_two_claimed_stills_shows_both_in_beat_order(self):
+        # PR #337, measured in 30 seconds of a reviewer's time: the
+        # first-with-a-still rule picked one half of a two-sided clause and
+        # withheld the other. AC-3's row shows both stills, beat 6 first,
+        # each followed by its own label line.
+        self.take()
+        body = self.block()
+        six = body.index("The still is beat 6's.")
+        nine = body.index("The still is beat 9's.")
+        url9 = body.index("images/09-highlight.png")
+        self.assertLess(six, url9)
+        self.assertLess(url9, nine)
+
+    def test_the_readers_beat_joins_the_claimed_stills(self):
+        # The set is the reader's beat plus the claimed beats. AC-2's reader
+        # placed it at beat 7 while the storyboard claims beat 6; both wrote
+        # stills, so both render, beat 6 first.
+        self.take(
+            claimed={"AC-1": [3], "AC-2": [6], "AC-3": [], "AC-4": []},
+            stills={
+                3: "images/03-search.png",
+                6: "images/06-requester.png",
+                7: "images/07-heading.png",
+            },
+        )
+        body = self.block()
+        six = body.index("The still is beat 6's.")
+        seven = body.index("The still is beat 7's.")
+        self.assertLess(six, seven)
+        self.assertIn("![AC-2](", body)
+
+    def test_two_beats_sharing_one_image_embed_it_once(self):
+        # Dedup is by image path. Two claimed beats that wrote the same file
+        # show it once, labelled with the first beat in beat order.
+        self.take(
+            stills={
+                3: "images/03-search.png",
+                6: "images/06-requester.png",
+                9: "images/06-requester.png",
+            }
+        )
+        body = self.block()
+        self.assertEqual(body.count("images/06-requester.png"), 1, body)
+        self.assertIn("The still is beat 6's.", body)
+        self.assertNotIn("The still is beat 9's.", body)
 
     def test_a_cited_beat_with_no_still_says_so_instead_of_borrowing_one(self):
         # AC-2's reader beat is 7, nothing claims it, and beat 7 wrote no
@@ -3133,9 +3189,45 @@ INJECTIONS = [
         # plausible wrong picture, worse evidence than none.
         "a beat with no still borrows another beat's picture",
         "scripts/demo-grade",
-        '        return [f"No still exists for beat {beat}.", ""], False',
+        '        return [f"No still exists for beat {cited[0]}.", ""], False',
         '        return [f"![x]({url_for(next(iter(stills.values())))})", ""], True',
         ["PrBlock.test_a_cited_beat_with_no_still_says_so_instead_of_borrowing_one"],
+    ),
+    (
+        # PR #337's rule restored: one still per clause, the first found.
+        # AC-1's stills sat at beats 5 and 16, the rule picked the empty
+        # box, and the reviewer never saw the half the clause hinges on.
+        "the row shows only the first cited still",
+        "scripts/demo-grade",
+        "    for beat in sorted(set(cited)):",
+        "    for beat in sorted(set(cited))[:1]:",
+        [
+            "PrBlock.test_a_clause_with_two_claimed_stills_shows_both_in_beat_order",
+            "PrBlock.test_the_picture_is_the_committed_still_raw_at_head",
+        ],
+    ),
+    (
+        # Dedup gone: two beats that wrote the same file show it twice, and
+        # the block reads as though there were two pieces of evidence.
+        "two beats sharing one image embed it twice",
+        "scripts/demo-grade",
+        "        if still is None or still in shown:",
+        "        if still is None:",
+        ["PrBlock.test_two_beats_sharing_one_image_embed_it_once"],
+    ),
+    (
+        # The reader's beat dropped from the cited set: the still of the
+        # beat where they actually saw the clause never renders, and a row
+        # with no claimed beats loses its honest no-still line too.
+        "the reader's beat leaves the cited set",
+        "scripts/demo-grade",
+        '    if isinstance(reading.get("beat"), int):\n'
+        '        cited.append(reading["beat"])',
+        '    if False:\n        cited.append(reading["beat"])',
+        [
+            "PrBlock.test_the_readers_beat_joins_the_claimed_stills",
+            "PrBlock.test_a_cited_beat_with_no_still_says_so_instead_of_borrowing_one",
+        ],
     ),
     (
         # Seven characters resolve today and are ambiguous later — the


### PR DESCRIPTION
Second live read of PR #337: 30 seconds, decision from the description alone — and a correct DON'T MERGE against the wrong picture. AC-1's row showed the empty-box still and stopped. The still of the clause actually happening sat unclaimed-by-the-renderer at beat 16. The reviewer: "the images are not the things that display the AC acceptance."

Now a clause row embeds every distinct committed still among the reader's beat and the claimed beats, in beat order, deduped by path, each labelled with whose beat it is. A two-part clause shows its two parts. Findings-first, the top summary line, the no-still line, the footer, and the refusals are unchanged.

## Evidence

- tests/ci-unit: 127 OK, all 92 injections caught — including "the row shows only the first cited still", "two beats sharing one image embed it twice", "the reader's beat leaves the cited set". New assertions seen red before the implementation.
- tests/unit 499 OK, tests/lint green, ruff clean.
- Corpus renders by hand: clean-search AC-1 now shows beat 6's and beat 12's stills; caption-overclaims' finding shows both claimed stills under the reader's quote.

## Limit

- When no cited beat has a still, the no-still line names the reader's beat first, not the lowest — same behaviour as before, now stated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)