### PR TITLE
Downscale the review frames and name every picture the sheet withholds (#343)

### DIFF
--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -28,12 +28,14 @@ and a real terminal session (voice on):
   waits (recorded as segments, stitched losslessly).
 - **`images/*.png`** — stills captured at key moments, ready for a written
   guide.
-- **`frames/`** — one review frame per beat, plus `frames.md` embedding them
-  in order. It is what you hand the fresh-agent review: aimed at what the
-  storyboard did rather than at a stopwatch, so nothing is missed and a held
-  frame is photographed once. A stitched demo gets them too, off the merged
-  timeline. Deliberately uncaptioned, and aimed to within a beat or so rather
-  than exactly — `reference/review.md` says how far and why.
+- **`frames/`** — a review frame per beat, at most 1024 px wide, plus
+  `frames.md` embedding them in order. It is what you hand the fresh-agent
+  review: aimed at what the storyboard did rather than at a stopwatch, so
+  nothing is missed. A beat whose picture repeats an earlier frame's is not
+  reprinted — `frames.md` names it and says which kept frame holds its
+  picture. A stitched demo gets them too, off the merged timeline.
+  Deliberately uncaptioned, and aimed to within a beat or so rather than
+  exactly — `reference/review.md` says how far and why.
 - **`record.py`** — the storyboard that produced the media, and the thing
   that actually gets committed: re-runnable after the UI changes, so the
   video stays out of git history and is regenerated rather than archived.

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -438,9 +438,10 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
    [reference/timeline.md](reference/timeline.md).
 6. **Fresh-agent review (required).** You cannot watch the video, and you
    know too much anyway — have a context-free agent watch it for you. The
-   recorder has already written what they need: `frames/`, one PNG per
-   beat, and `frames/frames.md`, which embeds them in order. **Hand them
-   `frames/frames.md`.** Read
+   recorder has already written what they need: `frames/`, a PNG per beat
+   minus the repeats (a beat whose picture repeats an earlier frame's is
+   named in the sheet instead of reprinted), and `frames/frames.md`, which
+   embeds them in order. **Hand them `frames/frames.md`.** Read
    [reference/review.md](reference/review.md) first — it says how accurately a
    frame is aimed at its beat, which is what decides how much weight a
    reviewer's reading of one can carry.

--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -1,8 +1,10 @@
-"""Review frames: one PNG per beat, pulled out of the finished mp4.
+"""Review frames: one PNG per beat, deduplicated, pulled out of the finished mp4.
 
 Nobody reviewing a demo through this skill can watch a video, so every review
 is a review of frames. They are aligned to beats rather than to a clock — a
 clock misses a short beat entirely and photographs a long static one twice.
+A beat whose picture repeats the last kept frame's is dropped and named on
+the sheet rather than reprinted (see the dedupe section below).
 
 `beat_frames(out_dir)` regenerates the whole sheet from demo.mp4 and
 timeline.json without re-recording.
@@ -11,6 +13,7 @@ timeline.json without re-recording.
 from __future__ import annotations
 
 import json
+import math
 import re
 import subprocess
 import sys
@@ -90,7 +93,21 @@ from .timeline import capture_clock_correction, timeline_paths
 # early, in content that predates the step, and it was found by eye:
 # `seg-run1`'s `beat-05.png` was cut at 4.58 s and shows the previous caption.
 FRAMES_DIRNAME = "frames"
-FRAMES_SCHEMA = 1
+FRAMES_SCHEMA = 2
+
+# The sheet is read by agents, not played back, and image tokens are what
+# killed the first field run (#343): a 122 s demo produced 80 native-res
+# frames — ~98k image tokens — and three reviewer agents died on session
+# limits before one review finished. 44% of those frames were a picture
+# already shown. Two mechanical fixes, no judgement in either: `_extract`
+# scales every frame to at most 1024 px wide (never up), and a frame whose
+# picture is within DEDUPE_RMSE of the **last kept** frame's is dropped —
+# named in the manifest's `deduped` list and on the sheet, never silently.
+# The threshold is mechanical on purpose: a hand-picked subset can launder a
+# finding out of a review; a threshold cannot. The first and last frame of a
+# sheet are always kept, and a comparison that fails keeps its frame — a
+# broken comparator must fatten the sheet, never thin it.
+DEDUPE_RMSE = 3.0
 
 # Scene-change detection, the fallback for what the storyboard did not script.
 # A beat that holds the frame for seconds can still contain a transition
@@ -171,7 +188,15 @@ def scene_times(
 
 
 def _extract(mp4: Path, at: float, path: Path) -> bool:
-    """One frame of `mp4` at `at` seconds, written to `path`."""
+    """One frame of `mp4` at `at` seconds, written to `path`.
+
+    Scaled to at most 1024 px wide — `min(1024,iw)` so a smaller video is
+    never upscaled — because these frames are read by agents, in image
+    tokens, and 1024 was verified legible on the field app of #343:
+    burned-in captions, toast text, table digits, dropdown labels. Every
+    frame of one sheet comes out of one mp4 through this one filter, so the
+    kept frames stay mutually comparable.
+    """
     proc = subprocess.run(
         [
             "ffmpeg",
@@ -184,6 +209,8 @@ def _extract(mp4: Path, at: float, path: Path) -> bool:
             str(mp4),
             "-frames:v",
             "1",
+            "-vf",
+            "scale='min(1024,iw)':-1",
             "-update",
             "1",
             str(path),
@@ -193,8 +220,54 @@ def _extract(mp4: Path, at: float, path: Path) -> bool:
     return proc.returncode == 0 and path.is_file()
 
 
+def _frame_mse(kept: Path, candidate: Path) -> float | None:
+    """Mean squared error between two extracted frames, or None.
+
+    ffmpeg's `psnr` filter, because ffmpeg is already the hard dependency
+    that wrote both files — a Python imaging library would be a new import
+    for every storyboard that imports these helpers. Parsed from `mse_avg`
+    rather than from the psnr number itself: identical frames report an
+    `inf` psnr, and `inf` is a value to special-case where an mse of `0.0`
+    is just a number under the threshold. `metadata=print:file=-` for the
+    reason `scene_times` gives: the filter's default logging goes through
+    ffmpeg's logger at INFO level, which `-v error` throws away.
+
+    None means the comparison itself failed. The caller must keep the frame
+    then — a broken comparator must fatten the sheet, never thin it.
+    """
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-v",
+            "error",
+            "-i",
+            str(kept),
+            "-i",
+            str(candidate),
+            "-filter_complex",
+            "psnr,metadata=print:file=-",
+            "-f",
+            "null",
+            "-",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return None
+    match = re.search(r"lavfi\.psnr\.mse_avg=([0-9.]+)", proc.stdout)
+    return float(match.group(1)) if match else None
+
+
 def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
-    """Write one review frame per beat, and an index to read them in order.
+    """Write a review frame per beat, deduplicated, and an index to read them.
+
+    A frame whose picture is within DEDUPE_RMSE of the last kept frame's is
+    taken off the sheet and off disk, and recorded in the manifest's
+    `deduped` list — file, beat, kind, t, the kept file it matched and the
+    measured rmse — with a named line on the sheet. The first and last frame
+    are always kept, and a frame the comparator could not measure is kept
+    with a warning.
 
     Reads the timeline the take just wrote (or `doc`), extracts
     `frames/beat-NN.png` at each beat's midpoint **on the video's clock** — the
@@ -234,6 +307,11 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         "duration": doc.get("duration"),
         "recorder": doc.get("recorder"),
         "frames": [],
+        # The frames dropped because their picture repeats the last kept
+        # frame's. Named, never counted: file, beat, kind, t, which kept file
+        # they matched and the measured rmse, so no beat leaves the sheet
+        # without a record a reader can check.
+        "deduped": [],
         # Filled in below, once there is a sheet for it to describe: whether
         # these frames were cut on the video's clock or on the beat log's, and
         # why not when they were not. Null on a manifest that wrote no frames.
@@ -368,7 +446,62 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
                 f"{record['t']}s for beat {record['beat']}",
                 file=sys.stderr,
             )
-    manifest["frames"] = written
+
+    # Drop the frames that repeat a picture already kept, in sheet order and
+    # against the **last kept** frame — never against a fixed neighbour, or a
+    # slow fade would survive as a chain of pairwise near-duplicates. Scene
+    # frames participate exactly like beat frames: a "transition" that left
+    # the picture where it was is the same non-information either way. See
+    # the note over DEDUPE_RMSE for why the threshold is mechanical.
+    kept: list[dict] = []
+    deduped: list[dict] = []
+    for n, record in enumerate(written):
+        # The sheet's anchors: where the demo started and where it ended stay
+        # visible even when nothing on screen ever moved.
+        if n == 0 or n == len(written) - 1:
+            kept.append(record)
+            continue
+        mse = _frame_mse(
+            frames_dir / str(kept[-1]["file"]), frames_dir / str(record["file"])
+        )
+        if mse is None:
+            print(
+                f"demo-video: WARNING — could not compare {record['file']} "
+                f"with {kept[-1]['file']}; keeping the frame. A broken "
+                f"comparator must fatten the sheet, never thin it.",
+                file=sys.stderr,
+            )
+            kept.append(record)
+            continue
+        if mse >= DEDUPE_RMSE * DEDUPE_RMSE:
+            kept.append(record)
+            continue
+        png = frames_dir / str(record["file"])
+        try:
+            png.unlink()
+        except OSError:
+            # A picture on disk that the manifest disowned is worse than a
+            # duplicate: it is a frame nobody indexed in a directory the
+            # skill says to hand over whole. Keep it listed instead.
+            print(
+                f"demo-video: WARNING — could not remove the duplicate "
+                f"{record['file']}, so it stays on the sheet",
+                file=sys.stderr,
+            )
+            kept.append(record)
+            continue
+        deduped.append(
+            {
+                "file": record["file"],
+                "beat": record["beat"],
+                "kind": record["kind"],
+                "t": record["t"],
+                "matches": kept[-1]["file"],
+                "rmse": round(math.sqrt(mse), 2),
+            }
+        )
+    manifest["frames"] = kept
+    manifest["deduped"] = deduped
     manifest["scene_search_skipped"] = skipped_scenes
     # How far the video is *known* to have slid under the beat log, as a floor
     # rather than a correction: a beat that ends after the video does is wall
@@ -414,7 +547,12 @@ def write_beat_frames(out_dir: Path | str, doc: dict, where: str) -> dict | None
             file=sys.stderr,
         )
         return manifest
-    print(f"wrote {frames_paths(out_dir)[0]} ({len(manifest['frames'])} review frames)")
+    dropped = len(manifest.get("deduped") or [])
+    print(
+        f"wrote {frames_paths(out_dir)[0]} ({len(manifest['frames'])} review frames"
+        + (f", {dropped} dropped as repeats and named in frames.md" if dropped else "")
+        + ")"
+    )
     return manifest
 
 
@@ -543,8 +681,9 @@ def render_frames_md(manifest: dict) -> str:
         " · ".join(head),
         "",
         "One frame per beat of the demo — per thing the storyboard did — rather "
-        "than one every N seconds, so nothing the demo does is missed and a "
-        "held frame is photographed once. Read them in order. Written by the "
+        "than one every N seconds, so nothing the demo does is missed. A beat "
+        "whose picture repeats an earlier frame's is named below instead of "
+        "reprinted. Read them in order. Written by the "
         "demo-video recorder whenever it encodes an mp4 — which now includes a "
         "take that crashed, whose recording stops where the storyboard gave up "
         "(see `failure/`); re-record rather than editing it.",
@@ -577,6 +716,17 @@ def render_frames_md(manifest: dict) -> str:
             f"frames were looked for**. The sheet is that much thinner than it "
             f"would be on a steady host; nothing is missing from the beat's "
             f"own frame above.",
+            "",
+        ]
+    # One line per dropped frame, named like everything else this sheet
+    # withholds — `scene_search_skipped` above set the rule. The reader's
+    # question is which beat is not pictured and where its picture is, and a
+    # count answers neither.
+    for drop in manifest.get("deduped") or []:
+        out += [
+            f"`{_md_cell(drop.get('file'))}` is not on this sheet: its "
+            f"picture is `{_md_cell(drop.get('matches'))}`'s "
+            f"(RMSE {drop.get('rmse')} < {DEDUPE_RMSE}).",
             "",
         ]
     loss = manifest.get("capture_loss_at_least") or 0.0

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -15,6 +15,17 @@ beat under `frames/`, named `beat-NN.png` for the beat's index in
 embeds them in order — and `frames/frames.json` for anything reading them by
 machine.
 
+Two things keep the sheet readable by an agent at all
+([#343](https://github.com/rogvid/skills/issues/343): 80 native-res frames of
+a 122 s demo were ~98k image tokens, and 44% were a picture already shown).
+Frames are extracted at most 1024 px wide, never upscaled. And a frame whose
+picture is within RMSE 3.0 of the last kept frame's is dropped — off the sheet
+and off disk — with a named line in `frames.md` saying which kept frame holds
+its picture, and a `deduped` entry in `frames.json` carrying the beat, the
+match and the measured rmse. The first and last frame are always kept, and the
+threshold is mechanical on purpose: a hand-picked subset can launder a finding
+out of a review; a threshold cannot.
+
 They are aligned to **beats, not to a clock**. The old advice was
 `ffmpeg -vf fps=1/3`, which misses a short beat entirely and photographs a long
 static one twice. Each frame is taken at its beat's **midpoint**, moved onto

--- a/tests/README.md
+++ b/tests/README.md
@@ -702,13 +702,16 @@ or a run-up that was not quiet. They look identical from inside the window, and
 only the first is the recorder losing a caption.
 
 **Review frames** — the `frames/` a reviewer is actually handed: one PNG per
-beat, and `frames.md` embedding them in order. What is graded is what the
-recorder claims, and it deliberately claims very little:
+beat, at most 1024 px wide and minus the deduplicated repeats (#343), and
+`frames.md` embedding them in order. What is graded is what the recorder
+claims, and it deliberately claims very little:
 
-- **One frame per beat, named for it.** Counted against the hand-written
-  `WEB_BEATS`/`TERMINAL_BEATS`, so a dropped frame, a doubled one or an
-  off-by-one name fails without a pixel being read. Every file on disk is named
-  by the manifest and vice versa.
+- **Every beat is a kept frame or a named drop.** Kept plus `deduped` are
+  counted together against the hand-written `WEB_BEATS`/`TERMINAL_BEATS`, so a
+  dropped frame, a doubled one or an off-by-one name fails without a pixel
+  being read. Every file on disk is named by the manifest and vice versa; a
+  deduplicated frame must be off disk, named in `frames.md`, and matched to a
+  kept frame under the hand-written 3.0 RMSE bound.
 - **Each frame is the moment it says it is.** Two halves, and only together.
   Its timestamp must be its beat's midpoint **moved onto the video's clock by
   this harness's own wall-clock watcher, read at the midpoint**
@@ -721,9 +724,11 @@ recorder claims, and it deliberately claims very little:
   placement-graded and is counted in the arm's output: two samplers on their
   own 20 ms grids do not both know which side of a step a beat fell on.
   And the PNG must be that frame: the harness **cuts the same second
-  out of `demo.mp4` again and compares the bytes**. 56 of 56 identical across
-  the three graded takes — 23 web, 18 terminal, and 15 off the stitched
-  `segments/` demo; one frame away (40 ms) is already a different file.
+  out of `demo.mp4` again, through the recorder's own hand-copied scale
+  filter, and compares the bytes**. 37 of 37 identical across the three
+  graded takes — 18 kept web frames, 10 terminal, and 9 off the stitched
+  `segments/` demo (a deduplicated beat has no PNG to compare); one frame
+  away (40 ms) is already a different file.
 
   Exact rather than approximate, because approximate does not work here. A PNG
   and a decoded video frame reach a luma reduction through different colour

--- a/tests/smoke
+++ b/tests/smoke
@@ -978,7 +978,9 @@ MIN_ALIGN_BAND_DELTA = {"web": 6.0, "terminal": 1.0, "segments": 6.0}
 
 # -- review frames (frames/, issue #8) ---------------------------------------
 #
-# The recorder extracts one frame per beat and writes `frames/frames.md` for a
+# The recorder extracts one frame per beat — at most 1024 px wide, and minus
+# the frames whose picture repeats the last kept one, each of those named in
+# the manifest's `deduped` list (#343) — and writes `frames/frames.md` for a
 # reviewer to read in order. It makes **no claim about what is in a frame** —
 # no caption, no verb, no selector — and the two things worth grading follow
 # from that:
@@ -7200,6 +7202,11 @@ def _same_frame(mp4: Path, at: float, png: Path) -> bool:
     argue about. What it does *not* grade is whether `at` is the right second —
     that is the midpoint check above, and the two are only worth anything
     together.
+
+    The scale filter is the recorder's own (#343: review frames are at most
+    1024 px wide, never upscaled), written out by hand here rather than
+    imported — the comparison is byte-exact, so an unasked-for change to the
+    recorder's filter fails this check instead of being absorbed by it.
     """
     with tempfile.TemporaryDirectory() as tmp:
         reference = Path(tmp) / "reference.png"
@@ -7215,6 +7222,8 @@ def _same_frame(mp4: Path, at: float, png: Path) -> bool:
                 str(mp4),
                 "-frames:v",
                 "1",
+                "-vf",
+                "scale='min(1024,iw)':-1",
                 "-update",
                 "1",
                 str(reference),
@@ -7422,13 +7431,16 @@ def check_beat_frames(
     expected_interludes: list[str] = [],  # noqa: B006 - read-only, never mutated
     clock: HostClock | None = None,
 ) -> list[str]:
-    """`frames/` — one frame per beat, at the beat's midpoint, showing it.
+    """`frames/` — every beat a kept frame or a named drop, at its midpoint.
 
     Four claims, and the last one is the acceptance criterion of issue #8:
 
-      * **one frame per beat**, named for the beat, counted against the
-        hand-written beat list rather than against the recorder's own idea of
-        how many beats there were;
+      * **every beat is accounted for**: a kept frame named for the beat, or
+        a `deduped` entry naming which kept picture it repeats (#343) — both
+        counted against the hand-written beat list rather than against the
+        recorder's own idea of how many beats there were, and a dropped
+        frame must be named in frames.md, matched to a kept frame under the
+        threshold, and off disk;
       * **each frame is the moment it says it is** — its timestamp is the
         beat's midpoint computed here from `timeline.json`, moved onto the
         video's clock by *this harness's own* wall-clock watcher (issue #229),
@@ -7479,17 +7491,23 @@ def check_beat_frames(
             f"{label}: the recorder wrote no review frames — {manifest['skipped']}"
         ]
 
-    # -- one frame per beat, named for the beat it came from -----------------
+    # -- every beat: a kept frame or a named drop, named for its beat --------
+    #
+    # Kept and deduplicated together must cover the hand-written beat list
+    # exactly (#343). Counting only the kept frames would let a beat vanish
+    # without a record; counting kept plus deduped and nothing else is what
+    # makes "no beat disappears silently" a checkable sentence.
     listed = [f for f in manifest.get("frames") or [] if f.get("kind") == "beat"]
+    dropped = [f for f in manifest.get("deduped") or [] if f.get("kind") == "beat"]
     wanted = [f"beat-{i:02d}.png" for i in range(len(expected_beats))]
-    named = [str(f.get("file")) for f in listed]
+    named = sorted(str(f.get("file")) for f in [*listed, *dropped])
     if named != wanted:
         failures.append(
-            f"{label}: frames/ holds {named!r} for the {len(expected_beats)} "
-            f"beats the storyboard performs — first difference at index "
-            f"{_first_difference(named, wanted)}"
+            f"{label}: frames/ accounts for {named!r} (kept plus deduped) for "
+            f"the {len(expected_beats)} beats the storyboard performs — first "
+            f"difference at index {_first_difference(named, wanted)}"
         )
-    for frame in listed:
+    for frame in [*listed, *dropped]:
         if frame.get("file") != f"beat-{frame.get('beat'):02d}.png":
             failures.append(
                 f"{label}: frame {frame.get('file')!r} claims to be beat "
@@ -7497,6 +7515,39 @@ def check_beat_frames(
                 f"disagree about which beat a reviewer is looking at"
             )
             break
+
+    # -- a dropped frame is named on the sheet, matched, and off disk --------
+    #
+    # The threshold is written out by hand (3.0 RMSE, so mse 9.0): a bound
+    # imported from the recorder would agree with whatever the recorder says.
+    kept_files = {str(f.get("file")) for f in manifest.get("frames") or []}
+    sheet_text = md_path.read_text() if md_path.is_file() else ""
+    for drop in manifest.get("deduped") or []:
+        name = str(drop.get("file"))
+        if (frames_dir / name).exists():
+            failures.append(
+                f"{label}: {name} was deduplicated off the sheet but its PNG "
+                f"is still on disk — the directory the skill hands over whole "
+                f"carries a picture the manifest disowned"
+            )
+        if str(drop.get("matches")) not in kept_files:
+            failures.append(
+                f"{label}: frames.json says {name} repeats "
+                f"{drop.get('matches')!r}, which is not a kept frame — the "
+                f"reader is pointed at a picture that is not on the sheet"
+            )
+        rmse = drop.get("rmse")
+        if not isinstance(rmse, (int, float)) or rmse >= 3.0:
+            failures.append(
+                f"{label}: {name} was dropped with rmse {rmse!r}, at or over "
+                f"the 3.0 the recorder promises — the sheet withheld a frame "
+                f"whose picture is not a repeat"
+            )
+        if f"`{name}` is not on this sheet" not in sheet_text:
+            failures.append(
+                f"{label}: frames.md never says {name} was left off the sheet "
+                f"— the beat disappears without a printed line saying so"
+            )
 
     on_disk = sorted(p.name for p in frames_dir.glob("*.png"))
     claimed = sorted(str(f.get("file")) for f in manifest.get("frames") or [])
@@ -7656,7 +7707,9 @@ def check_beat_frames(
         label,
         out_dir,
         frame_size,
-        listed,
+        # Kept frames plus the deduplicated beats, which are graded through
+        # the kept picture each one matched — see the loop's own comment.
+        [*listed, *dropped],
         beats,
         _expected_context(expected_beats, expected_captions, expected_interludes),
         clock,
@@ -7674,7 +7727,8 @@ def check_beat_frames(
             else "on a wall clock that was watched and held still"
         )
         print(
-            f"smoke: {label} frames/ ok ({len(listed)} beat frames, each "
+            f"smoke: {label} frames/ ok ({len(listed)} beat frames kept, "
+            f"{len(dropped)} deduplicated and named, each kept frame "
             f"byte-identical to the demo.mp4 frame it claims to be; cut {cut}"
             + (
                 f", {ungraded} not placement-graded within "
@@ -7730,27 +7784,46 @@ def _check_frame_captions(
     recorder's own account of the same thing and is graded against those same
     lists in `check_timeline()`.
     """
-    if context is None or len(context) != len(listed):
+    if context is None or any(
+        not isinstance(f.get("beat"), int) or not 0 <= f["beat"] < len(context)
+        for f in listed
+    ):
         # The count and the caption list are graded above and in
         # check_timeline(); saying so a third time adds nothing, and grading a
-        # misaligned pairing would report the wrong beat.
+        # misaligned pairing would report the wrong beat. Indexed by the
+        # frame's own beat rather than by position, because dedupe (#343)
+        # means the kept frames are a subset of the beats.
         return []
 
     # A change is where the expected context stops being what it was. The
     # *times* have to come from the log — it is the only record of when a beat
-    # ran — but which beats are boundaries does not.
+    # ran — but which beats are boundaries does not. Over every expected
+    # beat, not only the kept frames: a boundary whose frame was deduplicated
+    # away still moved the caption under its neighbours.
     changes = [
-        float(beats[frame["beat"]]["t_start"])
-        for i, frame in enumerate(listed)
-        if frame.get("beat") in beats and context[i] != (context[i - 1] if i else "")
+        float(beats[i]["t_start"])
+        for i in range(len(context))
+        if i in beats and context[i] != (context[i - 1] if i else "")
     ]
 
-    band = caption_band(frame_size)
+    # The band, at the size the PNGs actually are: review frames are scaled
+    # to at most 1024 px wide (#343), and a band computed for the recording's
+    # native size would crop a region the smaller picture does not have.
+    width, height = frame_size
+    factor = min(1024, width) / width
+    band = caption_band((round(width * factor), round(height * factor)))
     stepped = clock.before if clock is not None else (lambda _t: 0.0)
     reference: bytes | None = None
     graded: list[tuple[int, str, bytes]] = []
-    for i, frame in enumerate(listed):
-        png = out_dir / "frames" / str(frame.get("file"))
+    for frame in listed:
+        # A deduplicated beat is graded through the kept frame it matched:
+        # the manifest asserts the two pictures are the same, so the twin's
+        # pixels stand in at the dropped beat's own timestamp and against the
+        # dropped beat's own expected caption. That is not a concession — it
+        # is the check on the dedupe itself: a drop that merged across a
+        # caption change puts a picture of the wrong caption state under this
+        # beat's expectation, and the margin collapses.
+        png = out_dir / "frames" / str(frame.get("matches") or frame.get("file"))
         if not png.is_file():
             continue
         # Where the frame was cut, and where it actually sits in the story.
@@ -7778,8 +7851,9 @@ def _check_frame_captions(
             return [f"{label}: {exc}"]
         if not reduced:
             return [f"{label}: {png.name} decoded to no frames"]
-        graded.append((int(frame["beat"]), context[i], reduced[0]))
-        if reference is None and not context[i]:
+        expected = context[int(frame["beat"])]
+        graded.append((int(frame["beat"]), expected, reduced[0]))
+        if reference is None and not expected:
             reference = reduced[0]
 
     captioned = [(b, c, g) for b, c, g in graded if c]

--- a/tests/unit
+++ b/tests/unit
@@ -7294,12 +7294,24 @@ class FrameClockCorrection(unittest.TestCase):
         out_dir = Path(tempfile.mkdtemp())
         self.addCleanup(shutil.rmtree, out_dir, ignore_errors=True)
         (out_dir / "demo.mp4").write_bytes(b"a stand-in for a recording")
-        was = frames_module._extract, frames_module.scene_times
+        was = (
+            frames_module._extract,
+            frames_module.scene_times,
+            frames_module._frame_mse,
+        )
         frames_module._extract, frames_module.scene_times = extract, scenes
+        # Every frame this stub writes has the same bytes, so the real
+        # comparator would drop all of them. Dedupe is FrameDedupe's subject;
+        # here every picture reads as distinct so every planned cut is kept.
+        frames_module._frame_mse = lambda kept, candidate: 1e6
         try:
             manifest = beat_frames(out_dir, doc)
         finally:
-            frames_module._extract, frames_module.scene_times = was
+            (
+                frames_module._extract,
+                frames_module.scene_times,
+                frames_module._frame_mse,
+            ) = was
         return manifest, cuts, windows
 
     def take(self, clock: object, *starts: float, span: float = 0.1) -> dict:
@@ -7738,6 +7750,248 @@ class FrameClockCorrection(unittest.TestCase):
         manifest, cuts, _windows = self.sheet(doc)
         self.assertEqual(cuts, [])
         self.assertIsNone(manifest["clock_correction"])
+
+
+class FrameDedupe(unittest.TestCase):
+    """Which frames the sheet withholds as repeats, and how it says so (#343).
+
+    The measured problem: 80 native-res frames of a 122 s demo cost ~98k
+    image tokens and killed three reviewer agents, and 44% of them were a
+    picture already shown. The fix is mechanical — RMSE against the last
+    kept frame, threshold DEDUPE_RMSE — because a hand-picked subset can
+    launder a finding out of a review and a threshold cannot. What these
+    tests hold: a drop is never silent (manifest `deduped` entry plus a
+    named line on the sheet, PNG off disk), the first and last frame are
+    kept unconditionally, and a comparator that fails keeps its frame — a
+    broken comparator must fatten the sheet, never thin it.
+
+    The comparator itself is a stub, like `_extract` and `scene_times` one
+    class up: what ffmpeg's psnr filter reports about two PNGs is not a
+    claim this suite can grade without ffmpeg, and `tests/smoke` re-runs
+    the whole dedupe against real extractions on every take.
+    """
+
+    def sheet(
+        self, doc: dict, mse: dict[tuple[str, str], object]
+    ) -> tuple[dict, Path, list[tuple[str, str]]]:
+        """(manifest, out_dir, the pairs the comparator was shown).
+
+        `mse` maps (kept file, candidate file) to what the stub comparator
+        answers; a pair it does not name reads as plainly different (1e6).
+        The pairs are captured so a test can assert *which* frame a
+        candidate was compared against — the last kept one, not a fixed
+        neighbour.
+        """
+        compared: list[tuple[str, str]] = []
+
+        def extract(mp4: Path, at: float, path: Path) -> bool:
+            path.write_bytes(path.name.encode())
+            return True
+
+        def fake_mse(kept: Path, candidate: Path) -> object:
+            compared.append((kept.name, candidate.name))
+            return mse.get((kept.name, candidate.name), 1e6)
+
+        out_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, out_dir, ignore_errors=True)
+        (out_dir / "demo.mp4").write_bytes(b"a stand-in for a recording")
+        was = (
+            frames_module._extract,
+            frames_module.scene_times,
+            frames_module._frame_mse,
+        )
+        frames_module._extract = extract
+        frames_module.scene_times = lambda *a, **k: []
+        frames_module._frame_mse = fake_mse
+        try:
+            manifest = beat_frames(out_dir, doc)
+        finally:
+            (
+                frames_module._extract,
+                frames_module.scene_times,
+                frames_module._frame_mse,
+            ) = was
+        return manifest, out_dir, compared
+
+    def take(self, *starts: float) -> dict:
+        beats = [beat(n, "caption", t) for n, t in enumerate(starts)]
+        return envelope(duration=20.0, capture_clock=clock_record(), beats=beats)
+
+    # 0.16 is an rmse of 0.4 — the number the issue's own example uses.
+    DUP_01 = {("beat-00.png", "beat-01.png"): 0.16}
+
+    def test_a_middle_frame_that_repeats_the_last_kept_is_dropped(self):
+        manifest, out_dir, _pairs = self.sheet(
+            self.take(1.0, 2.0, 3.0, 4.0), self.DUP_01
+        )
+        self.assertEqual(
+            [f["file"] for f in manifest["frames"]],
+            ["beat-00.png", "beat-02.png", "beat-03.png"],
+        )
+        # Off disk as well as off the index: the directory is handed over
+        # whole, and a picture the manifest disowned is a frame nobody
+        # indexed sitting in it.
+        self.assertFalse((out_dir / "frames" / "beat-01.png").exists())
+        for name in ("beat-00.png", "beat-02.png", "beat-03.png"):
+            self.assertTrue((out_dir / "frames" / name).exists())
+
+    def test_the_manifest_names_the_drop_its_match_and_the_measured_rmse(self):
+        manifest, _out_dir, _pairs = self.sheet(
+            self.take(1.0, 2.0, 3.0, 4.0), self.DUP_01
+        )
+        self.assertEqual(
+            manifest["deduped"],
+            [
+                {
+                    "file": "beat-01.png",
+                    "beat": 1,
+                    "kind": "beat",
+                    "t": 2.05,
+                    "matches": "beat-00.png",
+                    "rmse": 0.4,
+                }
+            ],
+        )
+
+    def test_the_sheet_names_every_dropped_frame_and_stops_embedding_it(self):
+        manifest, _out_dir, _pairs = self.sheet(
+            self.take(1.0, 2.0, 3.0, 4.0), self.DUP_01
+        )
+        sheet = render_frames_md(manifest)
+        self.assertIn(
+            "`beat-01.png` is not on this sheet: its picture is "
+            "`beat-00.png`'s (RMSE 0.4 < 3.0).",
+            sheet,
+        )
+        self.assertNotIn("](beat-01.png)", sheet)
+        self.assertNotIn("| `beat-01.png` |", sheet)
+
+    def test_a_candidate_is_compared_against_the_last_kept_frame(self):
+        # beat-01 is dropped, so beat-02's comparison partner must be
+        # beat-00 — comparing against the dropped neighbour instead would
+        # let a slow fade survive as a chain of pairwise near-duplicates.
+        _manifest, _out_dir, pairs = self.sheet(
+            self.take(1.0, 2.0, 3.0, 4.0), self.DUP_01
+        )
+        self.assertEqual(
+            pairs,
+            [("beat-00.png", "beat-01.png"), ("beat-00.png", "beat-02.png")],
+        )
+
+    def test_the_first_and_last_frames_are_kept_even_when_identical(self):
+        # Identical frames report mse 0 (ffmpeg calls that inf psnr), which
+        # is under any threshold — so everything here is a candidate, and
+        # only the anchors survive. The last frame is also never compared:
+        # it is kept by position, not by luck of the pictures.
+        everything = {
+            (kept, cand): 0.0
+            for kept in ("beat-00.png", "beat-01.png", "beat-02.png")
+            for cand in ("beat-01.png", "beat-02.png", "beat-03.png")
+        }
+        manifest, _out_dir, _pairs = self.sheet(
+            self.take(1.0, 2.0, 3.0, 4.0), everything
+        )
+        self.assertEqual(
+            [f["file"] for f in manifest["frames"]],
+            ["beat-00.png", "beat-03.png"],
+        )
+        self.assertEqual(
+            [(d["file"], d["matches"], d["rmse"]) for d in manifest["deduped"]],
+            [
+                ("beat-01.png", "beat-00.png", 0.0),
+                ("beat-02.png", "beat-00.png", 0.0),
+            ],
+        )
+
+    def test_a_failed_comparison_keeps_the_frame_and_warns(self):
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            manifest, out_dir, _pairs = self.sheet(
+                self.take(1.0, 2.0, 3.0), {("beat-00.png", "beat-01.png"): None}
+            )
+        self.assertEqual(
+            [f["file"] for f in manifest["frames"]],
+            ["beat-00.png", "beat-01.png", "beat-02.png"],
+        )
+        self.assertEqual(manifest["deduped"], [])
+        self.assertTrue((out_dir / "frames" / "beat-01.png").exists())
+        self.assertIn("could not compare beat-01.png", stderr.getvalue())
+
+    def test_a_scene_frame_that_repeats_its_beats_frame_is_dropped_like_one(self):
+        # One long beat so the scene search runs, plus a short one so the
+        # scene frame is not the last frame of the sheet.
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record(),
+            beats=[beat(0, "hold", 1.0, t_end=5.0), beat(1, "caption", 6.0)],
+        )
+        compared: list[tuple[str, str]] = []
+
+        def extract(mp4: Path, at: float, path: Path) -> bool:
+            path.write_bytes(path.name.encode())
+            return True
+
+        out_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, out_dir, ignore_errors=True)
+        (out_dir / "demo.mp4").write_bytes(b"a stand-in for a recording")
+        was = (
+            frames_module._extract,
+            frames_module.scene_times,
+            frames_module._frame_mse,
+        )
+        frames_module._extract = extract
+        frames_module.scene_times = lambda *a, **k: [4.5]
+        frames_module._frame_mse = lambda kept, candidate: (
+            compared.append((kept.name, candidate.name)) or 0.0
+        )
+        try:
+            manifest = beat_frames(out_dir, doc)
+        finally:
+            (
+                frames_module._extract,
+                frames_module.scene_times,
+                frames_module._frame_mse,
+            ) = was
+        self.assertEqual(
+            [f["file"] for f in manifest["frames"]],
+            ["beat-00.png", "beat-01.png"],
+        )
+        self.assertEqual(
+            [(d["file"], d["kind"], d["matches"]) for d in manifest["deduped"]],
+            [("beat-00-scene-1.png", "scene", "beat-00.png")],
+        )
+        self.assertFalse((out_dir / "frames" / "beat-00-scene-1.png").exists())
+
+    def test_extract_asks_ffmpeg_for_at_most_1024_wide_never_upscaled(self):
+        """The downscale is in the extraction, not a second pass.
+
+        Asserted on the argv `_extract` hands ffmpeg, with subprocess
+        stubbed: whether ffmpeg honours `scale` is ffmpeg's contract, but
+        whether the recorder asks for it is this file's. `min(1024,iw)` is
+        the half that keeps a video already smaller than 1024 px at its own
+        size — an upscale would spend more tokens to show fewer pixels.
+        """
+        argv: list[list[str]] = []
+
+        def run(cmd: list[str], **kwargs: object) -> object:
+            argv.append(cmd)
+            Path(cmd[-1]).write_bytes(b"a stand-in for a frame")
+            return types.SimpleNamespace(returncode=0)
+
+        out_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, out_dir, ignore_errors=True)
+        was = frames_module.subprocess
+        frames_module.subprocess = types.SimpleNamespace(run=run)  # type: ignore[assignment]
+        try:
+            ok = frames_module._extract(
+                out_dir / "demo.mp4", 1.0, out_dir / "beat-00.png"
+            )
+        finally:
+            frames_module.subprocess = was
+        self.assertTrue(ok)
+        self.assertEqual(len(argv), 1)
+        self.assertIn("scale='min(1024,iw)':-1", argv[0])
+        self.assertEqual(argv[0][argv[0].index("scale='min(1024,iw)':-1") - 1], "-vf")
 
 
 class TimelineClockNote(unittest.TestCase):
