### PR TITLE
Tell the agent to run the pixel loop before it says done

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,18 @@ The skill's catalogue of *measurements that grade nothing* is the reviewer's
 checklist. Every entry in it came from a change in this repo that had green CI
 and an honest author.
 
+### A change to a rendered frame runs `tests/pixel` first
+
+Some changes move what a viewer sees: the chrome in
+`skills/demo-video/helpers/demo_recording/` — captions, cards, cursor,
+spotlight, framing. Before such a change opens its pull request, run
+`tests/pixel` (#324). Put its pass/fail lines in the PR body. For anything
+that changed on purpose, attach `--dump` frames from before and after.
+
+The loop takes no lock, and a warm run measures ~2 s, so not running it is
+the odd choice. It is the iteration loop, not the gate — `tests/smoke` in CI
+stays the gate.
+
 ### Where an eval replaces the injections
 
 **Code whose correctness is measured by an eval does not also owe injections.**

--- a/GOAL.md
+++ b/GOAL.md
@@ -67,7 +67,8 @@ and not the product.
   Arbitrating a value across screenshots, or comparing two hex codes by eye, is
   the harness's job, and a human doing it is a bug in the harness. **Asking one
   whether the result reads right is not that.** The harness answers what the
-  value *is*; only a person answers whether it *works* — #291 was a card the
+  value *is* (`tests/pixel`, for the recorder's chrome, warm in seconds); only
+  a person answers whether it *works* — #291 was a card the
   harness measured correctly, 1.3 luma levels of separation with every
   assertion green, that a viewer watching read as a terminal window
   (`skills/demo-video/reference/review.md`). Do not route that question away

--- a/tests/README.md
+++ b/tests/README.md
@@ -101,6 +101,12 @@ caption timing are time-measuring and belong to smoke's lock; whether a
 viewer *recognises* the card as a card is graded nowhere (Known gaps); and
 `frames.md` ordering is manifest arithmetic, owned by
 [#300](https://github.com/rogvid/skills/issues/300).
+The contract: a change to anything that draws a frame - the chrome in
+`skills/demo-video/helpers/demo_recording/` - runs this loop before its PR
+opens and pastes its lines and `--dump` frames there (`AGENTS.md`, "A change
+to a rendered frame runs `tests/pixel` first"). And it never replaces `smoke`
+as the gate: CI merges on `smoke`'s verdict, and the time-measuring bars stay
+under `smoke`'s lock.
 Its cache arithmetic - digest, staleness, marker - is graded browser-free in
 `unit` (`PixelCache`), and the checks' pure arithmetic - the opening
 classifier, the card-stretch locator, the accent predicate and centroid, the


### PR DESCRIPTION
Slice 4 of #324. Fixes #352. Doc-only, ordinary read, one round.

Three files, each naming the loop and its trigger:

- **AGENTS.md** (CLAUDE.md symlinks to it): new subsection under Reviewing — a change to the chrome in `skills/demo-video/helpers/demo_recording/` (captions, cards, cursor, spotlight, framing) runs `tests/pixel` before the PR opens, pastes its pass/fail lines, and attaches `--dump` before/after frames for anything changed on purpose. No lock, warm ~2 s.
- **tests/README.md**: the pixel section gains its contract line — the trigger, the pointer to the AGENTS.md rule, and that the loop never replaces `smoke` as the gate (time-measuring bars stay under smoke's lock).
- **GOAL.md**: the "never ask a human to measure a pixel" rule gets its harness citation — one clause naming `tests/pixel` as the tool that answers what the value *is*.

Numbers quoted are from a run on this branch: warm `./tests/pixel` measured 2.0 s, printed `cached terminal` / `cached web`, `pixel: 6 checks, 0 failing`.

Verified: `tests/lint` OK, `tests/ci-unit` OK, `tests/unit` 528 tests OK.

Stated limit: the tree diagram in tests/README.md says "warm ~0.1 s" where the prose above it says "measured 2.2 s" and this run measured 2.0 s. Pre-existing, not touched — the prose figure is the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)