### PR TITLE
Say whether the storyboard still quotes the ticket (#276)

### DIFF
--- a/.github/scripts/demo-comment
+++ b/.github/scripts/demo-comment
@@ -34,7 +34,10 @@ rendering of `timeline.json`'s `coverage` and it grades nothing — see
 the take answers and the many it does not (issue #303). The take's own line
 says **which** ticket those clauses were copied out of, linked when the string
 can be turned into a URL without guessing (issue #275); nothing here reads
-that ticket.
+that ticket. What did read it, when the CI step ran, is `demo-ticket-check`
+(issue #276): its gitignored sidecar `review/ticket-check.json` is rendered
+under the clause table by `render_ticket_check` — three states per clause,
+`not checked` printed rather than omitted.
 
 The body opens with an HTML marker so the workflow can find and rewrite this
 comment rather than appending a new one on every push.
@@ -72,6 +75,24 @@ DIFF_LIMIT = (
     "below?** It answers nothing else. A widened permission, a deleted check "
     "or a new dependency is invisible to a demo. The diff still answers those."
 )
+
+
+#: What the ticket re-read is and is not evidence of (issue #276). Printed
+#: with the states, unconditionally, because `matched` beside a clause is
+#: exactly where "so the demo is right" is tempting — and the check compared
+#: two pieces of text, never a frame. Fixed text, hand-written here rather
+#: than read out of the sidecar: the sidecar is a generated file, and a
+#: sentence about this comment's own reach is this script's to state. It
+#: carries no word from `tests/ci-unit`'s `VERDICT_WORDS` and is swept like
+#: every other sentence this script writes.
+TICKET_CHECK_LIMIT = (
+    "**This grades quotation, not meaning.** A storyboard that quotes a "
+    "clause word for word can still record something else entirely; whether "
+    "the frames show the clause is the reviewer's call, not this line's."
+)
+
+#: The only states the sidecar may carry, three and never two (#276).
+_TICKET_STATES = ("matched", "not verbatim", "not checked")
 
 
 def _cell(text: str) -> str:
@@ -291,6 +312,69 @@ def _picture(
             False,
         )
     return _Picture("*no still*", False)
+
+
+def _ticket_check(directory: Path) -> dict | None:
+    """The ticket re-read this run left beside the timeline, if it ran (#276).
+
+    `review/ticket-check.json` is a gitignored working file of one review,
+    written by `demo-ticket-check` after the recording. Absent on every take
+    the CI step did not run on — a local render, a take with no declared
+    clauses — and rendering nothing then is correct: the check made no
+    statement. A file that exists but cannot be parsed is also rendered as
+    nothing, which is a stated limit rather than an oversight: the states in
+    a half-written file are not states this comment can repeat.
+    """
+    path = directory / "review" / "ticket-check.json"
+    if not path.exists():
+        return None
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def render_ticket_check(check: object) -> list[str]:
+    """Whether each quoted clause still occurs in the ticket's body (#276).
+
+    One line, three states, and `not checked` is printed rather than
+    omitted: a reader who sees nothing assumes the check came back clean,
+    and the confidently-wrong artifact is the one blocking finding this
+    repository will not ship. A state this renderer does not recognise is
+    printed as `not checked` for the same reason — whatever it meant, it was
+    not `matched`.
+
+    The wording is about text and says so. `matched` is a statement that two
+    strings agree, `not verbatim` that they no longer do; neither is a
+    verdict on the take, and `TICKET_CHECK_LIMIT` closes the block by saying
+    exactly that.
+    """
+    doc = check if isinstance(check, dict) else {}
+    clauses = doc.get("clauses")
+    if not isinstance(clauses, dict) or not clauses:
+        return []
+    states = {}
+    for key, row in clauses.items():
+        state = row.get("state") if isinstance(row, dict) else None
+        if state not in _TICKET_STATES:
+            state = "not checked"
+        states[key] = state
+    parts = " · ".join(f"`{_cell(key)}` {state}" for key, state in states.items())
+    lines = [f"**The ticket's body, re-read after the take:** {parts}.", ""]
+    if "not verbatim" in states.values():
+        lines += [
+            "*not verbatim*: the issue body no longer contains that clause's "
+            "declared text word for word. The ticket moved, or the storyboard "
+            "never quoted it.",
+            "",
+        ]
+    if "not checked" in states.values():
+        reason = doc.get("reason")
+        why = _cell(str(reason)) if reason else "the sidecar gives no reason"
+        lines += [f"*not checked*: {why}.", ""]
+    lines += [TICKET_CHECK_LIMIT, ""]
+    return lines
 
 
 def _failure_lead(failure: dict, criteria: dict, claimed: dict) -> list[str]:
@@ -590,6 +674,11 @@ def render_demo(
         # (issue #278).
         failure=failure,
     )
+
+    # Under the clause table it is a statement about, above the diagnostics:
+    # the ticket re-read, if this run made one (#276). Reads the same staged
+    # directory the stills were checked against, for the same reason.
+    lines += render_ticket_check(_ticket_check(demo_dir(demo_root, name)))
 
     if failure:
         beat = failure.get("beat")

--- a/.github/scripts/demo-ticket-check
+++ b/.github/scripts/demo-ticket-check
@@ -1,0 +1,221 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Say whether each clause a storyboard quotes still occurs in its ticket.
+
+    demo-ticket-check --demo demos/x --demo-root stage/
+
+Once a take names its ticket and quotes its clauses, the two can drift: the
+issue gets reworded, the storyboard does not, and the demo goes on recording a
+sentence nobody is asking for any more (issue #276). The take itself never
+fetches the ticket — reproducibility is the storyboard's job (#275) — so this
+step, which runs in CI after the recording and outside the take, is the one
+place that may. For each demo it reads `ticket` and `coverage.criteria` out of
+the staged `timeline.json`, fetches the issue body with the token in
+`GH_TOKEN` or `GITHUB_TOKEN`, and writes `<demo>/review/ticket-check.json` —
+a gitignored working file of one review, which `demo-comment` renders.
+
+Three states per clause, never two:
+
+    matched        the declared text occurs verbatim in the issue body
+    not verbatim   it does not
+    not checked    the body was never read — no token, an unrecognised
+                   reference, an unreadable issue — with the reason
+
+**The match rule, exactly** (written into the sidecar as `rule` too): every
+run of whitespace in the clause text and in the issue body is collapsed to
+one space, and the clause must then occur in the body as a **case-sensitive
+substring**. No markdown stripping, no case folding, no fuzzy anything —
+verbatim or nothing. A fuzzy match would produce a number nobody can act on,
+and would invite exactly the "close enough" reading the three states exist to
+prevent.
+
+**Never fatal.** A reworded issue is not a broken demo, and a check that
+reddens because somebody fixed a typo in the ticket teaches people to ignore
+the check. This script exits 0 on every path; what it could not do it reports
+as `not checked`, in the sidecar, with the reason.
+
+Only `owner/repo#N` references are fetched, from the API host every Actions
+step is given (`GITHUB_API_URL`). Anything else — a bare `#129`, a private
+tracker's id, a URL — is `not checked`, which is the correct and complete
+answer for a tracker this repository does not use.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+#: The rule, stated in the sidecar so a reader of the file does not have to
+#: guess which normalisation produced the states in it.
+MATCH_RULE = (
+    "every run of whitespace in the clause text and in the issue body is "
+    "collapsed to one space, then the clause must occur in the body as a "
+    "case-sensitive substring — verbatim or nothing"
+)
+
+#: What the states are and are not evidence of, in the artifact itself rather
+#: than in a comment nobody reads. `demo-comment` prints its own copy of this
+#: limit beside the rendered states; this one is for whoever opens the file.
+LIMIT = (
+    "This grades quotation, not meaning: a storyboard can quote a clause "
+    "word for word and record something else entirely. Nothing here reads "
+    "the frames."
+)
+
+#: `owner/repo#N` — the same shape `demo-comment` links, and the one ticket
+#: spelling that can be turned into an API call without guessing a host.
+_TICKET_REF = re.compile(r"^([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)#([0-9]+)$")
+
+
+def flat(text: object) -> str:
+    """Every run of whitespace collapsed to one space. Half of MATCH_RULE."""
+    return " ".join(str(text).split())
+
+
+def clause_states(criteria: dict, body: str) -> dict:
+    """matched / not verbatim per clause, by MATCH_RULE and nothing else."""
+    haystack = flat(body)
+    states = {}
+    for key, text in criteria.items():
+        needle = flat(text)
+        # `needle and` is load-bearing: an empty declared text occurs in every
+        # body, and reporting it `matched` would be a state about nothing.
+        state = "matched" if needle and needle in haystack else "not verbatim"
+        states[key] = {"state": state}
+    return states
+
+
+def unchecked(criteria: dict, reason: str) -> tuple[dict, str]:
+    """Every clause `not checked`, with the one reason they share."""
+    return {key: {"state": "not checked"} for key in criteria}, reason
+
+
+def fetch_issue_body(ref: re.Match, token: str) -> str:
+    """The issue's current body, off the API host this runner was given.
+
+    `GITHUB_API_URL` rather than a hardcoded api.github.com, for the same
+    reason `demo-comment` reads `GITHUB_SERVER_URL`: a GitHub Enterprise
+    caller's tickets live on its own host.
+    """
+    api = os.environ.get("GITHUB_API_URL", "https://api.github.com").rstrip("/")
+    request = urllib.request.Request(
+        f"{api}/repos/{ref.group(1)}/issues/{ref.group(2)}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "demo-ticket-check",
+        },
+    )
+    with urllib.request.urlopen(request, timeout=10) as response:
+        doc = json.load(response)
+    # `body` is null on an issue opened with an empty description; that is a
+    # body containing no clause, not a fetch that failed.
+    return doc.get("body") or ""
+
+
+def check_demo(directory: Path, token: str, fetch, cache: dict) -> dict | None:
+    """One demo's sidecar document, or None when there is nothing to check.
+
+    None only when the take declared no clauses — then there is no text to
+    look for and a sidecar would be a file about nothing. Every other path,
+    including a take that names no ticket at all, produces a document: a
+    reader who finds no states assumes the check came back clean, which is
+    the confidently-wrong artifact this repo does not ship.
+    """
+    timeline = json.loads((directory / "timeline.json").read_text(encoding="utf-8"))
+    coverage = timeline.get("coverage") or {}
+    criteria = coverage.get("criteria")
+    if not isinstance(criteria, dict) or not criteria:
+        print(f"{directory}: no declared clauses, nothing to check")
+        return None
+    ticket = flat(timeline.get("ticket") or "")
+    doc: dict = {"ticket": ticket or None, "rule": MATCH_RULE, "limit": LIMIT}
+    reason = None
+    ref = _TICKET_REF.match(ticket) if ticket else None
+    if not ticket:
+        states, reason = unchecked(
+            criteria, "the take names no ticket, so there is nothing to read"
+        )
+    elif ref is None:
+        # A URL, a bare `#129`, a private tracker's id. Not guessed at: a
+        # fetch against an invented host would grade the clauses against
+        # somebody else's requirement.
+        states, reason = unchecked(
+            criteria,
+            f"{ticket} is not an owner/repo#N reference, the one form this "
+            f"step reads — other trackers stay unchecked by design",
+        )
+    elif not token:
+        states, reason = unchecked(
+            criteria,
+            "no token in GH_TOKEN or GITHUB_TOKEN, so the ticket was never read",
+        )
+    else:
+        try:
+            if ticket not in cache:
+                cache[ticket] = fetch(ref, token)
+            states = clause_states(criteria, cache[ticket])
+        except urllib.error.HTTPError as error:
+            states, reason = unchecked(
+                criteria, f"reading {ticket} answered HTTP {error.code}"
+            )
+        except (urllib.error.URLError, OSError, ValueError) as error:
+            states, reason = unchecked(criteria, f"reading {ticket} raised {error}")
+    doc["clauses"] = states
+    if reason:
+        doc["reason"] = reason
+    return doc
+
+
+def main(argv: list[str] | None = None, fetch=fetch_issue_body) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--demo",
+        action="append",
+        default=[],
+        help="a demo directory holding timeline.json, relative to --demo-root",
+    )
+    ap.add_argument(
+        "--demo-root",
+        default="",
+        help=(
+            "directory the --demo paths are read from — in CI the staging "
+            "area, where the freshness filter has already been applied. The "
+            "sidecar is written beside the timeline it was read from."
+        ),
+    )
+    args = ap.parse_args(argv)
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN") or ""
+    cache: dict = {}
+    for raw in args.demo:
+        name = raw.rstrip("/")
+        directory = Path(args.demo_root) / name if args.demo_root else Path(name)
+        try:
+            doc = check_demo(directory, token, fetch, cache)
+        except Exception as error:  # never fatal, by design (#276)
+            print(f"{name}: not checked — {error}", file=sys.stderr)
+            continue
+        if doc is None:
+            continue
+        out = directory / "review" / "ticket-check.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(json.dumps(doc, indent=2) + "\n", encoding="utf-8")
+        summary = ", ".join(
+            f"{key} {row['state']}" for key, row in doc["clauses"].items()
+        )
+        print(f"{name}: {summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/demo-video.yml
+++ b/.github/workflows/demo-video.yml
@@ -9,6 +9,8 @@ name: Demo video
 #       permissions:
 #         contents: read
 #         pull-requests: write
+#         issues: read     # so the ticket re-read (#276) can fetch the issue;
+#                          # without it that check reports `not checked`
 #       uses: rogvid/skills/.github/workflows/demo-video.yml@main
 #       with:
 #         working-directory: examples/ticket-queue
@@ -135,6 +137,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # For the ticket re-read (#276) only. A caller who does not grant it
+      # gets `not checked` in the comment rather than a failed check.
+      issues: read
     outputs:
       recorded: ${{ steps.discover.outputs.count }}
       artifact-url: ${{ steps.upload-demo.outputs.artifact-url }}
@@ -188,7 +193,7 @@ jobs:
           dir="$root/.github/scripts"
           skill="$root/skills/demo-video"
           # Packaging and some checkout paths drop the executable bit.
-          chmod +x "$dir"/demo-storyboards "$dir"/demo-comment
+          chmod +x "$dir"/demo-storyboards "$dir"/demo-comment "$dir"/demo-ticket-check
           chmod +x "$skill"/scripts/demo-target-guard
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
           echo "skill=$skill" >> "$GITHUB_OUTPUT"
@@ -505,6 +510,28 @@ jobs:
           path: ${{ github.workspace }}/.demo-video-ci/failure
           if-no-files-found: warn
           retention-days: ${{ inputs.evidence-retention-days }}
+
+      # Did the ticket move under the storyboard? Each staged timeline.json
+      # names the ticket its clauses were copied out of (#275); the take
+      # itself never fetches it, so this step — outside the take — re-reads
+      # the issue and writes review/ticket-check.json beside the staged
+      # timeline for the comment step below to render (#276). Never fatal:
+      # a reworded issue is not a broken demo, and a check that reddens
+      # because somebody fixed a typo in the ticket teaches people to ignore
+      # it. The script exits 0 on every path; whatever it could not read it
+      # reports as `not checked`, with the reason, in the sidecar.
+      - name: Re-read the ticket each demo names
+        if: always() && steps.discover.outputs.count != '0' && steps.record.conclusion != 'skipped'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SCRIPTS: ${{ steps.helpers.outputs.dir }}
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS= read -r dir; do
+            if [ -n "$dir" ]; then args+=(--demo "$dir"); fi
+          done < "$DEMO_DIRS"
+          "$SCRIPTS/demo-ticket-check" "${args[@]}" --demo-root "$STAGE_DEMO"
 
       - name: Render the comment
         if: always() && steps.discover.outputs.count != '0' && steps.record.conclusion != 'skipped'

--- a/.github/workflows/ticket-queue-demo.yml
+++ b/.github/workflows/ticket-queue-demo.yml
@@ -33,6 +33,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # So the ticket re-read (#276) can fetch the issue a storyboard names;
+      # without it that check reports every clause `not checked`.
+      issues: read
     uses: ./.github/workflows/demo-video.yml
     with:
       working-directory: examples/ticket-queue

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -37,6 +37,7 @@ import sys
 import tempfile
 import textwrap
 import unittest
+import urllib.error
 from pathlib import Path
 from types import ModuleType
 
@@ -65,6 +66,7 @@ _SKILL = Path(os.environ.get("CI_UNIT_SKILL", SKILL))
 _WORKFLOW = Path(os.environ.get("CI_UNIT_WORKFLOW", WORKFLOW))
 storyboards = load("demo-storyboards", _DIR)
 comment = load("demo-comment", _DIR)
+ticket_check = load("demo-ticket-check", _DIR)
 
 # **The classifier is the skill's, not the workflow's** — `demo-target-guard`
 # moved under `skills/demo-video/` so that `npx skills add` carries it, and the
@@ -1849,6 +1851,346 @@ class Ticket(unittest.TestCase):
         self.assertIn("https://github.com/acme/app/issues/7", body)
 
 
+# --------------------------------------------------------------------------
+# demo-ticket-check — does the ticket still say what the storyboard quotes
+# --------------------------------------------------------------------------
+
+# The recorded fixture body the check is graded against — never the live API
+# (issue #276). It holds AC-1's declared text, rewrapped across lines with
+# ragged spacing the way issue bodies are, and nothing that reads like AC-2's.
+FIXTURE_ISSUE_BODY = textwrap.dedent(
+    """\
+    ## Acceptance
+
+    - A search box above the queue narrows
+      the list   as you type.
+    - The heading counts only what is on screen.
+    """
+)
+
+#: Sidecars shaped as `demo-ticket-check` writes them. `TICKET_CHECKED` is
+#: #276's acceptance case: the issue still holds AC-1's text and no longer
+#: AC-2's. `TICKET_UNCHECKED` is the no-token run, whose reason must reach
+#: the reader rather than being folded into silence.
+TICKET_CHECKED = {
+    "ticket": "rogvid/skills#129",
+    "clauses": {
+        "AC-1": {"state": "matched"},
+        "AC-2": {"state": "not verbatim"},
+        "AC-3": {"state": "matched"},
+        "AC-4": {"state": "matched"},
+    },
+}
+TICKET_UNCHECKED = {
+    "ticket": "rogvid/skills#129",
+    "reason": ("no token in GH_TOKEN or GITHUB_TOKEN, so the ticket was never read"),
+    "clauses": {key: {"state": "not checked"} for key in COVERAGE["criteria"]},
+}
+
+#: The limit sentence #276 puts in the artifact itself, hand-written here the
+#: way DIFF_LIMIT is rather than imported: copied text goes stale loudly,
+#: which is the direction to be wrong in.
+TICKET_LIMIT = (
+    "**This grades quotation, not meaning.** A storyboard that quotes a "
+    "clause word for word can still record something else entirely; whether "
+    "the frames show the clause is the reviewer's call, not this line's."
+)
+
+
+class TicketCheck(unittest.TestCase):
+    """Three states per clause, never two, and exit 0 on every path (#276).
+
+    Graded against `FIXTURE_ISSUE_BODY`, never the live API: the fetched
+    paths hand `main` a fake fetch, and the paths that must not fetch run
+    with `GITHUB_API_URL` pointed at a closed loopback port, so a fetch that
+    escaped its guard fails loudly instead of quietly reading github.com.
+    """
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        (self.root / "demos/x").mkdir(parents=True)
+
+    def write_timeline(self, timeline: dict) -> None:
+        (self.root / "demos/x/timeline.json").write_text(
+            json.dumps(timeline), encoding="utf-8"
+        )
+
+    def sidecar(self) -> dict:
+        path = self.root / "demos/x/review/ticket-check.json"
+        self.assertTrue(path.exists(), "no sidecar was written")
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def states(self, doc: dict) -> dict:
+        return {key: row["state"] for key, row in doc["clauses"].items()}
+
+    def with_token(self) -> None:
+        """GH_TOKEN set for an in-process `main`, restored afterwards."""
+        old = {key: os.environ.get(key) for key in ("GH_TOKEN", "GITHUB_TOKEN")}
+
+        def restore():
+            for key, value in old.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
+
+        self.addCleanup(restore)
+        os.environ["GH_TOKEN"] = "test-token"
+        os.environ.pop("GITHUB_TOKEN", None)
+
+    def run_main(self, fetch) -> int:
+        return ticket_check.main(
+            ["--demo", "demos/x", "--demo-root", str(self.root)], fetch=fetch
+        )
+
+    def cli_env(self, **extra: str) -> dict:
+        out = {
+            key: value
+            for key, value in os.environ.items()
+            if key not in ("GH_TOKEN", "GITHUB_TOKEN")
+        }
+        out["GITHUB_API_URL"] = "http://127.0.0.1:9"
+        out.update(extra)
+        return out
+
+    def run_cli(self, env: dict) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(_DIR / "demo-ticket-check"),
+                "--demo",
+                "demos/x",
+                "--demo-root",
+                str(self.root),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    # -- the match rule, exactly ---------------------------------------------
+
+    def test_a_clause_the_body_holds_is_matched_and_one_it_does_not_is_not(self):
+        states = ticket_check.clause_states(COVERAGE["criteria"], FIXTURE_ISSUE_BODY)
+        self.assertEqual(states["AC-1"], {"state": "matched"})
+        self.assertEqual(states["AC-2"], {"state": "not verbatim"})
+
+    def test_the_match_survives_rewrapping_and_nothing_else(self):
+        # The whole rule: whitespace is normalised on both sides, case is
+        # not. A rule that folded case would be the first step down the
+        # "close enough" slope the three states exist to prevent.
+        rewrapped = {
+            "AC-1": "A search box above\n   the queue narrows the list as you type."
+        }
+        self.assertEqual(
+            ticket_check.clause_states(rewrapped, FIXTURE_ISSUE_BODY)["AC-1"],
+            {"state": "matched"},
+        )
+        lowered = {"AC-1": "a search box above the queue narrows the list as you type."}
+        self.assertEqual(
+            ticket_check.clause_states(lowered, FIXTURE_ISSUE_BODY)["AC-1"],
+            {"state": "not verbatim"},
+        )
+
+    def test_an_empty_clause_is_not_reported_matched(self):
+        # "" occurs in every body, and `matched` about nothing is the
+        # confidently-wrong artifact this file exists to refuse.
+        states = ticket_check.clause_states({"AC-1": "   "}, FIXTURE_ISSUE_BODY)
+        self.assertEqual(states["AC-1"], {"state": "not verbatim"})
+
+    # -- the three acceptance cases, each of them green (#276) ---------------
+
+    def test_a_fetched_body_yields_both_states_and_exit_zero(self):
+        self.write_timeline(TICKETED)
+        self.with_token()
+        calls = []
+
+        def fetch(ref, token):
+            calls.append((ref.group(1), ref.group(2), token))
+            return FIXTURE_ISSUE_BODY
+
+        self.assertEqual(self.run_main(fetch), 0)
+        doc = self.sidecar()
+        self.assertEqual(self.states(doc)["AC-1"], "matched")
+        self.assertEqual(self.states(doc)["AC-2"], "not verbatim")
+        self.assertEqual(calls, [("rogvid/skills", "129", "test-token")])
+        # The sidecar states its own rule and its own limit, so a reader of
+        # the file does not have to guess what produced the states in it.
+        self.assertIn("case-sensitive substring", doc["rule"])
+        self.assertIn("quotation, not meaning", doc["limit"])
+
+    def test_with_no_token_every_clause_is_not_checked_and_says_why(self):
+        self.write_timeline(TICKETED)
+        done = self.run_cli(self.cli_env())
+        self.assertEqual(done.returncode, 0, done.stderr)
+        doc = self.sidecar()
+        self.assertEqual(len(self.states(doc)), 4)
+        self.assertEqual(set(self.states(doc).values()), {"not checked"})
+        self.assertIn("token", doc["reason"])
+
+    def test_an_unreadable_issue_is_not_checked_with_the_status(self):
+        self.write_timeline(TICKETED)
+        self.with_token()
+
+        def fetch(ref, token):
+            raise urllib.error.HTTPError("u", 404, "Not Found", None, io.BytesIO())
+
+        self.assertEqual(self.run_main(fetch), 0)
+        doc = self.sidecar()
+        self.assertEqual(set(self.states(doc).values()), {"not checked"})
+        self.assertIn("404", doc["reason"])
+
+    # -- the paths that never fetch ------------------------------------------
+
+    def test_an_unrecognised_reference_is_not_checked_never_guessed_at(self):
+        # A URL, a bare `#129`, a private tracker's id: a fetch against an
+        # invented host would grade the clauses against somebody else's
+        # requirement, which is worse than answering nothing.
+        self.write_timeline(
+            dict(TAGGED, ticket="https://example.invalid/browse/QUEUE-4412")
+        )
+        done = self.run_cli(self.cli_env(GH_TOKEN="test-token"))
+        self.assertEqual(done.returncode, 0, done.stderr)
+        doc = self.sidecar()
+        self.assertEqual(set(self.states(doc).values()), {"not checked"})
+        self.assertIn("QUEUE-4412", doc["reason"])
+
+    def test_clauses_with_no_ticket_are_not_checked_rather_than_silent(self):
+        self.write_timeline(TAGGED)
+        done = self.run_cli(self.cli_env(GH_TOKEN="test-token"))
+        self.assertEqual(done.returncode, 0, done.stderr)
+        doc = self.sidecar()
+        self.assertEqual(set(self.states(doc).values()), {"not checked"})
+        self.assertIn("names no ticket", doc["reason"])
+
+    def test_a_take_with_no_declared_clauses_writes_no_sidecar(self):
+        # There is no text to look for, and a sidecar would be a file about
+        # nothing that the comment would then have to explain.
+        self.write_timeline(dict(TIMELINE, ticket="rogvid/skills#129"))
+        done = self.run_cli(self.cli_env(GH_TOKEN="test-token"))
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertFalse((self.root / "demos/x/review").exists())
+
+    def test_a_timeline_that_cannot_be_read_is_reported_not_fatal(self):
+        # Never fatal (#276): a take that crashed before writing a readable
+        # timeline already failed the check that owns that; this one says so
+        # on stderr and moves on.
+        (self.root / "demos/x/timeline.json").write_text("{not json", "utf-8")
+        done = self.run_cli(self.cli_env(GH_TOKEN="test-token"))
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertIn("not checked", done.stderr)
+        self.assertFalse((self.root / "demos/x/review").exists())
+
+
+class TicketCheckRender(unittest.TestCase):
+    """The sidecar in the comment: three states, `not checked` printed (#276)."""
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        (self.root / "demos/x").mkdir(parents=True)
+
+    def sidecar(self, doc: dict) -> None:
+        review = self.root / "demos/x/review"
+        review.mkdir(exist_ok=True)
+        (review / "ticket-check.json").write_text(json.dumps(doc), encoding="utf-8")
+
+    def body(self, timeline=None, **kw):
+        opts = dict(
+            artifact_url=None,
+            artifact_bytes=None,
+            retention_days=30,
+            evidence_retention_days=None,
+            failure_artifact_url=None,
+            run_url=None,
+            sha=None,
+            repo_url=None,
+            demo_root=str(self.root),
+            path_prefix="",
+        )
+        opts.update(kw)
+        return comment.render([("demos/x", timeline or TICKETED)], **opts)
+
+    def line(self, body: str) -> str:
+        found = [
+            ln
+            for ln in body.splitlines()
+            if ln.startswith("**The ticket's body, re-read")
+        ]
+        self.assertEqual(len(found), 1, f"no single ticket-check line in:\n{body}")
+        return found[0]
+
+    def test_each_clause_reports_its_own_state(self):
+        # #276's acceptance case, in the artifact a reviewer actually opens:
+        # the issue still holds AC-1's text and no longer AC-2's.
+        self.sidecar(TICKET_CHECKED)
+        line = self.line(self.body())
+        self.assertIn("`AC-1` matched", line)
+        self.assertIn("`AC-2` not verbatim", line)
+
+    def test_not_checked_is_printed_with_the_reason_not_omitted(self):
+        # A reader who sees nothing assumes the check came back clean, and
+        # the confidently-wrong artifact is the one blocking finding in
+        # wip/verified-review/SKILL.md that this repo will not ship.
+        self.sidecar(TICKET_UNCHECKED)
+        body = self.body()
+        line = self.line(body)
+        for key in COVERAGE["criteria"]:
+            self.assertIn(f"`{key}` not checked", line)
+        self.assertIn(TICKET_UNCHECKED["reason"], body)
+
+    def test_the_block_states_its_own_limit(self):
+        # In the artifact itself, on the clean branch too — the take where
+        # every clause matched is the one where "so the demo is right" is
+        # most tempting, and the sentence exists for exactly that reader.
+        for doc in (TICKET_CHECKED, TICKET_UNCHECKED):
+            self.sidecar(doc)
+            self.assertEqual(self.body().count(TICKET_LIMIT), 1)
+
+    def test_a_take_with_no_sidecar_renders_no_ticket_check(self):
+        # A local render, or a take the CI step did not run on: the check
+        # made no statement, so the comment repeats none.
+        body = self.body()
+        self.assertIn("AC-1", body)  # control: the clause table is there
+        self.assertNotIn("re-read", body)
+        self.assertNotIn(TICKET_LIMIT, body)
+
+    def test_a_state_the_renderer_does_not_recognise_reads_as_not_checked(self):
+        # Whatever a fourth state meant, it was not `matched`, and the
+        # degradation has to point away from the clean reading.
+        self.sidecar(dict(TICKET_CHECKED, clauses={"AC-1": {"state": "ok"}}))
+        self.assertIn("`AC-1` not checked", self.line(self.body()))
+
+    def test_the_states_render_under_the_clause_table(self):
+        # Below the table they are a statement about, not among the gap
+        # headlines above it: a drifted quotation is a finding about text,
+        # and the gaps above the table are findings about the take.
+        self.sidecar(TICKET_CHECKED)
+        body = self.body()
+        self.assertLess(
+            body.index("| clause | claimed at | look at |"),
+            body.index(self.line(body)),
+        )
+
+    def test_no_rendered_sentence_reads_as_a_verdict(self):
+        # The same sweep the rest of the comment lives under, over both
+        # branches this renderer writes. The reason is a sentence
+        # `demo-ticket-check` wrote, so it is swept too, not subtracted.
+        for doc in (TICKET_CHECKED, TICKET_UNCHECKED):
+            self.sidecar(doc)
+            swept = self.body()
+            for span in _quoted(TICKETED):
+                flat = _as_rendered(span)
+                self.assertIn(flat, swept)
+                swept = swept.replace(flat, " ")
+            self.assertIn("re-read", swept)  # control: the block survived
+            hits = _verdict_hits(swept)
+            self.assertEqual(hits, [], f"{hits} read as a verdict in:\n{swept}")
+
+
 class CommentStep(unittest.TestCase):
     """The one fact about the repository only the workflow knows (#274).
 
@@ -3463,6 +3805,124 @@ INJECTIONS += [
         "    elif refs:",
         "    elif not refs:",
         ["Ticket.test_a_stitched_demo_whose_parts_disagree_names_every_ticket"],
+    ),
+]
+
+# -- demo-ticket-check: does the ticket still say what was quoted (#276) -----
+
+INJECTIONS += [
+    (
+        # The check that can only agree: every clause `matched`, whatever the
+        # body says. The drift this whole step exists to notice is exactly
+        # what this break makes invisible.
+        "every clause is reported matched regardless of the body",
+        "demo-ticket-check",
+        '        state = "matched" if needle and needle in haystack else "not verbatim"',
+        '        state = "matched"',
+        [
+            "TicketCheck.test_a_clause_the_body_holds_is_matched_and_one_it_does_not_is_not",
+            "TicketCheck.test_a_fetched_body_yields_both_states_and_exit_zero",
+        ],
+    ),
+    (
+        # The first step down the "close enough" slope the issue rules out:
+        # a case fold reads as harmless and is precisely the fuzzy match
+        # MATCH_RULE says there is none of.
+        "the match rule folds case, so a reworded clause still matches",
+        "demo-ticket-check",
+        '        state = "matched" if needle and needle in haystack else "not verbatim"',
+        '        state = "matched" if needle and needle.lower() in haystack.lower() else "not verbatim"',
+        ["TicketCheck.test_the_match_survives_rewrapping_and_nothing_else"],
+    ),
+    (
+        # `"" in body` is True for every body, so an empty declared text
+        # would read as the strongest state the check can produce.
+        "an empty clause is reported matched because it occurs everywhere",
+        "demo-ticket-check",
+        '        state = "matched" if needle and needle in haystack else "not verbatim"',
+        '        state = "matched" if needle in haystack else "not verbatim"',
+        ["TicketCheck.test_an_empty_clause_is_not_reported_matched"],
+    ),
+    (
+        # The two-state check #276 forbids, in the likeliest shape: nothing
+        # to say, so say nothing. A reader who sees nothing assumes the check
+        # came back clean.
+        "the no-token run writes no sidecar instead of not checked",
+        "demo-ticket-check",
+        "    elif not token:\n"
+        "        states, reason = unchecked(\n"
+        "            criteria,\n"
+        '            "no token in GH_TOKEN or GITHUB_TOKEN, so the ticket was never read",\n'
+        "        )",
+        "    elif not token:\n        return None",
+        ["TicketCheck.test_with_no_token_every_clause_is_not_checked_and_says_why"],
+    ),
+    (
+        # Never fatal is the acceptance criterion, not a nicety: a step that
+        # reddens the check because a timeline was unreadable teaches people
+        # to ignore the check.
+        "an unreadable timeline fails the step instead of being reported",
+        "demo-ticket-check",
+        "        except Exception as error:  # never fatal, by design (#276)\n"
+        '            print(f"{name}: not checked — {error}", file=sys.stderr)\n'
+        "            continue",
+        "        except Exception as error:  # never fatal, by design (#276)\n"
+        '            raise SystemExit(f"{name}: {error}")',
+        ["TicketCheck.test_a_timeline_that_cannot_be_read_is_reported_not_fatal"],
+    ),
+    (
+        # `not checked` omitted, which is #276's one explicit rendering rule:
+        # the line survives, the clauses the check could not read vanish, and
+        # their absence reads as the clean state.
+        "the renderer omits the clauses the check could not read",
+        "demo-comment",
+        "        states[key] = state",
+        '        if state != "not checked":\n            states[key] = state',
+        ["TicketCheckRender.test_not_checked_is_printed_with_the_reason_not_omitted"],
+    ),
+    (
+        # The degradation pointed the wrong way: a state this renderer does
+        # not know is not the clean one, whatever it turns out to mean.
+        "an unrecognised sidecar state reads as matched",
+        "demo-comment",
+        '        if state not in _TICKET_STATES:\n            state = "not checked"',
+        '        if state not in _TICKET_STATES:\n            state = "matched"',
+        [
+            "TicketCheckRender.test_a_state_the_renderer_does_not_recognise_reads_as_not_checked"
+        ],
+    ),
+    (
+        # The limit gone from the artifact itself, which is where #276 says
+        # it lives — a comment nobody reads is not a substitute.
+        "the ticket-check block stops stating its own limit",
+        "demo-comment",
+        '    lines += [TICKET_CHECK_LIMIT, ""]',
+        '    lines += [""]',
+        ["TicketCheckRender.test_the_block_states_its_own_limit"],
+    ),
+    (
+        # The sentence a `matched` row invites, appended so the assertions
+        # that locate the limit stay green and only the sweep can notice —
+        # the same shape as the per-word disclaimer injections.
+        "the ticket-check limit promotes the matched clauses",
+        "demo-comment",
+        "    \"the frames show the clause is the reviewer's call, not this line's.\"",
+        "    \"the frames show the clause is the reviewer's call, not this line's. \"\n"
+        '    "Each matched clause was verified against the ticket."',
+        ["TicketCheckRender.test_no_rendered_sentence_reads_as_a_verdict"],
+    ),
+    (
+        # The wiring: the renderer can be perfect and never be handed the
+        # sidecar. Same break class as `render_demo stops rendering the
+        # coverage section`.
+        "render_demo stops reading the ticket-check sidecar",
+        "demo-comment",
+        "    lines += render_ticket_check(_ticket_check(demo_dir(demo_root, name)))",
+        "    lines += render_ticket_check(None)",
+        [
+            "TicketCheckRender.test_each_clause_reports_its_own_state",
+            "TicketCheckRender.test_not_checked_is_printed_with_the_reason_not_omitted",
+        ],
     ),
 ]
 


### PR DESCRIPTION
Fixes #276, together with #341 (the corpus half).

A new CI step re-reads the ticket each recorded demo names and reports three states per clause, never two: `matched` (the declared text occurs in the issue body, whitespace collapsed, case-sensitive), `not verbatim`, `not checked` (with the reason — no token, not an `owner/repo#N` reference, unreadable issue). Never fatal: the step exits 0 on every path. The comment renders it under the clause table, and the limit is stated in the artifact itself:

> **This grades quotation, not meaning.** A storyboard that quotes a clause word for word can still record something else entirely; whether the frames show the clause is the reviewer's call, not this line's.

The result is a gitignored sidecar (`review/ticket-check.json`); `timeline.json` carries no state of a network call. The take itself still never fetches anything — #275's rule holds; this step runs outside the take, after recording.

## Evidence

- tests/ci-unit: 147 OK, all 107 injections caught (10 new — e.g. "the no-token run writes no sidecar instead of not checked" and "the renderer omits the clauses the check could not read" each redden their test).
- tests/unit 499 OK, tests/lint green.
- All three acceptance cases from #276 rendered end-to-end by the real scripts: matched + not-verbatim; no token → all not checked with the reason; foreign tracker URL → not checked, "other trackers stay unchecked by design".

## Limits

- The reusable workflow's job now asks for `issues: read`. An external caller granting only `contents` + `pull-requests` may fail the permission check until they add it; with a token that lacks the scope the design degrades to `not checked`.
- Only `owner/repo#N` references are fetched. URLs, including github.com ones, are `not checked`.
- A sidecar that exists but does not parse renders nothing; stated in the reader's docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)