@@ -14833,6 +15087,101 @@ INJECTIONS = [
         "        except Exception:\n"
         "            pass",
         ["ActBeat.test_an_exception_in_the_block_still_closes_the_beat_and_propagates"],
+    ),
+    # -- the sheet's dedupe (issue #343) -------------------------------------
+    (
+        # Dedupe switched off whole (#343): every repeated picture is back on
+        # the sheet and the manifest's `deduped` list is empty. This is the
+        # as-shipped behaviour the issue measured at 44% duplicate frames and
+        # ~98k image tokens, restored exactly.
+        "a repeated picture is reprinted on the sheet instead of deduplicated",
+        "frames.py",
+        "        if mse >= DEDUPE_RMSE * DEDUPE_RMSE:",
+        "        if True:",
+        [
+            "FrameDedupe.test_a_middle_frame_that_repeats_the_last_kept_is_dropped",
+            "FrameDedupe.test_the_first_and_last_frames_are_kept_even_when_identical",
+        ],
+    ),
+    (
+        # The drop happens but nothing records it: the PNG is gone, the
+        # manifest lists nothing under `deduped`, and the sheet prints no
+        # line — the beat disappears silently, which is the one outcome the
+        # issue forbids outright.
+        "a dropped frame leaves no record in the manifest or on the sheet",
+        "frames.py",
+        "        deduped.append(",
+        "        _unrecorded = (",
+        [
+            "FrameDedupe.test_the_manifest_names_the_drop_its_match_and_the_measured_rmse",
+            "FrameDedupe."
+            "test_the_sheet_names_every_dropped_frame_and_stops_embedding_it",
+        ],
+    ),
+    (
+        # The renderer stops naming the drops while the manifest still
+        # carries them — the sheet a human reads is the one that goes silent,
+        # which is worse than the manifest doing so: nobody opens frames.json
+        # unless frames.md gives a reason to.
+        "frames.md stops naming the frames it withholds",
+        "frames.py",
+        '    for drop in manifest.get("deduped") or []:',
+        "    for drop in []:",
+        ["FrameDedupe.test_the_sheet_names_every_dropped_frame_and_stops_embedding_it"],
+    ),
+    (
+        # The sheet's anchors join the dedupe: a demo that ends where it
+        # started loses its final frame, and a reviewer can no longer see
+        # where the demo stopped.
+        "the last frame of the sheet is deduplicated away like any other",
+        "frames.py",
+        "        if n == 0 or n == len(written) - 1:",
+        "        if n == 0:",
+        ["FrameDedupe.test_the_first_and_last_frames_are_kept_even_when_identical"],
+    ),
+    (
+        # A comparator failure read as "identical": every frame ffmpeg cannot
+        # compare is silently dropped, so the breakage that should fatten the
+        # sheet thins it instead — on a box with a broken ffmpeg that is the
+        # whole sheet reduced to its two anchors.
+        "a failed comparison drops the frame instead of keeping it",
+        "frames.py",
+        "        if mse is None:",
+        "        if (mse := 0.0 if mse is None else mse) is None:",
+        ["FrameDedupe.test_a_failed_comparison_keeps_the_frame_and_warns"],
+    ),
+    (
+        # The comparison anchored to the written neighbour instead of the
+        # last kept frame: a slow fade survives as a chain of pairwise
+        # near-duplicates, each within threshold of the one before it.
+        "a candidate is compared against its neighbour, not the last kept frame",
+        "frames.py",
+        '            frames_dir / str(kept[-1]["file"]), frames_dir / str(record["file"])',
+        '            frames_dir / str(written[n - 1]["file"]),\n'
+        '            frames_dir / str(record["file"]),',
+        ["FrameDedupe.test_a_candidate_is_compared_against_the_last_kept_frame"],
+    ),
+    (
+        # The duplicate is off the index but still on disk: the directory the
+        # skill says to hand over whole carries a picture the manifest
+        # disowned, and `frames.json names X but frames/ holds Y` is exactly
+        # the smoke failure this shape produces on a real take.
+        "a deduplicated frame's PNG stays on disk",
+        "frames.py",
+        "            png.unlink()",
+        "            pass",
+        ["FrameDedupe.test_a_middle_frame_that_repeats_the_last_kept_is_dropped"],
+    ),
+    (
+        # The downscale removed: frames go back to native resolution, which
+        # is the ~98k-token sheet of #343 with the dedupe still running. The
+        # assertion is on the argv the recorder hands ffmpeg, so this is the
+        # one injection that can prove it watches anything.
+        "review frames are extracted at native resolution again",
+        "frames.py",
+        '            "-vf",\n            "scale=\'min(1024,iw)\':-1",\n',
+        "",
+        ["FrameDedupe.test_extract_asks_ffmpeg_for_at_most_1024_wide_never_upscaled"],
     ),
 ]
 

