### PR TITLE
Wrapper chrome parity: cards over the app rect, a frame-0 opening hold, captions that survive navigation, uncompensated colour (#360)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -264,7 +264,7 @@ exception, or a non-zero exit. Both are
 |---|---|
 | `goto(path)` | Navigate (relative to base_url); waits for networkidle, but gives up after 10 s for apps that poll |
 | `pause(s)` / `shot(name)` | Hold the frame / capture `images/<name>.png` |
-| `caption(text)` | Narrator line at the bottom; `""` clears; dies on full page loads — the beat log clears with it and records a `caption_lost` issue naming the line — survives SPA routing; re-caption after a load |
+| `caption(text)` | Narrator line at the bottom; `""` clears. On the composite path it dies on full page loads — the beat log clears with it, records a `caption_lost` issue naming the line, survives SPA routing; re-caption after a load. A wrapper take's caption lives in the recorder's own band, survives navigation, and `caption_lost` can never fire there |
 | `caption(text, ac="AC-3")` / `shot(name, ac="AC-3")` | Tag this beat with the acceptance criterion it is there to demonstrate. Needs `Recorder(criteria={...})`; a tag naming an undeclared criterion is refused. See [reference/review.md](reference/review.md). |
 | `criterion("AC-3")` | Raise a card carrying **AC-3's own declared sentence**, read out of `criteria={...}` rather than retyped — so the viewer meets the clause and then watches it happen. The beat claims AC-3 and nothing else; the beats after it are untagged. Held to reading speed, and cleared by `interlude("")` like any card. |
 | `hold(min_s=1.5)` | Keep the current frame up until the current caption's narration finishes (min `min_s`). Use after a spotlight/action so the emphasis rides the whole spoken line instead of flashing. See **Pacing and perception** below. |

--- a/skills/demo-video/helpers/demo_recording/chrome.py
+++ b/skills/demo-video/helpers/demo_recording/chrome.py
@@ -4,19 +4,38 @@ Issue #358 (design record: #355). A wrapper take records a recorder-owned
 page carrying the window chrome: the pastel background, the dark rounded
 window with its title bar and traffic lights, a **content slot** the medium
 fills (the web recorder mounts the app iframe in it; #362 mounts xterm.js in
-the same slot), a **caption band** reserved BELOW the slot, and an empty card
-layer #360 will use. By construction the slot and the band share no pixels —
-`chrome_geometry` is the arithmetic behind that sentence. This repository's
-`tests/unit` (not shipped with the installed skill) grades it, and this
-repository's `tests/smoke --wrapper-only` reads the same claim out of a
-recorded take's frames.
+the same slot), a **caption band** reserved BELOW the slot, and a **card
+layer** over the slot (#360). By construction the slot and the band share no
+pixels — `chrome_geometry` is the arithmetic behind that sentence. This
+repository's `tests/unit` (not shipped with the installed skill) grades it,
+and this repository's `tests/smoke --wrapper-only` reads the same claim out
+of a recorded take's frames.
 
-Every visual constant here is ported from `web._FRAME_HTML` and
+**The card layer covers the app rect — not the chrome, not the caption
+band.** `interlude()`, `criterion()` and the `light` bridge scrim render in
+it, so a card replaces the *app's* content and nothing else: the window
+frame and the narration line are the recorder's own furniture, and taking
+them down to show a recorder-authored card would be the chrome hiding from
+itself. The legacy composite path cannot make that distinction — its card is
+an element inside the app page, so full-bleed there means the whole page —
+which is why its card sits above the caption bar and this one sits beside
+it. The decorative terminal prop (`Recorder.terminal()`) is deliberately
+**not** here: it is content, a styled element inside the demo's story that
+rides over the app the way an app dialog would, and the card layer stays
+reserved for the recorder's own furniture — #362 mounts a *real* terminal in
+the slot, and a prop living on the chrome layer would blur exactly that line.
+
+**The wrapper card declares the window's own colour — no compensation.** The
+card and the window body reach `demo.mp4` through one encoder on this path,
+so both paint the `window_body` the document was built with
+(`core.WEB_WINDOW_BODY` for the web recorder). The compensated
+`core.WEB_CARD_BODY` (#291/#301) exists because the legacy composite sends
+the card and the window through two different encoders; it stays legacy-only
+until #361 deletes it, and nothing here reads it.
+
+Every other visual constant here is ported from `web._FRAME_HTML` and
 `terminal._TERM_HOST_JS`, which stay untouched while the legacy composite
-path exists; #361 and #362 retire those copies. The window body colour is
-**not** declared here — it stays `core.WEB_WINDOW_BODY`, because the interlude
-card's compensated colour (`core.WEB_CARD_BODY`, #291/#301) is documented
-against it and the two must be read together.
+path exists; #361 and #362 retire those copies.
 """
 
 from __future__ import annotations
@@ -52,15 +71,26 @@ CAPTION_BAND_PX = 96
 CAPTION_FONT_PX = 26
 
 # Element ids. The slot is what a medium fills; the band holds the caption
-# element; the card layer is #360's mount point and ships empty this slice.
-# The caption element deliberately keeps the id `core._CAPTION_JS` uses, so
-# "the caption element" is one selector whichever path drew it. The cursor
-# dot keeps `web._CURSOR_JS`'s id for the same reason.
+# element; the card layer holds the interlude/criterion card and the bridge
+# scrim (#360). The caption element deliberately keeps the id
+# `core._CAPTION_JS` uses, so "the caption element" is one selector whichever
+# path drew it. The cursor dot keeps `web._CURSOR_JS`'s id, and the card and
+# scrim keep `core.INTERLUDE_ID`/`core.BRIDGE_ID` — that is what lets
+# `interlude("")` and core's end-of-take overlay probe (`_OVERLAY_PROBE_JS`,
+# issue #163) find them with no wrapper-specific dispatch.
 SLOT_ID = "__chrome_slot"
 BAND_ID = "__chrome_band"
 CARD_ID = "__chrome_card"
+HOLD_ID = "__chrome_hold"
 CAPTION_ID = "__demo_caption"
 CURSOR_ID = "__demo_cursor"
+
+# The card layer's stacking, against the opening hold below it and the cursor
+# dot above it. Root-context values: `#__chrome_win` is position:fixed with no
+# z-index of its own, so it opens no stacking context and its children's
+# z-indexes rank directly against the fixed-position hold's.
+HOLD_Z = 2147483644
+CARD_LAYER_Z = 2147483645
 
 
 def chrome_geometry(
@@ -141,9 +171,16 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
     font: 13px/1 ui-monospace, monospace; color: __BARFG__; }
   .dot { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
   #__chrome_ttl { flex: 1; text-align: center; letter-spacing: .02em; }
+  /* The slot's underlay is the browser's own white canvas, not the window
+     body: an app document that paints no background of its own sits on
+     white in any real browser, and a transparent about:blank iframe
+     borrowing the recorder's window colour would make the opening hold
+     unfalsifiable — with or without the hold, the app rect would read the
+     same dark field. White underneath is what the hold exists to cover
+     (#360), and what lets a frame-0 reading tell the two apart. */
   #__chrome_slot { position: absolute; left: __PAD__px;
     top: __SLOTTOP__px; width: __APPW__px; height: __APPH__px;
-    overflow: hidden; }
+    overflow: hidden; background: #fff; }
   #__chrome_slot iframe { display: block; border: 0;
     width: __APPW__px; height: __APPH__px; }
   #__chrome_band { position: absolute; left: __PAD__px; top: __BANDTOP__px;
@@ -155,7 +192,40 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
     font: 600 __CAPFONT__px/1.36 system-ui, sans-serif; letter-spacing: .01em;
     pointer-events: none; opacity: 0;
     transition: opacity .3s ease; box-shadow: 0 6px 24px rgba(0,0,0,.28); }
-  #__chrome_card { position: absolute; inset: 0; display: none; }
+  /* The card layer sits exactly on the content slot — the app rect and
+     nothing else. See the module docstring for why a card covers the app
+     and never the chrome or the caption band. */
+  #__chrome_card { position: absolute; left: __PAD__px; top: __SLOTTOP__px;
+    width: __APPW__px; height: __APPH__px; overflow: hidden;
+    pointer-events: none; z-index: __CARDZ__; }
+  /* The full card: the window's own colour, one flat field with the sentence
+     on it — no compensation, one encoder (see the module docstring). Above
+     the scrim and the opening hold, so a clause is legible over either. */
+  #__demo_interlude { position: absolute; inset: 0; display: flex;
+    align-items: center; justify-content: center;
+    font: 500 30px/1.5 system-ui, sans-serif; text-align: center;
+    padding: 0 12%; opacity: 0; transition: opacity .45s ease;
+    background: __WINBG__; color: #f2f0ec; z-index: 3; }
+  /* The light bridge: a soft scrim with the app still visible behind it. */
+  #__demo_bridge { position: absolute; inset: 0; display: flex;
+    align-items: center; justify-content: center; opacity: 0;
+    transition: opacity .4s ease;
+    background: radial-gradient(ellipse at center,
+      rgba(18,15,28,.58) 0%, rgba(18,15,28,.16) 70%, rgba(18,15,28,0) 100%);
+    z-index: 2; }
+  #__demo_bridge_t { color: #fff; font: 600 34px/1.4 system-ui, sans-serif;
+    text-align: center; max-width: 72%;
+    text-shadow: 0 2px 22px rgba(0,0,0,.65); }
+  /* The opening hold, in this document's own markup and **already opaque**
+     (_OPENING_CARD_JS's construction): `set_content` replaces the initial
+     document without re-running the context init scripts, measured — a
+     hold that relied on the init script alone left frame 0 reading the
+     slot's white canvas at 255 mean luma. The init script (OPENING_HOLD_JS)
+     covers the documents before this one; whichever builds first owns the
+     id. Below the cards: a storyboard that interludes before its first
+     goto must show the clause over the hold. */
+  #__chrome_hold { position: absolute; inset: 0; background: __WINBG__;
+    opacity: 1; transition: opacity .45s ease; z-index: 1; }
   #__demo_cursor { position: fixed; top: -40px; left: -40px; width: 18px;
     height: 18px; border-radius: 50%; background: rgba(__ACCENT__,.45);
     border: 2px solid rgba(__ACCENT__,.95); pointer-events: none;
@@ -173,7 +243,11 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
   </div>
   <div id="__chrome_slot"></div>
   <div id="__chrome_band"><div id="__demo_caption"></div></div>
-  <div id="__chrome_card"></div>
+  <div id="__chrome_card">
+    <div id="__chrome_hold"></div>
+    <div id="__demo_bridge"><div id="__demo_bridge_t"></div></div>
+    <div id="__demo_interlude"></div>
+  </div>
 </div>
 <div id="__demo_cursor"></div>
 <script>
@@ -190,6 +264,28 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
     if (!text) return 0;
     const band = document.getElementById('__chrome_band');
     return Math.max(0, el.scrollHeight - band.clientHeight);
+  };
+  // The card and the scrim, band-aware for the same reason __demoCaption
+  // above is: this document's versions render in the card layer over the app
+  // rect, so the init-script versions (core's, which cover the *viewport*
+  // they run in) never paint here. Same ids, same contract — text raises,
+  // '' fades — so core's interlude(''), criterion() and end-of-take overlay
+  // probe need no wrapper dispatch.
+  window.__demoInterlude = (text) => {
+    const card = document.getElementById('__demo_interlude');
+    card.textContent = text;
+    card.style.opacity = text ? '1' : '0';
+  };
+  window.__demoBridge = (text) => {
+    document.getElementById('__demo_bridge_t').textContent = text;
+    document.getElementById('__demo_bridge').style.opacity = text ? '1' : '0';
+  };
+  // Defined here as well as in OPENING_HOLD_JS: this document carries its
+  // own hold element, and the reveal must not depend on when (or whether)
+  // the context init script re-ran for it.
+  window.__demoChromeHoldClear = () => {
+    const el = document.getElementById('__chrome_hold');
+    if (el) el.style.opacity = '0';
   };
   window.__demoChromeCursor = (x, y) => {
     const dot = document.getElementById('__demo_cursor');
@@ -217,11 +313,15 @@ def chrome_html(
 ) -> str:
     """The wrapper document, ready for `page.set_content`.
 
-    `geom` is `chrome_geometry`'s dict. `window_body` is the window's fill —
-    `core.WEB_WINDOW_BODY` for the web path (see this module's docstring for
-    why it is not declared here). `accent` is the recorder's `R,G,B` string,
-    used only by the cursor dot. The slot ships empty: the medium mounts its
-    content (an iframe, or #362's xterm host) into `#__chrome_slot`.
+    `geom` is `chrome_geometry`'s dict. `window_body` is the window's fill
+    **and the card's** — `core.WEB_WINDOW_BODY` for the web path. One
+    parameter for both on purpose: the two ride one encoder here, so "the
+    card is the window's own colour" is a single substitution rather than a
+    compensated pair (see the module docstring, and #291/#301 for the pair
+    the legacy composite still needs). `accent` is the recorder's `R,G,B`
+    string, used only by the cursor dot. The slot ships empty: the medium
+    mounts its content (an iframe, or #362's xterm host) into
+    `#__chrome_slot`.
     """
     slot_top = geom["bar"] + geom["pad"]
     band_top = slot_top + geom["apph"]
@@ -247,8 +347,91 @@ def chrome_html(
         "__BAND__": str(geom["band"]),
         "__CAPFONT__": str(caption_font_px),
         "__ACCENT__": accent,
+        "__CARDZ__": str(CARD_LAYER_Z),
     }
     html = _CHROME_HTML
     for token, value in replacements.items():
         html = html.replace(token, value)
     return html
+
+
+# The opening hold: an opaque field in the window's own colour over the app
+# rect, up in **frame 0** and cleared by the storyboard's first content beat
+# (the web recorder clears it when its first `goto()` lands). It is what
+# replaces the legacy composite's ffmpeg `enable='lt(t,held)'` second overlay
+# (issue #360): with one encoder there is no exit-time compositing to hide a
+# blank opening behind, so the blank opening is never on screen instead.
+#
+# An **init script**, and appended **already opaque** — both halves are
+# `terminal._OPENING_CARD_JS`'s pattern, kept for its reasons: an init script
+# runs on the wrapper page's *initial empty document*, which is earlier than
+# any Python statement or `set_content` can reach; and an element whose
+# computed opacity has been 1 since it entered the tree has no fade-in to run
+# over the recorder's own setup. The chrome document then carries its own
+# copy of the hold **in its markup** (`_CHROME_HTML`'s card layer) rather
+# than relying on this script re-running for it: measured, the init script's
+# re-run on the `set_content` document lands only at that document's
+# DOMContentLoaded, after its first paint — frame 0 read the slot's white
+# canvas at 255 mean luma. One id, and whichever document builds first owns
+# it, so the two sources can never stack. The clear is a fade, because by
+# then the app has painted underneath.
+#
+# Top-window guarded: context init scripts run in every frame, and the app
+# iframe painting a copy of the hold over its own content would be the hold
+# covering the thing it exists to reveal.
+#
+# The pastel paint on the document element is `terminal._init_context`'s
+# issue-#25 guard, for the same white flash: the initial document is up
+# before the chrome document replaces it, and an unpainted document is white.
+OPENING_HOLD_JS = """
+(() => {
+  if (window !== window.top) return;
+  const paint = (el) => { if (el) el.style.background = '__BG__'; };
+  paint(document.documentElement);
+  const build = () => {
+    paint(document.documentElement);
+    if (!document.body || document.getElementById('__chrome_hold')) return;
+    const el = document.createElement('div');
+    el.id = '__chrome_hold';
+    el.style.cssText = 'position: fixed; left: __APPX__px; top: __APPY__px;'
+      + ' width: __APPW__px; height: __APPH__px; background: __WINBG__;'
+      + ' z-index: __HOLDZ__; pointer-events: none;'
+      + ' transition: opacity .45s ease;';
+    el.style.opacity = '1';
+    document.body.appendChild(el);
+  };
+  if (document.body) build();
+  else addEventListener('DOMContentLoaded', build);
+  window.__demoChromeHoldClear = () => {
+    const el = document.getElementById('__chrome_hold');
+    if (el) el.style.opacity = '0';
+  };
+})();
+"""
+
+
+def opening_hold_script(
+    geom: dict,
+    *,
+    window_body: str,
+    background: str = CHROME_BG,
+) -> str:
+    """`OPENING_HOLD_JS` with this take's geometry and colours in it.
+
+    `window_body` is the same fill `chrome_html` paints the window and the
+    card with, so the hold, the card and the window are one declared colour
+    on this path — the single-encoder point the module docstring makes.
+    """
+    replacements = {
+        "__BG__": background,
+        "__WINBG__": window_body,
+        "__APPX__": str(geom["appx"]),
+        "__APPY__": str(geom["appy"]),
+        "__APPW__": str(geom["appw"]),
+        "__APPH__": str(geom["apph"]),
+        "__HOLDZ__": str(HOLD_Z),
+    }
+    script = OPENING_HOLD_JS
+    for token, value in replacements.items():
+        script = script.replace(token, value)
+    return script

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -31,7 +31,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import urlparse
 
-from .chrome import chrome_geometry, chrome_html
+from .chrome import chrome_geometry, chrome_html, opening_hold_script
 from .content import OPENING_HOLD_LIMIT_S, content_rect, opening_gap
 from .core import (
     INTERLUDE_CSS_WEB,
@@ -537,6 +537,11 @@ class Recorder(_DemoBase):
         self._wrapper = bool(wrapper)
         # The app iframe's Frame, once `_start` has mounted it (wrapper only).
         self._app_frame: object | None = None
+        # Whether the wrapper take's opening hold has been cleared (#360).
+        # The hold is up from frame 0 (see chrome.OPENING_HOLD_JS) and the
+        # first goto() that lands is what clears it — the storyboard's first
+        # content beat, the moment there is an app to reveal.
+        self._hold_cleared = False
         # Where the wrapper take last commanded the pointer, in wrapper-page
         # coordinates. Seeded at the origin, where a fresh page's pointer
         # actually sits; `_glide` is the only writer.
@@ -552,7 +557,11 @@ class Recorder(_DemoBase):
         # one: the terminal palette is the colour of a *terminal*, and inside
         # this window frame a full-bleed field of it reads as one — the whole
         # of issue #291. The web card is the window's own body colour instead,
-        # as it lands in demo.mp4. See core.INTERLUDE_CSS_WEB.
+        # as it lands in demo.mp4. See core.INTERLUDE_CSS_WEB. On a wrapper
+        # take this dispatch is moot: the wrapper document defines its own
+        # `__demoInterlude` in the card layer (chrome.py, #360), declaring
+        # `WEB_WINDOW_BODY` uncompensated, and the init script this CSS rides
+        # never paints there.
         self._interlude_css = INTERLUDE_CSS_WEB
         # What spotlight() is currently pointing at, which is what a beat's
         # evidence is scoped to. Held here rather than read back out of the
@@ -635,6 +644,20 @@ class Recorder(_DemoBase):
         # dot on top of the chrome's.
         if not self._wrapper:
             context.add_init_script(_CURSOR_JS.replace("__ACCENT__", self._accent))
+        else:
+            # The opening hold (#360): frame 0 is the window's own colour
+            # over the app rect, not a white iframe waiting for the first
+            # goto. An init script for _OPENING_CARD_JS's reasons — see
+            # chrome.OPENING_HOLD_JS — and the geometry is recomputed here
+            # because init scripts are registered before the page (and
+            # therefore before `_start_wrapper` runs); `chrome_geometry` is
+            # pure, so the two calls cannot disagree.
+            context.add_init_script(
+                opening_hold_script(
+                    chrome_geometry(self._size["width"], self._size["height"]),
+                    window_body=WEB_WINDOW_BODY,
+                )
+            )
         context.add_init_script(
             _TERMINAL_JS.replace("__TERM_TITLE__", self._terminal_title)
             .replace("__TERM_PROMPT__", self._terminal_prompt)
@@ -687,14 +710,20 @@ class Recorder(_DemoBase):
         # and 151, and the suite replays each one through this subscription
         # (issue #179).
         #
-        # On a **wrapper** take (#358) that main-frame-only property is what
-        # ends the #134 class: the caption lives in the wrapper document,
-        # `goto()` navigates the app *iframe*, and the wrapper document is
-        # never replaced — so this never fires mid-take, no `caption_lost`
-        # issue is recorded, and both are the truth rather than a suppression:
-        # the line really is still on screen after the app navigates, and the
-        # beats that keep reporting it are right.
-        page.on("domcontentloaded", self._note_document_replaced)
+        # On a **wrapper** take (#358, #360) the subscription itself is what
+        # goes: the caption lives in the wrapper document, `goto()` navigates
+        # the app *iframe*, and the wrapper document is never replaced — a
+        # caption structurally cannot be destroyed by navigation there, so
+        # `caption_lost` can never fire and the recorder does not listen for
+        # it. Not listening rather than listening-and-never-firing is the
+        # honest shape: it makes "this issue cannot exist on a wrapper take"
+        # a property of the code instead of an observation about one
+        # Playwright's event routing, and the beats that keep reporting the
+        # caption across a mid-take goto are right — the line really is
+        # still on screen (tests/smoke --wrapper-only reads it out of the
+        # band's pixels across a full document load).
+        if not self._wrapper:
+            page.on("domcontentloaded", self._note_document_replaced)
 
     def _start(self) -> None:
         if self._wrapper:
@@ -808,10 +837,13 @@ class Recorder(_DemoBase):
     def _postprocess(self, mp4: Path) -> None:
         if self._wrapper:
             # The recorded page already is the framed picture — one encoder,
-            # no composite, no opening-hold overlay (the wrapper's opening is
-            # #360's). `_opening_held` stays None: this path never claims to
-            # cover a gap, which is the same honest answer the terminal
-            # recorder gives.
+            # no composite, and no ffmpeg opening-hold overlay: the wrapper's
+            # opening is held in-page instead, by the frame-0 hold in
+            # chrome.OPENING_HOLD_JS (#360). `_opening_held` stays None: this
+            # path never claims the *encode* covered a gap, which is the same
+            # honest answer the terminal recorder gives about its own opening
+            # card, and `content.opening.gap` then describes the hold as the
+            # featureless stretch it really is, warning-free.
             return
         # Composite the recorded video into the window body on the background.
         g = self._geom
@@ -1043,6 +1075,13 @@ class Recorder(_DemoBase):
             target.wait_for_load_state("networkidle", timeout=10_000)
         except Exception:
             pass  # apps that poll never go network-idle; the page is up
+        if self._wrapper and not self._hold_cleared:
+            # The storyboard's first content beat landed: there is an app in
+            # the slot now, so the opening hold (up since frame 0 — see
+            # chrome.OPENING_HOLD_JS) fades out. Inside this beat on purpose:
+            # the beat log's account of when the app appeared is the goto.
+            self.page.evaluate("() => window.__demoChromeHoldClear()")
+            self._hold_cleared = True
 
     def _frame_refusal(self, url: str) -> str:
         """Why this app cannot be recorded through the wrapper's iframe.

--- a/skills/demo-video/reference/failures.md
+++ b/skills/demo-video/reference/failures.md
@@ -22,7 +22,7 @@ app itself and writes what it saw into `timeline.json` as `issues`:
 | `request_failed` | a request that never got a response | no |
 | `http_error` | a response with status ≥ 400 (3xx redirects are normal) | no |
 | `nonzero_exit` | a `TerminalRecorder` `run()` whose command failed | yes |
-| `caption_lost` | a page load took the caption bar off the screen; the beat log clears with it and the issue names the line and the new URL | no |
+| `caption_lost` | a page load took the caption bar off the screen; the beat log clears with it and the issue names the line and the new URL. Composite takes only: a wrapper take's caption lives in the recorder's own document, which no app navigation can destroy, so this can never fire there — the recorder does not even subscribe the signal (#360) | no |
 
 Each issue is **attributed to the beat that was running when it fired** —
 `beat` (an index into `beats`), plus the beat's `verb` and `caption` copied

--- a/tests/README.md
+++ b/tests/README.md
@@ -117,7 +117,7 @@ seen red under a planted recorder defect in #351's pull request.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~51 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~55 min, nightly)
 ├── unit               # the browser-free half (~6 s, 536 tests, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
@@ -296,7 +296,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~225 s)
-tests/smoke-inject                # all 70 entries, ~51 min
+tests/smoke-inject                # all 73 entries, ~55 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -2153,7 +2153,7 @@ are what changed that, and they are now load-bearing rather than a convenience.
 | `--polish-only` | 26 s |
 | `--segments-only` | 29 s |
 | `--overlay-only` | 31 s |
-| `--wrapper-only` | 36 s |
+| `--wrapper-only` | 48 s |
 | `--failure-only` | 48 s |
 | `--web-only` | 123 s |
 | `--content-only` | 148 s |
@@ -2221,7 +2221,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-70 entries, 14 arms, ~51.0 min of takes
+73 entries, 14 arms, ~54.8 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -2258,14 +2258,14 @@ paragraph whose job is to say what this manifest does not cover.
 | `--segments-only` | 14 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the sheet stops saying **which clock** it cut them on, so a reviewer cannot tell a corrected sheet from one cut on the raw beat log ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
-| `--wrapper-only` | 6 | the wrapper take (#358) stops keeping its promises silently: a caption dispatched and never painted in its band; a caption too tall for the band shaved at both edges with no caption_clipped issue saying so (#366's review finding); the caption's appearance repainting pixels inside the app rect, which is the overlap the band exists to remove; evidence captured from the wrapper chrome instead of the app frame, with url, title and aria all plausible; a frame-refused app surfacing as a bare `ERR_BLOCKED_BY_RESPONSE` naming no header; or the block swallowed entirely, so a silently blank window records to the end as a demo — the artifact-lie outcome the issue names outright |
+| `--wrapper-only` | 9 | the wrapper take (#358, #360) stops keeping its promises silently: a caption dispatched and never painted in its band; a caption too tall for the band shaved at both edges with no caption_clipped issue saying so (#366's review finding); the caption's appearance repainting pixels inside the app rect, which is the overlap the band exists to remove; evidence captured from the wrapper chrome instead of the app frame, with url, title and aria all plausible; a frame-refused app surfacing as a bare `ERR_BLOCKED_BY_RESPONSE` naming no header; or the block swallowed entirely, so a silently blank window records to the end as a demo — the artifact-lie outcome the issue names outright. Three more are #360's chrome parity, each invisible to every artifact but the encoded frames: the card layer shipping transparent, so the take opens on the slot's white canvas instead of the hold; the card's field nudged off the window body it must equal on the single-encoder path; and a mid-take goto emptying the caption band while the beat log keeps reporting the line |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
 | `--web-only` | 6 | the form verbs lie about what they did: `press` logging a key it never sent or returning before the page saw it, `clear` selecting without deleting or emptying the field between two frames, either of them driving the page and writing no beat |
 | `--content-only` | 3 | the recorder stops noticing a recording nobody can watch, starts warning about honest demos that hold still, or goes back to scoring the whole frame (issue #17's anti-correlated metric) |
 
 ### What it does **not** cover
 
-- **17 of `tests/smoke`'s 48 check functions have no entry**, and the harness
+- **17 of `tests/smoke`'s 51 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 

--- a/tests/fixture/second.html
+++ b/tests/fixture/second.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Northwind Ops — weekly report</title>
+<style>
+  /* A deliberately mid-luma page, nothing like the dashboard's near-white
+     (#f5f6f9, ~240 mean luma) and nothing like the recorder's window body
+     (#181825, ~24): tests/smoke's wrapper arm locates the mid-take goto in
+     the encoded pixels by this page arriving in the app rect, so its mean
+     luma must sit in a band of its own. Measured ~100 over the app rect. */
+  body {
+    margin: 0; min-height: 100vh; background: #3f6f5f; color: #f2f7f4;
+    font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+    display: flex; align-items: center; justify-content: center;
+  }
+  main { max-width: 640px; padding: 40px; text-align: center; }
+  h1 { margin: 0 0 12px; font-size: 28px; letter-spacing: -0.01em; }
+  p { margin: 0; color: #cfe2d9; }
+</style>
+</head>
+<body>
+<main>
+  <h1>Weekly report</h1>
+  <p>A second document, reached by a real mid-take navigation.</p>
+</main>
+</body>
+</html>

--- a/tests/smoke
+++ b/tests/smoke
@@ -127,6 +127,7 @@ _HERE = str(Path(__file__).resolve().parent)
 if _HERE not in sys.path:
     sys.path.insert(0, _HERE)
 from _pixels import (  # noqa: E402
+    FRAME_BAND,
     Rect,
     caption_band,
     card_strip,
@@ -9336,19 +9337,30 @@ def run_strict_terminal(out_root: Path) -> list[str]:
     return check_strict_failure("terminal-strict", out_dir, raised, ["nonzero_exit"])
 
 
-# -- the wrapper take (issue #358) --------------------------------------------
+# -- the wrapper take (issues #358, #360) --------------------------------------
 #
 # The opt-in wrapper path: chrome in the recorded page, the app in an iframe
 # at true pixel size, the caption in a reserved band BELOW the app rect. Two
-# takes: one healthy — every locator verb driven through the frame, the band
-# graded out of the pixels — and one against a fixture served with
-# X-Frame-Options: DENY, which the recorder must refuse by name rather than
-# record as a silently blank window.
+# takes: one healthy — every locator verb driven through the frame, the band,
+# the opening hold, the criterion card and a caption surviving a real
+# mid-take goto all graded out of the pixels — and one against a fixture
+# served with X-Frame-Options: DENY, which the recorder must refuse by name
+# rather than record as a silently blank window.
 
 # The line the wrapper take captions with, and the line the refusal take must
 # never reach.
 WRAPPER_CAPTION = "The caption sits in its own band below the app."
 WRAPPER_UNREACHED = "this caption must never be recorded"
+
+# The clause the wrapper take's criterion card shows (#360): declared as the
+# take's one acceptance criterion and put on screen by `rec.criterion`.
+WRAPPER_CLAUSE = "The caption band survives a full page navigation."
+
+# The line that has to outlive a document (#360): captioned, then the app
+# frame is sent to a second fixture page, and the band must still be lit
+# after the load — the wrapper document holds the caption and never
+# navigates, so the #134 caption_lost class cannot exist here.
+WRAPPER_SURVIVES = "This line must outlive the document below it."
 
 # A caption the band cannot hold: 174 characters, three rendered lines
 # against the band's two. The wrapper take says it with a caption_clipped
@@ -9380,6 +9392,50 @@ WRAPPER_APP_MAX_DELTA = 3.0
 # the two instants.
 WRAPPER_APP_CONTROL_S = 0.3
 WRAPPER_APP_SAMPLE_S = 0.5
+
+# The opening hold's bars (#360), the terminal opening card's discipline over
+# the wrapper's own strip: the hold is the window body (`#181825`, ~24 mean
+# luma as encoded) and the bare fixture app's top band is near-white (~226).
+# The deliberately empty stretch between them is a frame that is neither —
+# the slot's white canvas showing before the app painted would read ~255,
+# and a mid-fade frame lands between.
+WRAPPER_HOLD_MAX_LUMA = 60.0
+WRAPPER_BARE_MIN_LUMA = 150.0
+# How much of the take is decoded for its first frame: read with `-t` and no
+# `fps` filter, so what comes back is frame zero exactly (the filter answers
+# with whichever frame lands nearest its first slot's middle — the defect
+# content.py's `_content_frames` docstring records).
+WRAPPER_FIRST_FRAME_S = 0.05
+
+# The card-vs-window bar (#360): on the wrapper path the criterion card and
+# the window body declare ONE colour and ride ONE encoder, so as encoded
+# they sit within this, worst channel — measured 1.0 on a healthy take.
+# There is no compensated pair here to compare declarations of, and the
+# check deliberately reads pixels rather than declarations either way
+# (#297's two recorded anti-patterns).
+WRAPPER_CARD_WINDOW_TOLERANCE = 2.0
+# Where inside the criterion beat the card is sampled, and how far past its
+# end the no-card control is read. Fractions well inside the beat because
+# the beat log's clock and the video's sit ~130 ms apart (#245); the control
+# lands in the storyboard's deliberate pause after `interlude("")`.
+WRAPPER_CARD_FRACTIONS = (0.3, 0.6)
+WRAPPER_CARD_CONTROL_AFTER_S = 1.2
+# Under this separation between the no-card control and the window body, the
+# app cannot be told from the card and the readings above prove nothing.
+WRAPPER_CARD_CONTROL_MIN_GAP = 12.0
+
+# The second fixture page's band in the app rect (#360): `second.html` is a
+# deliberate mid-luma page (~100 as encoded) so the mid-take goto is located
+# in the pixels — nothing like the dashboard (~226), the window body (~24)
+# or the slot's white canvas (255). A frame counts only as part of a run
+# (WRAPPER_SECOND_MIN_FRAMES at WRAPPER_BAND_SWEEP_FPS), because a fade
+# passes through any single band.
+WRAPPER_SECOND_MIN_LUMA = 75.0
+WRAPPER_SECOND_MAX_LUMA = 140.0
+WRAPPER_SECOND_MIN_FRAMES = 4
+# Instants after the second document's arrival at which the caption band
+# must still be lit — the pixel form of "the caption survived the load".
+WRAPPER_SURVIVES_SAMPLES_S = (0.2, 0.5, 0.8)
 
 
 @contextmanager
@@ -9461,9 +9517,15 @@ def record_wrapper(out_dir: Path, base_url: str) -> dict:
         strict=True,
         deterministic=True,
         wrapper=True,
+        criteria={"AC-1": WRAPPER_CLAUSE},
     ) as rec:
         rec.goto("/")
         rec.wait_for("#kpi-rev")
+        # Distance between the opening hold's reveal (the end of the goto,
+        # #360) and the first caption: check_wrapper_band reads an app-rect
+        # control frame 0.3s before the band lights, and that frame must
+        # show the settled app, not the tail of the reveal.
+        rec.pause(1.0)
         rec.caption(WRAPPER_CAPTION)
         rec.spotlight("#kpi-rev")
         rec.hold()
@@ -9489,6 +9551,21 @@ def record_wrapper(out_dir: Path, base_url: str) -> dict:
         # (check_wrapper_clipped), and the band must still end dark for the
         # band sweep's last-frame claim.
         rec.caption(WRAPPER_LONG_CAPTION)
+        rec.caption("")
+        # The criterion card (#360): over the app rect only, the window
+        # frame and the caption band still on screen while it is up, the
+        # card and the window one declared colour on one encoder
+        # (check_wrapper_card). The pause after the clear is the check's
+        # no-card control window.
+        rec.criterion("AC-1")
+        rec.interlude("")
+        rec.pause(1.5)
+        # The caption survives a real mid-take goto (#360): the wrapper
+        # document holds the line and outlives the app document
+        # (check_wrapper_caption_survives).
+        rec.caption(WRAPPER_SURVIVES)
+        rec.goto("/second.html")
+        rec.pause(1.0)
         rec.caption("")
         rec.pause(0.6)
         geom = dict(rec._geom)
@@ -9604,6 +9681,276 @@ def longest_true_run(flags: list[bool]) -> tuple[int, int] | None:
                 best = (start, i - start)
             start = None
     return best
+
+
+def wrapper_pad_band(geom: dict) -> Rect:
+    """The strip of flat window body a wrapper card is compared against.
+
+    The window's **bottom pad** — between the caption band's end and the
+    window's bottom edge — because it is the one stretch of bare window body
+    a wrapper frame always shows: the pad `frame_band` reads on a composite
+    take is the caption band here, which carries a bubble whenever a line is
+    up. Inset from the pad's own edges for `frame_band`'s reasons — the
+    outermost rows blend into the drop shadow and the band above.
+    """
+    pad_top = geom["bandy"] + geom["bandh"]
+    pad_bottom = geom["winy"] + geom["winh"]
+    fx, fw = FRAME_BAND
+    return (
+        geom["bandx"] + int(geom["bandw"] * fx),
+        pad_top + 2,
+        max(8, int(geom["bandw"] * fw)),
+        max(2, pad_bottom - pad_top - 4),
+    )
+
+
+def check_wrapper_opening(out_dir: Path, info: dict) -> list[str]:
+    """The wrapper take's first frame is the opening hold (#360).
+
+    The wrapper path has no exit-time composite, so the legacy ffmpeg
+    `enable='lt(t,held)'` overlay cannot cover a blank opening — the hold is
+    in the page instead, opaque from frame 0 (chrome.OPENING_HOLD_JS), and
+    this reads it the way `check_opening_card` reads the terminal's: a strip
+    of the frame, frame zero **exactly** (`-t`, no fps filter — the filter
+    hands back a frame from mid-slot, the defect content.py records), bars
+    an order of magnitude apart.
+
+    The strip is inside the app rect, where the hold is told apart from the
+    slot's white canvas (~255) and from the bare app (~226) by the window
+    body's ~24. Two claims: frame zero reads the hold, and the strip later
+    reads the bare app — without the second, a hold never cleared (the #91
+    shape) satisfies the first forever.
+    """
+    mp4 = out_dir / "demo.mp4"
+    geom = info["geom"]
+    app: Rect = (geom["appx"], geom["appy"], geom["appw"], geom["apph"])
+    strip = card_strip(app)
+    failures: list[str] = []
+    first = gray_frames(mp4, rect=strip, duration=WRAPPER_FIRST_FRAME_S)
+    if not first:
+        return [
+            f"wrapper-opening: nothing decoded from the first "
+            f"{WRAPPER_FIRST_FRAME_S}s of demo.mp4 over {strip}, so what the "
+            f"take opened on cannot be read"
+        ]
+    luma0 = sum(first[0]) / len(first[0])
+    if luma0 > WRAPPER_HOLD_MAX_LUMA:
+        failures.append(
+            f"wrapper-opening: the wrapper take's first frame reads {luma0:.1f} "
+            f"mean luma over {strip}, over the {WRAPPER_HOLD_MAX_LUMA} bar for "
+            f"the opening hold — the card layer was not opaque in frame 0, so "
+            f"the take opens on the slot's canvas or the loading app instead "
+            f"of the hold (#360)"
+        )
+    sweep = gray_frames(mp4, rect=strip, sample_fps=WRAPPER_BAND_SWEEP_FPS)
+    bare = [
+        i
+        for i, frame in enumerate(sweep)
+        if sum(frame) / len(frame) >= WRAPPER_BARE_MIN_LUMA
+    ]
+    if not bare:
+        failures.append(
+            f"wrapper-opening: no frame of {len(sweep)} at "
+            f"{WRAPPER_BAND_SWEEP_FPS} fps ever reads {WRAPPER_BARE_MIN_LUMA} "
+            f"mean luma over {strip} — the hold (or a card) covers the app "
+            f"for the whole take, so the first-frame reading above would be "
+            f"satisfied by a recorder that painted a rectangle and stopped"
+        )
+    if not failures:
+        print(
+            f"wrapper-opening: frame 0 reads {luma0:.1f} over {strip} (hold "
+            f"<= {WRAPPER_HOLD_MAX_LUMA}), and the app shows from "
+            f"{bare[0] / WRAPPER_BAND_SWEEP_FPS:.1f}s (bare >= "
+            f"{WRAPPER_BARE_MIN_LUMA})"
+        )
+    return failures
+
+
+def check_wrapper_card(out_dir: Path, info: dict) -> list[str]:
+    """The wrapper card is the window's colour on screen, uncompensated (#360).
+
+    `check_criterion_card`'s question asked of the single-encoder path: the
+    card and the window body declare **one** colour (`core.WEB_WINDOW_BODY`)
+    and reach demo.mp4 through one encoder, so as encoded they must sit
+    within WRAPPER_CARD_WINDOW_TOLERANCE, worst channel. Read out of the
+    pixels on both sides — #297 recorded both declaration-shaped
+    alternatives (pinned equal, pinned apart) as anti-patterns, and neither
+    is asserted here or anywhere.
+
+    The premise the readings need: after the card is down, the strip must
+    read as something *other* than the window body, or an app the colour of
+    the card would pass with no card in the recording at all.
+    """
+    mp4 = out_dir / "demo.mp4"
+    doc = json.loads((out_dir / "timeline.json").read_text(encoding="utf-8"))
+    cards = [b for b in doc.get("beats") or [] if b.get("verb") == "criterion"]
+    if len(cards) != 1:
+        return [
+            f"wrapper-card: the take logged {len(cards)} criterion beats, "
+            f"expected 1 — there is no card span to read"
+        ]
+    start, end = float(cards[0]["t_start"]), float(cards[0]["t_end"])
+    geom = info["geom"]
+    app: Rect = (geom["appx"], geom["appy"], geom["appw"], geom["apph"])
+    strip = card_strip(app)
+    pad = wrapper_pad_band(geom)
+
+    control_at = end + WRAPPER_CARD_CONTROL_AFTER_S
+    control = strip_rgb(mp4, control_at, strip)
+    control_pad = strip_rgb(mp4, control_at, pad)
+    if control is None or control_pad is None:
+        return [
+            f"wrapper-card: demo.mp4 decodes no frame at {control_at:.2f}s, "
+            f"so there is no no-card control to compare with"
+        ]
+    control_gap = channels_apart(control, control_pad)
+    if control_gap <= WRAPPER_CARD_CONTROL_MIN_GAP:
+        return [
+            f"wrapper-card: with the card down since {end:.2f}s the strip "
+            f"{strip} reads {tuple(round(v) for v in control)} at "
+            f"{control_at:.2f}s, only {control_gap:.0f} levels off the window "
+            f"body {tuple(round(v) for v in control_pad)} (premise bar "
+            f"{WRAPPER_CARD_CONTROL_MIN_GAP}) — either the app cannot be told "
+            f"from the card, or the card was never taken down"
+        ]
+
+    failures: list[str] = []
+    gaps: list[float] = []
+    for fraction in WRAPPER_CARD_FRACTIONS:
+        at = start + (end - start) * fraction
+        card = strip_rgb(mp4, at, strip)
+        body = strip_rgb(mp4, at, pad)
+        if card is None or body is None:
+            failures.append(
+                f"wrapper-card: demo.mp4 decodes no frame at {at:.2f}s over "
+                f"{strip} or {pad}"
+            )
+            continue
+        gap = channels_apart(card, body)
+        gaps.append(gap)
+        if gap > WRAPPER_CARD_WINDOW_TOLERANCE:
+            failures.append(
+                f"wrapper-card: {(fraction * 100):.0f}% through the criterion "
+                f"beat the card reads {tuple(round(v) for v in card)} over "
+                f"{strip} and the window body "
+                f"{tuple(round(v) for v in body)} over {pad}, {gap:.1f} levels "
+                f"apart, worst channel (bar {WRAPPER_CARD_WINDOW_TOLERANCE}). "
+                f"On the wrapper path the two declare one colour and ride one "
+                f"encoder (#360), so this gap means the card's field was "
+                f"repainted away from core.WEB_WINDOW_BODY — the #291 mismatch "
+                f"a human once had to spot by eye"
+            )
+    if not failures:
+        print(
+            f"wrapper-card: card and window body sit {max(gaps):.1f} apart, "
+            f"worst channel over {len(gaps)} samples (bar "
+            f"{WRAPPER_CARD_WINDOW_TOLERANCE}); the no-card control reads "
+            f"{control_gap:.0f} off the body (premise bar "
+            f"{WRAPPER_CARD_CONTROL_MIN_GAP}) — one declared colour, one "
+            f"encoder, uncompensated"
+        )
+    return failures
+
+
+def check_wrapper_caption_survives(out_dir: Path, info: dict) -> list[str]:
+    """The caption outlives the app's document, in the pixels (#360).
+
+    The wrapper document holds the caption and never navigates, so a
+    mid-take `goto()` — a full document replacement in the app iframe —
+    cannot take the line off the screen, which is where the #134
+    `caption_lost` class ends. Graded from the frames: the second document's
+    arrival is located by its own luma band in the app rect (a run, not a
+    single frame — any fade passes through any band), and the caption band
+    must be lit before it and stay lit after it. The beat log must agree:
+    no `caption_lost` issue anywhere (the wrapper recorder does not even
+    listen for it), and the goto's own beat still reporting the line.
+    """
+    mp4 = out_dir / "demo.mp4"
+    geom = info["geom"]
+    app: Rect = (geom["appx"], geom["appy"], geom["appw"], geom["apph"])
+    band: Rect = (geom["bandx"], geom["bandy"], geom["bandw"], geom["bandh"])
+    sweep = gray_frames(mp4, rect=app, sample_fps=WRAPPER_BAND_SWEEP_FPS)
+    means = [sum(f) / len(f) for f in sweep]
+    in_band = [
+        WRAPPER_SECOND_MIN_LUMA <= value <= WRAPPER_SECOND_MAX_LUMA for value in means
+    ]
+    arrival: int | None = None
+    for i in range(len(in_band) - WRAPPER_SECOND_MIN_FRAMES + 1):
+        if all(in_band[i : i + WRAPPER_SECOND_MIN_FRAMES]):
+            arrival = i
+            break
+    failures: list[str] = []
+    if arrival is None:
+        return [
+            f"wrapper-survives: no {WRAPPER_SECOND_MIN_FRAMES}-frame run of "
+            f"the app rect ever reads inside {WRAPPER_SECOND_MIN_LUMA}.."
+            f"{WRAPPER_SECOND_MAX_LUMA} mean luma — second.html never arrived "
+            f"on screen, so nothing survived anything"
+        ]
+    arrived_s = arrival / WRAPPER_BAND_SWEEP_FPS
+    before = gray_frames(
+        mp4,
+        rect=band,
+        start=max(0.0, arrived_s - WRAPPER_APP_CONTROL_S),
+        duration=0.05,
+    )
+    if not before or contrast(before[0]) < WRAPPER_BAND_LIT:
+        failures.append(
+            f"wrapper-survives: the caption band was not lit just before the "
+            f"second document arrived at {arrived_s:.1f}s (contrast "
+            f"{contrast(before[0]) if before else 'unreadable'} vs bar "
+            f"{WRAPPER_BAND_LIT}) — with no line up across the load, nothing "
+            f"here can claim one survived it"
+        )
+    for offset in WRAPPER_SURVIVES_SAMPLES_S:
+        at = arrived_s + offset
+        frames = gray_frames(mp4, rect=band, start=at, duration=0.05)
+        if not frames:
+            failures.append(
+                f"wrapper-survives: the band {band} decoded no frame at {at:.2f}s"
+            )
+            continue
+        lit = contrast(frames[0])
+        if lit < WRAPPER_BAND_LIT:
+            failures.append(
+                f"wrapper-survives: {offset:.1f}s after the second document "
+                f"arrived the caption band reads {lit:.1f} contrast, under "
+                f"the {WRAPPER_BAND_LIT} lit bar — the caption band went dark "
+                f"across the load, which is the #134 loss the wrapper "
+                f"document exists to end (#360)"
+            )
+    doc = json.loads((out_dir / "timeline.json").read_text(encoding="utf-8"))
+    lost = [
+        issue
+        for issue in doc.get("issues") or []
+        if issue.get("kind") == "caption_lost"
+    ]
+    if lost:
+        failures.append(
+            f"wrapper-survives: the take recorded {len(lost)} caption_lost "
+            f"issue(s) — on the wrapper path the caption cannot be destroyed "
+            f"by navigation, so this record claims a loss that cannot happen"
+        )
+    gotos = [b for b in doc.get("beats") or [] if b.get("verb") == "goto"]
+    second = [b for b in gotos if "second.html" in str(b.get("selector"))]
+    if len(second) != 1:
+        failures.append(
+            f"wrapper-survives: {len(second)} goto beats name second.html, "
+            f"expected 1 — the beat-log half of the claim has no beat to read"
+        )
+    elif second[0].get("caption") != WRAPPER_SURVIVES:
+        failures.append(
+            f"wrapper-survives: the goto beat to second.html reports caption "
+            f"{second[0].get('caption')!r}, not {WRAPPER_SURVIVES!r} — the "
+            f"beat log dropped a line that is still on screen"
+        )
+    if not failures:
+        print(
+            f"wrapper-survives: second.html arrives at {arrived_s:.1f}s, band "
+            f"lit before and at +{WRAPPER_SURVIVES_SAMPLES_S}s after; no "
+            f"caption_lost recorded, goto beat still reports the line"
+        )
+    return failures
 
 
 def check_wrapper_evidence(out_dir: Path) -> list[str]:
@@ -9736,6 +10083,9 @@ def run_wrapper(out_root: Path) -> list[str]:
     except Exception as exc:  # noqa: BLE001 - a raising take is the failure
         return [f"wrapper: recording raised {type(exc).__name__}: {exc}"]
     failures += check_wrapper_band(out_dir, info)
+    failures += check_wrapper_opening(out_dir, info)
+    failures += check_wrapper_card(out_dir, info)
+    failures += check_wrapper_caption_survives(out_dir, info)
     failures += check_wrapper_evidence(out_dir)
     failures += check_wrapper_clipped(out_dir)
 

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -118,7 +118,7 @@ ARM_SECONDS = {
     "--polish-only": 26,
     "--segments-only": 29,
     "--overlay-only": 31,
-    "--wrapper-only": 36,
+    "--wrapper-only": 48,
     "--failure-only": 48,
     "--web-only": 123,
     "--content-only": 148,
@@ -1151,6 +1151,60 @@ INJECTIONS = [
         arm="--wrapper-only",
         sites=("check_wrapper_clipped",),
         must_contain=("left no caption_clipped issue",),
+    ),
+    Injection(
+        # #360's frame-0 claim: the chrome document's hold ships transparent,
+        # so the wrapper take opens on the slot's white canvas instead of the
+        # opening hold — the blank opening the legacy ffmpeg overlay used to
+        # cover, back on screen. Only the encoded first frame can see it: the
+        # element is present, the beat log is perfect, the take is green.
+        name="the card layer ships transparent at frame 0",
+        module="chrome.py",
+        old=(
+            "  #__chrome_hold { position: absolute; inset: 0; "
+            "background: __WINBG__;\n"
+            "    opacity: 1; transition: opacity .45s ease; z-index: 1; }"
+        ),
+        new=(
+            "  #__chrome_hold { position: absolute; inset: 0; "
+            "background: __WINBG__;\n"
+            "    opacity: 0; transition: opacity .45s ease; z-index: 1; }"
+        ),
+        arm="--wrapper-only",
+        sites=("check_wrapper_opening",),
+        must_contain=("was not opaque in frame 0",),
+    ),
+    Injection(
+        # #360's colour claim: the wrapper card's field nudged four levels off
+        # the window body it must equal — the single declared colour replaced
+        # by a second, slightly different one, which is the #291 mismatch a
+        # human once had to spot by eye in a shipped frame. Read out of the
+        # encoded mp4, card strip against window pad, never out of the
+        # declarations (#297's anti-patterns).
+        name="the wrapper card's palette is nudged four levels off the window",
+        module="chrome.py",
+        old="    background: __WINBG__; color: #f2f0ec; z-index: 3; }",
+        new="    background: #1c1c29; color: #f2f0ec; z-index: 3; }",
+        arm="--wrapper-only",
+        sites=("check_wrapper_card",),
+        must_contain=("the card's field was repainted away from core.WEB_WINDOW_BODY",),
+    ),
+    Injection(
+        # #360's survival claim: a mid-take goto empties the caption band the
+        # way a document replacement used to (#134). The beat log still
+        # reports the line — the recorder's Python state is untouched — so
+        # only the band's pixels across the load can say it left the screen.
+        name="a mid-take goto kills the caption band",
+        module="web.py",
+        old="        if self._wrapper and not self._hold_cleared:",
+        new=(
+            "        if self._wrapper:\n"
+            "            self.page.evaluate(\"() => window.__demoCaption('')\")\n"
+            "        if self._wrapper and not self._hold_cleared:"
+        ),
+        arm="--wrapper-only",
+        sites=("check_wrapper_caption_survives",),
+        must_contain=("went dark across the load",),
     ),
     Injection(
         # The artifact-lie direction, the one #358 names outright: the block

--- a/tests/unit
+++ b/tests/unit
@@ -163,7 +163,11 @@ sys.modules["playwright.sync_api"] = _pw_sync
 
 import demo_recording.core as core_module  # noqa: E402
 import demo_recording.frames as frames_module  # noqa: E402
-from demo_recording.chrome import chrome_geometry, chrome_html  # noqa: E402
+from demo_recording.chrome import (  # noqa: E402
+    chrome_geometry,
+    chrome_html,
+    opening_hold_script,
+)
 from demo_recording.core import (  # noqa: E402
     CRITERION_HOLD_MAX_S,
     CRITERION_HOLD_MIN_S,
@@ -5343,6 +5347,156 @@ class WrapperChrome(unittest.TestCase):
         self.assertEqual(
             [i for i in legacy._issues if i["kind"] == "caption_clipped"], []
         )
+
+    def test_the_card_layer_sits_on_the_slot_and_carries_card_and_scrim(self):
+        # #360: interlude(), criterion() and the bridge scrim render in the
+        # card layer, which covers the app rect — not the chrome, not the
+        # caption band. The elements keep core's ids (`INTERLUDE_ID`,
+        # `BRIDGE_ID`) so `interlude("")` and the end-of-take overlay probe
+        # (#163) find them with no wrapper dispatch.
+        geom = chrome_geometry(1280, 720)
+        html = chrome_html(geom, title="t", window_body="#0b0c1d", accent="1,2,3")
+        for element_id in ("__demo_interlude", "__demo_bridge"):
+            self.assertIn(f'id="{element_id}"', html)
+        found = re.search(r"#__chrome_card \{([^}]*)\}", html)
+        self.assertIsNotNone(found, "the card layer has no stylesheet rule")
+        rule = found.group(1)
+        slot_top = geom["bar"] + geom["pad"]
+        for declaration in (
+            f"left: {geom['pad']}px",
+            f"top: {slot_top}px",
+            f"width: {geom['appw']}px",
+            f"height: {geom['apph']}px",
+        ):
+            self.assertIn(
+                declaration,
+                rule,
+                f"the card layer does not sit on the slot: {rule!r} lacks "
+                f"{declaration!r}, so a card would cover chrome or band "
+                f"instead of the app rect",
+            )
+
+    def test_the_wrapper_card_paints_from_the_window_body_it_was_built_with(self):
+        # Single-encoder colour (#360): the card's field is the `window_body`
+        # argument itself — one substitution serves the window and the card,
+        # so there is no second declaration to compensate and none to drift.
+        # What grades the *result* is pixels (`tests/smoke --wrapper-only`'s
+        # check_wrapper_card), deliberately never a comparison between two
+        # declared colours — #297 recorded both shapes of that assertion as
+        # anti-patterns. This asserts only the wiring: the parameter reaches
+        # the card's rule.
+        html = chrome_html(
+            chrome_geometry(1280, 720),
+            title="t",
+            window_body="#0b0c1d",
+            accent="1,2,3",
+        )
+        found = re.search(r"#__demo_interlude \{([^}]*)\}", html)
+        self.assertIsNotNone(found, "the wrapper card has no stylesheet rule")
+        self.assertIn("background: #0b0c1d", found.group(1))
+
+    def test_the_opening_hold_script_carries_the_app_rect(self):
+        geom = chrome_geometry(1280, 720)
+        js = opening_hold_script(geom, window_body="#0b0c1d")
+        for declaration in (
+            f"left: {geom['appx']}px",
+            f"top: {geom['appy']}px",
+            f"width: {geom['appw']}px",
+            f"height: {geom['apph']}px",
+            "background: #0b0c1d",
+        ):
+            self.assertIn(declaration, js)
+        leftover = re.findall(r"__[A-Z][A-Z0-9]*__", js)
+        self.assertEqual(
+            leftover,
+            [],
+            f"unsubstituted hold tokens would reach the page: {sorted(set(leftover))}",
+        )
+
+    def test_a_wrapper_take_registers_the_hold_script_and_a_legacy_take_none(self):
+        # The hold is an init script for _OPENING_CARD_JS's reasons — it has
+        # to exist on the wrapper page's initial document, before set_content
+        # — and the legacy composite path must not gain one: its opening is
+        # covered by the ffmpeg overlay, byte-untouched until #361.
+        wrapped = recorder(self, wrapper=True)
+        context = _RecordingContext()
+        wrapped._init_context(context)
+        holds = [s for s in context.scripts if "__chrome_hold" in s]
+        self.assertEqual(len(holds), 1, "the wrapper take registers no opening hold")
+        legacy = recorder(self)
+        legacy_context = _RecordingContext()
+        legacy._init_context(legacy_context)
+        self.assertEqual(
+            [s for s in legacy_context.scripts if "__chrome_hold" in s],
+            [],
+            "the legacy path gained an opening-hold init script",
+        )
+
+    class HoldPage(FakePage):
+        """A page that remembers every script `evaluate` was handed."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.evaluated: list[str] = []
+
+        def evaluate(self, script, *args):
+            self.evaluated.append(str(script))
+            return None
+
+    @staticmethod
+    def app_frame():
+        return types.SimpleNamespace(
+            goto=lambda url, timeout=None: None,
+            wait_for_load_state=lambda *args, **kwargs: None,
+        )
+
+    def clears(self, page) -> list[str]:
+        return [s for s in page.evaluated if "__demoChromeHoldClear" in s]
+
+    def test_the_first_goto_clears_the_opening_hold_and_only_the_first(self):
+        # "Cleared by the storyboard's first content beat" (#360): the first
+        # goto that lands is when there is an app to reveal. Once — a second
+        # navigation must not re-run the clear, because the hold it would
+        # clear is already down and a re-clear on every goto would be the
+        # verb quietly depending on chrome state it does not own.
+        page = self.HoldPage()
+        rec = recorder(self, wrapper=True, page=page)
+        rec._app_frame = self.app_frame()
+        rec.goto("/")
+        self.assertEqual(
+            len(self.clears(page)),
+            1,
+            f"the first goto did not clear the opening hold "
+            f"(scripts: {page.evaluated!r})",
+        )
+        rec.goto("/second.html")
+        self.assertEqual(len(self.clears(page)), 1, "a later goto re-cleared the hold")
+
+    def test_a_legacy_goto_never_touches_the_hold(self):
+        page = self.HoldPage()
+        page.goto = lambda url, timeout=None: None
+        page.wait_for_load_state = lambda *args, **kwargs: None
+        legacy = recorder(self, page=page)
+        legacy.goto("/")
+        self.assertEqual(self.clears(page), [])
+
+    def test_a_wrapper_take_does_not_listen_for_a_replaced_document(self):
+        # #360's beat-log honesty: the wrapper document holds the caption and
+        # never navigates, so `caption_lost` cannot happen there — and the
+        # recorder must not even subscribe the signal. Not listening is the
+        # structural form of "this issue can never fire"; a listener that
+        # merely happens never to fire would be an observation about one
+        # Chromium's event routing, one engine bump away from a false loss.
+        wrapped = recorder(self, wrapper=True)
+        page = FakePage()
+        wrapped._watch_extra(page)
+        self.assertNotIn("domcontentloaded", page.subscribed)
+        # #142's kept listener stays on both paths.
+        self.assertIn("framenavigated", page.subscribed)
+        legacy = recorder(self)
+        legacy_page = FakePage()
+        legacy._watch_extra(legacy_page)
+        self.assertIn("domcontentloaded", legacy_page.subscribed)
 
 
 class VerbTarget(unittest.TestCase):
@@ -15787,6 +15941,103 @@ INJECTIONS = [
         "        if not isinstance(clipped, (int, float)) or clipped < 0:\n"
         "            return\n",
         ["WrapperChrome.test_a_caption_that_fits_its_band_records_nothing"],
+    ),
+    # -- the wrapper take's cards and opening hold (issue #360) ---------------
+    (
+        # The card layer slides off the slot: a card raised in it would cover
+        # chrome instead of the app rect. The pixel half of the same claim is
+        # `tests/smoke --wrapper-only`'s check_wrapper_card reading the pad.
+        "the card layer stops sitting on the content slot",
+        "chrome.py",
+        "  #__chrome_card { position: absolute; left: __PAD__px; top: __SLOTTOP__px;",
+        "  #__chrome_card { position: absolute; inset: 0;",
+        [
+            "WrapperChrome.test_the_card_layer_sits_on_the_slot_and_carries_card_and_scrim"
+        ],
+    ),
+    (
+        # The single-source colour rewired to a literal: the card would keep
+        # passing today's pixels while losing the one property that makes the
+        # wrapper path uncompensated — repaint the window and the card stays.
+        "the wrapper card's field is painted from a literal, not window_body",
+        "chrome.py",
+        "    background: __WINBG__; color: #f2f0ec; z-index: 3; }",
+        "    background: #181825; color: #f2f0ec; z-index: 3; }",
+        [
+            "WrapperChrome."
+            "test_the_wrapper_card_paints_from_the_window_body_it_was_built_with"
+        ],
+    ),
+    (
+        # A hold token survives substitution, so the page is handed a style
+        # with a literal __APPX__ in it — a hold parked at left: __APPX__px
+        # is a hold that covers nothing.
+        "the opening hold ships with an unsubstituted geometry token",
+        "chrome.py",
+        '        "__APPX__": str(geom["appx"]),',
+        '        # "__APPX__" left unsubstituted',
+        ["WrapperChrome.test_the_opening_hold_script_carries_the_app_rect"],
+    ),
+    (
+        # The hold never registered: the wrapper take opens on the slot's
+        # white canvas. The pixel form is smoke's check_wrapper_opening; this
+        # is the browser-free half of the same seam.
+        "the wrapper take registers no opening-hold init script",
+        "web.py",
+        "            context.add_init_script(\n                opening_hold_script(",
+        "            _unused = (\n                opening_hold_script(",
+        [
+            "WrapperChrome."
+            "test_a_wrapper_take_registers_the_hold_script_and_a_legacy_take_none"
+        ],
+    ),
+    (
+        # The reveal never runs: the first content beat lands and the viewer
+        # keeps looking at the hold — #91's card-left-up shape, on the
+        # opening cover.
+        "no goto ever clears the opening hold",
+        "web.py",
+        "        if self._wrapper and not self._hold_cleared:",
+        "        if self._wrapper and False:",
+        [
+            "WrapperChrome."
+            "test_the_first_goto_clears_the_opening_hold_and_only_the_first"
+        ],
+    ),
+    (
+        # The once-guard dropped: every wrapper goto re-clears chrome state
+        # it does not own, and a legacy-shaped reading of the same line —
+        # `if not self._hold_cleared:` alone — would clear it on the
+        # composite path too.
+        "every goto re-clears the opening hold",
+        "web.py",
+        "        if self._wrapper and not self._hold_cleared:",
+        "        if self._wrapper:",
+        [
+            "WrapperChrome."
+            "test_the_first_goto_clears_the_opening_hold_and_only_the_first"
+        ],
+    ),
+    (
+        # ...and the other half of the same line: the wrapper guard dropped,
+        # so a legacy goto evaluates wrapper chrome that is not in its page.
+        "a legacy goto clears a hold its page never had",
+        "web.py",
+        "        if self._wrapper and not self._hold_cleared:",
+        "        if not self._hold_cleared:",
+        ["WrapperChrome.test_a_legacy_goto_never_touches_the_hold"],
+    ),
+    (
+        # The #134 listener re-subscribed on the wrapper path: one engine
+        # bump in event routing away from recording a caption_lost that
+        # cannot happen — the timeline claiming a loss the band's pixels
+        # disprove (#360).
+        "the wrapper take listens for a document replacement again",
+        "web.py",
+        "        if not self._wrapper:\n"
+        '            page.on("domcontentloaded", self._note_document_replaced)',
+        '        page.on("domcontentloaded", self._note_document_replaced)',
+        ["WrapperChrome.test_a_wrapper_take_does_not_listen_for_a_replaced_document"],
     ),
 ]
 


### PR DESCRIPTION
Slice 2 of #355's structural half. Needs #358 (merged as fc32e01). Fixes #360.

## Acceptance, per the issue's three bullets

**1. Cards render in the wrapper document, over the app rect.** chrome.py's card layer now sits exactly on the content slot and carries the interlude/criterion card and the bridge scrim, under core's own element ids — so `interlude("")`, `criterion()` and the end-of-take overlay probe (#163) work with no wrapper dispatch. The viewer keeps the window frame and the narration line during a card: the card replaces the app's content, the chrome is the recorder's. The opening hold is wrapper-native: opaque in frame 0 (the `_OPENING_CARD_JS` init-script pattern, plus a markup copy in the chrome document — measured, the init script's re-run on the `set_content` document lands only after its first paint), cleared by the storyboard's first `goto()`. The ffmpeg `enable='lt(t,held)'` overlay does not run on the wrapper path. The slot's underlay is the browser's white canvas, which is what makes "the hold was up in frame 0" falsifiable in pixels — a transparent iframe borrowing the window colour would read the same with or without the hold.

**2. The caption survives a real mid-take goto, in pixels.** The wrapper arm captions a line, sends the app frame to a new fixture page (`tests/fixture/second.html`, a deliberately mid-luma document the check locates in the app rect's own pixels), and reads the band lit before the load and at +0.2/+0.5/+0.8 s after it. Beat-log honesty is structural: the wrapper recorder does not even subscribe the `domcontentloaded` signal that `caption_lost` rides, the check asserts zero `caption_lost` issues, and the goto beat still reports the line. SKILL.md's caption row and reference/failures.md's `caption_lost` row now say so (SKILL.md edited in place — budget stays 630/630).

**3. Colour, single-encoder.** The wrapper card paints from the same `window_body` substitution as the window itself — `core.WEB_WINDOW_BODY`, one declaration, no compensation. `check_wrapper_card` reads the encoded mp4: card strip vs window pad at worst-channel |Δ| ≤ 2, measured **0.1–0.6** across runs, with a no-card control that must sit ≥ 12 off the body (reads 213). No assertion anywhere pins the declarations equal or apart (#297's recorded anti-patterns) — the check reads pixels on both sides. `WEB_CARD_BODY` and `INTERLUDE_CSS_WEB` are untouched, legacy-only, and #361 deletes them.

## Green, with numbers

```
wrapper-opening: frame 0 reads 24.0 over (230, 118, 819, 57) (hold <= 60.0), and the app shows from 0.7s (bare >= 150.0)
wrapper-card: card and window body sit 0.5 apart, worst channel over 2 samples (bar 2.0); the no-card control reads 213 off the body (premise bar 12.0)
wrapper-survives: second.html arrives at 25.9s, band lit before and at +(0.2, 0.5, 0.8)s after; no caption_lost recorded, goto beat still reports the line
wrapper: band lit 9.7s from 1.7s, app rect moved 0.08 (bar 3.0) across the caption's appearance
smoke: PASSED
```

- `./tests/unit` — 543 tests OK (8 new WrapperChrome tests)
- `./tests/unit --fault-inject` — **All 355 injections were caught** (8 new entries: card layer off the slot, card painted from a literal, hold token unsubstituted, hold script unregistered, hold never cleared / re-cleared / cleared on legacy, `caption_lost` listener re-subscribed)
- `./tests/ci-unit`, `./tests/lint`, mypy 1.18.2 per ci.yml — clean
- `./tests/pixel` — re-recorded from these source edits, **6 checks, 0 failing** (legacy goldens green; wrapper goldens are #361's, per the note pinned there)
- `./tests/smoke --wrapper-only` — three consecutive green runs; `./tests/smoke --cheap` — PASSED
- `./tests/smoke-inject --self-test` — every guard holds; README manifest figures re-synced (73 entries, 14 arms; `--wrapper-only` 9 entries at a re-measured 48 s)

## Red demos (exactly-once injections, failure output verbatim)

**Card layer transparent at frame 0** (`chrome.py`, hold `opacity: 1` → `0`):

```
BASE  --wrapper-only passes clean (50s)
PASS  break: the card layer ships transparent at frame 0  [49s]
      caught: wrapper-opening: the wrapper take's first frame reads 255.0 mean luma over (230, 118, 819, 57), over the 60.0 bar for the opening hold — the card layer was not opaque in frame 0 ...
```

**Card palette nudged 4 levels** (`chrome.py`, `background: __WINBG__` → `#1c1c29`):

```
BASE  --wrapper-only passes clean (49s)
PASS  break: the wrapper card's palette is nudged four levels off the window  [49s]
      caught: wrapper-card: 30% through the criterion beat the card reads (27, 27, 39) ... and the window body (22, 22, 34) ...
      caught: wrapper-card: 60% through the criterion beat the card reads (27, 27, 39) ... and the window body (22, 22, 34) ...
```

**Caption band killed on navigation** (`web.py`, goto clears `__demoCaption` on the wrapper path):

```
BASE  --wrapper-only passes clean (49s)
PASS  break: a mid-take goto kills the caption band  [50s]
      caught: wrapper-survives: 0.8s after the second document arrived the caption band reads 0.6 contrast, under the 12.0 lit bar — the caption band went dark across the load ...
```

All three staged copies confirmed the injection landed (exactly-once match, enforced by the harness).

## Decisions the issue left to the author

- **The decorative terminal prop stays app-side.** It is content — a prop inside the demo's story that rides over the app the way an app dialog would — and the card layer stays reserved for recorder furniture. #362 mounts a *real* terminal in the slot, and a prop on the chrome layer would blur exactly that line. (chrome.py module docstring states this.)
- **The hold clears at the end of the first `goto()`**, inside that beat — the storyboard's first content beat, the moment there is an app to reveal.

## Stated limits (#361/#362 boundaries and other measured edges)

- `content.opening.gap` on a wrapper take describes the hold's own featureless stretch (~0.7 s here) with `held: null` — a description, warning-free, since only a recorder that claims to cover can warn. Whether wrapper takes should self-report the hold the way terminal takes report their card (#235's `content.opening.card`, still `null` on web) is #361's reporting sweep.
- A wrapper storyboard that never calls `goto()` keeps the hold up for the whole take; the picture check reads a blank app rect and `check_wrapper_opening`'s bare-frame control goes red in the arm, but no recorder-side warning names the hold specifically.
- The bridge scrim renders in the card layer and is graded structurally (ids, unit tests); no pixel check reads the scrim itself on the wrapper path — the legacy overlay arm still grades scrim behaviour.
- Wrapper card text sizes match the terminal recorder's declared 30 px/34 px (the shared chrome #362 unifies on), not the composite's ~0.8-scaled effective sizes.
- Legacy path byte-untouched in behaviour: web.py's composite, `_opening_hold`, `WEB_CARD_BODY`, `INTERLUDE_CSS_WEB` all remain; #361 owns the cutover and deletions, #362 the terminal mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
