### PR TITLE
tests/pixel: the lock-free, digest-cached chrome reference takes (#350)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,10 @@ demo-video-FAILED.md
 # covers pointing it back into the repo (tests/smoke --out-dir tests/out).
 tests/out/
 
+# The pixel loop's cached reference takes (tests/pixel, #350). Regenerated
+# whenever their inputs digest changes; nothing here is history.
+tests/.pixel-cache/
+
 # Best practice
 .env
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -20,6 +20,7 @@ extend-include = [
     "tests/ci-unit",
     "tests/unit",
     "tests/lint",
+    "tests/pixel",
     "tests/eval-grader",
     ".github/scripts/*",   # the CI workflow's PEP 723 executables
     "skills/*/scripts/*",  # every skill's PEP 723 executables

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,7 +18,7 @@ takes an exclusive lock.
 `unit` answers everything that never needed a browser: the coverage report, the
 timeline's two renderings, the content and opening warnings, the merge a stitch
 performs, and whether `SKILL.md`'s reference links still resolve. It costs about
-3 s for its 499 tests and has no dependencies at all.
+5 s for its 521 tests and has no dependencies at all.
 
 **That split is the point, not tidiness.** [#136] measured the asymmetry it
 exists to remove: the fault-injection rule was *executed* for `ci-unit` and
@@ -46,14 +46,38 @@ and `score` phases, so it is run deliberately rather than on a push. `AGENTS.md`
 ("Where an eval replaces the injections") is why code graded this way does not
 also owe an injection manifest; `tests/eval/grader/README.md` is the corpus.
 
+`pixel` is not a gate either - it is the iteration loop, slice 2 of
+[#324](https://github.com/rogvid/skills/issues/324).
+It records two short chrome reference takes into the gitignored
+`tests/.pixel-cache/` - a terminal opening on its title card, and the web
+chrome (criterion card, interlude, caption, spotlight, cursor park) against
+`tests/fixture` on an ephemeral port - keyed by a digest over every
+`helpers/demo_recording/*.py`, each take's own storyboard source, the vendored
+xterm assets and the fixture page.
+Cold (a stale or missing take) costs ~20-25 s per take, one Chromium launch
+each; warm costs ~0.1 s, prints `cached <take>`, and launches nothing.
+**It takes no lock and must never create one**: the smoke lock exists for
+smoke's time-measuring bars under encoder contention
+([#78](https://github.com/rogvid/skills/issues/78)), and every reading this
+loop makes is colour or geometry off frames already on disk.
+What it grades today is only completeness - demo.mp4, timeline.json, at least
+one review frame per take; the golden properties (opening-card prefix,
+card-vs-window colour, the cursor disc and the pointer-absence probe) are
+[#351](https://github.com/rogvid/skills/issues/351) and land in its `CHECKS`
+registry.
+Its cache arithmetic - digest, staleness, marker - is graded browser-free in
+`unit` (`PixelCache`), with three entries in the `INJECTIONS` table.
+
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
 ├── smoke-inject       # proves smoke's assertions can still fail (~47 min, nightly)
-├── unit               # the browser-free half (~3 s, 499 tests, no dependencies)
+├── unit               # the browser-free half (~5 s, 521 tests, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
 │                      #   sees, plus the docs' python fences (~0.3 s)
+├── pixel              # the iteration loop: two cached chrome reference takes,
+│                      #   digest-keyed, no lock (cold ~45 s, warm ~0.1 s)
 ├── eval-grader        # scores the blind reader against a known-answer corpus
 │                      #   (record ~2 min and cached; score ~0.3 s)
 ├── eval/grader/takes/ # the five corpus takes and their expectations

--- a/tests/pixel
+++ b/tests/pixel
@@ -1,0 +1,564 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["playwright>=1.49"]
+# ///
+"""The pixel loop: two cached reference takes to assert chrome properties on.
+
+    tests/pixel            # re-record whatever is stale, then run the checks
+    tests/pixel record     # only refresh the cache (--force re-records all)
+    tests/pixel check      # grade the cache as it is, recording nothing
+
+Slice 2 of #324. `tests/smoke` gives an agent a verdict on the recorder in ten
+minutes behind a machine-wide lock; this gives it the *take* to read pixels off
+in seconds, because the take is cached and only re-recorded when something that
+decides its frames has changed.
+
+Two takes land in `tests/.pixel-cache/` (gitignored):
+
+- `terminal` - a terminal segment opened on a title card, two commands, no
+  server. The shape issue #110 was measured on.
+- `web` - the recorder's web chrome against `tests/fixture/index.html` on an
+  ephemeral port: criterion card, interlude, caption, spotlight, and a cursor
+  park. Its storyboard keeps every pointer verb until late in the take, and
+  the marker says at which beat the pointer first moves, so #351 can probe
+  cursor *absence* over the front stretch without a third take.
+
+**Caching.** Each take carries a `.pixel-recording.json` marker naming the
+digest of everything whose bytes decide what its frames look like: every
+module in `helpers/demo_recording/`, the take's own storyboard function
+source, and per take the vendored xterm assets or the fixture page. A warm
+run prints `cached <take>` and never launches a browser; a stale or missing
+take is re-recorded alone. Staleness is never fatal: `check` grades whatever
+is cached and says so when the frames predate today's inputs. The pattern is
+`tests/eval-grader`'s, marker and all.
+
+**No lock, on purpose.** `tests/smoke` serialises suites through
+/tmp/demo-video-smoke.lock because its time-measuring bars fail under encoder
+contention (#78). Every reading this loop will ever make is colour or
+geometry off frames that are already on disk, none of it contention
+sensitive, so it has no claim to that lock and must not create one of its
+own. This file never opens the lock path.
+
+**What `check` grades today** is only completeness: the take has a demo.mp4,
+a timeline.json, and at least one review frame. The golden properties -
+opening-card prefix, card-vs-window colour, cursor disc, the absence probe -
+are #351, and they land in the CHECKS registry below.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import inspect
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HELPERS = REPO / "skills" / "demo-video" / "helpers"
+FIXTURE = REPO / "tests" / "fixture"
+CACHE = REPO / "tests" / ".pixel-cache"
+
+MARKER = ".pixel-recording.json"
+MARKER_SCHEMA = 1
+
+TAKES = ("terminal", "web")
+
+# Below this, the recorder package was not hashed: an empty or misresolved
+# helpers directory would give every take a digest over nothing, and a cache
+# keyed on nothing is warm forever. 13 modules today; the floor is a refusal,
+# not a policy.
+MIN_RECORDER_MODULES = 8
+
+# The web storyboard's contract with #351: at least this many beats run before
+# the first pointer verb. Below it the pointer-free stretch is too thin for an
+# absence probe to mean anything, and the take is refused rather than cached.
+MIN_POINTERLESS_BEATS = 3
+
+SERVER_START_TIMEOUT_S = 10.0
+
+HEADER = (
+    "pixel: no suite lock - this loop reads colour and geometry off cached "
+    "frames, none of it sensitive to encoder contention, which is all the "
+    "smoke lock exists for (tests/smoke, #78)."
+)
+
+
+class PixelFailure(Exception):
+    """A named refusal; main() prints it and exits 1."""
+
+
+# -- the storyboards -----------------------------------------------------------
+#
+# Constants a storyboard uses are defined *inside* its function on purpose:
+# the cache digest hashes each record function's own source, so a constant
+# defined out here could change what the frames look like without changing
+# any digest.
+
+
+def record_terminal(out_dir: Path) -> dict:
+    """The terminal reference take: opened on a card, two commands, no server.
+
+    `tests/smoke`'s record_terminal_opening shape (#110): the card comes from
+    the constructor, not the storyboard, so its first frame is the recorder's
+    own behaviour. Returns what only the live recorder knows - where the
+    window and the app sit in the frame (issue #17).
+    """
+    from demo_recording import TerminalRecorder
+
+    card = "The reference terminal take."
+    with TerminalRecorder(
+        out_dir,
+        speech=False,
+        strict=True,
+        deterministic=True,
+        interlude=card,
+        interlude_hold=2.5,
+    ) as rec:
+        rec.caption("Two quick commands.")
+        rec.run("echo reference")
+        rec.wait_for_prompt(timeout_s=15)
+        rec.caption("And a second, so the screen moves.")
+        rec.run("printf 'a\\nb\\n'")
+        rec.wait_for_prompt(timeout_s=15)
+        rec.pause(0.4)
+        rec.caption("")
+
+        win = rec.page.locator("#__term_win").bounding_box()
+        host = rec.page.locator("#__term_host").bounding_box()
+        if win is None or host is None:
+            raise PixelFailure(
+                "terminal: #__term_win/#__term_host has no box - the terminal "
+                "window never rendered"
+            )
+        size = (rec._size["width"], rec._size["height"])
+    return {
+        "card": card,
+        "app": [
+            int(host["x"]),
+            int(host["y"]),
+            int(host["width"]),
+            int(host["height"]),
+        ],
+        "win": [int(win["x"]), int(win["y"]), int(win["width"]), int(win["height"])],
+        "size": list(size),
+    }
+
+
+def record_web(out_dir: Path, base_url: str) -> dict:
+    """The web chrome take: criterion card, interlude, caption, spotlight, park.
+
+    Every pointer verb is held back until the end: the whole front of the take
+    runs with a cursor that has never moved, which is the stretch #351's
+    absence probe needs. The marker records the beat index where that stretch
+    ends, read back off the take's own timeline rather than counted by hand.
+    """
+    from demo_recording import Recorder
+
+    criteria = {"AC-1": "The dashboard shows the current figures."}
+    with Recorder(
+        out_dir,
+        base_url=base_url,
+        speech=False,
+        strict=True,
+        deterministic=True,
+        criteria=criteria,
+    ) as rec:
+        rec.goto("/")
+        rec.wait_for("#kpi-rev")
+        # -- the pointer-free stretch: nothing above or below this comment
+        # moves the cursor until the move_to further down -------------------
+        rec.criterion("AC-1")
+        rec.interlude("")
+        rec.caption("A small dashboard.", ac="AC-1")
+        rec.hold()
+        rec.spotlight("#kpi-rev")
+        rec.hold()
+        rec.spotlight()
+        rec.caption("The pointer has not moved yet.")
+        # -- first pointer verb of the take: the park ------------------------
+        rec.move_to("#refresh")
+        rec.hold()
+        rec.caption("")
+
+        geom = dict(rec._geom)
+        size = (rec._size["width"], rec._size["height"])
+        park = rec.page.locator("#refresh").bounding_box()
+        if park is None:
+            raise PixelFailure("web: #refresh has no box - the page never rendered")
+
+    doc = json.loads((out_dir / "timeline.json").read_text(encoding="utf-8"))
+    beats = doc.get("beats") or []
+    first_pointer = next(
+        (i for i, beat in enumerate(beats) if beat.get("verb") == "move_to"), None
+    )
+    if first_pointer is None:
+        raise PixelFailure(
+            "web: the take logged no move_to beat - the storyboard must keep "
+            "its cursor park, it is what #351 reads the parked disc at"
+        )
+    if first_pointer < MIN_POINTERLESS_BEATS:
+        raise PixelFailure(
+            f"web: the first pointer verb is beat {first_pointer}, under the "
+            f"{MIN_POINTERLESS_BEATS} floor - the pointer-free stretch is too "
+            f"thin for an absence probe to mean anything"
+        )
+    return {
+        "geom": geom,
+        "size": list(size),
+        # The page-space box of the parked element; to_video_rect + geom maps
+        # it into the composite.
+        "park": [
+            int(park["x"]),
+            int(park["y"]),
+            int(park["width"]),
+            int(park["height"]),
+        ],
+        # Beats [0, this) ran with a pointer that had never moved.
+        "no_pointer_until_beat": first_pointer,
+    }
+
+
+RECORD: dict[str, Callable] = {"terminal": record_terminal, "web": record_web}
+
+
+# -- the digest, and the marker beside each take -------------------------------
+
+
+def _digest(pairs: list[tuple[str, bytes]]) -> str:
+    """A hash over (label, bytes), order-independent.
+
+    The label is hashed alongside the bytes, so a rename that leaves the same
+    bytes under a different name is still a different input.
+    """
+    sha = hashlib.sha256()
+    for label, data in sorted(pairs):
+        sha.update(label.encode("utf-8"))
+        sha.update(b"\0")
+        sha.update(data)
+        sha.update(b"\0")
+    return sha.hexdigest()
+
+
+def digest_inputs(
+    name: str, helpers: Path = HELPERS, fixture: Path = FIXTURE
+) -> list[tuple[str, bytes]]:
+    """Everything whose bytes decide what this take's frames look like.
+
+    The recorder, the storyboard, and what the storyboard is recorded against
+    - all three, for the same reason `tests/eval-grader` hashes all three: a
+    key that named only the storyboard would serve pictures of an older
+    recorder while the checks report on today's.
+    """
+    pkg = helpers / "demo_recording"
+    modules = sorted(pkg.glob("*.py"))
+    if len(modules) < MIN_RECORDER_MODULES:
+        raise PixelFailure(
+            f"digest: {pkg} holds {len(modules)} modules, under the "
+            f"{MIN_RECORDER_MODULES} floor - hashing it would key the cache "
+            f"on nothing, and a cache keyed on nothing is warm forever"
+        )
+    pairs = [("demo_recording/" + p.name, p.read_bytes()) for p in modules]
+    pairs.append(("storyboard/" + name, inspect.getsource(RECORD[name]).encode()))
+    if name == "terminal":
+        # The vendored terminal stack, manifest included: the take's screen is
+        # xterm.js's rendering, so its bytes are frame inputs.
+        assets = helpers / "assets" / "xterm"
+        pairs += [
+            ("assets/xterm/" + p.name, p.read_bytes())
+            for p in sorted(assets.iterdir())
+            if p.is_file()
+        ]
+    else:
+        pairs.append(("fixture/index.html", (fixture / "index.html").read_bytes()))
+    return pairs
+
+
+def inputs_digest(name: str, helpers: Path = HELPERS, fixture: Path = FIXTURE) -> str:
+    return _digest(digest_inputs(name, helpers=helpers, fixture=fixture))
+
+
+def marker(take: Path) -> dict | None:
+    """What the last recording of this take was made from, if it said."""
+    try:
+        doc = json.loads((take / MARKER).read_text(encoding="utf-8"))
+    except (FileNotFoundError, ValueError):
+        return None
+    return doc if isinstance(doc, dict) else None
+
+
+def write_marker(take: Path, inputs: str, seconds: float, info: dict) -> None:
+    (take / MARKER).write_text(
+        json.dumps(
+            {
+                "schema": MARKER_SCHEMA,
+                "inputs": inputs,
+                "seconds": seconds,
+                "info": info,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def stale(
+    take: Path, name: str, helpers: Path = HELPERS, fixture: Path = FIXTURE
+) -> bool:
+    """Whether the frames on disk are of a different recorder or storyboard.
+
+    Never fatal anywhere: a stale cache still checks - it is simply checking
+    older pictures, and `check` says so instead of refusing.
+    """
+    doc = marker(take)
+    return not doc or doc.get("inputs") != inputs_digest(
+        name, helpers=helpers, fixture=fixture
+    )
+
+
+# -- the checks ----------------------------------------------------------------
+
+
+def check_complete(take: Path, info: dict | None) -> list[str]:
+    """The slice-2 placeholder: the take exists and has something to read.
+
+    #351 replaces the weight of this with the golden properties; this stays
+    as the floor under them - a property check over a take with no frames
+    would fail for a reason it does not name.
+    """
+    problems = []
+    if not (take / "demo.mp4").is_file():
+        problems.append(f"{take.name}: demo.mp4 is missing")
+    if not (take / "timeline.json").is_file():
+        problems.append(f"{take.name}: timeline.json is missing")
+    pngs = sorted((take / "frames").glob("beat-*.png"))
+    if not pngs:
+        problems.append(f"{take.name}: no review frames under frames/")
+    return problems
+
+
+def recorded(take: Path) -> bool:
+    """Whether there is a complete recording here to check or serve as cached."""
+    return not check_complete(take, None)
+
+
+# The seam #351 fills: one entry per take, each check a function of the take
+# directory and the marker's `info` (the geometry only the recorder knew).
+# Append golden-property checks here; do not fold them into check_complete.
+CHECKS: dict[str, list[Callable[[Path, dict | None], list[str]]]] = {
+    "terminal": [check_complete],
+    "web": [check_complete],
+}
+
+
+# -- recording machinery -------------------------------------------------------
+#
+# `free_port`, `fixture_server` and `scrub_env` are small local copies of
+# tests/smoke's helpers. Deliberately not imported: tests/smoke is a 12k-line
+# executable whose import would drag suite state (and a playwright import)
+# into a loop whose warm path must load neither.
+
+
+def scrub_env() -> None:
+    """Strip every recorder knob out of the environment.
+
+    Same reason as tests/smoke's: a sourced project .env would otherwise
+    record the reference takes at someone's viewport, and the cached frames
+    would mean something different per machine.
+    """
+    for key in [k for k in os.environ if k.startswith("DEMO_VIDEO_")]:
+        del os.environ[key]
+    os.environ.pop("ELEVENLABS_API_KEY", None)
+
+
+def free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@contextmanager
+def fixture_server() -> Iterator[str]:
+    """Serve tests/fixture on an ephemeral port; always shut it down."""
+    if not (FIXTURE / "index.html").is_file():
+        raise PixelFailure(f"fixture app missing: {FIXTURE / 'index.html'}")
+    port = free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "http.server",
+            str(port),
+            "--bind",
+            "127.0.0.1",
+            "--directory",
+            str(FIXTURE),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.monotonic() + SERVER_START_TIMEOUT_S
+        while True:
+            if proc.poll() is not None:
+                raise PixelFailure(
+                    f"fixture server exited immediately (code {proc.returncode})"
+                )
+            try:
+                with urllib.request.urlopen(base_url + "/", timeout=1):
+                    break
+            except (urllib.error.URLError, OSError):
+                if time.monotonic() > deadline:
+                    raise PixelFailure(
+                        f"fixture server not answering on port {port} after "
+                        f"{SERVER_START_TIMEOUT_S:.0f}s"
+                    ) from None
+                time.sleep(0.1)
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:  # pragma: no cover - a wedged server
+            proc.kill()
+
+
+def fresh_take_dir(name: str) -> Path:
+    """An empty directory for one take, deleted only inside the cache.
+
+    No marker dance like tests/smoke's fresh_take_dir: the cache directory is
+    wholly this tool's (gitignored, created here, never a source tree), and a
+    crashed take must be re-recordable without a human deleting anything. The
+    resolve() guard is what keeps a bad TAKES entry from reaping outside it.
+    """
+    take = CACHE / name
+    if CACHE.resolve() not in take.resolve().parents:
+        raise PixelFailure(f"refusing to touch {take}: it is not under {CACHE}")
+    if take.exists():
+        shutil.rmtree(take)
+    take.mkdir(parents=True)
+    return take
+
+
+def cmd_record(force: bool) -> list[str]:
+    """Re-record what is stale or missing; leave the rest alone."""
+    CACHE.mkdir(exist_ok=True)
+    wanted = [
+        n for n in TAKES if force or not recorded(CACHE / n) or stale(CACHE / n, n)
+    ]
+    for name in TAKES:
+        if name not in wanted:
+            print(f"cached {name}")
+    if not wanted:
+        return []
+
+    if shutil.which("ffmpeg") is None or shutil.which("ffprobe") is None:
+        raise PixelFailure(
+            "ffmpeg and ffprobe must be on PATH - the recorders shell out to both"
+        )
+    if not (HELPERS / "demo_recording").is_dir():
+        raise PixelFailure(f"helpers not found at {HELPERS}")
+    if str(HELPERS) not in sys.path:
+        sys.path.insert(0, str(HELPERS))
+    scrub_env()
+
+    problems: list[str] = []
+    for name in wanted:
+        take = fresh_take_dir(name)
+        started = time.monotonic()
+        print(f"recording {name} ...", flush=True)
+        try:
+            if name == "web":
+                with fixture_server() as base_url:
+                    info = RECORD[name](take, base_url)
+            else:
+                info = RECORD[name](take)
+        except Exception as exc:  # noqa: BLE001 - a raising take is a failure
+            problems.append(f"{name}: recording raised {type(exc).__name__}: {exc}")
+            continue
+        missing = check_complete(take, None)
+        if missing:
+            # No marker: a hollow take must read as never recorded, not as
+            # cached - the marker written after success is what keeps a crash
+            # out of the cache (same rule as tests/eval-grader's).
+            problems += missing
+            continue
+        seconds = round(time.monotonic() - started, 1)
+        write_marker(take, inputs_digest(name), seconds, info)
+        print(f"recorded {name} in {seconds:.0f}s")
+    return problems
+
+
+def cmd_check() -> list[str]:
+    """Grade whatever is cached, recording nothing. Staleness is a note."""
+    problems: list[str] = []
+    for name in TAKES:
+        take = CACHE / name
+        if not recorded(take):
+            problems.append(
+                f"{name}: nothing cached at {take} - run tests/pixel (or "
+                f"tests/pixel record) first"
+            )
+            continue
+        if stale(take, name):
+            print(
+                f"note: {name} is stale - its frames predate today's recorder "
+                f"or storyboard; a bare tests/pixel re-records it"
+            )
+        doc = marker(take)
+        info = doc.get("info") if doc else None
+        for check in CHECKS[name]:
+            problems += check(take, info)
+    return problems
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Record and check the cached chrome reference takes."
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=("record", "check"),
+        help="default: record what is stale, then check",
+    )
+    parser.add_argument("--force", action="store_true", help="re-record even if cached")
+    args = parser.parse_args()
+    if args.force and args.command == "check":
+        parser.error("--force records; it has no meaning with `check`")
+
+    print(HEADER)
+    try:
+        if args.command == "record":
+            problems = cmd_record(args.force)
+        elif args.command == "check":
+            problems = cmd_check()
+        else:
+            problems = cmd_record(args.force)
+            problems += cmd_check()
+    except PixelFailure as exc:
+        problems = [str(exc)]
+
+    if problems:
+        print("\npixel: FAILED", file=sys.stderr)
+        for problem in problems:
+            print(f"  - {problem}", file=sys.stderr)
+        return 1
+    print("pixel: OK")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit
+++ b/tests/unit
@@ -3335,6 +3335,221 @@ class VendoredAssets(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
+# The pixel loop's cache arithmetic (tests/pixel, #350)
+# --------------------------------------------------------------------------
+#
+# `tests/pixel` serves cached reference takes off an inputs digest, so the
+# failure worth money here is the catalogue's stale-input pass: a digest that
+# quietly stops covering an input serves yesterday's frames as today's, and
+# every check downstream grades pictures of an older recorder. The digest,
+# staleness and marker arithmetic are functions of paths and bytes, so they
+# are graded here, browser-free, against private copies the tests may edit.
+# The takes themselves, and the checks that read them, are graded by running
+# `tests/pixel`.
+
+PIXEL = Path(os.environ.get("UNIT_PIXEL", REPO / "tests" / "pixel"))
+
+
+def _pixel_module():
+    """`tests/pixel` imported as a module, so its cache arithmetic can be called.
+
+    Importing it runs nothing: main() is behind __main__, the recorders are
+    imported inside the record functions, and everything at module level is a
+    constant. No browser, no playwright import.
+    """
+    import importlib.util
+    from importlib.machinery import SourceFileLoader
+
+    loader = SourceFileLoader("_pixel_under_test", str(PIXEL))
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class PixelCache(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.px = _pixel_module()
+
+    def _tmp(self) -> Path:
+        holder = tempfile.TemporaryDirectory()
+        self.addCleanup(holder.cleanup)
+        return Path(holder.name)
+
+    def editable_inputs(self) -> tuple[Path, Path]:
+        """A private copy of the helpers tree, and a minimal fixture page.
+
+        Copies, because half these tests prove a digest by *editing* an input,
+        and the working tree is not theirs to edit.
+        """
+        tmp = self._tmp()
+        helpers = tmp / "helpers"
+        shutil.copytree(_PKG_PARENT, helpers)
+        fixture = tmp / "fixture"
+        fixture.mkdir()
+        (fixture / "index.html").write_bytes(b"<!doctype html><p>pixel</p>")
+        return helpers, fixture
+
+    def digests(self, helpers: Path, fixture: Path) -> dict:
+        return {
+            name: self.px.inputs_digest(name, helpers=helpers, fixture=fixture)
+            for name in self.px.TAKES
+        }
+
+    def test_every_recorder_module_is_an_input_of_every_take(self):
+        helpers, fixture = self.editable_inputs()
+        modules = {
+            f"demo_recording/{p.name}"
+            for p in (helpers / "demo_recording").glob("*.py")
+        }
+        # The haystack, before anything is claimed about it.
+        self.assertGreaterEqual(
+            len(modules),
+            self.px.MIN_RECORDER_MODULES,
+            "the recorder package was not read; every claim below would hold "
+            "over an empty set",
+        )
+        for name in self.px.TAKES:
+            labels = {
+                label
+                for label, _ in self.px.digest_inputs(
+                    name, helpers=helpers, fixture=fixture
+                )
+            }
+            self.assertEqual(
+                sorted(modules - labels),
+                [],
+                f"{name}: recorder modules missing from its cache key - an "
+                f"edit to any of these would be served stale frames as cached",
+            )
+            self.assertIn(
+                f"storyboard/{name}",
+                labels,
+                f"{name}: its own storyboard source is not a cache input",
+            )
+
+    def test_a_one_byte_helpers_change_changes_both_digests(self):
+        helpers, fixture = self.editable_inputs()
+        before = self.digests(helpers, fixture)
+        core = helpers / "demo_recording" / "core.py"
+        core.write_bytes(core.read_bytes() + b"#")
+        after = self.digests(helpers, fixture)
+        for name in self.px.TAKES:
+            self.assertNotEqual(
+                before[name],
+                after[name],
+                f"{name}: one byte appended to core.py left its digest "
+                f"unchanged - the recorder's bytes are not in the key, which "
+                f"is the stale-input pass",
+            )
+
+    def test_the_fixture_page_is_a_web_only_input(self):
+        helpers, fixture = self.editable_inputs()
+        before = self.digests(helpers, fixture)
+        page = fixture / "index.html"
+        page.write_bytes(page.read_bytes() + b"<!-- x -->")
+        after = self.digests(helpers, fixture)
+        self.assertNotEqual(before["web"], after["web"])
+        self.assertEqual(
+            before["terminal"],
+            after["terminal"],
+            "a fixture edit invalidated the terminal take, which never loads "
+            "the fixture - the whole point of per-take digests is re-recording "
+            "only what the change can reach",
+        )
+
+    def test_the_vendored_terminal_stack_is_a_terminal_only_input(self):
+        helpers, fixture = self.editable_inputs()
+        labels = {
+            label
+            for label, _ in self.px.digest_inputs(
+                "terminal", helpers=helpers, fixture=fixture
+            )
+        }
+        for wanted in ("assets/xterm/xterm.js", "assets/xterm/VERSIONS.txt"):
+            self.assertIn(wanted, labels)
+        before = self.digests(helpers, fixture)
+        xterm = helpers / "assets" / "xterm" / "xterm.js"
+        xterm.write_bytes(xterm.read_bytes() + b"\n// x")
+        after = self.digests(helpers, fixture)
+        self.assertNotEqual(before["terminal"], after["terminal"])
+        self.assertEqual(before["web"], after["web"])
+
+    def test_a_take_with_no_marker_or_a_garbage_one_is_stale(self):
+        helpers, fixture = self.editable_inputs()
+        take = self._tmp() / "web"
+        take.mkdir()
+
+        def is_stale() -> bool:
+            return self.px.stale(take, "web", helpers=helpers, fixture=fixture)
+
+        self.assertTrue(is_stale(), "a take with no marker read as cached")
+        (take / self.px.MARKER).write_text("not json")
+        self.assertTrue(is_stale(), "an unreadable marker read as cached")
+        (take / self.px.MARKER).write_text("[]")
+        self.assertTrue(is_stale(), "a non-object marker read as cached")
+
+    def test_freshness_is_the_digest_and_nothing_else(self):
+        helpers, fixture = self.editable_inputs()
+        take = self._tmp() / "web"
+        take.mkdir()
+        good = self.px.inputs_digest("web", helpers=helpers, fixture=fixture)
+        self.px.write_marker(take, good, 1.0, {})
+        self.assertFalse(self.px.stale(take, "web", helpers=helpers, fixture=fixture))
+        self.px.write_marker(take, "0" * 64, 1.0, {})
+        self.assertTrue(self.px.stale(take, "web", helpers=helpers, fixture=fixture))
+
+    def test_the_marker_round_trips_what_slice_3_will_read(self):
+        take = self._tmp() / "web"
+        take.mkdir()
+        self.px.write_marker(take, "d" * 64, 2.5, {"no_pointer_until_beat": 10})
+        doc = self.px.marker(take)
+        self.assertEqual(doc["schema"], self.px.MARKER_SCHEMA)
+        self.assertEqual(doc["inputs"], "d" * 64)
+        self.assertEqual(doc["info"]["no_pointer_until_beat"], 10)
+
+    def test_check_complete_names_each_missing_artifact(self):
+        take = self._tmp() / "terminal"
+        take.mkdir()
+        problems = self.px.check_complete(take, None)
+        for artifact in ("demo.mp4", "timeline.json", "review frames"):
+            self.assertTrue(
+                any(artifact in problem for problem in problems),
+                f"an empty take dir raised no problem naming {artifact}",
+            )
+        self.assertFalse(self.px.recorded(take))
+        (take / "demo.mp4").write_bytes(b"x")
+        (take / "timeline.json").write_text("{}")
+        (take / "frames").mkdir()
+        (take / "frames" / "beat-00.png").write_bytes(b"x")
+        self.assertEqual(self.px.check_complete(take, None), [])
+        self.assertTrue(self.px.recorded(take))
+
+    def test_the_loop_never_touches_the_smoke_lock(self):
+        """The no-lock contract, held as an absence in the source itself.
+
+        Scoped to the code: the module docstring names the lock path in order
+        to say why this loop has no claim to it, so the sweep reads the source
+        with that docstring taken out. The haystack floor keeps a truncated
+        read from making the absence trivial.
+        """
+        source = PIXEL.read_text(encoding="utf-8")
+        docstring = ast.get_docstring(ast.parse(source)) or ""
+        self.assertGreater(len(docstring), 100, f"{PIXEL} has no docstring")
+        body = source.replace(docstring, "")
+        self.assertGreater(len(body), 5000, f"{PIXEL} was not read")
+        for needle in ("fcntl", "flock", "demo-video-smoke"):
+            self.assertNotIn(
+                needle,
+                body,
+                f"tests/pixel's code mentions {needle!r} - the loop's "
+                f"contract is that it never takes or creates a suite lock",
+            )
+        self.assertIn("lock", self.px.HEADER, "the header stopped saying why")
+
+
+# --------------------------------------------------------------------------
 # What a recorder refuses to be pointed at (target.py)
 # --------------------------------------------------------------------------
 #
@@ -10846,6 +11061,39 @@ _CURSOR_LISTENS_AT_DOMCONTENTLOADED = """\
 
 # (name, module, exact text to replace, replacement, tests that must then fail)
 INJECTIONS = [
+    # -- the pixel loop's cache key (tests/pixel, #350) -----------------------
+    (
+        # The stale-input pass, exactly: the digest still names every recorder
+        # module but hashes none of their bytes, so a helpers edit is served
+        # yesterday's frames as "cached" and every downstream check grades
+        # pictures of an older recorder. Shown live in #350's pull request;
+        # this keeps it caught after that PR is forgotten.
+        "the pixel cache digest stops reading the recorder's bytes",
+        "tests/pixel",
+        '    pairs = [("demo_recording/" + p.name, p.read_bytes()) for p in modules]',
+        '    pairs = [("demo_recording/" + p.name, b"") for p in modules]',
+        ["PixelCache.test_a_one_byte_helpers_change_changes_both_digests"],
+    ),
+    (
+        # A take that was never recorded, or whose marker did not survive,
+        # served as warm. `record` then never re-records it and `check` grades
+        # whatever is lying in the directory.
+        "a pixel take with no marker is served as cached",
+        "tests/pixel",
+        '    return not doc or doc.get("inputs") != inputs_digest(',
+        '    return bool(doc) and doc.get("inputs") != inputs_digest(',
+        ["PixelCache.test_a_take_with_no_marker_or_a_garbage_one_is_stale"],
+    ),
+    (
+        # The completeness floor under the future golden properties: a take
+        # with no review frames passes, so a crash that wrote demo.mp4 and
+        # timeline.json but died before the frames still reads as complete.
+        "the pixel completeness check passes a take with no review frames",
+        "tests/pixel",
+        "    if not pngs:",
+        "    if pngs is None:",
+        ["PixelCache.test_check_complete_names_each_missing_artifact"],
+    ),
     (
         # **The defect issue #226 is about**, restored exactly: each clip mixed
         # at the offset the beat log recorded, on a video that is not on that
@@ -15269,6 +15517,11 @@ def fault_inject() -> int:
             # decision nobody has watched go the wrong way is a claim.
             smoke_inject = Path(tmp) / "smoke-inject"
             shutil.copy(REPO / "tests" / "smoke-inject", smoke_inject)
+            # ...and the pixel loop, whose cache arithmetic three injections
+            # above break. `PixelCache` resolves it through UNIT_PIXEL for the
+            # same reason everything else here is an environment variable.
+            pixel = Path(tmp) / "pixel"
+            shutil.copy(REPO / "tests" / "pixel", pixel)
             # ...and this suite's own README, which used to be read straight
             # out of the working tree. It carries prose that assertions here
             # grade — a stated figure, and the explanation of a positive skew
@@ -15294,6 +15547,9 @@ def fault_inject() -> int:
                 # Before the `"/" in module` branch below, which would send it
                 # into the skill directory and fail on a file that is not there.
                 target = smoke_inject
+            elif module == "tests/pixel":
+                # Same reason: a path with a "/" that is not under the skill.
+                target = pixel
             elif module == "tests/README.md":
                 # Before the `.md` branch below, which would look for it under
                 # the skill directory.
@@ -15331,6 +15587,7 @@ def fault_inject() -> int:
                     "UNIT_SKILL_DIR": str(skill),
                     "UNIT_SMOKE": str(smoke),
                     "UNIT_SMOKE_INJECT": str(smoke_inject),
+                    "UNIT_PIXEL": str(pixel),
                     "UNIT_README": str(readme),
                     "UNIT_EXAMPLES": str(examples),
                 },


### PR DESCRIPTION
Slice 2 of #324 (design record in that issue's comments). Closes #350.

## What this adds

`tests/pixel` records two short chrome reference takes into the gitignored `tests/.pixel-cache/` and serves them off an inputs digest.
It is the iteration loop, not a gate: it is not in CI.

- `terminal`: a segment opened on its title card, two commands, about:blank, no server. 13.8 s of video.
- `web`: criterion card, interlude, caption, spotlight and a cursor park against `tests/fixture` on an ephemeral port, `deterministic=True`. 14.8 s of video. Every pointer verb is held to the end; the marker records `no_pointer_until_beat: 10` so #351 can probe cursor absence over the front stretch without a third take.

The digest hashes (label, bytes) of every `helpers/demo_recording/*.py`, each take's own storyboard function source, and per take the vendored xterm assets or the fixture page.
The marker is written only after a completeness check passes, so a crashed take is never served as cached.

No lock: the smoke lock protects time-measuring bars under encoder contention (#78); every reading this loop makes is colour or geometry off frames already on disk, so it takes no lock and creates none.
A unit test holds that as an absence in the source (`PixelCache.test_the_loop_never_touches_the_smoke_lock`).

## Acceptance, measured

- **Cold**: both takes record and exit green. 41.9-51.4 s wall for both (terminal ~20 s, web ~23 s), 2.7 MB on disk.
- **Warm**: 0.12-0.14 s wall, prints `cached terminal` / `cached web`, exits 0. Under `PLAYWRIGHT_BROWSERS_PATH=/nonexistent` the warm run is still green; the control (same env, one marker removed) went `pixel: FAILED` trying to launch Chromium, so the env var is live and the warm green means no browser started.
- **One-byte helpers change re-records**: `printf '# probe' >> core.py` re-recorded both takes. A one-byte `tests/fixture/index.html` change re-recorded **web only**, terminal stayed cached. A storyboard edit alone also re-recorded (observed when trimming the takes).

## The invalidation assertion, seen red

Break: the digest keeps every module's *name* but hashes none of its *bytes* (`p.read_bytes()` -> `b""`), confirmed to land exactly once. With the cache settled under the break, a one-byte `core.py` edit produced the false verdict:

```
== one-byte helpers edit under the broken digest ==
cached terminal
cached web
pixel: OK
```

Break undone, same cache, same edit:

```
recording terminal ...
recorded terminal in 20s
recording web ...
recorded web in 23s
pixel: OK
```

The same break is now permanent as an `INJECTIONS` entry, with two more:

```
PASS  break: the pixel cache digest stops reading the recorder's bytes
      FAIL: test_a_one_byte_helpers_change_changes_both_digests
PASS  break: a pixel take with no marker is served as cached
      FAIL: test_a_take_with_no_marker_or_a_garbage_one_is_stale
PASS  break: the pixel completeness check passes a take with no review frames
      FAIL: test_check_complete_names_each_missing_artifact
```

`tests/unit --fault-inject`: all 338 injections were caught. `tests/unit`: 521 tests, OK. `tests/lint`: exit 0.

## Stated limits

- `check` today grades only completeness (demo.mp4, timeline.json, >0 review frames). The golden properties are #351; the seam is the `CHECKS` registry.
- The web digest hashes `tests/fixture/index.html` only, not `entropy-worker.js` - the reference storyboard never starts the worker, but an index.html edit that changes how it loads the worker still re-records, since index.html itself is hashed.
- `free_port`/`fixture_server`/`scrub_env` are small local copies of tests/smoke's helpers, deliberately not imported: tests/smoke is a 12k-line executable whose import would drag suite state into a loop whose warm path must load nothing heavy.
- Storyboard constants must live inside the record functions (the digest hashes function source only); a comment in the file says so.
- Terminal take is 13.8 s against the issue's ~8-12 s sketch: 2.5 s card hold plus two visibly-typed commands is the floor of the shape.
- On this WSL2 box the host clock stepped during two of the demonstration recordings (the recorder's `capture_clock` warning, #245); harmless here since nothing in this slice reads timing.
- tests/smoke was not re-run: this change touches none of its inputs (recorder untouched, tests/smoke untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