--- a/tests/unit
+++ b/tests/unit
@@ -12988,8 +12988,8 @@ INJECTIONS = [
         # seven sites `SkillDocs`'s link check structurally cannot see.
         "a shipped document names a reference file that is not there",
         "README.md",
-        "than exactly — `reference/review.md` says how far and why.",
-        "than exactly — `reference/reviews.md` says how far and why.",
+        "exactly — `reference/review.md` says how far and why.",
+        "exactly — `reference/reviews.md` says how far and why.",
         ["DocPointers.test_every_reference_document_the_skill_names_exists"],
     ),
     (


### PR DESCRIPTION
Fixes #343.

## Acceptance criterion

On takes with held frames: total frame bytes fall by more than half, frames.md names each dropped beat, and no beat disappears without a printed line saying so.

## What changed

`_extract` scales every review frame to at most 1024 px wide (`min(1024,iw)`, never upscaled). After extraction, frames are walked in sheet order and a frame within RMSE 3.0 of the last kept frame's picture is dropped. A drop is never silent: the PNG comes off disk, the manifest gains a `deduped` entry (file, beat, kind, t, matched kept file, measured rmse), and frames.md prints one line per drop, e.g. `` `beat-01.png` is not on this sheet: its picture is `beat-00.png`'s (RMSE 0.15 < 3.0). `` The first and last frame are always kept. Scene frames participate like beat frames. A failed comparison keeps the frame and warns — a broken comparator must fatten the sheet, never thin it. The comparator is ffmpeg's `psnr` filter (`mse_avg`; identical frames report mse 0 under an inf psnr and drop too) — no new Python dependency reaches the helpers. `FRAMES_SCHEMA` is now 2, and the sheet's header no longer promises "a held frame is photographed once".

## Measurement

Same video each row: frames regenerated from the identical demo.mp4 + timeline.json by the old code (main) and the new.

| take | before | after | bytes |
|---|---|---|---|
| segments (14.9 s, 15 beats) | 15 frames, 2,985,725 B, 1280x720 | 8 kept + 7 named drops, 1,156,800 B, 1024x576 | **-61.3%** |
| web (31 beats) | 31 frames, 6,547,536 B | 18 kept + 13 named drops, 2,839,713 B | **-56.6%** |

Every dropped beat is named in frames.md and carried in `manifest.deduped`; the smoke harness now counts kept + deduped together against the hand-written beat lists, so a silent disappearance is a red arm.

## Consumers

- **tests/smoke** assumed one frame per beat, native-res byte identity, and positional caption-context alignment — all updated. `_same_frame` re-cuts through a hand-copied (not imported) scale filter. Kept + deduped must cover the beat list; each drop must be named in frames.md, matched to a kept frame under a hand-written 3.0 bound, and off disk. The caption-state check grades a deduplicated beat through the kept twin the manifest says holds its picture — so a dedupe that merged across a caption change puts the wrong caption state under that beat's expectation and collapses the margin. The caption band is scaled to the PNGs' actual size.
- **scripts/demo-grade** needed nothing: `frame_records` already documents that beat-to-frame is neither 1:1 nor monotone and reads only `manifest.frames`.
- **`.github/scripts/*`** read no frame manifests.

## Fault injections (tests/unit --fault-inject, 330/330 caught)

Each injection lands via the manifest's exact-once match (the harness aborts on 0 or 2+ matches). The eight new ones, with their failure output verbatim:

```
PASS  break: a repeated picture is reprinted on the sheet instead of deduplicated
      in frames.py: if mse >= DEDUPE_RMSE * DEDUPE_RMSE:…
      FAIL: test_a_middle_frame_that_repeats_the_last_kept_is_dropped (__main__.FrameDedupe.test_a_middle_frame_that_repeats_the_last_kept_is_dropped)
      FAIL: test_the_first_and_last_frames_are_kept_even_when_identical (__main__.FrameDedupe.test_the_first_and_last_frames_are_kept_even_when_identical)

PASS  break: a dropped frame leaves no record in the manifest or on the sheet
      in frames.py: deduped.append(…
      FAIL: test_the_manifest_names_the_drop_its_match_and_the_measured_rmse (__main__.FrameDedupe.test_the_manifest_names_the_drop_its_match_and_the_measured_rmse)
      FAIL: test_the_sheet_names_every_dropped_frame_and_stops_embedding_it (__main__.FrameDedupe.test_the_sheet_names_every_dropped_frame_and_stops_embedding_it)

PASS  break: frames.md stops naming the frames it withholds
      in frames.py: for drop in manifest.get("deduped") or []:…
      FAIL: test_the_sheet_names_every_dropped_frame_and_stops_embedding_it (__main__.FrameDedupe.test_the_sheet_names_every_dropped_frame_and_stops_embedding_it)

PASS  break: the last frame of the sheet is deduplicated away like any other
      in frames.py: if n == 0 or n == len(written) - 1:…
      FAIL: test_the_first_and_last_frames_are_kept_even_when_identical (__main__.FrameDedupe.test_the_first_and_last_frames_are_kept_even_when_identical)

PASS  break: a failed comparison drops the frame instead of keeping it
      in frames.py: if mse is None:…
      FAIL: test_a_failed_comparison_keeps_the_frame_and_warns (__main__.FrameDedupe.test_a_failed_comparison_keeps_the_frame_and_warns)

PASS  break: a candidate is compared against its neighbour, not the last kept frame
      in frames.py: frames_dir / str(kept[-1]["file"]), frames_dir / str(record["file"])…
      FAIL: test_a_candidate_is_compared_against_the_last_kept_frame (__main__.FrameDedupe.test_a_candidate_is_compared_against_the_last_kept_frame)

PASS  break: a deduplicated frame's PNG stays on disk
      in frames.py: png.unlink()…
      FAIL: test_a_middle_frame_that_repeats_the_last_kept_is_dropped (__main__.FrameDedupe.test_a_middle_frame_that_repeats_the_last_kept_is_dropped)

PASS  break: review frames are extracted at native resolution again
      in frames.py: "-vf",…
      FAIL: test_extract_asks_ffmpeg_for_at_most_1024_wide_never_upscaled (__main__.FrameDedupe.test_extract_asks_ffmpeg_for_at_most_1024_wide_never_upscaled)
```

## Runs

- tests/unit: 507 OK. tests/unit --fault-inject: 330/330.
- tests/ci-unit: 147 OK. --fault-inject: 107/107.
- tests/smoke-inject --self-test, tests/lint, mypy: clean.
- tests/smoke --web-only, --terminal-only, --segments-only, --polish-only: PASSED with the new checks (web 18 kept + 13 named drops, terminal 10 + 8, segments 9 + 6; every kept frame byte-identical on re-cut).

## Stated limits

- `tests/smoke --cheap` went red twice on this WSL2 box, both times only in the spotlight luma windows (enter/exit ends differ by 0.05-2.13 luma, floor 5.0) — a check that reads demo.mp4 pixels this diff never touches, green when the arm runs alone (`--polish-only`: "spotlight eases both ways"). This host steps its wall clock ~0.74 s during most takes; tests/README.md's own reference `--cheap` measurements record a red of this class (#215/#224). CI's runner is the authoritative `--cheap`.
- A deduplicated beat whose midpoint the host's clock deleted (#256) loses its `no_video` marker with its frame record; the `deduped` entry says which kept picture stands for it, but not that its own moment is missing from the file. `_check_unstated_holes` grades kept frames only.
- The blind reader's brief lists kept frames only; a clause satisfied only by a deduplicated beat is read through the kept twin's picture without knowing the beat number. The picture is the same by construction (RMSE < 3.0).
- The RMSE threshold is whole-frame. A caption text change confined to the caption band could in principle sit under 3.0; the smoke caption-state check now grades deduplicated beats through their kept twin precisely so that merge would collapse the margin, and no take showed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
