### PR TITLE
Wrapper takes: the web app records in an iframe on a recorder-owned page, caption in its own band below the app rect (#358)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -237,7 +237,7 @@ three it is not the variable lowercased, so do not infer it:
 | `DEMO_VIDEO_LOCALE` | `locale` — browser locale, always applied | `en-US` |
 | `DEMO_VIDEO_SPEECH` | `speech` — force narration on/off (`1`/`0`). **`speech=False` records silently even with a key set**; with no key it is off already, and forcing it *on* without one refuses the take | auto by API key |
 | `DEMO_VIDEO_STRICT` | `strict` — fail the take on console errors / non-zero exits (`1`/`0`) | off |
-| `DEMO_VIDEO_WRAPPER` | `wrapper` — record the web app in an iframe on a recorder-owned page: chrome in the recording, caption in its own band below the app, no exit composite. `rec.page` stays the wrapper page; `rec.app` is the app's document. Refuses apps sending `X-Frame-Options`/CSP `frame-ancestors`. Transitional (#358; #361 makes it the default) | off |
+| `DEMO_VIDEO_WRAPPER` | `wrapper` — record the web app in an iframe on a recorder-owned page: chrome in the recording, caption in its own band below the app, no exit composite. `rec.page` stays the wrapper page; `rec.app` is the app's document. The cursor dot is verb-driven, so raw `rec.page.mouse` work moves it nowhere; a caption taller than its band is clipped and recorded as a `caption_clipped` issue. Refuses apps sending `X-Frame-Options`/CSP `frame-ancestors`. Transitional (#358; #361 makes it the default) | off |
 | `DEMO_VIDEO_EVIDENCE` | `evidence` — write `evidence/beat-NN.json` per beat (`1`/`0`) — see [reference/review.md](reference/review.md) | **on** |
 | `DEMO_VIDEO_VOICE_ID` | `voice_id` — ElevenLabs voice | Sarah (premade) |
 | `DEMO_VIDEO_SPEECH_MODEL` | `speech_model` — ElevenLabs model | `eleven_multilingual_v2` |

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -237,6 +237,7 @@ three it is not the variable lowercased, so do not infer it:
 | `DEMO_VIDEO_LOCALE` | `locale` — browser locale, always applied | `en-US` |
 | `DEMO_VIDEO_SPEECH` | `speech` — force narration on/off (`1`/`0`). **`speech=False` records silently even with a key set**; with no key it is off already, and forcing it *on* without one refuses the take | auto by API key |
 | `DEMO_VIDEO_STRICT` | `strict` — fail the take on console errors / non-zero exits (`1`/`0`) | off |
+| `DEMO_VIDEO_WRAPPER` | `wrapper` — record the web app in an iframe on a recorder-owned page: chrome in the recording, caption in its own band below the app, no exit composite. `rec.page` stays the wrapper page; `rec.app` is the app's document. Refuses apps sending `X-Frame-Options`/CSP `frame-ancestors`. Transitional (#358; #361 makes it the default) | off |
 | `DEMO_VIDEO_EVIDENCE` | `evidence` — write `evidence/beat-NN.json` per beat (`1`/`0`) — see [reference/review.md](reference/review.md) | **on** |
 | `DEMO_VIDEO_VOICE_ID` | `voice_id` — ElevenLabs voice | Sarah (premade) |
 | `DEMO_VIDEO_SPEECH_MODEL` | `speech_model` — ElevenLabs model | `eleven_multilingual_v2` |

--- a/skills/demo-video/helpers/demo_recording/chrome.py
+++ b/skills/demo-video/helpers/demo_recording/chrome.py
@@ -1,0 +1,244 @@
+"""The wrapper take's window chrome — one source for the frame both media share.
+
+Issue #358 (design record: #355). A wrapper take records a recorder-owned
+page carrying the window chrome: the pastel background, the dark rounded
+window with its title bar and traffic lights, a **content slot** the medium
+fills (the web recorder mounts the app iframe in it; #362 mounts xterm.js in
+the same slot), a **caption band** reserved BELOW the slot, and an empty card
+layer #360 will use. By construction the slot and the band share no pixels —
+`chrome_geometry` is the arithmetic behind that sentence, and `tests/unit`
+grades it while `tests/smoke --wrapper-only` reads the same claim out of a
+recorded take's frames.
+
+Every visual constant here is ported from `web._FRAME_HTML` and
+`terminal._TERM_HOST_JS`, which stay untouched while the legacy composite
+path exists; #361 and #362 retire those copies. The window body colour is
+**not** declared here — it stays `core.WEB_WINDOW_BODY`, because the interlude
+card's compensated colour (`core.WEB_CARD_BODY`, #291/#301) is documented
+against it and the two must be read together.
+"""
+
+from __future__ import annotations
+
+# The pastel gradient behind the window. The same string web.py and
+# terminal.py paint today (`_WEB_BG`, `_TERM_BG`); this copy is the one the
+# wrapper path reads, and the one that survives #361/#362.
+CHROME_BG = "linear-gradient(135deg, #f6d5f0 0%, #d7e3fb 52%, #cdeede 100%)"
+
+# Title bar: height, fill and text colour, and the three traffic lights —
+# ported from `_FRAME_HTML` (web) which `_TERM_HOST_JS` (terminal) matches.
+CHROME_BAR_PX = 36
+CHROME_BAR_BG = "#232334"
+CHROME_BAR_FG = "#9399b2"
+TRAFFIC_LIGHTS = ("#ff5f57", "#febc2e", "#28c840")
+
+# The pad the window keeps around the content slot, so its rounded corners
+# stay visible — `_frame_geometry`'s 14, ported.
+CHROME_PAD_PX = 14
+
+# The caption band reserved below the content slot, inside the window. Sized
+# for two lines of the wrapper caption font (2 x 26px x 1.36 line height +
+# the bubble's 24px vertical padding = 95): a caption that needs a third line
+# is clipped by the band rather than allowed to grow over the app — the whole
+# point of the band is that the app never shares a pixel with the caption.
+CAPTION_BAND_PX = 96
+
+# The wrapper caption's font size. The composite path renders captions at
+# 34px because ffmpeg scales the page by ~0.8 into the window (~27px on
+# screen); the wrapper page is recorded at true pixel size, so the caption
+# uses the base 26px directly — the same effective size the terminal
+# recorder's captions have. No compensation, because there is no scale.
+CAPTION_FONT_PX = 26
+
+# Element ids. The slot is what a medium fills; the band holds the caption
+# element; the card layer is #360's mount point and ships empty this slice.
+# The caption element deliberately keeps the id `core._CAPTION_JS` uses, so
+# "the caption element" is one selector whichever path drew it. The cursor
+# dot keeps `web._CURSOR_JS`'s id for the same reason.
+SLOT_ID = "__chrome_slot"
+BAND_ID = "__chrome_band"
+CARD_ID = "__chrome_card"
+CAPTION_ID = "__demo_caption"
+CURSOR_ID = "__demo_cursor"
+
+
+def chrome_geometry(
+    width: int,
+    height: int,
+    *,
+    pad: int = CHROME_PAD_PX,
+    bar: int = CHROME_BAR_PX,
+    band: int = CAPTION_BAND_PX,
+) -> dict:
+    """Where the window, the content slot and the caption band sit.
+
+    All in recorded-frame pixels — the wrapper page is the video, unscaled.
+    The slot is `int(width * 0.80)` wide (the composite's app width, kept so
+    the window is the size viewers already know) and `int(height * 2/3)`
+    tall, both forced even for the encoder. The band sits directly below the
+    slot: `bandy == appy + apph`, so the two rectangles are disjoint by
+    construction — the property `tests/unit` asserts on this function and
+    `tests/smoke` asserts on the pixels.
+
+    The `app*`/`win*` keys deliberately match `Recorder._frame_geometry`'s,
+    so `_content_rect` and every geometry consumer reads one shape.
+    """
+    appw = int(width * 0.80) & ~1
+    apph = int(height * 2 / 3) & ~1
+    winw = appw + 2 * pad
+    winh = bar + pad + apph + band + pad
+    winx = (width - winw) // 2
+    winy = (height - winh) // 2
+    if winx < 0 or winy < 0:
+        raise ValueError(
+            f"a {width}x{height} viewport cannot hold the wrapper chrome: the "
+            f"window would be {winw}x{winh}. Use a viewport of at least "
+            f"{winw}x{winh}."
+        )
+    return {
+        "pad": pad,
+        "bar": bar,
+        "band": band,
+        "appw": appw,
+        "apph": apph,
+        "winw": winw,
+        "winh": winh,
+        "winx": winx,
+        "winy": winy,
+        "appx": winx + pad,
+        "appy": winy + bar + pad,
+        "bandx": winx + pad,
+        "bandy": winy + bar + pad + apph,
+        "bandw": appw,
+        "bandh": band,
+    }
+
+
+# The wrapper document. Substitutions are literal tokens, same pattern as
+# `web._FRAME_HTML`. The inline <script> runs after the recorder's context
+# init scripts (init scripts run at document_start), so the band-aware
+# `__demoCaption` below is the one `caption()` reaches in this document —
+# core's fixed-bottom overlay version never paints here.
+#
+# The cursor dot is the wrapper document's, riding *over* the iframe, so an
+# app navigation cannot destroy it (the wrapper never navigates). It is
+# driven explicitly by the recorder — `__demoChromeCursor(x, y)` per pointer
+# step — never by mouse events: events over the iframe are delivered to the
+# iframe's document and no wrapper listener can hear them, and a dot that
+# only moves when the storyboard says so is structurally immune to the
+# synthetic-mousemove race of #186.
+_CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
+<style>
+  html, body { margin: 0; height: 100%; }
+  body { background: __BG__; }
+  #__chrome_win { position: fixed; left: __WINX__px; top: __WINY__px;
+    width: __WINW__px; height: __WINH__px; border-radius: 14px;
+    overflow: hidden; background: __WINBG__;
+    box-shadow: 0 34px 90px rgba(20,16,40,.40), 0 8px 22px rgba(20,16,40,.28); }
+  #__chrome_bar { height: __BAR__px; display: flex; align-items: center;
+    gap: 8px; padding: 0 14px; background: __BARBG__;
+    font: 13px/1 ui-monospace, monospace; color: __BARFG__; }
+  .dot { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
+  #__chrome_ttl { flex: 1; text-align: center; letter-spacing: .02em; }
+  #__chrome_slot { position: absolute; left: __PAD__px;
+    top: __SLOTTOP__px; width: __APPW__px; height: __APPH__px;
+    overflow: hidden; }
+  #__chrome_slot iframe { display: block; border: 0;
+    width: __APPW__px; height: __APPH__px; }
+  #__chrome_band { position: absolute; left: __PAD__px; top: __BANDTOP__px;
+    width: __APPW__px; height: __BAND__px; overflow: hidden;
+    display: flex; align-items: center; justify-content: center; }
+  #__demo_caption { max-width: 90%; padding: 12px 30px; border-radius: 12px;
+    background: rgba(22,20,16,.72); backdrop-filter: blur(3px);
+    color: #f7f4ee; text-align: center;
+    font: 600 __CAPFONT__px/1.36 system-ui, sans-serif; letter-spacing: .01em;
+    pointer-events: none; opacity: 0;
+    transition: opacity .3s ease; box-shadow: 0 6px 24px rgba(0,0,0,.28); }
+  #__chrome_card { position: absolute; inset: 0; display: none; }
+  #__demo_cursor { position: fixed; top: -40px; left: -40px; width: 18px;
+    height: 18px; border-radius: 50%; background: rgba(__ACCENT__,.45);
+    border: 2px solid rgba(__ACCENT__,.95); pointer-events: none;
+    z-index: 2147483647; transform: translate(-50%,-50%);
+    transition: width .1s, height .1s; }
+  #__demo_cursor.__down { width: 12px; height: 12px; }
+</style>
+<div id="__chrome_win">
+  <div id="__chrome_bar">
+    <span class="dot" style="background:__DOT1__"></span>
+    <span class="dot" style="background:__DOT2__"></span>
+    <span class="dot" style="background:__DOT3__"></span>
+    <span id="__chrome_ttl">__TITLE__</span>
+    <span style="width:44px"></span>
+  </div>
+  <div id="__chrome_slot"></div>
+  <div id="__chrome_band"><div id="__demo_caption"></div></div>
+  <div id="__chrome_card"></div>
+</div>
+<div id="__demo_cursor"></div>
+<script>
+  window.__demoCaption = (text) => {
+    const el = document.getElementById('__demo_caption');
+    el.textContent = text;
+    el.style.opacity = text ? '1' : '0';
+  };
+  window.__demoChromeCursor = (x, y) => {
+    const dot = document.getElementById('__demo_cursor');
+    dot.style.left = x + 'px';
+    dot.style.top = y + 'px';
+  };
+  window.__demoChromeCursorDown = () => {
+    document.getElementById('__demo_cursor').classList.add('__down');
+  };
+  window.__demoChromeCursorUp = () => {
+    document.getElementById('__demo_cursor').classList.remove('__down');
+  };
+</script>
+"""
+
+
+def chrome_html(
+    geom: dict,
+    *,
+    title: str,
+    window_body: str,
+    accent: str,
+    background: str = CHROME_BG,
+    caption_font_px: int = CAPTION_FONT_PX,
+) -> str:
+    """The wrapper document, ready for `page.set_content`.
+
+    `geom` is `chrome_geometry`'s dict. `window_body` is the window's fill —
+    `core.WEB_WINDOW_BODY` for the web path (see this module's docstring for
+    why it is not declared here). `accent` is the recorder's `R,G,B` string,
+    used only by the cursor dot. The slot ships empty: the medium mounts its
+    content (an iframe, or #362's xterm host) into `#__chrome_slot`.
+    """
+    slot_top = geom["bar"] + geom["pad"]
+    band_top = slot_top + geom["apph"]
+    replacements = {
+        "__TITLE__": title,
+        "__BG__": background,
+        "__WINBG__": window_body,
+        "__BARBG__": CHROME_BAR_BG,
+        "__BARFG__": CHROME_BAR_FG,
+        "__DOT1__": TRAFFIC_LIGHTS[0],
+        "__DOT2__": TRAFFIC_LIGHTS[1],
+        "__DOT3__": TRAFFIC_LIGHTS[2],
+        "__WINX__": str(geom["winx"]),
+        "__WINY__": str(geom["winy"]),
+        "__WINW__": str(geom["winw"]),
+        "__WINH__": str(geom["winh"]),
+        "__BAR__": str(geom["bar"]),
+        "__PAD__": str(geom["pad"]),
+        "__SLOTTOP__": str(slot_top),
+        "__BANDTOP__": str(band_top),
+        "__APPW__": str(geom["appw"]),
+        "__APPH__": str(geom["apph"]),
+        "__BAND__": str(geom["band"]),
+        "__CAPFONT__": str(caption_font_px),
+        "__ACCENT__": accent,
+    }
+    html = _CHROME_HTML
+    for token, value in replacements.items():
+        html = html.replace(token, value)
+    return html

--- a/skills/demo-video/helpers/demo_recording/chrome.py
+++ b/skills/demo-video/helpers/demo_recording/chrome.py
@@ -6,8 +6,9 @@ window with its title bar and traffic lights, a **content slot** the medium
 fills (the web recorder mounts the app iframe in it; #362 mounts xterm.js in
 the same slot), a **caption band** reserved BELOW the slot, and an empty card
 layer #360 will use. By construction the slot and the band share no pixels —
-`chrome_geometry` is the arithmetic behind that sentence, and `tests/unit`
-grades it while `tests/smoke --wrapper-only` reads the same claim out of a
+`chrome_geometry` is the arithmetic behind that sentence. This repository's
+`tests/unit` (not shipped with the installed skill) grades it, and this
+repository's `tests/smoke --wrapper-only` reads the same claim out of a
 recorded take's frames.
 
 Every visual constant here is ported from `web._FRAME_HTML` and
@@ -180,6 +181,15 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
     const el = document.getElementById('__demo_caption');
     el.textContent = text;
     el.style.opacity = text ? '1' : '0';
+    // How many pixels of this caption the band cannot show. The band has a
+    // fixed height and overflow: hidden — the construction that keeps the
+    // app rect caption-free — so a line too tall for it is shaved at the
+    // band's edges. The recorder records that as a caption_clipped issue
+    // (core.caption reads this return value); the in-page overlay version
+    // of this function grows with its text and returns nothing.
+    if (!text) return 0;
+    const band = document.getElementById('__chrome_band');
+    return Math.max(0, el.scrollHeight - band.clientHeight);
   };
   window.__demoChromeCursor = (x, y) => {
     const dot = document.getElementById('__demo_cursor');

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -2599,10 +2599,44 @@ take with fewer beats than the last one would otherwise leave the
         # that timestamp expects to see.
         clip = self._prepare_line(text)
         with self._beat("caption", caption=text, **_ac_field(claims)):
-            self.page.evaluate("t => window.__demoCaption(t)", text)
+            clipped = self.page.evaluate("t => window.__demoCaption(t)", text)
+            self._note_caption_clipped(text, clipped)
             self._caption = text
             self._start_line(clip)
             self.pause(self._caption_hold(text))
+
+    def _note_caption_clipped(self, text: str, clipped: object) -> None:
+        """A caption surface that measured itself clipped gets written down.
+
+        Only the wrapper chrome's `__demoCaption` (chrome.py, #358) returns a
+        number: its caption band has a fixed height and `overflow: hidden` —
+        the construction that keeps the app rect caption-free — so a caption
+        too tall for the band is shaved at the band's edges while the beat
+        log records the full sentence. Without this, that is `timeline.json`
+        claiming a line the pixels do not show: measured on a 174-character
+        caption, the band's flex centring shaved ~17 px off the top of the
+        first line and the bottom of the third, `warnings` stayed empty and a
+        strict take stayed green. The in-page overlay `_CAPTION_JS` grows
+        with its text and returns nothing, so nothing fires off this path.
+
+        The text is deliberately **not** capped or reflowed — the honest
+        artifact is the point. An issue rather than a refusal, and not in
+        `STRICT_KINDS`: like `caption_lost` (#180), this is the storyboard's
+        mistake, not the app saying it is broken. Attributed to the caption
+        beat explicitly — it is the beat that painted the line.
+        """
+        if not isinstance(clipped, (int, float)) or clipped <= 0:
+            return
+        beat = self._beats[-1] if self._in_beat and self._beats else None
+        self._note_issue(
+            "caption_clipped",
+            f"the caption {text!r} is {round(clipped)}px taller than the "
+            f"caption band, so the band's edges shave its first and last "
+            f"lines and the frames do not show the sentence the beat log "
+            f"records — shorten the line, or split it over two captions",
+            beat=beat,
+            clipped_px=round(clipped),
+        )
 
     def _caption_hold(self, text: str) -> float:
         """Minimum time a caption stays up. With speech on, the spoken line's

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -22,6 +22,7 @@ actual CLI or TUI, use `TerminalRecorder` instead (see terminal.py).
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 import time
@@ -30,8 +31,16 @@ from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import urlparse
 
+from .chrome import chrome_geometry, chrome_html
 from .content import OPENING_HOLD_LIMIT_S, content_rect, opening_gap
-from .core import INTERLUDE_CSS_WEB, WEB_WINDOW_BODY, _beat_verb, _DemoBase, _env
+from .core import (
+    INTERLUDE_CSS_WEB,
+    WEB_WINDOW_BODY,
+    _beat_verb,
+    _DemoBase,
+    _env,
+    _env_flag,
+)
 from .target import guard_target
 
 # Pastel gradient behind the window — matches the terminal recorder's
@@ -496,6 +505,7 @@ class Recorder(_DemoBase):
         criteria: dict[str, str] | None = None,
         ticket: str | None = None,
         allow_private: bool | None = None,
+        wrapper: bool | None = None,
     ) -> None:
         super().__init__(
             out_dir, segment=segment, accent_rgb=accent_rgb,
@@ -517,9 +527,27 @@ class Recorder(_DemoBase):
             self._allow_private,
             source="this take's base_url",
         )
-        # The recording is composited into a window and scaled down (~0.8),
-        # so captions are rendered larger to stay readable in the final mp4.
-        self._caption_font_px = 34
+        # Opt-in wrapper path (issue #358, design record #355): the take
+        # records a recorder-owned wrapper page — window chrome, a caption
+        # band below the app rect — with the app in an iframe at true pixel
+        # size, and the exit-time composite does not run. Transitional: #361
+        # makes it the only path and removes the flag.
+        if wrapper is None:
+            wrapper = _env_flag("WRAPPER")
+        self._wrapper = bool(wrapper)
+        # The app iframe's Frame, once `_start` has mounted it (wrapper only).
+        self._app_frame: object | None = None
+        # Where the wrapper take last commanded the pointer, in wrapper-page
+        # coordinates. Seeded at the origin, where a fresh page's pointer
+        # actually sits; `_glide` is the only writer.
+        self._cursor_at: tuple[float, float] = (0.0, 0.0)
+        if not self._wrapper:
+            # The recording is composited into a window and scaled down
+            # (~0.8), so captions are rendered larger to stay readable in the
+            # final mp4. A wrapper take is recorded at true pixel size and
+            # keeps the base 26px — the terminal recorder's effective size —
+            # because there is no scale to compensate for.
+            self._caption_font_px = 34
         # And the same composite is why the interlude card is not the default
         # one: the terminal palette is the colour of a *terminal*, and inside
         # this window frame a full-bleed field of it reads as one — the whole
@@ -568,8 +596,45 @@ class Recorder(_DemoBase):
             (geom["appx"], geom["appy"], geom["appw"], geom["apph"])
         )
 
+    @property
+    def app(self):
+        """The app's document — where the verbs point.
+
+        On a wrapper take this is the app iframe's Playwright `Frame`; the
+        wrapper document around it is the recorder's own chrome, so
+        `rec.app.locator(...)` is the escape hatch that reaches the app the
+        way the verbs do. `rec.page` stays the wrapper `Page` — the whole
+        browser surface, chrome included — so nothing an escape hatch could
+        reach before is out of reach now.
+
+        Off the wrapper path it is the page's main frame, so a storyboard
+        written against `rec.app` records identically on both paths.
+        """
+        if self._wrapper:
+            if self._app_frame is None:
+                raise RuntimeError(
+                    "this wrapper take has no app frame yet — rec.app exists "
+                    "once the recorder has entered (`with Recorder(...) as "
+                    "rec:`), which is what mounts the iframe"
+                )
+            return self._app_frame
+        return self.page.main_frame
+
+    def _target(self):
+        """What locator-driving verbs run against: the app frame on a wrapper
+        take, the page otherwise. `Frame` and `Page` share the whole surface
+        used here (locator/evaluate/url/title), so one call site serves both.
+        """
+        return self._app_frame if self._wrapper else self.page
+
     def _init_context(self, context) -> None:
-        context.add_init_script(_CURSOR_JS.replace("__ACCENT__", self._accent))
+        # The wrapper take's cursor lives in the wrapper document (see
+        # chrome.py) and is driven explicitly by the recorder, so the
+        # event-following dot is not injected there: context init scripts run
+        # in every frame, and the app iframe would otherwise draw a second
+        # dot on top of the chrome's.
+        if not self._wrapper:
+            context.add_init_script(_CURSOR_JS.replace("__ACCENT__", self._accent))
         context.add_init_script(
             _TERMINAL_JS.replace("__TERM_TITLE__", self._terminal_title)
             .replace("__TERM_PROMPT__", self._terminal_prompt)
@@ -621,9 +686,20 @@ class Recorder(_DemoBase):
         # SPA route changes and an iframe load, identical on Chromium 136, 147
         # and 151, and the suite replays each one through this subscription
         # (issue #179).
+        #
+        # On a **wrapper** take (#358) that main-frame-only property is what
+        # ends the #134 class: the caption lives in the wrapper document,
+        # `goto()` navigates the app *iframe*, and the wrapper document is
+        # never replaced — so this never fires mid-take, no `caption_lost`
+        # issue is recorded, and both are the truth rather than a suppression:
+        # the line really is still on screen after the app navigates, and the
+        # beats that keep reporting it are right.
         page.on("domcontentloaded", self._note_document_replaced)
 
     def _start(self) -> None:
+        if self._wrapper:
+            self._start_wrapper()
+            return
         # Render the window+background frame once (on a throwaway page, so the
         # app page stays clean for goto). ffmpeg composites the recording into
         # it in _postprocess.
@@ -644,6 +720,50 @@ class Recorder(_DemoBase):
         p.wait_for_timeout(150)
         p.screenshot(path=str(self._frame_png))
         p.close()
+
+    def _start_wrapper(self) -> None:
+        """Build the wrapper page on the recorded page itself (issue #358).
+
+        The chrome is the recording, not a still ffmpeg composites later: the
+        recorded page carries the window, the caption band and the cursor
+        overlay, and the app loads into an iframe sized to the app rect at
+        true pixel size. `self._geom` keeps `_frame_geometry`'s key names, so
+        `_content_rect` and every other geometry consumer reads one shape.
+        """
+        self._geom = chrome_geometry(self._size["width"], self._size["height"])
+        title = urlparse(self.base_url).netloc or "app"
+        self.page.set_content(
+            chrome_html(
+                self._geom,
+                title=title,
+                window_body=WEB_WINDOW_BODY,
+                accent=self._accent,
+                caption_font_px=self._caption_font_px,
+            )
+        )
+        # Mounted here rather than shipped in the chrome document because the
+        # iframe is the *web* medium's content — #362 mounts xterm.js in the
+        # same slot. Size comes from the slot's CSS (chrome.py), which is the
+        # app rect exactly.
+        self.page.evaluate(
+            "() => {"
+            " const frame = document.createElement('iframe');"
+            " frame.id = '__chrome_app';"
+            " frame.name = '__chrome_app';"
+            " frame.src = 'about:blank';"
+            " document.getElementById('__chrome_slot').appendChild(frame);"
+            " }"
+        )
+        handle = self.page.wait_for_selector(
+            "#__chrome_app", state="attached", timeout=10_000
+        )
+        frame = handle.content_frame()
+        if frame is None:
+            raise RuntimeError(
+                "the wrapper page mounted the app iframe but Playwright "
+                "returned no frame for it — the take cannot drive the app"
+            )
+        self._app_frame = frame
 
     def _opening_hold(self, mp4: Path) -> Path | None:
         """Cover this take's blank opening with the app's first painted frame.
@@ -686,6 +806,13 @@ class Recorder(_DemoBase):
         return still
 
     def _postprocess(self, mp4: Path) -> None:
+        if self._wrapper:
+            # The recorded page already is the framed picture — one encoder,
+            # no composite, no opening-hold overlay (the wrapper's opening is
+            # #360's). `_opening_held` stays None: this path never claims to
+            # cover a gap, which is the same honest answer the terminal
+            # recorder gives.
+            return
         # Composite the recorded video into the window body on the background.
         g = self._geom
         hold = self._opening_hold(mp4)
@@ -748,11 +875,17 @@ class Recorder(_DemoBase):
         return self._failure_page_text()
 
     def _failure_page_text(self) -> str:
-        """The ARIA tree, the URL and the title, as one document."""
-        aria, aria_format = self._aria(self.page.locator("body"))
-        head = [f"url: {self.page.url}"]
+        """The ARIA tree, the URL and the title, as one document.
+
+        Read off `_target()`: on a wrapper take the page is the recorder's
+        own chrome and the crash happened in the app, so the app frame is
+        what a failure dump has to show.
+        """
+        target = self._target()
+        aria, aria_format = self._aria(target.locator("body"))
+        head = [f"url: {target.url}"]
         try:
-            head.append(f"title: {self.page.title()}")
+            head.append(f"title: {target.title()}")
         except Exception:  # noqa: BLE001 - a dying page still has a URL
             head.append("title: (unreadable)")
         head.append(f"aria_format: {aria_format}")
@@ -835,19 +968,25 @@ class Recorder(_DemoBase):
         return locator.aria_snapshot(), "aria-yaml"
 
     def _capture_page(self) -> dict:
-        """One pass: the ARIA snapshot, the URL, and the spotlight target."""
-        aria, aria_format = self._aria(self.page.locator("body"))
+        """One pass: the ARIA snapshot, the URL, and the spotlight target.
+
+        Captured from `_target()`: on a wrapper take (#358) the page's own
+        body is the recorder's chrome and one opaque iframe node, so evidence
+        read there would describe the recorder instead of the app.
+        """
+        doc = self._target()
+        aria, aria_format = self._aria(doc.locator("body"))
         payload: dict = {
             "scope": self._spotlit,
-            "url": self.page.url,
-            "title": self.page.title(),
+            "url": doc.url,
+            "title": doc.title(),
             "aria_format": aria_format,
             "aria": aria,
             "scope_aria": None,
             "html": None,
         }
         if self._spotlit:
-            target = self.page.locator(self._spotlit).first
+            target = doc.locator(self._spotlit).first
             payload["scope_aria"] = self._aria(target)[0]
             payload["html"] = target.evaluate(_EVIDENCE_HTML_JS)
         return payload
@@ -878,40 +1017,93 @@ class Recorder(_DemoBase):
     @_beat_verb("goto")
     def goto(self, path: str = "") -> None:
         url = path if path.startswith("http") else self.base_url + path
+        # On a wrapper take the *iframe* navigates; the wrapper document —
+        # which holds the caption, the cursor and the chrome — never does,
+        # so a mid-take goto cannot take the caption off the screen (see
+        # `_watch_extra`).
+        target = self._target()
         # Asset fetches hang occasionally on a busy dev box — a reload
         # recovers, so retry rather than dying mid-recording.
         for attempt in range(3):
             try:
-                self.page.goto(url, timeout=45_000)
+                target.goto(url, timeout=45_000)
                 break
-            except Exception:
+            except Exception as exc:
+                # An app that refuses framing is not a flake: Chromium
+                # cancels the iframe navigation over X-Frame-Options or CSP
+                # frame-ancestors with exactly this error, and what a retry
+                # would buy is the artifact-lie this slice must not ship — a
+                # silently blank window recorded as a demo. Refuse instead,
+                # naming the header (issue #358).
+                if self._wrapper and "ERR_BLOCKED_BY_RESPONSE" in str(exc):
+                    raise RuntimeError(self._frame_refusal(url)) from exc
                 if attempt == 2:
                     raise
         try:
-            self.page.wait_for_load_state("networkidle", timeout=10_000)
+            target.wait_for_load_state("networkidle", timeout=10_000)
         except Exception:
             pass  # apps that poll never go network-idle; the page is up
+
+    def _frame_refusal(self, url: str) -> str:
+        """Why this app cannot be recorded through the wrapper's iframe.
+
+        Chromium's `ERR_BLOCKED_BY_RESPONSE` says a response header blocked
+        the frame but not which, so the recorder asks once more —
+        `context.request` reuses the browser's own network stack — and reads
+        the header out of the answer. Named, because "the iframe stayed
+        blank" is not something a storyboard author can act on and the header
+        is.
+        """
+        header = None
+        try:
+            answer = self._context.request.get(url)
+            xfo = answer.headers.get("x-frame-options")
+            if xfo:
+                header = f"X-Frame-Options: {xfo}"
+            else:
+                csp = answer.headers.get("content-security-policy", "")
+                found = re.search(r"frame-ancestors[^;]*", csp)
+                if found:
+                    header = f"Content-Security-Policy: {found.group(0).strip()}"
+        except Exception:  # noqa: BLE001 - the refusal stands without a name
+            pass
+        named = header or (
+            "a frame-blocking response header (the follow-up request could "
+            "not read which)"
+        )
+        return (
+            f"this app refuses to be framed: {url} answered with {named}, so "
+            f"Chromium blocked the wrapper take's iframe. Recording on would "
+            f"produce a silently blank window presented as a demo, so the "
+            f"take refuses instead. Record without wrapper=True, or serve "
+            f"the demo target without that header."
+        )
 
     @_beat_verb("terminal")
     def terminal(self, command: str) -> None:
         """Type a command in an on-screen terminal card, then perform the
-        real action it describes right after this returns."""
-        self.page.evaluate("cmd => window.__demoTerminal(cmd)", command)
+        real action it describes right after this returns.
+
+        The card is raised in the app's document (`_target()`), so on a
+        wrapper take it appears over the app inside the window — the same
+        place it lands on a composite take — rather than over the chrome.
+        """
+        self._target().evaluate("cmd => window.__demoTerminal(cmd)", command)
 
     @_beat_verb("terminal_output")
     def terminal_output(self, text: str) -> None:
         """Reveal real command output inside the terminal card, line by
         line — run the command first, pass its actual (trimmed) output."""
-        self.page.evaluate("t => window.__demoTerminalOutput(t)", text)
+        self._target().evaluate("t => window.__demoTerminalOutput(t)", text)
 
     @_beat_verb("terminal_close")
     def terminal_close(self, stamp: str | None = None) -> None:
         """Stamp a closing line ('✓ delivered' by default, "" for none)
         on the terminal card and fade it out."""
         if stamp != "":
-            self.page.evaluate("s => window.__demoTerminalDone(s)", stamp)
+            self._target().evaluate("s => window.__demoTerminalDone(s)", stamp)
             self.pause(1.2)
-        self.page.evaluate("() => window.__demoTerminalHide()")
+        self._target().evaluate("() => window.__demoTerminalHide()")
         self.pause(0.5)
 
     @_beat_verb("spotlight")
@@ -942,9 +1134,14 @@ class Recorder(_DemoBase):
         # not come back until the exit transition has run to its end and the
         # style attribute has been put back. That is the whole of the paragraph
         # above, and it is one word: `evaluate`.
-        self.page.evaluate("() => window.__demoSpotlightClear()")
+        #
+        # Both calls run in the app's document (`_target()`): the spotlight
+        # functions are context init scripts, which Playwright evaluates in
+        # every frame, so they exist in the wrapper take's iframe too — and
+        # the element being lit lives there.
+        self._target().evaluate("() => window.__demoSpotlightClear()")
         if selector:
-            self.page.locator(selector).first.evaluate(
+            self._target().locator(selector).first.evaluate(
                 "el => window.__demoSpotlight(el)"
             )
         # Set after the highlight actually landed, so a selector that matched
@@ -954,13 +1151,51 @@ class Recorder(_DemoBase):
         self._spotlit = selector or None
         self.pause(0.3)
 
+    def _glide(self, x: float, y: float, steps: int) -> None:
+        """Move the pointer to page coordinates `(x, y)`, dot included.
+
+        The legacy path is one Playwright call: the injected dot follows the
+        `mousemove` events. On a wrapper take the dot lives in the wrapper
+        document, and no wrapper listener can hear a move whose target is
+        inside the iframe — the browser delivers it to the iframe's document
+        — so the recorder drives the dot itself, one explicit update per
+        pointer step. The dot is exactly where the pointer was commanded to
+        be, by construction, which is also what makes the #186/#202 class
+        (a dot placed by an event the storyboard never sent) unreachable
+        here: nothing listens, so nothing synthetic can move it.
+
+        Coordinates are wrapper-page coordinates either way — Playwright's
+        `bounding_box()` answers relative to the main frame's viewport even
+        for elements inside an iframe, so the app-rect offset is already in
+        every box the verbs read.
+        """
+        if not self._wrapper:
+            self.page.mouse.move(x, y, steps=steps)
+            return
+        sx, sy = self._cursor_at
+        for i in range(1, steps + 1):
+            xi = sx + (x - sx) * i / steps
+            yi = sy + (y - sy) * i / steps
+            self.page.mouse.move(xi, yi)
+            self.page.evaluate(
+                "([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi]
+            )
+        self._cursor_at = (x, y)
+
+    def _cursor_pressed(self, down: bool) -> None:
+        """Squeeze (or release) the wrapper document's cursor dot."""
+        if not self._wrapper:
+            return
+        fn = "__demoChromeCursorDown" if down else "__demoChromeCursorUp"
+        self.page.evaluate(f"() => window.{fn}()")
+
     @_beat_verb("move_to")
     def move_to(self, selector: str) -> None:
         """Glide the cursor onto an element (smooth, watchable motion)."""
-        box = self.page.locator(selector).first.bounding_box()
+        box = self._target().locator(selector).first.bounding_box()
         if box is None:
             raise RuntimeError(f"no visible element for {selector!r}")
-        self.page.mouse.move(
+        self._glide(
             box["x"] + box["width"] / 2, box["y"] + box["height"] / 2, steps=30
         )
 
@@ -968,7 +1203,11 @@ class Recorder(_DemoBase):
     def click(self, selector: str) -> None:
         self.move_to(selector)
         self.pause(0.4)
-        self.page.locator(selector).first.click()
+        self._cursor_pressed(True)
+        try:
+            self._target().locator(selector).first.click()
+        finally:
+            self._cursor_pressed(False)
 
     @_beat_verb("click_fast")
     def click_fast(self, selector: str) -> None:
@@ -979,15 +1218,19 @@ class Recorder(_DemoBase):
         deadline = time.monotonic() + 10
         box = None
         while box is None:
-            box = self.page.locator(selector).first.bounding_box()
+            box = self._target().locator(selector).first.bounding_box()
             if box is None:
                 if time.monotonic() > deadline:
                     raise RuntimeError(f"no visible element for {selector!r}")
                 time.sleep(0.1)
         x, y = box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
-        self.page.mouse.move(x, y, steps=15)
+        self._glide(x, y, steps=15)
         self.pause(0.3)
-        self.page.mouse.click(x, y)
+        self._cursor_pressed(True)
+        try:
+            self.page.mouse.click(x, y)
+        finally:
+            self._cursor_pressed(False)
 
     @_beat_verb("type_into")
     def type_into(self, selector: str, text: str, delay_ms: int = 40) -> None:
@@ -1033,7 +1276,7 @@ class Recorder(_DemoBase):
         `fill("")` sends no key events at all.
         """
         self.click(selector)
-        self.page.locator(selector).first.select_text()
+        self._target().locator(selector).first.select_text()
         self.pause(CLEAR_SELECT_HOLD_S)
         self.page.keyboard.press("Backspace")
         self.pause(0.3)
@@ -1065,7 +1308,7 @@ class Recorder(_DemoBase):
 
     @_beat_verb("scroll_to")
     def scroll_to(self, selector: str) -> None:
-        self.page.locator(selector).first.evaluate(
+        self._target().locator(selector).first.evaluate(
             "el => el.scrollIntoView({behavior: 'smooth', block: 'center'})"
         )
         self.pause(1.2)
@@ -1073,7 +1316,7 @@ class Recorder(_DemoBase):
     @_beat_verb("wait_for")
     def wait_for(self, selector: str, timeout_s: float = 60) -> None:
         """Wait for something the app does on its own (a job, a run)."""
-        self.page.locator(selector).first.wait_for(timeout=timeout_s * 1000)
+        self._target().locator(selector).first.wait_for(timeout=timeout_s * 1000)
 
     @contextmanager
     def act(self, label: str) -> Iterator[None]:

--- a/tests/README.md
+++ b/tests/README.md
@@ -117,7 +117,7 @@ seen red under a planted recorder defect in #351's pull request.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~47 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~50 min, nightly)
 ├── unit               # the browser-free half (~5 s, 528 tests, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
@@ -293,7 +293,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~225 s)
-tests/smoke-inject                # all 64 entries, ~47 min
+tests/smoke-inject                # all 69 entries, ~50 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -2148,6 +2148,7 @@ are what changed that, and they are now load-bearing rather than a convenience.
 | `--polish-only` | 26 s |
 | `--segments-only` | 29 s |
 | `--overlay-only` | 31 s |
+| `--wrapper-only` | 36 s |
 | `--failure-only` | 48 s |
 | `--web-only` | 123 s |
 | `--content-only` | 148 s |
@@ -2215,7 +2216,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-64 entries, 13 arms, ~46.8 min of takes
+69 entries, 14 arms, ~50.4 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -2252,13 +2253,14 @@ paragraph whose job is to say what this manifest does not cover.
 | `--segments-only` | 14 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the sheet stops saying **which clock** it cut them on, so a reviewer cannot tell a corrected sheet from one cut on the raw beat log ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
+| `--wrapper-only` | 5 | the wrapper take (#358) stops keeping its promises silently: a caption dispatched and never painted in its band; the caption's appearance repainting pixels inside the app rect, which is the overlap the band exists to remove; evidence captured from the wrapper chrome instead of the app frame, with url, title and aria all plausible; a frame-refused app surfacing as a bare `ERR_BLOCKED_BY_RESPONSE` naming no header; or the block swallowed entirely, so a silently blank window records to the end as a demo — the artifact-lie outcome the issue names outright |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
 | `--web-only` | 6 | the form verbs lie about what they did: `press` logging a key it never sent or returning before the page saw it, `clear` selecting without deleting or emptying the field between two frames, either of them driving the page and writing no beat |
 | `--content-only` | 3 | the recorder stops noticing a recording nobody can watch, starts warning about honest demos that hold still, or goes back to scoring the whole frame (issue #17's anti-correlated metric) |
 
 ### What it does **not** cover
 
-- **17 of `tests/smoke`'s 44 check functions have no entry**, and the harness
+- **17 of `tests/smoke`'s 47 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,7 +18,7 @@ takes an exclusive lock.
 `unit` answers everything that never needed a browser: the coverage report, the
 timeline's two renderings, the content and opening warnings, the merge a stitch
 performs, and whether `SKILL.md`'s reference links still resolve. It costs about
-5 s for its 528 tests and has no dependencies at all.
+5 s for its 536 tests and has no dependencies at all.
 
 **That split is the point, not tidiness.** [#136] measured the asymmetry it
 exists to remove: the fault-injection rule was *executed* for `ci-unit` and
@@ -117,8 +117,8 @@ seen red under a planted recorder defect in #351's pull request.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~50 min, nightly)
-├── unit               # the browser-free half (~5 s, 528 tests, no dependencies)
+├── smoke-inject       # proves smoke's assertions can still fail (~51 min, nightly)
+├── unit               # the browser-free half (~6 s, 536 tests, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
 │                      #   sees, plus the docs' python fences (~0.3 s)
@@ -275,6 +275,9 @@ tests/smoke --content-only        # just the pair that grades whether a
 tests/smoke --overlay-only        # just the light-interlude pair (#162/#163)
 tests/smoke --coverage-only       # just the acceptance-criterion take (#12)
 tests/smoke --strict-only         # just the two takes strict=True must refuse
+tests/smoke --wrapper-only        # just the wrapper pair: verbs through the
+                                  #   app iframe, caption band, and the take
+                                  #   that must refuse X-Frame-Options (#358)
 tests/smoke --issues-only         # just the broken page and the failing
                                   #   commands, which is what check_issues
                                   #   grades (issue #197)
@@ -293,7 +296,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~225 s)
-tests/smoke-inject                # all 69 entries, ~50 min
+tests/smoke-inject                # all 70 entries, ~51 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -501,7 +504,9 @@ off `/proc/loadavg` immediately before each:
 
 So **~222 s**, spread 1.5 s across the three: a 48% cut against the whole
 suite's 427 s, or about 3.4 minutes off every push once the runner's ~1.1x is
-applied.
+applied. That measurement predates the `--wrapper-only` arm (#358), which
+`--cheap` now also runs and which costs ~36 s clean on the same box; the
+total above is left as measured rather than corrected by addition.
 
 Run 3's red is [#215](https://github.com/rogvid/skills/issues/215)/[#224](https://github.com/rogvid/skills/issues/224)
 and not this selection: the host's wall clock stepped **-875 ms at 0.6s inside
@@ -2216,7 +2221,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-69 entries, 14 arms, ~50.4 min of takes
+70 entries, 14 arms, ~51.0 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -2253,14 +2258,14 @@ paragraph whose job is to say what this manifest does not cover.
 | `--segments-only` | 14 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the sheet stops saying **which clock** it cut them on, so a reviewer cannot tell a corrected sheet from one cut on the raw beat log ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
-| `--wrapper-only` | 5 | the wrapper take (#358) stops keeping its promises silently: a caption dispatched and never painted in its band; the caption's appearance repainting pixels inside the app rect, which is the overlap the band exists to remove; evidence captured from the wrapper chrome instead of the app frame, with url, title and aria all plausible; a frame-refused app surfacing as a bare `ERR_BLOCKED_BY_RESPONSE` naming no header; or the block swallowed entirely, so a silently blank window records to the end as a demo — the artifact-lie outcome the issue names outright |
+| `--wrapper-only` | 6 | the wrapper take (#358) stops keeping its promises silently: a caption dispatched and never painted in its band; a caption too tall for the band shaved at both edges with no caption_clipped issue saying so (#366's review finding); the caption's appearance repainting pixels inside the app rect, which is the overlap the band exists to remove; evidence captured from the wrapper chrome instead of the app frame, with url, title and aria all plausible; a frame-refused app surfacing as a bare `ERR_BLOCKED_BY_RESPONSE` naming no header; or the block swallowed entirely, so a silently blank window records to the end as a demo — the artifact-lie outcome the issue names outright |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
 | `--web-only` | 6 | the form verbs lie about what they did: `press` logging a key it never sent or returning before the page saw it, `clear` selecting without deleting or emptying the field between two frames, either of them driving the page and writing no beat |
 | `--content-only` | 3 | the recorder stops noticing a recording nobody can watch, starts warning about honest demos that hold still, or goes back to scoring the whole frame (issue #17's anti-correlated metric) |
 
 ### What it does **not** cover
 
-- **17 of `tests/smoke`'s 47 check functions have no entry**, and the harness
+- **17 of `tests/smoke`'s 48 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -9350,6 +9350,17 @@ def run_strict_terminal(out_root: Path) -> list[str]:
 WRAPPER_CAPTION = "The caption sits in its own band below the app."
 WRAPPER_UNREACHED = "this caption must never be recorded"
 
+# A caption the band cannot hold: 174 characters, three rendered lines
+# against the band's two. The wrapper take says it with a caption_clipped
+# issue rather than reflowing the text — PR #366's review measured ~17 px
+# shaved off the first and last lines of exactly this length with nothing
+# anywhere saying so.
+WRAPPER_LONG_CAPTION = (
+    "This caption is deliberately far too long for the reserved caption "
+    "band below the app rect, so the band's edges shave its first and its "
+    "last line instead of covering the app."
+)
+
 # The band sweep's bars. Measured on a real wrapper take: the empty band
 # reads 0.4-1.4 contrast (3.5 mid-fade), the caption bubble 29-30. The gap
 # between the bars is deliberate — a mid-fade frame is neither.
@@ -9472,6 +9483,12 @@ def record_wrapper(out_dir: Path, base_url: str) -> dict:
                 f"{rows} rows visible, expected 1"
             )
         rec.scroll_to("#rows")
+        rec.caption("")
+        # A caption the band cannot hold, then the clear again: the take
+        # must record caption_clipped for this line and only this line
+        # (check_wrapper_clipped), and the band must still end dark for the
+        # band sweep's last-frame claim.
+        rec.caption(WRAPPER_LONG_CAPTION)
         rec.caption("")
         rec.pause(0.6)
         geom = dict(rec._geom)
@@ -9622,6 +9639,48 @@ def check_wrapper_evidence(out_dir: Path) -> list[str]:
     return []
 
 
+def check_wrapper_clipped(out_dir: Path) -> list[str]:
+    """The band says so when it cannot show a caption (#366's review).
+
+    The take captions one line the band holds and one it cannot; the second
+    must leave a `caption_clipped` issue naming the line and the overflow,
+    and the first must leave none — over-reporting would file an issue on
+    every caption of every wrapper take. The text is deliberately not capped
+    or reflowed by the recorder; the record is the whole fix.
+    """
+    doc = json.loads((out_dir / "timeline.json").read_text(encoding="utf-8"))
+    issues = [
+        issue
+        for issue in doc.get("issues") or []
+        if issue.get("kind") == "caption_clipped"
+    ]
+    failures = []
+    named = [i for i in issues if i.get("caption") == WRAPPER_LONG_CAPTION]
+    if not named:
+        failures.append(
+            f"wrapper: the {len(WRAPPER_LONG_CAPTION)}-char caption left no "
+            f"caption_clipped issue — the band shaved its first and last "
+            f"lines and no artifact says so, which is timeline.json claiming "
+            f"a line the pixels do not show"
+        )
+    else:
+        clipped_px = named[0].get("clipped_px")
+        if not isinstance(clipped_px, (int, float)) or clipped_px <= 0:
+            failures.append(
+                f"wrapper: the caption_clipped issue carries clipped_px="
+                f"{clipped_px!r} — without a positive reading nobody can say "
+                f"how much of the line the band shaved"
+            )
+    fitting = [i for i in issues if i.get("caption") != WRAPPER_LONG_CAPTION]
+    if fitting:
+        failures.append(
+            f"wrapper: caption_clipped was recorded for {len(fitting)} "
+            f"caption(s) that fit their band — an issue filed on every "
+            f"caption is the artifact crying wolf"
+        )
+    return failures
+
+
 def check_wrapper_refusal(out_dir: Path, raised: BaseException | None) -> list[str]:
     """An app that refuses framing is refused by name, before any beat shows
     it (#358): a blocked iframe recorded as a demo is the artifact-lie
@@ -9678,6 +9737,7 @@ def run_wrapper(out_root: Path) -> list[str]:
         return [f"wrapper: recording raised {type(exc).__name__}: {exc}"]
     failures += check_wrapper_band(out_dir, info)
     failures += check_wrapper_evidence(out_dir)
+    failures += check_wrapper_clipped(out_dir)
 
     refused_dir = fresh_take_dir(out_root, "wrapper-refused")
     raised: BaseException | None = None

--- a/tests/smoke
+++ b/tests/smoke
@@ -9336,6 +9336,370 @@ def run_strict_terminal(out_root: Path) -> list[str]:
     return check_strict_failure("terminal-strict", out_dir, raised, ["nonzero_exit"])
 
 
+# -- the wrapper take (issue #358) --------------------------------------------
+#
+# The opt-in wrapper path: chrome in the recorded page, the app in an iframe
+# at true pixel size, the caption in a reserved band BELOW the app rect. Two
+# takes: one healthy — every locator verb driven through the frame, the band
+# graded out of the pixels — and one against a fixture served with
+# X-Frame-Options: DENY, which the recorder must refuse by name rather than
+# record as a silently blank window.
+
+# The line the wrapper take captions with, and the line the refusal take must
+# never reach.
+WRAPPER_CAPTION = "The caption sits in its own band below the app."
+WRAPPER_UNREACHED = "this caption must never be recorded"
+
+# The band sweep's bars. Measured on a real wrapper take: the empty band
+# reads 0.4-1.4 contrast (3.5 mid-fade), the caption bubble 29-30. The gap
+# between the bars is deliberate — a mid-fade frame is neither.
+WRAPPER_BAND_SWEEP_FPS = 10
+WRAPPER_BAND_LIT = 12.0
+WRAPPER_BAND_UNLIT = 6.0
+# The caption must hold the band at least this long — under it the band lit
+# for a flicker, not for the caption beat the timeline logs.
+WRAPPER_BAND_MIN_S = 1.0
+
+# App-rect stillness across the caption's appearance. Measured 0.65 on a
+# healthy take (encoder noise over a static fixture); a caption rendered
+# over the app instead of in the band moves this by an order of magnitude.
+WRAPPER_APP_MAX_DELTA = 3.0
+# How far around the band's first lit frame the app is compared: far enough
+# back to predate the fade, close enough that nothing else happened between
+# the two instants.
+WRAPPER_APP_CONTROL_S = 0.3
+WRAPPER_APP_SAMPLE_S = 0.5
+
+
+@contextmanager
+def refusing_fixture_server() -> Iterator[str]:
+    """Serve tests/fixture with X-Frame-Options: DENY on every response.
+
+    `python -m http.server` cannot add a header, so this is the same server
+    run through `-c` with `end_headers` overridden — the smallest honest way
+    to stand up an app that refuses framing.
+    """
+    handler_code = (
+        "import functools, http.server, sys\n"
+        "class Handler(http.server.SimpleHTTPRequestHandler):\n"
+        "    def end_headers(self):\n"
+        "        self.send_header('X-Frame-Options', 'DENY')\n"
+        "        super().end_headers()\n"
+        "    def log_message(self, *args):\n"
+        "        pass\n"
+        "http.server.ThreadingHTTPServer(\n"
+        "    ('127.0.0.1', int(sys.argv[1])),\n"
+        "    functools.partial(Handler, directory=sys.argv[2]),\n"
+        ").serve_forever()\n"
+    )
+    port = free_port()
+    base_url = f"http://127.0.0.1:{port}"
+    proc = subprocess.Popen(
+        [sys.executable, "-c", handler_code, str(port), str(FIXTURE_DIR)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        deadline = time.time() + SERVER_START_TIMEOUT_S
+        while True:
+            if proc.poll() is not None:
+                raise SmokeFailure(
+                    f"refusing fixture server exited immediately "
+                    f"(code {proc.returncode})"
+                )
+            try:
+                with urllib.request.urlopen(base_url, timeout=1) as resp:
+                    if resp.headers.get("X-Frame-Options") != "DENY":
+                        raise SmokeFailure(
+                            "the refusing fixture server is not sending "
+                            "X-Frame-Options: DENY — the refusal take would "
+                            "grade a server that refuses nothing"
+                        )
+                    break
+            except (urllib.error.URLError, OSError):
+                pass
+            if time.time() > deadline:
+                raise SmokeFailure(
+                    f"refusing fixture server did not answer on {base_url} "
+                    f"within {SERVER_START_TIMEOUT_S:.0f}s"
+                )
+            time.sleep(0.1)
+        yield base_url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait(timeout=5)
+
+
+def record_wrapper(out_dir: Path, base_url: str) -> dict:
+    """One wrapper take driving every locator verb through the app frame.
+
+    The storyboard asserts each verb's observable post-condition against
+    `rec.app` as it goes — a click that lands in the wrapper chrome instead
+    of the iframe advances nothing, and this is where that surfaces.
+    """
+    from demo_recording import Recorder
+
+    with Recorder(
+        out_dir,
+        base_url=base_url,
+        speech=False,
+        strict=True,
+        deterministic=True,
+        wrapper=True,
+    ) as rec:
+        rec.goto("/")
+        rec.wait_for("#kpi-rev")
+        rec.caption(WRAPPER_CAPTION)
+        rec.spotlight("#kpi-rev")
+        rec.hold()
+        rec.spotlight()
+        rec.click("#refresh")
+        status = rec.app.locator("#status").inner_text()
+        if status != "snapshot 2 of 3":
+            raise _StoryboardFailed(
+                f"click('#refresh') through the app frame did not advance "
+                f"the fixture: #status reads {status!r}"
+            )
+        rec.type_into("#search", "harbor")
+        rows = rec.app.locator("#rows tr").count()
+        if rows != 1:
+            raise _StoryboardFailed(
+                f"type_into('#search') through the app frame did not filter: "
+                f"{rows} rows visible, expected 1"
+            )
+        rec.scroll_to("#rows")
+        rec.caption("")
+        rec.pause(0.6)
+        geom = dict(rec._geom)
+        size = (rec._size["width"], rec._size["height"])
+    return {"geom": geom, "size": size}
+
+
+def check_wrapper_band(out_dir: Path, info: dict) -> list[str]:
+    """The caption lit its band and left the app rect's pixels alone (#358).
+
+    The geometry half of "the band and the app share no pixels" is
+    `tests/unit`'s (`WrapperChrome`); this is the pixel half, read out of
+    demo.mp4 the way a viewer meets it. The band is located by sweeping its
+    own rect for contrast — the empty band is flat window body — rather than
+    by trusting a beat timestamp through a steppable wall clock (#245).
+    """
+    failures = []
+    mp4 = out_dir / "demo.mp4"
+    geom = info["geom"]
+    band: Rect = (geom["bandx"], geom["bandy"], geom["bandw"], geom["bandh"])
+    app: Rect = (geom["appx"], geom["appy"], geom["appw"], geom["apph"])
+    sweep = gray_frames(mp4, rect=band, sample_fps=WRAPPER_BAND_SWEEP_FPS)
+    if len(sweep) < WRAPPER_BAND_SWEEP_FPS * 3:
+        return [
+            f"wrapper: the band sweep decoded {len(sweep)} frames — too few "
+            f"to hold a caption at all, so nothing below could fail honestly"
+        ]
+    lit = [contrast(f) >= WRAPPER_BAND_LIT for f in sweep]
+    run = longest_true_run(lit)
+    if run is None:
+        return [
+            f"wrapper: no frame of the caption band {band} ever reaches "
+            f"{WRAPPER_BAND_LIT} contrast across "
+            f"{len(sweep) / WRAPPER_BAND_SWEEP_FPS:.1f}s — the caption "
+            f"{WRAPPER_CAPTION!r} never painted in its band"
+        ]
+    start, length = run
+    if length / WRAPPER_BAND_SWEEP_FPS < WRAPPER_BAND_MIN_S:
+        failures.append(
+            f"wrapper: the band was lit for only "
+            f"{length / WRAPPER_BAND_SWEEP_FPS:.1f}s — a flicker, not the "
+            f"caption beat the timeline logs"
+        )
+    if start == 0:
+        failures.append(
+            "wrapper: the band is lit from frame 0, so there is no unlit "
+            "control — nothing separates a caption in its band from a band "
+            "that is simply always painted"
+        )
+    else:
+        unlit_before = contrast(sweep[start - 1])
+        # One frame back can be mid-fade; the claim is about the stretch
+        # before the caption, so read the quietest frame in it.
+        quietest = min(contrast(f) for f in sweep[:start])
+        if quietest > WRAPPER_BAND_UNLIT:
+            failures.append(
+                f"wrapper: before the caption the band never drops under "
+                f"{WRAPPER_BAND_UNLIT} contrast (quietest {quietest:.1f}, "
+                f"frame before the stretch {unlit_before:.1f}) — the unlit "
+                f"control is missing"
+            )
+    if lit[-1]:
+        failures.append(
+            "wrapper: the band is still lit in the last sampled frame — "
+            "caption('') did not clear it"
+        )
+    # The app rect across the caption's appearance: the two instants bracket
+    # the fade and nothing else, so any movement is the caption painting
+    # where it must not.
+    control_at = max(0.0, start / WRAPPER_BAND_SWEEP_FPS - WRAPPER_APP_CONTROL_S)
+    sample_at = start / WRAPPER_BAND_SWEEP_FPS + WRAPPER_APP_SAMPLE_S
+    before = gray_frames(mp4, rect=app, start=control_at, duration=0.05)
+    during = gray_frames(mp4, rect=app, start=sample_at, duration=0.05)
+    if not before or not during:
+        failures.append(
+            f"wrapper: the app rect {app} decoded no frame at "
+            f"{control_at:.2f}s/{sample_at:.2f}s — the stillness claim has "
+            f"nothing to read"
+        )
+    else:
+        moved = frame_difference(before[0], during[0])
+        if moved > WRAPPER_APP_MAX_DELTA:
+            failures.append(
+                f"wrapper: the app rect moved {moved:.2f} mean luma between "
+                f"{control_at:.2f}s and {sample_at:.2f}s, over the "
+                f"{WRAPPER_APP_MAX_DELTA} bar — the caption's appearance "
+                f"changed pixels inside the app rect, which is the overlap "
+                f"the band exists to remove (#355)"
+            )
+        else:
+            print(
+                f"wrapper: band lit {length / WRAPPER_BAND_SWEEP_FPS:.1f}s "
+                f"from {start / WRAPPER_BAND_SWEEP_FPS:.1f}s, app rect moved "
+                f"{moved:.2f} (bar {WRAPPER_APP_MAX_DELTA}) across the "
+                f"caption's appearance"
+            )
+    return failures
+
+
+def longest_true_run(flags: list[bool]) -> tuple[int, int] | None:
+    """(start, length) of the longest contiguous True stretch, or None.
+
+    tests/pixel's `longest_run`, duplicated for the same reason its
+    thresholds are: the loop and the suite must not import each other.
+    """
+    best: tuple[int, int] | None = None
+    start: int | None = None
+    for i, flag in enumerate([*flags, False]):
+        if flag and start is None:
+            start = i
+        elif not flag and start is not None:
+            if best is None or i - start > best[1]:
+                best = (start, i - start)
+            start = None
+    return best
+
+
+def check_wrapper_evidence(out_dir: Path) -> list[str]:
+    """Evidence on a wrapper take describes the app, not the recorder.
+
+    The wrapper page's own body is chrome and one opaque iframe node, so an
+    evidence capture that stayed on `rec.page` would still write plausible
+    files — url, title, a well-formed aria tree — describing the recorder.
+    The fixture's own heading is what tells the two apart.
+    """
+    doc = json.loads((out_dir / "timeline.json").read_text(encoding="utf-8"))
+    caption_beats = [
+        b
+        for b in doc.get("beats") or []
+        if b.get("verb") == "caption" and b.get("caption") == WRAPPER_CAPTION
+    ]
+    if len(caption_beats) != 1:
+        return [
+            f"wrapper: {len(caption_beats)} beats caption {WRAPPER_CAPTION!r},"
+            f" expected 1 — there is no beat to read evidence for"
+        ]
+    evidence_rel = caption_beats[0].get("evidence")
+    if not evidence_rel:
+        return ["wrapper: the caption beat carries no evidence pointer"]
+    evidence = json.loads((out_dir / evidence_rel).read_text(encoding="utf-8"))
+    aria = evidence.get("aria") or ""
+    if "Northwind Ops" not in aria:
+        return [
+            f"wrapper: the caption beat's evidence aria never mentions the "
+            f"fixture's own heading — evidence reads the wrapper chrome, not "
+            f"the app ({out_dir / evidence_rel})"
+        ]
+    return []
+
+
+def check_wrapper_refusal(out_dir: Path, raised: BaseException | None) -> list[str]:
+    """An app that refuses framing is refused by name, before any beat shows
+    it (#358): a blocked iframe recorded as a demo is the artifact-lie
+    outcome this arm exists to keep out.
+
+    The take this grades records with `strict=False`, deliberately: the
+    blocked navigation also logs a console error, so under strict a
+    swallowed refusal would still surface as `StrictTakeFailed` and the
+    completed-without-raising claim below could never fail for the reason it
+    names. The refusal has to stand on its own, not lean on strict's net.
+    """
+    failures = []
+    if raised is None:
+        failures.append(
+            "wrapper-refused: recording against X-Frame-Options: DENY "
+            "completed without raising — the take recorded a silently blank "
+            "window as a demo"
+        )
+    else:
+        message = str(raised)
+        if "X-Frame-Options" not in message or "DENY" not in message:
+            failures.append(
+                f"wrapper-refused: the refusal does not name the header that "
+                f"caused it — a storyboard author cannot act on "
+                f"{type(raised).__name__}: {message[:200]!r}"
+            )
+    doc_path = out_dir / "timeline.json"
+    if doc_path.is_file():
+        doc = json.loads(doc_path.read_text(encoding="utf-8"))
+        reached = [
+            b for b in doc.get("beats") or [] if b.get("caption") == WRAPPER_UNREACHED
+        ]
+        if reached:
+            failures.append(
+                "wrapper-refused: the storyboard line after the refused goto "
+                "still recorded a beat — the take went on recording after "
+                "the app refused to be framed"
+            )
+    return failures
+
+
+def run_wrapper(out_root: Path) -> list[str]:
+    """The wrapper pair (#358): the healthy take, then the refused one."""
+    from demo_recording import Recorder
+
+    failures: list[str] = []
+    out_dir = fresh_take_dir(out_root, "wrapper")
+    try:
+        with fixture_server() as base_url:
+            info = record_wrapper(out_dir, base_url)
+    except _StoryboardFailed as exc:
+        return [f"wrapper: {exc}"]
+    except Exception as exc:  # noqa: BLE001 - a raising take is the failure
+        return [f"wrapper: recording raised {type(exc).__name__}: {exc}"]
+    failures += check_wrapper_band(out_dir, info)
+    failures += check_wrapper_evidence(out_dir)
+
+    refused_dir = fresh_take_dir(out_root, "wrapper-refused")
+    raised: BaseException | None = None
+    with refusing_fixture_server() as base_url:
+        try:
+            # strict=False on purpose — see check_wrapper_refusal: the
+            # refusal must not need strict's console-error net to surface.
+            with Recorder(
+                refused_dir,
+                base_url=base_url,
+                speech=False,
+                strict=False,
+                wrapper=True,
+            ) as rec:
+                rec.goto("/")
+                rec.caption(WRAPPER_UNREACHED)
+        except Exception as exc:  # noqa: BLE001 - the raise is the assertion
+            raised = exc
+    failures += check_wrapper_refusal(refused_dir, raised)
+    return failures
+
+
 def last_frame(mp4: Path, rect: Rect) -> bytes | None:
     """The final second of a recording, reduced over `rect`, last frame first
     available. Both takes end on the same static page, so this is the frame
@@ -12185,6 +12549,13 @@ def main() -> int:
         help="record only the two short takes that strict=True must refuse (issue #3)",
     )
     parser.add_argument(
+        "--wrapper-only",
+        action="store_true",
+        help="record only the wrapper pair: verbs through the app iframe with "
+        "the caption in its own band, and the take that must refuse an app "
+        "sending X-Frame-Options (issue #358)",
+    )
+    parser.add_argument(
         "--issues-only",
         action="store_true",
         help="record only the broken-page and failing-command takes, which is "
@@ -12240,6 +12611,7 @@ def main() -> int:
             ("--overlay-only", args.overlay_only),
             ("--coverage-only", args.coverage_only),
             ("--strict-only", args.strict_only),
+            ("--wrapper-only", args.wrapper_only),
             ("--issues-only", args.issues_only),
             ("--lock-only", args.lock_only),
             ("--cheap", args.cheap),
@@ -12467,6 +12839,12 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
     # as its cheapest arm.
     if selects(only, ("--web-only", "--strict-only")):
         failures += run_strict_web(out_root)
+    # The wrapper pair (#358). Reachable from --web-only as well as its own
+    # flag: it is a web take, and whoever is changing the web recorder is
+    # running --web-only. Its own flag is what keeps its assertions gradeable
+    # — the arm records in well under a minute against --web-only's 123 s.
+    if selects(only, ("--web-only", "--wrapper-only")):
+        failures += run_wrapper(out_root)
     if selects(only, ("--web-only", "--evidence-only")):
         failures += run_evidence(out_root)
     # Speech end to end (issue #157). A web take, so it is reachable from

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -118,6 +118,7 @@ ARM_SECONDS = {
     "--polish-only": 26,
     "--segments-only": 29,
     "--overlay-only": 31,
+    "--wrapper-only": 36,
     "--failure-only": 48,
     "--web-only": 123,
     "--content-only": 148,
@@ -464,14 +465,21 @@ INJECTIONS = [
         # the entry would be graded by an exception rather than by the pixels.
         name="a web take is painted the terminal's card",
         module="web.py",
-        old="from .core import INTERLUDE_CSS_WEB, WEB_WINDOW_BODY, "
-        "_beat_verb, _DemoBase, _env",
+        old="from .core import (\n"
+        "    INTERLUDE_CSS_WEB,\n"
+        "    WEB_WINDOW_BODY,\n"
+        "    _beat_verb,\n"
+        "    _DemoBase,\n"
+        "    _env,\n"
+        "    _env_flag,\n"
+        ")",
         new="from .core import (  # noqa: I001\n"
         "    INTERLUDE_CSS_TERMINAL as INTERLUDE_CSS_WEB,\n"
         "    WEB_WINDOW_BODY,\n"
         "    _beat_verb,\n"
         "    _DemoBase,\n"
         "    _env,\n"
+        "    _env_flag,\n"
         ")",
         arm="--coverage-only",
         sites=("check_criterion_card",),
@@ -1056,6 +1064,98 @@ INJECTIONS = [
         arm="--overlay-only",
         sites=("check_overlay_pair",),
         must_contain=("the take that cleared its scrim never said ",),
+    ),
+    # -- the wrapper take (issue #358), 36 s an entry --------------------------
+    Injection(
+        # The band's positive half: a caption dispatched and never painted.
+        # The wrapper document's own `__demoCaption` goes quiet, the beat log
+        # stays perfect, and only the pixels can say the band held nothing.
+        name="the wrapper caption is dispatched and never painted in the band",
+        module="chrome.py",
+        old="    el.textContent = text;\n    el.style.opacity = text ? '1' : '0';",
+        new="    el.textContent = '';\n    el.style.opacity = '0';",
+        arm="--wrapper-only",
+        sites=("check_wrapper_band",),
+        must_contain=("never painted in its band",),
+    ),
+    Injection(
+        # The band's negative half — the overlap the wrapper exists to
+        # remove, reintroduced: the caption's appearance also repaints pixels
+        # inside the app rect (here, by dimming the slot). The band claim
+        # alone stays green, which is why the app-stillness claim is its own
+        # assertion.
+        name="the caption's appearance repaints pixels inside the app rect",
+        module="chrome.py",
+        old=(
+            "  window.__demoCaption = (text) => {\n"
+            "    const el = document.getElementById('__demo_caption');"
+        ),
+        new=(
+            "  window.__demoCaption = (text) => {\n"
+            "    document.getElementById('__chrome_slot').style.opacity ="
+            " text ? '0.75' : '1';\n"
+            "    const el = document.getElementById('__demo_caption');"
+        ),
+        arm="--wrapper-only",
+        sites=("check_wrapper_band",),
+        must_contain=("changed pixels inside the app rect",),
+    ),
+    Injection(
+        # Evidence capture left on the wrapper page: url, title and aria all
+        # come back well-formed and describe the recorder's own chrome. The
+        # fixture's heading is what tells the two documents apart — measured:
+        # a wrapper-page aria_snapshot does not descend into the iframe.
+        name="evidence on a wrapper take reads the chrome, not the app",
+        module="web.py",
+        old="        doc = self._target()",
+        new="        doc = self.page",
+        arm="--wrapper-only",
+        sites=("check_wrapper_evidence",),
+        must_contain=("evidence reads the wrapper chrome, not the app",),
+    ),
+    Injection(
+        # The refusal loses its name: the blocked navigation surfaces as a
+        # bare Playwright error after the retry loop, and a storyboard author
+        # is left holding ERR_BLOCKED_BY_RESPONSE with no header to act on.
+        name="a frame-refused app fails with an error naming no header",
+        module="web.py",
+        old=(
+            "                if self._wrapper and "
+            '"ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
+            "                    raise RuntimeError(self._frame_refusal(url)) "
+            "from exc"
+        ),
+        new=(
+            "                if self._wrapper and "
+            '"ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
+            "                    pass"
+        ),
+        arm="--wrapper-only",
+        sites=("check_wrapper_refusal",),
+        must_contain=("the refusal does not name the header",),
+    ),
+    Injection(
+        # The artifact-lie direction, the one #358 names outright: the block
+        # is swallowed, the take records a blank window to the end, and every
+        # artifact reads like a demo of an app that was never on screen.
+        name="a frame-refused app is recorded as a silently blank demo",
+        module="web.py",
+        old=(
+            "                if self._wrapper and "
+            '"ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
+            "                    raise RuntimeError(self._frame_refusal(url)) "
+            "from exc\n"
+            "                if attempt == 2:"
+        ),
+        new=(
+            "                if self._wrapper and "
+            '"ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
+            "                    break\n"
+            "                if attempt == 2:"
+        ),
+        arm="--wrapper-only",
+        sites=("check_wrapper_refusal",),
+        must_contain=("recorded a silently blank",),
     ),
     # -- what a take that did not finish leaves behind (#11/#20/#24/#46), 48 s -
     Injection(

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -1135,6 +1135,24 @@ INJECTIONS = [
         must_contain=("the refusal does not name the header",),
     ),
     Injection(
+        # The band's honesty half (#366's review): a caption too tall for the
+        # band is shaved at both edges, and the measurement that turns that
+        # into a caption_clipped issue goes quiet. The Python half is graded
+        # browser-free in tests/unit; this breaks the JS reading itself,
+        # which only a recorded take can see.
+        name="the band shaves a too-tall caption and no artifact says so",
+        module="chrome.py",
+        old=(
+            "    if (!text) return 0;\n"
+            "    const band = document.getElementById('__chrome_band');\n"
+            "    return Math.max(0, el.scrollHeight - band.clientHeight);"
+        ),
+        new="    return 0;",
+        arm="--wrapper-only",
+        sites=("check_wrapper_clipped",),
+        must_contain=("left no caption_clipped issue",),
+    ),
+    Injection(
         # The artifact-lie direction, the one #358 names outright: the block
         # is swallowed, the take records a blank window to the end, and every
         # artifact reads like a demo of an app that was never on screen.

--- a/tests/unit
+++ b/tests/unit
@@ -163,6 +163,7 @@ sys.modules["playwright.sync_api"] = _pw_sync
 
 import demo_recording.core as core_module  # noqa: E402
 import demo_recording.frames as frames_module  # noqa: E402
+from demo_recording.chrome import chrome_geometry, chrome_html  # noqa: E402
 from demo_recording.core import (  # noqa: E402
     CRITERION_HOLD_MAX_S,
     CRITERION_HOLD_MIN_S,
@@ -5199,6 +5200,98 @@ class OpeningCardOnATake(unittest.TestCase):
         self.assertIn(
             "does not know where its window sits", opening["card"]["note"] or ""
         )
+
+
+class WrapperChrome(unittest.TestCase):
+    """The wrapper take's chrome geometry and wiring (issue #358).
+
+    The load-bearing claim is the band: the caption band and the app rect
+    share no pixels, **by construction**, at any viewport. `tests/smoke
+    --wrapper-only` reads the same claim out of a recorded take's frames;
+    this is the arithmetic half, so a geometry change that reintroduces the
+    overlap the wrapper exists to remove is red without a browser.
+    """
+
+    VIEWPORTS = ((1280, 720), (1920, 1080), (1000, 620), (1366, 768))
+
+    def test_the_caption_band_and_the_app_rect_share_no_pixels(self):
+        for width, height in self.VIEWPORTS:
+            geom = chrome_geometry(width, height)
+            app_bottom = geom["appy"] + geom["apph"]
+            self.assertGreaterEqual(
+                geom["bandy"],
+                app_bottom,
+                f"{width}x{height}: the band starts at y={geom['bandy']}, "
+                f"inside the app rect that runs to y={app_bottom} — the app "
+                f"and the caption share pixels, which is the overlap #355 "
+                f"exists to remove",
+            )
+
+    def test_the_band_sits_directly_below_the_slot_inside_the_window(self):
+        # Adjacent, not merely disjoint: a gap between the two would be a
+        # strip of bare window body the caption was supposed to own.
+        for width, height in self.VIEWPORTS:
+            geom = chrome_geometry(width, height)
+            self.assertEqual(geom["bandy"], geom["appy"] + geom["apph"])
+            self.assertEqual(geom["bandx"], geom["appx"])
+            self.assertEqual(geom["bandw"], geom["appw"])
+            self.assertLessEqual(
+                geom["bandy"] + geom["bandh"] + geom["pad"],
+                geom["winy"] + geom["winh"],
+                f"{width}x{height}: the band runs past the window's bottom pad",
+            )
+            self.assertGreaterEqual(geom["winx"], 0)
+            self.assertGreaterEqual(geom["winy"], 0)
+            self.assertLessEqual(geom["winx"] + geom["winw"], width)
+            self.assertLessEqual(geom["winy"] + geom["winh"], height)
+
+    def test_a_viewport_too_small_for_the_chrome_is_refused_with_the_floor(self):
+        with self.assertRaises(ValueError) as caught:
+            chrome_geometry(1280, 300)
+        self.assertIn("viewport of at least", str(caught.exception))
+
+    def test_the_chrome_document_carries_the_slot_the_band_and_the_card_layer(self):
+        # The slot is #362's mount point and the card layer is #360's; a
+        # rename here silently strands both. Every substitution token must be
+        # consumed, or the page ships with a literal __TOKEN__ on screen.
+        html = chrome_html(
+            chrome_geometry(1280, 720),
+            title="localhost:9",
+            window_body="#181825",
+            accent="235,110,20",
+        )
+        for element_id in (
+            "__chrome_slot",
+            "__chrome_band",
+            "__chrome_card",
+            "__demo_caption",
+            "__demo_cursor",
+        ):
+            self.assertIn(f'id="{element_id}"', html)
+        leftover = re.findall(r"__[A-Z][A-Z0-9]*__", html)
+        self.assertEqual(
+            leftover,
+            [],
+            f"unsubstituted chrome tokens reached the page: {sorted(set(leftover))}",
+        )
+
+    def test_a_wrapper_take_keeps_the_base_caption_font(self):
+        # The 34px compensation exists because the composite scales the page
+        # by ~0.8; the wrapper page is recorded at true size, so inheriting
+        # it would put visibly oversized captions in the band.
+        self.assertEqual(recorder(self, wrapper=True)._caption_font_px, 26)
+        self.assertEqual(recorder(self)._caption_font_px, 34)
+
+    def test_rec_app_is_the_main_frame_until_a_wrapper_take_mounts_its_iframe(self):
+        legacy = recorder(self)
+        legacy.page = types.SimpleNamespace(main_frame="the main frame")
+        self.assertEqual(legacy.app, "the main frame")
+        wrapped = recorder(self, wrapper=True)
+        with self.assertRaises(RuntimeError) as caught:
+            wrapped.app  # noqa: B018 - the property's refusal is the claim
+        self.assertIn("no app frame yet", str(caught.exception))
+        wrapped._app_frame = "the app frame"
+        self.assertEqual(wrapped.app, "the app frame")
 
 
 class VerbTarget(unittest.TestCase):
@@ -14845,13 +14938,21 @@ INJECTIONS = [
         # the assertions it names.
         "a web take is given the terminal's card",
         "web.py",
-        "from .core import INTERLUDE_CSS_WEB, WEB_WINDOW_BODY, _beat_verb, _DemoBase, _env",
+        "from .core import (\n"
+        "    INTERLUDE_CSS_WEB,\n"
+        "    WEB_WINDOW_BODY,\n"
+        "    _beat_verb,\n"
+        "    _DemoBase,\n"
+        "    _env,\n"
+        "    _env_flag,\n"
+        ")",
         "from .core import (  # noqa: I001\n"
         "    INTERLUDE_CSS_TERMINAL as INTERLUDE_CSS_WEB,\n"
         "    WEB_WINDOW_BODY,\n"
         "    _beat_verb,\n"
         "    _DemoBase,\n"
         "    _env,\n"
+        "    _env_flag,\n"
         ")",
         [
             "InterludePalette.test_a_web_take_raises_the_palette_smoke_grades_in_pixels",
@@ -15582,6 +15683,33 @@ INJECTIONS = [
         '            "-vf",\n            "scale=\'min(1024,iw)\':-1",\n',
         "",
         ["FrameDedupe.test_extract_asks_ffmpeg_for_at_most_1024_wide_never_upscaled"],
+    ),
+    # -- the wrapper take's chrome (issue #358) -----------------------------
+    (
+        # The overlap the wrapper exists to remove, reintroduced by geometry:
+        # the band raised half its height into the app rect. The pixel half
+        # of the same claim lives in `tests/smoke --wrapper-only`; this is
+        # what keeps the arithmetic half honest without a browser.
+        "the caption band is raised into the app rect it must sit below",
+        "chrome.py",
+        '        "bandy": winy + bar + pad + apph,',
+        '        "bandy": winy + bar + pad + apph - band // 2,',
+        [
+            "WrapperChrome.test_the_caption_band_and_the_app_rect_share_no_pixels",
+            "WrapperChrome.test_the_band_sits_directly_below_the_slot_inside_the_window",
+        ],
+    ),
+    (
+        # The composite's caption compensation inherited by the path that has
+        # no composite: a wrapper take is recorded at true pixel size, so
+        # 34px in the band is visibly oversized, and nothing else pins it.
+        "a wrapper take inherits the composite's 34px caption compensation",
+        "web.py",
+        "        if not self._wrapper:\n"
+        "            # The recording is composited into a window and scaled down\n",
+        "        if True:\n"
+        "            # The recording is composited into a window and scaled down\n",
+        ["WrapperChrome.test_a_wrapper_take_keeps_the_base_caption_font"],
     ),
 ]
 

--- a/tests/unit
+++ b/tests/unit
@@ -5293,6 +5293,57 @@ class WrapperChrome(unittest.TestCase):
         wrapped._app_frame = "the app frame"
         self.assertEqual(wrapped.app, "the app frame")
 
+    class CaptionSurface(FakePage):
+        """A page whose `__demoCaption` reports what the band could not show.
+
+        The wrapper chrome's caption renderer (chrome.py) returns the pixels
+        the band's `overflow: hidden` shaved off the bubble; the in-page
+        overlay version returns nothing. Scripted here, because the recorder
+        half under test is what `caption()` does with the answer.
+        """
+
+        def __init__(self, clipped) -> None:
+            super().__init__()
+            self.clipped = clipped
+
+        def evaluate(self, script, *args):
+            if "__demoCaption" in script:
+                return self.clipped
+            return None
+
+    def test_a_caption_the_band_cannot_hold_is_recorded_with_its_overflow(self):
+        # The PR #366 review's blocking finding: a 174-char caption lost
+        # ~17 px off its first and last lines to the band's edges while
+        # timeline.json recorded the full sentence, warnings stayed empty and
+        # a strict take stayed green — the artifact claiming a line the
+        # pixels do not show. The text is deliberately not capped or
+        # reflowed; the record is the fix.
+        rec = recorder(self, wrapper=True, page=self.CaptionSurface(34))
+        rec.caption("a caption far too tall for the band")
+        clipped = [i for i in rec._issues if i["kind"] == "caption_clipped"]
+        self.assertEqual(len(clipped), 1, rec._issues)
+        self.assertEqual(clipped[0]["clipped_px"], 34)
+        self.assertIn("a caption far too tall for the band", clipped[0]["message"])
+        # Attributed to the caption beat that painted it, not to null.
+        self.assertEqual(clipped[0]["beat"], rec._beats[-1]["index"])
+        self.assertEqual(clipped[0]["verb"], "caption")
+        # The storyboard's mistake, not the app's: never fatal under strict.
+        self.assertEqual(rec._fatal_count, 0)
+
+    def test_a_caption_that_fits_its_band_records_nothing(self):
+        # Both quiet answers: the wrapper surface measuring zero overflow,
+        # and the legacy overlay returning nothing at all.
+        fits = recorder(self, wrapper=True, page=self.CaptionSurface(0))
+        fits.caption("short")
+        legacy = recorder(self)  # FakePage.evaluate returns None
+        legacy.caption("short")
+        self.assertEqual(
+            [i for i in fits._issues if i["kind"] == "caption_clipped"], []
+        )
+        self.assertEqual(
+            [i for i in legacy._issues if i["kind"] == "caption_clipped"], []
+        )
+
 
 class VerbTarget(unittest.TestCase):
     """Which target a verb's beat names, by position and by keyword (#177).
@@ -15710,6 +15761,32 @@ INJECTIONS = [
         "        if True:\n"
         "            # The recording is composited into a window and scaled down\n",
         ["WrapperChrome.test_a_wrapper_take_keeps_the_base_caption_font"],
+    ),
+    (
+        # The PR #366 review's blocking finding, restored: the band shaves a
+        # too-tall caption at both edges and no artifact says so — the beat
+        # log records the full sentence over pixels that do not show it.
+        "a caption the band cannot hold is recorded nowhere",
+        "core.py",
+        "        if not isinstance(clipped, (int, float)) or clipped <= 0:\n"
+        "            return\n",
+        "        if True:\n            return\n",
+        [
+            "WrapperChrome."
+            "test_a_caption_the_band_cannot_hold_is_recorded_with_its_overflow"
+        ],
+    ),
+    (
+        # The over-reporting direction, which the entry above cannot see: a
+        # zero-overflow reading treated as a clip files an issue on every
+        # caption of every wrapper take, and the artifact cries wolf.
+        "a caption that exactly fits its band is recorded as clipped",
+        "core.py",
+        "        if not isinstance(clipped, (int, float)) or clipped <= 0:\n"
+        "            return\n",
+        "        if not isinstance(clipped, (int, float)) or clipped < 0:\n"
+        "            return\n",
+        ["WrapperChrome.test_a_caption_that_fits_its_band_records_nothing"],
     ),
 ]
 


### PR DESCRIPTION
Slice 1 of #355's structural half (design record in that issue's comments; the shared-chrome amendment is on #358).

## What this adds

`Recorder(wrapper=True)` (or `DEMO_VIDEO_WRAPPER=1`) records the web app inside an iframe on a recorder-owned wrapper page.
The wrapper page is the recording: window chrome, title bar, pads, a caption band reserved **below** the app rect, and the cursor overlay all live in the wrapper document, and the exit-time ffmpeg composite does not run on this path.
The app loads at the app rect's true pixel size — no 0.8 scale, so the caption keeps the base 26px instead of the composite's 34px compensation.
Off by default; the legacy composite path is untouched.

- **`helpers/demo_recording/chrome.py`** — the shared chrome module the owner amendment asked for: one source for the background gradient, window frame, title bar + traffic lights, pads, the caption band below the content slot, and an (empty, for #360) card layer. `chrome_geometry(width, height)` is pure and unit-graded; `chrome_html(geom, ...)` renders the wrapper document with an **empty content slot** (`#__chrome_slot`) that the web path fills with the app iframe and #362 fills with the xterm host. Nothing web-only is hard-wired into the chrome — the iframe is mounted by `web.py`, not shipped in the chrome document.
- **Verbs re-target the app frame**: locators, spotlight (context init scripts run in every frame, so the spotlight functions exist in the iframe), `wait_for`, `scroll_to`, the terminal card, evidence capture (`_capture_page` reads the app frame's aria/url/title), and the failure dump. `goto()` navigates the **iframe**; the wrapper document never navigates.
- **Cursor**: the dot lives in the wrapper document and rides over the iframe. No wrapper listener can hear a mousemove targeted inside the iframe, so the recorder drives the dot explicitly, one update per pointer step — the dot is where the pointer was commanded to be by construction, which closes the #186/#202 synthetic-mousemove class on this path. Coordinates need no manual offset: Playwright's `bounding_box()` answers in main-frame coordinates even for iframe elements.
- **Frame refusal**: an app answering with `X-Frame-Options` or CSP `frame-ancestors` makes Chromium cancel the iframe navigation (`ERR_BLOCKED_BY_RESPONSE`); the take refuses with a `RuntimeError` naming the header (read back via `context.request`), instead of recording a silently blank window. Both header forms exercised live (below).

## rec.page / rec.app

`rec.page` stays the wrapper `Page` — the whole browser surface, chrome included, so the escape hatch loses nothing.
`rec.app` is new: the app iframe's `Frame` on a wrapper take, and the page's main frame otherwise, so a storyboard written against `rec.app` records identically on both paths.
SKILL.md gets one table row (the file is at its line budget; the row states the flag, the split, and the refusal).

## caption_lost on this path

`domcontentloaded` fires for the main frame only, and the wrapper document is never replaced — so `_note_document_replaced` cannot fire mid-take and no `caption_lost` issue is recorded.
That is the truth, not a suppression: the caption lives in the wrapper document, a mid-take `goto()` navigates only the iframe, and the line really is still on screen — the beats that keep reporting it are right.
The #134 class ends for wrapper takes.

## Acceptance

- Wrapper take against `tests/fixture` drives `click`, `type_into`, `scroll_to`, `spotlight`, `caption` through the frame; the storyboard asserts each verb's post-condition against `rec.app` (`#status` advances on click, the table filters on type). Green in the new `tests/smoke --wrapper-only` arm (~36 s, reachable from `--web-only`, **not** in `EXPENSIVE_ARMS`, so it runs under `--cheap` on every push — `tests/unit`'s `CheapArm` sweep confirms).
- Caption band disjoint from the app rect, twice:
  - **geometry** — `WrapperChrome` in `tests/unit` asserts band∩app = ∅ (band directly below the slot, inside the window, inside the viewport) at four viewports, on `chrome_geometry` itself;
  - **pixels** — `check_wrapper_band` sweeps the band rect of the recorded `demo.mp4` (tests/_pixels primitives): the caption lights the band (contrast 0.4–3.5 empty vs ~30 lit; bars 6/12) and the app rect moves ≤ 3.0 mean luma across the caption's appearance (measured 0.65–0.79 healthy; the planted overlap defect reads 55.27).
- Frame refusal seen red, live.

## The frame-refusal demo (seen red)

`tests/fixture` served with `X-Frame-Options: DENY`:

```
RAISED: RuntimeError
MESSAGE: this app refuses to be framed: http://127.0.0.1:45447/ answered with X-Frame-Options: DENY, so Chromium blocked the wrapper take's iframe. Recording on would produce a silently blank window presented as a demo, so the take refuses instead. Record without wrapper=True, or serve the demo target without that header.
```

And with `Content-Security-Policy: frame-ancestors 'none'`:

```
MESSAGE: this app refuses to be framed: http://127.0.0.1:45377/ answered with Content-Security-Policy: frame-ancestors 'none', so Chromium blocked the wrapper take's iframe. ...
```

The refusal take records with `strict=False` on purpose: the blocked navigation also logs a console error, so under strict a swallowed refusal would still surface as `StrictTakeFailed` and the completed-without-raising assertion could never fail for the reason it names. The refusal must stand without strict's net — the first run of the injection manifest caught exactly this (the "silently blank" entry went unnoticed under `strict=True`), and the fix is in this diff.

## Review round (FIX-FIRST) — both blocking findings fixed

**1. `tests/lint` red on the branch** — chrome.py's docstring named `tests/unit` and `tests/smoke` as bare paths; the pointer sweep rightly flagged them as repo-only. Reworded to "this repository's …"; `./tests/lint` exits 0.

**2. The band silently mangled long captions** — reproduced exactly as the verifier measured it (174-char caption, bubble 130 px vs band 96, ~17 px shaved off the first and last lines, timeline clean). Fixed by recording, not by reflowing: the wrapper's `__demoCaption` now returns the pixels the band could not show (`scrollHeight − band.clientHeight`), and `caption()` records a **`caption_clipped` issue** naming the caption and the overflow, attributed to the caption beat. Not in `STRICT_KINDS` — like `caption_lost`, it is the storyboard's mistake, not the app's. The text is deliberately never capped or reflowed.

Seen green on the reviewer's reproduction (174-char caption through a real wrapper take):

```
demo-video: 1 problem(s) recorded during this take (caption_clipped x1)
  [3.00s] caption_clipped in beat 3 (caption): the caption "This caption is deliberately far too long for the reserved caption band below the app rect, so the band's edges shave its first and its last line instead of covering the app." is 34px taller than the caption band, so the band's edges shave its first and last lines and the frames do not show the sentence the beat log records — shorten the line, or split it over two captions
```

with `"clipped_px": 34` on the issue record (the verifier's 130.08 − 96). The short caption in the same take records nothing, and the strict take still completes.

Seen red, exactly-once by the harnesses: the smoke arm now captions one line the band holds and one it cannot, and `check_wrapper_clipped` requires exactly one `caption_clipped` naming the long line (plus the over-reporting control):

```
PASS  break: the band shaves a too-tall caption and no artifact says so  [29s]
      --wrapper-only, in chrome.py: if (!text) return 0; ...
      caught: wrapper: the 174-char caption left no caption_clipped issue — the band shaved its first and last lines and no artifact says so, ...
```

and two browser-free entries in `tests/unit --fault-inject`: the recorder guard neutered (`caption_clipped` never recorded → the overflow test red) and the over-fire direction (`<= 0` → `< 0`, an exactly-fitting caption recorded as clipped → the fits-test red).

## Injections — every new assertion seen red, exactly-once by the harness

`tests/smoke-inject --arm wrapper` (6 new entries — 5 from the first round plus the caption_clipped one from the review round; the harness aborts unless each search string matches exactly once, and runs the arm clean first):

```
BASE  --wrapper-only passes clean (21s)
PASS  break: the wrapper caption is dispatched and never painted in the band
      caught: wrapper: no frame of the caption band (128, 570, 1024, 96) ever reaches 12.0 contrast across 12.5s — the caption ... never painted in its band
PASS  break: the caption's appearance repaints pixels inside the app rect
      caught: wrapper: the app rect moved 55.27 mean luma between 0.40s and 1.20s, over the 3.0 bar — the caption's appearance changed pixels inside the app rect
PASS  break: evidence on a wrapper take reads the chrome, not the app
      caught: wrapper: the caption beat's evidence aria never mentions the fixture's own heading — evidence reads the wrapper chrome, not the app
PASS  break: a frame-refused app fails with an error naming no header
      caught: wrapper-refused: the refusal does not name the header that caused it — a storyboard author cannot act on Error: 'Frame.goto: net::ERR_BLOCKED_BY_RESPO...
PASS  break: a frame-refused app is recorded as a silently blank demo
      caught: wrapper-refused: recording against X-Frame-Options: DENY completed without raising — the take recorded a silently blank window as a demo
All 5 injections were caught. [3.3 min]
```

`tests/unit --fault-inject` carries 2 new entries for the browser-free half (band geometry raised into the app rect → `WrapperChrome` red; the 34px compensation inherited by the wrapper → the caption-font test red):

```
PASS  break: the caption band is raised into the app rect it must sit below
      in chrome.py: "bandy": winy + bar + pad + apph,…
      FAIL: test_the_caption_band_and_the_app_rect_share_no_pixels (WrapperChrome)
      FAIL: test_the_band_sits_directly_below_the_slot_inside_the_window (WrapperChrome)

PASS  break: a wrapper take inherits the composite's 34px caption compensation
      in web.py: if not self._wrapper:…
      FAIL: test_a_wrapper_take_keeps_the_base_caption_font (WrapperChrome)

All 347 injections were caught.
```

One pre-existing entry in each harness pinned web.py's old single-line `from .core import ...`; both are updated to the reshaped import (the unit driver's exactly-once refusal is what caught it: `ABORT ... matched 0 times`, exit 3).

## Gate (re-run after the review fixes)

- `tests/unit` — 536 tests OK (8 new in `WrapperChrome`)
- `tests/unit --fault-inject` — all 347 caught (4 new entries)
- `tests/ci-unit` — OK
- `tests/lint` — exit 0 (ruff 0.16.1; the chrome.py pointer finding fixed)
- `mypy skills/demo-video/helpers/` at 1.18.2 — no issues, 14 files
- `tests/smoke --wrapper-only` — PASSED (28–36 s measured across runs)
- `tests/smoke-inject --arm wrapper` — 6/6 caught over a clean baseline
- `tests/smoke --cheap` — PASSED (the wrapper phase runs inside it). A first run failed in the **segments** phase only, each failure naming a −914 ms host wall-clock step at 1.8 s — the #255/#263 stepping-WSL2-host class this box hits regularly (takes in this session measured −631/−840/−842/−914 ms steps); `--segments-only` and the full `--cheap` both pass clean on the identical tree.
- `tests/smoke-inject --self-test` — every guard refused what it exists to refuse (README figures updated: 70 entries, 14 arms; one pre-existing entry's search string updated for the reshaped `web.py` import)
- `tests/pixel` — re-recorded both cached takes (this diff changes `demo_recording/` bytes, so the digest invalidation is the designed behaviour) and all six checks stay green on the **legacy-path** takes: `pixel: 6 checks, 0 failing`

## Stated limits (owned by later slices, or deliberate)

- **#360 owns**: interlude/criterion cards in the wrapper (today they still raise in the wrapper *document* as full-viewport overlays — they work, but cover the chrome too and keep the #291 compensated colour), the opening hold (a wrapper take's opening gap is measured and warned about but not covered; `_opening_held` stays `None`, the terminal recorder's honest answer), and caption survival across a real `goto` graded end to end.
- **#361 owns**: the cutover, composite deletion, flag removal, geometry-consumer migration, and the encode-time saving measurement.
- **#362 owns**: mounting the terminal in `#__chrome_slot` and retiring `_TERM_HOST_JS`'s copy of the window; until then the gradient/title-bar constants exist in `chrome.py` and in the two legacy copies, byte-identical.
- The app viewport on a wrapper take is `int(W·0.8) × int(H·2/3)` (1024×480 at 1280×720) — shorter than the composite's 1024×576, because the band's 96 px comes out of the window rather than growing it. A 16:9-assuming app gets an honest 2.13:1 viewport; revisit at #361 if it matters in practice.
- The caption band holds two lines at 26px; a longer caption clips at the band's edge (`overflow: hidden`) rather than growing over the app — growing upward is the overlap this slice exists to remove. The clip is no longer silent: the take records a `caption_clipped` issue naming the caption and the overflow in px (review fix above).
- On a wrapper take, escape-hatch pointer work through `rec.page.mouse` moves the real pointer but not the cursor dot — the dot is verb-driven by design (nothing listens for events), so raw mouse moves are invisible in the frames. Wrap such work in the verbs, or accept a dot that stays parked. Stated in SKILL.md's wrapper row too.
- `_content_rect` still trims `CONTENT_CAPTION_TRIM` (20%) off the app rect's bottom on the wrapper path, although no caption can sit there — the picture check scores a slightly smaller region than it could. Conservative, not a lie; #361 can drop the trim when the composite goes.
- `shot()` stills on a wrapper take are the framed wrapper page, not full-bleed — the "stills are full-bleed, video is windowed" mismatch the design record wanted gone ends on this path, but committed guides that expect full-bleed stills will see the window.
- `terminal()`'s card raises inside the app frame (clipped to the app rect), matching where it landed on composite takes.
- Frame-refusal detection keys on Chromium's `ERR_BLOCKED_BY_RESPONSE` plus one follow-up `context.request.get` to name the header; a proxy that strips the header from the probe answer would yield the refusal with the fallback "(the follow-up request could not read which)" wording — still a refusal, never a blank recording.

Fixes #358.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
