### PR TITLE
The wrapper is the only web path: composite, compensation and the event-following cursor deleted

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -64,12 +64,13 @@ the web recorder; the **Terminal demos** section below covers what differs,
 and is **Unix-only** because it uses a PTY.
 
 Both record into a **framed window on a soft pastel background** (rounded
-window, title bar, traffic-light buttons) so the eye has an obvious focus —
-the caption sits as a lower-third. The terminal frames itself in-page; the
-web recording is composited into the window by ffmpeg on exit, which scales
-it down (hence the larger web caption). One consequence: web `shot()` stills
-are captured full-bleed (no window frame) — good for embedding in a guide,
-but they will not match the windowed video exactly.
+window, title bar, traffic lights), framed in-page: the web app records in
+an iframe at true pixel size, caption in a reserved band **below** the app
+rect, so the page is the finished picture — no exit composite, one encode
+per take, and `shot()` stills match the video exactly, chrome included.
+`rec.page` is the framed page; `rec.app` is the app's document. Two edges:
+an app answering `X-Frame-Options`/CSP `frame-ancestors` refuses the take
+by name, and the dot is verb-driven — raw `rec.page.mouse` never moves it.
 
 Each demo gets one folder (suggested: `docs/guides/<YYYY-MM-DD>-<slug>/`):
 
@@ -237,7 +238,6 @@ three it is not the variable lowercased, so do not infer it:
 | `DEMO_VIDEO_LOCALE` | `locale` — browser locale, always applied | `en-US` |
 | `DEMO_VIDEO_SPEECH` | `speech` — force narration on/off (`1`/`0`). **`speech=False` records silently even with a key set**; with no key it is off already, and forcing it *on* without one refuses the take | auto by API key |
 | `DEMO_VIDEO_STRICT` | `strict` — fail the take on console errors / non-zero exits (`1`/`0`) | off |
-| `DEMO_VIDEO_WRAPPER` | `wrapper` — record the web app in an iframe on a recorder-owned page: chrome in the recording, caption in its own band below the app, no exit composite. `rec.page` stays the wrapper page; `rec.app` is the app's document. The cursor dot is verb-driven, so raw `rec.page.mouse` work moves it nowhere; a caption taller than its band is clipped and recorded as a `caption_clipped` issue. Refuses apps sending `X-Frame-Options`/CSP `frame-ancestors`. Transitional (#358; #361 makes it the default) | off |
 | `DEMO_VIDEO_EVIDENCE` | `evidence` — write `evidence/beat-NN.json` per beat (`1`/`0`) — see [reference/review.md](reference/review.md) | **on** |
 | `DEMO_VIDEO_VOICE_ID` | `voice_id` — ElevenLabs voice | Sarah (premade) |
 | `DEMO_VIDEO_SPEECH_MODEL` | `speech_model` — ElevenLabs model | `eleven_multilingual_v2` |
@@ -264,7 +264,7 @@ exception, or a non-zero exit. Both are
 |---|---|
 | `goto(path)` | Navigate (relative to base_url); waits for networkidle, but gives up after 10 s for apps that poll |
 | `pause(s)` / `shot(name)` | Hold the frame / capture `images/<name>.png` |
-| `caption(text)` | Narrator line at the bottom; `""` clears. On the composite path it dies on full page loads — the beat log clears with it, records a `caption_lost` issue naming the line, survives SPA routing; re-caption after a load. A wrapper take's caption lives in the recorder's own band, survives navigation, and `caption_lost` can never fire there |
+| `caption(text)` | Narrator line in the caption band below the app; `""` clears. The band is the recorder's own document, so the line survives full page loads and SPA routing alike and `caption_lost` cannot fire on a web take — caption death on navigation is a terminal-take concern only (its caption is in-page, until #362). A line taller than the two-line band is shaved at the band's edges and recorded as a `caption_clipped` issue: shorten it, or split it over two captions |
 | `caption(text, ac="AC-3")` / `shot(name, ac="AC-3")` | Tag this beat with the acceptance criterion it is there to demonstrate. Needs `Recorder(criteria={...})`; a tag naming an undeclared criterion is refused. See [reference/review.md](reference/review.md). |
 | `criterion("AC-3")` | Raise a card carrying **AC-3's own declared sentence**, read out of `criteria={...}` rather than retyped — so the viewer meets the clause and then watches it happen. The beat claims AC-3 and nothing else; the beats after it are untagged. Held to reading speed, and cleared by `interlude("")` like any card. |
 | `hold(min_s=1.5)` | Keep the current frame up until the current caption's narration finishes (min `min_s`). Use after a spotlight/action so the emphasis rides the whole spoken line instead of flashing. See **Pacing and perception** below. |
@@ -397,11 +397,11 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
      `rec.spotlight(selector)` on the element it talks about, so viewers
      never see a highlight belonging to the previous line.
 3. **Caption every beat.** A fresh caption before each thing the viewer
-   should understand, a new one after any navigation, `caption("")` to end
-   clean. On a full page load the caption dies with the DOM; in an SPA
-   (hash routing) it *survives* into the next view and reads as a mistimed
-   line — so `caption("")` before the click that navigates, fresh caption
-   after, in both cases. Rules (each earned in a fresh-eyes review round):
+   should understand, `caption("")` to end clean. The caption lives in the
+   recorder's own band and survives every navigation — full loads and SPA
+   routing alike — so a line left up across one reads as narrating the next
+   view too: `caption("")` before the click that navigates, fresh caption
+   after. Rules (each earned in a fresh-eyes review round):
    - A caption may only claim what is visible in the frame. Don't promise
      an action the demo never performs — scope the words to what's shown,
      or show it. The prohibition alone does not hold — captions get written

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -581,7 +581,8 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
   waste the take — script 1–2 steps per message.
 - **Layout shifts strand the cursor.** Elements the app inserts mid-recording
   move, the cursor does not — re-`move_to` after any wait that can reflow.
-  The dot stays undrawn until the pointer first moves, and after each `goto()`.
+  The dot stays undrawn until the first pointer verb — then it keeps its last
+  parked spot, `goto()` included: it lives in the recorder's page, not the app.
 - **A blind click to dismiss an overlay.** A `mouse.click(400, 400)` landed
   on a file row, opened a dialog, and its backdrop swallowed every later
   click — dead take. Dismiss via a named neutral element, never coordinates.

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -580,9 +580,8 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
   agent turns with a budget, one big scripted message can exhaust it and
   waste the take — script 1–2 steps per message.
 - **Layout shifts strand the cursor.** Elements the app inserts mid-recording
-  move, the cursor does not — re-`move_to` after any wait that can reflow.
-  The dot stays undrawn until the first pointer verb — then it keeps its last
-  parked spot, `goto()` included: it lives in the recorder's page, not the app.
+  move, the cursor does not — re-`move_to` after any reflowing wait. The dot
+  draws at the first pointer verb and keeps its spot across `goto()`.
 - **A blind click to dismiss an overlay.** A `mouse.click(400, 400)` landed
   on a file row, opened a dialog, and its backdrop swallowed every later
   click — dead take. Dismiss via a named neutral element, never coordinates.

--- a/skills/demo-video/helpers/demo_recording/chrome.py
+++ b/skills/demo-video/helpers/demo_recording/chrome.py
@@ -16,10 +16,10 @@ band.** `interlude()`, `criterion()` and the `light` bridge scrim render in
 it, so a card replaces the *app's* content and nothing else: the window
 frame and the narration line are the recorder's own furniture, and taking
 them down to show a recorder-authored card would be the chrome hiding from
-itself. The legacy composite path cannot make that distinction — its card is
-an element inside the app page, so full-bleed there means the whole page —
-which is why its card sits above the caption bar and this one sits beside
-it. The decorative terminal prop (`Recorder.terminal()`) is deliberately
+itself. The deleted composite path could not make that distinction — its
+card was an element inside the app page, so full-bleed there meant the whole
+page — which is why its card sat above the caption bar and this one sits
+beside it. The decorative terminal prop (`Recorder.terminal()`) is deliberately
 **not** here: it is content, a styled element inside the demo's story that
 rides over the app the way an app dialog would, and the card layer stays
 reserved for the recorder's own furniture — #362 mounts a *real* terminal in
@@ -28,25 +28,23 @@ the slot, and a prop living on the chrome layer would blur exactly that line.
 **The wrapper card declares the window's own colour — no compensation.** The
 card and the window body reach `demo.mp4` through one encoder on this path,
 so both paint the `window_body` the document was built with
-(`core.WEB_WINDOW_BODY` for the web recorder). The compensated
-`core.WEB_CARD_BODY` (#291/#301) exists because the legacy composite sends
-the card and the window through two different encoders; it stays legacy-only
-until #361 deletes it, and nothing here reads it.
+(`core.WEB_WINDOW_BODY` for the web recorder). The compensated pair the
+deleted composite needed (#291/#301) is recorded in that constant's history
+note; #361 deleted it with the composite.
 
-Every other visual constant here is ported from `web._FRAME_HTML` and
-`terminal._TERM_HOST_JS`, which stay untouched while the legacy composite
-path exists; #361 and #362 retire those copies.
+The visual constants here were ported from the composite's window frame
+(retired with it in #361) and from `terminal._TERM_HOST_JS`, whose copy
+stays until #362 mounts the terminal in this chrome too.
 """
 
 from __future__ import annotations
 
-# The pastel gradient behind the window. The same string web.py and
-# terminal.py paint today (`_WEB_BG`, `_TERM_BG`); this copy is the one the
-# wrapper path reads, and the one that survives #361/#362.
+# The pastel gradient behind the window. terminal.py still paints its own
+# copy (`_TERM_BG`) until #362; this one is the web recorder's since #361.
 CHROME_BG = "linear-gradient(135deg, #f6d5f0 0%, #d7e3fb 52%, #cdeede 100%)"
 
 # Title bar: height, fill and text colour, and the three traffic lights —
-# ported from `_FRAME_HTML` (web) which `_TERM_HOST_JS` (terminal) matches.
+# the frame both media share; `_TERM_HOST_JS` (terminal) still matches it.
 CHROME_BAR_PX = 36
 CHROME_BAR_BG = "#232334"
 CHROME_BAR_FG = "#9399b2"
@@ -63,19 +61,19 @@ CHROME_PAD_PX = 14
 # point of the band is that the app never shares a pixel with the caption.
 CAPTION_BAND_PX = 96
 
-# The wrapper caption's font size. The composite path renders captions at
-# 34px because ffmpeg scales the page by ~0.8 into the window (~27px on
-# screen); the wrapper page is recorded at true pixel size, so the caption
-# uses the base 26px directly — the same effective size the terminal
-# recorder's captions have. No compensation, because there is no scale.
+# The wrapper caption's font size: the base 26px, as declared, because the
+# page is recorded at true pixel size — the same effective size the terminal
+# recorder's captions have. (The deleted composite rendered captions at 34px
+# to survive its ~0.8 downscale; web.py's history note has the story.)
 CAPTION_FONT_PX = 26
 
 # Element ids. The slot is what a medium fills; the band holds the caption
 # element; the card layer holds the interlude/criterion card and the bridge
 # scrim (#360). The caption element deliberately keeps the id
 # `core._CAPTION_JS` uses, so "the caption element" is one selector whichever
-# path drew it. The cursor dot keeps `web._CURSOR_JS`'s id, and the card and
-# scrim keep `core.INTERLUDE_ID`/`core.BRIDGE_ID` — that is what lets
+# medium drew it. The cursor dot keeps the id the composite path's overlay
+# used (`__demo_cursor`, so committed selectors keep working), and the card
+# and scrim keep `core.INTERLUDE_ID`/`core.BRIDGE_ID` — that is what lets
 # `interlude("")` and core's end-of-take overlay probe (`_OVERLAY_PROBE_JS`,
 # issue #163) find them with no wrapper-specific dispatch.
 SLOT_ID = "__chrome_slot"
@@ -145,8 +143,8 @@ def chrome_geometry(
     }
 
 
-# The wrapper document. Substitutions are literal tokens, same pattern as
-# `web._FRAME_HTML`. The inline <script> runs after the recorder's context
+# The wrapper document. Substitutions are literal tokens (replaced by
+# `chrome_html`). The inline <script> runs after the recorder's context
 # init scripts (init scripts run at document_start), so the band-aware
 # `__demoCaption` below is the one `caption()` reaches in this document —
 # core's fixed-bottom overlay version never paints here.

--- a/skills/demo-video/helpers/demo_recording/content.py
+++ b/skills/demo-video/helpers/demo_recording/content.py
@@ -306,48 +306,39 @@ CONTENT_STATIC_BEATS_MAX = 8
 
 # -- the blank opening (issue #119) ------------------------------------------
 #
-# Chromium's screencast starts with the page, and the page is `about:blank`
-# until the storyboard's first `goto()` returns. `about:blank` paints white, so
-# every web take opened on a flat white app rect — measured at ~400 ms on the
-# reference demo, and reported by a human watching it, not by anything here.
+# Chromium's screencast starts with the page, and an unpainted page is white,
+# so a recorder that did nothing about its opening put a flat white app rect
+# in front of every viewer — measured at ~400 ms on the reference demo, and
+# reported by a human watching it, not by anything here.
 #
 # `_t0` cannot simply be moved later to skip it: the comment on it in
 # `__enter__` is load-bearing, and says why. Frame zero of the recording is the
 # page's creation, so pinning `_t0` anywhere else shifts every beat timestamp
 # and every narration offset earlier than the frame it describes.
 #
-# **So the gap is covered, not cut.** The web recorder finds the first frame
-# that differs from the one the take opened on, and composites *that* frame
-# over the app rect for the seconds before it. Content at every later time
-# stays exactly where it was: the video's duration is unchanged, the audio is
-# untouched, and not one timestamp moves — which is the whole reason this shape
-# was chosen over trimming, whose uniform `t -= trim` would have to be threaded
-# through `frames/` extraction, `stitch()`'s merged offsets and the capture-loss
-# offset in issue #18.
+# Both recorders now open on their own furniture instead: the terminal on its
+# opening card (#110), the web recorder on the wrapper hold — an opaque field
+# in the window's own colour over the app rect, up in frame 0 and cleared by
+# the first `goto()` (chrome.OPENING_HOLD_JS, #360). Neither fabricates a
+# frame the capture did not record, so `held` — the seconds a take's *encode*
+# covered with a composited still — is null on every take either records, and
+# `content.opening.gap` simply describes what the encoded file opens on: on a
+# healthy web take that is the hold's own featureless stretch, warning-free,
+# because only a recorder that claims to cover can warn.
 #
-# **What it costs, and why the artifact has to say so.** Those first frames show
-# the app before it painted. That is a picture the recording did not capture,
-# and a recorder that fabricates one silently is doing the thing this whole
-# package refuses to do everywhere else. So `content.opening` carries `held` —
-# how many seconds were covered — and the summary line says it out loud.
-#
-# **The number that grades it is measured from the other side.** `held` is what
-# the recorder believes it did; `gap` is measured afterwards, off the encoded
-# mp4, by the same sampling the picture check uses. On a web take that worked,
-# `gap` is 0.0 *because* the hold landed — so a hold that silently did nothing
-# shows up as a non-zero `gap` on the file somebody watches, and warns. The two
-# numbers come from different passes over different files on purpose.
-#
-# Neither number is invented for recorders that do not do this: `held` is null
-# for them (the terminal recorder frames itself in the page and `_postprocess`
-# is a no-op there), and only a recorder that holds can warn about a gap it
-# failed to cover.
+# `held` and `limit` stay in the report for the recorder that earned them
+# (#119's exit-time hold, deleted with the composite in #361 — web.py has the
+# history note): a committed timeline that says `held: 0.4` keeps meaning
+# what it meant, and `opening_warning` still reads the pair, so a future
+# medium that covers its opening at encode time inherits the honesty
+# machinery instead of re-inventing it.
 
-# How long an opening gap may be before the recorder refuses to cover it. Past
-# this the opening is not a screencast artefact, it is an app that takes a long
-# time to paint — which is information about the app, and covering seconds of it
-# would be inventing a demo rather than repairing one. Over the limit nothing is
-# held, `note` says why, and the measured `gap` then warns on its own.
+# How long an opening gap may be before a recorder that covers at encode time
+# should refuse to cover it. Past this the opening is not a screencast
+# artefact, it is an app that takes a long time to paint — which is
+# information about the app, and covering seconds of it would be inventing a
+# demo rather than repairing one. Reported as `content.opening.limit` on
+# every take, so the numbers beside it keep their scale.
 OPENING_HOLD_LIMIT_S = 1.5
 
 # How far in to look for the first change, and how finely. 20 fps because the

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -136,105 +136,43 @@ _INTERLUDE_LAYOUT = (
     " transition: opacity .45s ease; pointer-events: none;"
 )
 
-# The body of the window web.py composites a page into — its `#win` fill, and
-# the colour of the pad that shows around the app video on every side. It is
-# defined here rather than there because the web card below is painted to match
-# it *as encoded*, so the two numbers have to be read together.
-# `web._FRAME_HTML` paints the window with it.
+# The web window's body — the fill chrome.py paints the dark rounded window
+# with, and with it the pad around the app rect, the opening hold, and the
+# interlude/criterion card in the card layer. One declaration for all of
+# them, on purpose: on the wrapper path they all reach demo.mp4 through one
+# encoder, so "the card is the window's own colour" is a single substitution
+# (#360) — and the sameness is still graded out of the encoded pixels, never
+# out of declarations (#297's two recorded anti-patterns).
+#
+# History (#291/#301/#355): the exit-time composite this outlived sent the
+# card (a DOM element, through Chromium's VP8 screencast) and the window (a
+# lossless screenshot, encoded once) to demo.mp4 through two different
+# encoders. One declared colour arrived as two, five levels apart, spotted
+# by eye in a shipped frame (#291); "the window's own colour" itself was the
+# answer a human chose over warm paper and a bordered card, both rejected on
+# watching (recorded on #291). Matching *as encoded* then required declaring
+# two slightly different colours — the measured compensation constant
+# `WEB_CARD_BODY = "#181726"`, swept over a hundred candidates to land one
+# level off the window (#301). #355's structural half retired the class:
+# one encoder, one declaration, and #361 deleted the compensated pair.
 WEB_WINDOW_BODY = "#181825"
 
-# **The card's own field, and it is deliberately not `WEB_WINDOW_BODY`. Do not
-# "fix" it to be.** The card has to match the window in `demo.mp4`, and the two
-# reach that file by different encoders, so matching there means declaring two
-# slightly different colours here (issue #301).
+# The interlude card's stylesheet. One consumer today: the terminal
+# recorder, whose segments can *open* on this card (#110) — raised from an
+# init script before the recorder's own setup, so the id and the stylesheet
+# live here where both builders can reach them. The near-black terminal
+# palette is the feature there: the card blends with the terminal it covers.
 #
-# The frame is a Playwright **screenshot** — a lossless PNG that ffmpeg encodes
-# once. The card is a DOM element in the page, so it goes through Chromium's
-# **VP8** screencast encoder first, and VP8 quantises subsampled chroma onto a
-# coarse grid. Declare one colour for both and the window arrives at
-# `(23, 22, 37)` while the card arrives at `(24, 22, 32)`: five levels of blue,
-# which a human reviewer of #291's fix spotted by eye in a shipped frame.
-#
-# `#181726` is not arithmetic on a colour-space model — it is the value that
-# **measured** closest. A hundred declared colours around `#181825` were swept
-# through real takes and read back out of the encoded mp4, and this one arrives
-# at `(24, 21, 36)` against the window's `(23, 22, 37)`: one level per channel,
-# down from five.
-#
-# **One level is the floor, not a stopping point somebody chose.** Those 100
-# declared colours produce only 20 distinct encoded ones — VP8 quantises the
-# chroma planes, so the card can only land on a coarse grid — and `(23, 22, 37)`
-# is not on it. Of the twenty, three land 1 level off the window and seventeen
-# land 2 or more. None lands 0.
-#
-# **A drift here is a real failure, not a flake.** The compensation is tuned to
-# one encoder path (this Chromium's VP8, this ffmpeg, `yuv420p`). Change any of
-# them and `tests/smoke`'s card-against-window reading goes red, which is the
-# correct outcome: the two layers really have stopped matching on screen, and
-# the answer is to re-measure this constant, never to widen that bar.
-# tests/README.md says so where the bar is described.
-WEB_CARD_BODY = "#181726"
-
-# The palette, per medium — and the split is issue #291.
-#
-# One palette used to serve both, and it was the terminal's: `#f7f4ee` text on
-# a `#1c1a17` field, the same near-black as the on-screen terminal card web.py
-# draws for `Recorder.terminal()`. On a terminal take that match is the feature.
-# `eca42c5` made this card the thing a terminal segment *opens on* (#110), so
-# it has to blend with what is behind it and with what replaces it; tuned to
-# blend with a terminal, it blends with a terminal.
-#
-# On a **web** take that is the wrong thing to blend with. The web recorder
-# composites the page into a dark window frame with a title bar and traffic
-# lights, so a full-bleed near-black field with a line of centred text inside
-# that frame reads as *a terminal window*, not as a card over an app — which is
-# what a human watching `examples/ticket-queue/demos/2026-08-11-criterion-card`
-# read it as. Nothing in an artifact could say so: the element, the beat, the
-# aria snapshot and the frames were all exactly right.
-#
-# **So the web card is the window's own body colour, on screen.** Not a palette
-# chosen to stand out from the window: a human watched three rounds of
-# candidates and asked for exactly this — *"I want the interlude to match the
-# window, without a need for a border of another colour, or an additional edge
-# of a third colour."* The content area simply becomes the window's colour with
-# the sentence on it; whitish text, because that is what is legible on it. The
-# card declares `WEB_CARD_BODY` rather than `WEB_WINDOW_BODY` **so that it can
-# match** — see that constant for the encoder path the two levels of difference
-# pay for.
-#
-# Two earlier answers to #291 are recorded here because both were rejected by
-# the person watching, and a later reader will otherwise re-propose them:
-#
-#   * **warm paper** (`#efe7d8`), 205 luma levels off the window. Unmistakably
-#     a card, and a flashbang in the middle of a dark recording.
-#   * **black inside an 18 px border in the window's colour**, 23.5 levels off.
-#     Read as a card in a frame in a window — three colours where the reviewer
-#     wanted one, and the border and the recorder's own pad measured as two
-#     different colours in the encoded frame (#301 again).
-#
-# A third answer was rejected by the same person after it shipped: **one colour
-# declared for both**, which is what a reader expects "the card is the window's
-# colour" to mean. It reached `demo.mp4` as two colours five levels apart and
-# they saw it in a frame. That is why the two declarations differ, and why the
-# thing that grades this is a reading of the **encoded video**, not a reading of
-# these strings: `tests/smoke`'s `check_criterion_card` requires the card's
-# field and the window's pad to be within 2 levels per channel in `demo.mp4`.
-# An equality pinned between two declarations would be green on exactly the
-# build the reviewer rejected.
-#
-# What is still not graded anywhere: whether a viewer **reads the result as a
-# card**. Sameness is now measurable; recognition is not, and tests/README.md
-# says so under Known gaps rather than implying otherwise with a green check.
-#
-# The card stays **opaque and full-bleed** — `inset: 0`, one flat `#rrggbb`,
-# above the caption bar. That is not decoration: `reference/limits.md` reasons
-# from all three, and with no border there is no second box whose corners or
-# alpha could put the app back on screen at the edges.
+# The web recorder's card is deliberately **not** built from this. The
+# wrapper document carries its own `__demoInterlude` element in the card
+# layer over the app rect (chrome.py, #360), declaring `WEB_WINDOW_BODY`
+# uncompensated — `_INTERLUDE_JS` below only ever finds that element already
+# in the tree and toggles it, so the stylesheet here never paints on a web
+# take. The per-medium CSS split this replaces (`INTERLUDE_CSS_WEB`, painted
+# in the compensated `WEB_CARD_BODY`) died with the composite in #361; see
+# WEB_WINDOW_BODY's history note.
 INTERLUDE_CSS_TERMINAL = (
     _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"
-)
-INTERLUDE_CSS_WEB = (
-    _INTERLUDE_LAYOUT + f" background: {WEB_CARD_BODY}; color: #f2f0ec;"
 )
 _INTERLUDE_JS = """
 window.__demoInterlude = (text) => {
@@ -1105,21 +1043,21 @@ class _DemoBase:
             "SPEECH_MODEL", "eleven_multilingual_v2"
         )
         self._tts_dir = self.out_dir / ".tts"
-        # Caption font size in px. The web recorder raises this so captions
-        # stay readable after its window composite scales the frame down.
+        # Caption font size in px. Both media record at true pixel size now,
+        # so this is the size on screen: the web recorder's band caption and
+        # the terminal's in-page bar both render it as declared. (The deleted
+        # composite scaled the web page ~0.8 and compensated with 34px — see
+        # web.py's history note.)
         self._caption_font_px = 26
-        # Caption distance from the frame bottom, in px. The web recorder
-        # composites (and scales ~0.8) its page into a centered window, which
-        # lifts an in-page bottom:44px caption to ~89px in the final frame;
-        # non-composited media (terminal) raise this so the caption lands at
-        # the same height, keeping caption placement uniform across media.
+        # Caption distance from the frame bottom, in px — `_CAPTION_JS`'s
+        # in-page overlay only, which today means the terminal recorder (the
+        # web caption lives in the wrapper chrome's own band and never reads
+        # this). The terminal raises it so the bar clears its window's edge.
         self._caption_bottom_px = 44
-        # The interlude card's stylesheet, which is per-medium (issue #291) for
-        # the same reason the two numbers above are: the card is composited
-        # into the medium's own chrome, and what reads as a card there is a
-        # property of that chrome. The terminal palette is the default because
-        # it is the one a medium can *open* on (#110); the web recorder swaps
-        # it in its own `__init__`.
+        # The interlude card's stylesheet, read only when `_INTERLUDE_JS` has
+        # to *build* the element — which today means the terminal page: the
+        # web recorder's wrapper document ships the card element in its own
+        # card layer (chrome.py, #360), so the script only toggles it there.
         self._interlude_css = INTERLUDE_CSS_TERMINAL
         self._lines: list[tuple[float, Path]] = []  # (video offset s, clip)
         # Both are readings of time.monotonic(). Nothing in this package
@@ -1266,9 +1204,13 @@ class _DemoBase:
         """Teardown before the browser closes (kill child processes, etc.)."""
 
     def _postprocess(self, mp4: Path) -> None:
-        """Transform the finished mp4 in place (e.g. composite it into a
-        window on a background). No-op by default; the terminal recorder
-        frames itself in-page, so only the web recorder overrides this."""
+        """Transform the finished mp4 in place. No-op by default, and both
+        shipped recorders leave it that way: each frames itself in-page, so
+        the recorded page is the finished picture and a take costs one video
+        encode. (The web recorder's exit-time window composite was the one
+        override; #361 deleted it — see web.py's history note.) The hook
+        stays as the seam a future medium that must transform its file would
+        use."""
 
     def _content_rect(self) -> tuple[int, int, int, int] | None:
         """Where the app sits in the **encoded** frame, caption band trimmed.
@@ -2327,9 +2269,11 @@ take with fewer beats than the last one would otherwise leave the
         Only `TerminalRecorder` answers. Its segments open on a card raised
         before capture starts, and the strip of background beside its window
         says in one number whether the card was up when the recording began.
-        A web take has neither the card nor the window, so None here is
-        "this medium has nothing to say" and lands in the artifact as
-        `content.opening.card: null`.
+        The web recorder answers None — its opening is the wrapper hold, up
+        in frame 0 and cleared by the first `goto()` (#360), which the
+        review sheet names on the frames cut inside it (frames.py) rather
+        than this field claiming a card the medium did not measure — so None
+        lands in the artifact as `content.opening.card: null`.
         """
         return None
 

--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -503,6 +503,37 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
     manifest["frames"] = kept
     manifest["deduped"] = deduped
     manifest["scene_search_skipped"] = skipped_scenes
+    # The frames cut inside a wrapper take's opening hold (#360, #361). The
+    # web recorder stamps `opening_hold_until` on the beat whose goto cleared
+    # the hold, so any kept frame earlier than that instant shows an opaque
+    # field in the window's own colour where the app will be — most often the
+    # first goto's own mid-point frame. Named on the sheet, because a flat
+    # dark window under a heading that says `goto` reads as a failed load to
+    # anyone not told otherwise. Scoped per segment: a merged sheet carries
+    # one hold per wrapper segment, each shifted with its beat by stitch(),
+    # and a frame from another segment is never under it. The clear instant
+    # rides the same clock correction the frames did.
+    by_index = {
+        int(b["index"]): b
+        for b in beats
+        if isinstance(b.get("index"), int) and not isinstance(b.get("index"), bool)
+    }
+    holds: list[dict] = []
+    for hold_beat in beats:
+        until = hold_beat.get("opening_hold_until")
+        if not isinstance(until, (int, float)) or isinstance(until, bool):
+            continue
+        cleared_at = place(hold_beat, float(until)).at
+        named = [
+            str(frame["file"])
+            for frame in kept
+            if float(frame["t"]) < cleared_at
+            and by_index.get(int(frame["beat"]), {}).get("segment")
+            == hold_beat.get("segment")
+        ]
+        if named:
+            holds.append({"until": round(cleared_at, 3), "frames": named})
+    manifest["opening_hold"] = holds
     # How far the video is *known* to have slid under the beat log, as a floor
     # rather than a correction: a beat that ends after the video does is wall
     # time that never reached the file (issue #18). Measured against the last
@@ -716,6 +747,22 @@ def render_frames_md(manifest: dict) -> str:
             f"frames were looked for**. The sheet is that much thinner than it "
             f"would be on a steady host; nothing is missing from the beat's "
             f"own frame above.",
+            "",
+        ]
+    # The frames cut inside an opening hold — named like everything else this
+    # sheet qualifies, one line per hold. The reader's question is which
+    # frame's flat dark window is deliberate, and a count does not answer it.
+    for hold in manifest.get("opening_hold") or []:
+        named = hold.get("frames") or []
+        names = ", ".join(f"`{_md_cell(name)}`" for name in named)
+        out += [
+            f"{names} {'was' if len(named) == 1 else 'were'} cut inside the "
+            f"take's opening hold: until {float(hold.get('until')):.2f}s the "
+            f"app rect is an opaque field in the window's own colour, up from "
+            f"frame 0 and cleared when the first `goto` had an app to reveal. "
+            f"A flat dark window under "
+            f"{'this heading' if len(named) == 1 else 'these headings'} is "
+            f"the hold, not an app that failed to load.",
             "",
         ]
     # One line per dropped frame, named like everything else this sheet

--- a/skills/demo-video/helpers/demo_recording/stitching.py
+++ b/skills/demo-video/helpers/demo_recording/stitching.py
@@ -484,6 +484,14 @@ def _merged_timeline(
             merged["index"] = len(beats)
             merged["t_start"] = _shift(beat.get("t_start"), offset)
             merged["t_end"] = _shift(beat.get("t_end"), offset)
+            # A wrapper segment's hold-clear instant is a video offset like
+            # the two above, and the merged sheet's opening-hold note reads
+            # it (frames.py) — left unshifted it would name part one's
+            # frames as under part two's hold.
+            if "opening_hold_until" in merged:
+                merged["opening_hold_until"] = _shift(
+                    beat.get("opening_hold_until"), offset
+                )
             beats.append(merged)
         for issue in doc.get("issues") or []:
             moved = dict(issue)

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -424,6 +424,13 @@ EVIDENCE_LIMITS = {
     "scope_aria": EVIDENCE_MAX_ARIA,
     "html": EVIDENCE_MAX_HTML,
     "screen": EVIDENCE_MAX_SCREEN,
+    # The recorder's own chrome text — the caption line and any card, read
+    # out of the wrapper document's DOM at capture time (#361). Its own
+    # field because the app's aria cannot carry it any more: the caption
+    # left the app's document when the band did (#358), and evidence that
+    # silently stopped saying which line was on screen would fail #9's
+    # criterion while every remaining field stayed plausible.
+    "chrome": EVIDENCE_MAX_HTML,
 }
 EVIDENCE_TRUNCATED = "\n…[demo-video: truncated here, {n} more characters]"
 

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -1,9 +1,11 @@
 """Recorder — records a web app by driving a Playwright page.
 
-The original demo-video recorder, unchanged in behavior: overlays a visible
-cursor, burns narrator captions into the frame (via _DemoBase), and adds
-web storyboard verbs (goto/click/type_into/spotlight/…) plus the decorative
-on-screen "terminal card" for showing off-browser actions during a web demo.
+The web recorder records a wrapper page the recorder owns (issue #358,
+design record #355, cutover #361): window chrome, a caption band reserved
+below the app rect, the card layer and the cursor dot all live in the
+wrapper document (see chrome.py), and the app loads into an iframe at true
+pixel size. The recorded page *is* the framed picture — there is no
+exit-time composite, so a take costs one video encode, not two.
 
 Note: `Recorder.terminal()` is a *prop inside a web demo* — a styled card
 that fakes a command to make an off-browser action visible. To record an
@@ -18,203 +20,33 @@ actual CLI or TUI, use `TerminalRecorder` instead (see terminal.py).
         rec.shot("01-dashboard")          # -> images/01-dashboard.png
         rec.click("text=Orders")
     # exiting converts the recording into demo.mp4
+
+History: the composite path this replaced screenshotted a window frame once
+per run and had ffmpeg scale the app recording (~0.8) into it at exit —
+which cost a second full-video encode per retake, put the card and the
+window through two different encoders (the #291 colour mismatch and its
+measured #301 compensation, `WEB_CARD_BODY`), and rendered captions at 34px
+to survive the downscale. #355 records why in-page framing replaced it and
+#361 is the cutover that deleted it.
 """
 
 from __future__ import annotations
 
 import re
-import subprocess
-import sys
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from pathlib import Path
 from urllib.parse import urlparse
 
 from .chrome import chrome_geometry, chrome_html, opening_hold_script
-from .content import OPENING_HOLD_LIMIT_S, content_rect, opening_gap
+from .content import content_rect
 from .core import (
-    INTERLUDE_CSS_WEB,
     WEB_WINDOW_BODY,
     _beat_verb,
     _DemoBase,
     _env,
-    _env_flag,
 )
 from .target import guard_target
-
-# Pastel gradient behind the window — matches the terminal recorder's
-# background so web and terminal demos share one look.
-_WEB_BG = "linear-gradient(135deg, #f6d5f0 0%, #d7e3fb 52%, #cdeede 100%)"
-
-# The window frame drawn behind the recording: gradient background + a dark
-# rounded window with a title bar and traffic-light buttons. Screenshotted
-# once per run; the app video is composited into its body by ffmpeg.
-#
-# `__WINBG__` is `core.WEB_WINDOW_BODY`, and it is a shared constant rather
-# than a literal because the interlude card is painted to match this colour in
-# the encoded frame (issue #291) — see `core.WEB_CARD_BODY`, which is this value
-# compensated for the extra encoder the card goes through (#301). Paint this
-# from a literal and the two drift apart on the next edit, with nothing left
-# tying the card's compensation to the thing it compensates for.
-_FRAME_HTML = """<!doctype html><meta charset="utf-8">
-<style>
-  html, body { margin: 0; height: 100%; }
-  body { background: __BG__; }
-  #win { position: fixed; left: __WINX__px; top: __WINY__px;
-    width: __WINW__px; height: __WINH__px; border-radius: 14px;
-    overflow: hidden; background: __WINBG__;
-    box-shadow: 0 34px 90px rgba(20,16,40,.40), 0 8px 22px rgba(20,16,40,.28); }
-  #bar { height: 36px; display: flex; align-items: center; gap: 8px;
-    padding: 0 14px; background: #232334;
-    font: 13px/1 ui-monospace, monospace; color: #9399b2; }
-  .dot { width: 12px; height: 12px; border-radius: 50%; display: inline-block; }
-  #ttl { flex: 1; text-align: center; letter-spacing: .02em; }
-</style>
-<div id="win">
-  <div id="bar">
-    <span class="dot" style="background:#ff5f57"></span>
-    <span class="dot" style="background:#febc2e"></span>
-    <span class="dot" style="background:#28c840"></span>
-    <span id="ttl">__TITLE__</span>
-    <span style="width:44px"></span>
-  </div>
-</div>
-"""
-
-# A visible stand-in for the mouse: headless recordings have no OS cursor,
-# so inject a dot that follows pointer events (and squeezes on click).
-#
-# **The dot follows pointer *motion*, not every `mousemove` — issue #186.**
-#
-# Chromium dispatches one `mousemove` of its own per document, at the widget's
-# initial pointer position — `(0, 0)` on a fresh page — when it recomputes
-# hover state after the first layout. Nothing about it says "synthetic": it is
-# `isTrusted`, it carries a `pointerover`, a `mouseover` and a `pointermove`
-# beside it exactly as a real move does, and it belongs to no storyboard beat.
-# Measured on the fixture page here, it is *created* at `timeStamp` 9 ms and
-# *delivered* at ~89 ms, against a `DOMContentLoaded` at ~20 ms — and `attach`
-# below subscribes at `DOMContentLoaded`, because it needs `document.body`.
-# Which of the two wins is load-dependent, so whether an 18 px dot is burned
-# into the top-left corner of a take's opening stills is a coin flip: eleven of
-# twelve takes under 14-way CPU load had it, one did not. That is what makes a
-# `deterministic=True` take's stills fail to reproduce (#185, #188), and it is
-# the whole of it — two stills that disagree differ in 69 of 921 600 pixels,
-# all of them inside x 0-8, y 0-8.
-#
-# What tells that event apart from a real one is not its trust, its type or
-# its timing: it is that it reports **a position the pointer was already at**.
-# So the overlay remembers the position it has been told about — seeded with
-# `(0, 0)`, where a fresh page's pointer sits and where that event lands — and
-# drops a `mousemove` that repeats it. Nothing is drawn until the pointer is
-# somewhere it has not been, so the dot stays where the stylesheet parks it,
-# off screen, until the storyboard moves the pointer for the first time. That
-# is the one thing here that does not depend on when an event was delivered:
-# both orderings of the load-time event and a storyboard's first move end with
-# the dot at the position the storyboard asked for.
-#
-# **Positions rather than `movementX`/`movementY`, and this is issue #202.**
-# The delta the browser reports for the *first* mouse event in a page is a
-# build detail, because there is no previous event to measure it against:
-#
-#   | Chromium | park at (60, 640) as the page's first mouse event |
-#   |---|---|
-#   | 136 (playwright 1.52) | `movementX/Y` 60, 640 — measured from the origin |
-#   | 147 (playwright 1.59) | `movementX/Y` **0, 0** — measured from itself |
-#   | 151 (playwright 1.61) | 60, 640 — and a settle event precedes it |
-#
-# A guard reading `movementX === 0 && movementY === 0` therefore threw the
-# storyboard's own park away on 147 — indistinguishable there from the
-# load-time event — while staying green on 151, which is how it passed CI and
-# `tests/smoke` on one machine and failed on another. Reading positions costs
-# nothing on any of the three and does not ask the engine for a delta at all,
-# so an engine that implements no `movementX` behaves like every other.
-#
-# What it cannot do, and cannot be made to do: draw the dot for a pointer verb
-# that lands on exactly `(0, 0)`. The pointer *starts* there, so "the pointer
-# was moved to the origin" and "the pointer has not moved" are the same state
-# and no rule reading events can separate them. A storyboard that wants the
-# cursor at the very corner of the viewport has to pass through somewhere else.
-#
-# **The dot is built at `document_start` and inserted at `DOMContentLoaded`,
-# and that split is issue #203.** All of the above is a rule about events, and
-# a rule about events is worth nothing while nothing is listening. `attach`
-# needs `document.body`, so it can only run at `DOMContentLoaded` — and a
-# `mousemove` dispatched before that used to be delivered to no handler at
-# all. Nothing replaces it: the pointer is where it was asked to be, the
-# browser has no reason to say so again, and the dot stays at the stylesheet's
-# off-screen park for the rest of the document. Reachable only by combining
-# two `rec.page` calls, neither of which `SKILL.md` or `reference/` documents —
-# what they document is the escape hatch itself, `rec.page`:
-#
-#     rec.page.goto(url, wait_until="commit")   # Recorder.goto waits for load
-#     rec.page.mouse.move(60, 640)
-#
-# Measured against `tests/fixture` with the position rule above already in
-# place, 12 takes per build, counting only the takes where a probe confirmed
-# the move was delivered while `document.readyState` was still `'loading'`:
-# the dot was placed in **0 of 17** such takes before this split and **13 of
-# 13** after, on Chromium 136, 147 and 149. Chromium 151 never reached the
-# window in 24 takes — its `DOMContentLoaded` lands at 11-17 ms and
-# Playwright's move at 39-68 ms — so it is untested rather than passing.
-#
-# So the listeners are registered while the script itself is evaluated, which
-# for a Playwright init script is `document_start`, and the element they write
-# to is created there too. **A detached element can be styled**: the inline
-# `left`/`top` a `mousemove` writes is still on the div when `attach` puts it
-# in the document, so the dot appears at `DOMContentLoaded` already standing
-# where the pointer went. Nothing is drawn any earlier than it used to be —
-# the stylesheet and the insertion are both still at `DOMContentLoaded`, and
-# an untouched pointer still leaves the parked-off-screen dot #186 is about.
-#
-# What is deliberately *not* covered: a move dispatched before the navigation.
-# That one lands in the previous document, which had its own overlay and its
-# own dot, and no rule in the new document can recover it. Nor is the move
-# Chromium drops on the floor — in the same 48 takes the document received no
-# `mousemove` at all in 3 of 12 on 136, 4 of 12 on 147, 2 of 12 on 149 and 7
-# of 12 on 151, identically before and after this change, and a dot cannot be
-# placed for an event that never arrives. That is issue #230.
-#
-# What this does not do: place the dot after a navigation. A document that
-# replaces the one the dot lived in gets a fresh, parked dot, and Chromium
-# sends its hover-recompute move only for the *first* document — measured, two
-# further navigations with the pointer inside the viewport produced no
-# `mousemove` at all, over four seconds. So the cursor is already absent
-# between a `goto()` and the next pointer verb today, and this changes nothing
-# about that.
-_CURSOR_JS = """
-(() => {
-  const dot = document.createElement('div');
-  dot.id = '__demo_cursor';
-  let atX = 0, atY = 0;
-  window.addEventListener('mousemove', (e) => {
-    if (e.clientX === atX && e.clientY === atY) return;
-    atX = e.clientX;
-    atY = e.clientY;
-    dot.style.left = e.clientX + 'px';
-    dot.style.top = e.clientY + 'px';
-  }, true);
-  window.addEventListener('mousedown', () => dot.classList.add('__down'), true);
-  window.addEventListener('mouseup', () => dot.classList.remove('__down'), true);
-  const attach = () => {
-    if (document.getElementById('__demo_cursor')) return;
-    const style = document.createElement('style');
-    style.textContent = `
-      #__demo_cursor { position: fixed; top: -40px; left: -40px; width: 18px;
-        height: 18px; border-radius: 50%; background: rgba(__ACCENT__,.45);
-        border: 2px solid rgba(__ACCENT__,.95); pointer-events: none;
-        z-index: 2147483647; transform: translate(-50%,-50%);
-        transition: width .1s, height .1s; }
-      #__demo_cursor.__down { width: 12px; height: 12px; }
-    `;
-    document.head.appendChild(style);
-    document.body.appendChild(dot);
-  };
-  if (document.readyState === 'loading')
-    document.addEventListener('DOMContentLoaded', attach);
-  else attach();
-})();
-"""
 
 # Terminal card: a small terminal-styled window that "types" a command on
 # screen, so events the demo triggers from outside the browser (a file
@@ -411,6 +243,30 @@ window.__demoSpotlightClear = () => {
 
 
 
+# What the recorder's own chrome is saying on screen, read out of the wrapper
+# document's DOM at capture time — never out of `self._caption`, which is the
+# beat log quoting itself (#134's blind spot). The caption and the cards left
+# the app's document with the wrapper (#358), so an evidence file that only
+# captured the app frame would silently stop saying which line was on screen —
+# and "a reviewer holding only this file can state what the frame showed"
+# (#9) includes the narration line the frame showed. Visibility-gated the way
+# core's overlay probe is (#163): a cleared caption is opacity 0, not removed.
+_CHROME_TEXT_JS = """() => {
+  const line = (id, name) => {
+    const el = document.getElementById(id);
+    if (!el || !el.textContent) return null;
+    const style = getComputedStyle(el);
+    if (style.display === 'none' || style.visibility === 'hidden') return null;
+    if (parseFloat(style.opacity || '1') <= 0.5) return null;
+    return name + ': ' + el.textContent;
+  };
+  return [
+    line('__demo_caption', 'caption'),
+    line('__demo_interlude', 'card'),
+    line('__demo_bridge_t', 'bridge'),
+  ].filter(Boolean).join('\\n');
+}"""
+
 # The spotlight target's markup, cleaned, from a *clone* — nothing here may
 # touch the live page, which is being recorded.
 #
@@ -505,7 +361,6 @@ class Recorder(_DemoBase):
         criteria: dict[str, str] | None = None,
         ticket: str | None = None,
         allow_private: bool | None = None,
-        wrapper: bool | None = None,
     ) -> None:
         super().__init__(
             out_dir, segment=segment, accent_rgb=accent_rgb,
@@ -527,42 +382,29 @@ class Recorder(_DemoBase):
             self._allow_private,
             source="this take's base_url",
         )
-        # Opt-in wrapper path (issue #358, design record #355): the take
-        # records a recorder-owned wrapper page — window chrome, a caption
-        # band below the app rect — with the app in an iframe at true pixel
-        # size, and the exit-time composite does not run. Transitional: #361
-        # makes it the only path and removes the flag.
-        if wrapper is None:
-            wrapper = _env_flag("WRAPPER")
-        self._wrapper = bool(wrapper)
-        # The app iframe's Frame, once `_start` has mounted it (wrapper only).
+        # The app iframe's Frame, once `_start` has mounted it.
         self._app_frame: object | None = None
-        # Whether the wrapper take's opening hold has been cleared (#360).
-        # The hold is up from frame 0 (see chrome.OPENING_HOLD_JS) and the
-        # first goto() that lands is what clears it — the storyboard's first
+        # Whether this take's opening hold has been cleared (#360). The hold
+        # is up from frame 0 (see chrome.OPENING_HOLD_JS) and the first
+        # goto() that lands is what clears it — the storyboard's first
         # content beat, the moment there is an app to reveal.
         self._hold_cleared = False
-        # Where the wrapper take last commanded the pointer, in wrapper-page
+        # Where the take last commanded the pointer, in wrapper-page
         # coordinates. Seeded at the origin, where a fresh page's pointer
         # actually sits; `_glide` is the only writer.
         self._cursor_at: tuple[float, float] = (0.0, 0.0)
-        if not self._wrapper:
-            # The recording is composited into a window and scaled down
-            # (~0.8), so captions are rendered larger to stay readable in the
-            # final mp4. A wrapper take is recorded at true pixel size and
-            # keeps the base 26px — the terminal recorder's effective size —
-            # because there is no scale to compensate for.
-            self._caption_font_px = 34
-        # And the same composite is why the interlude card is not the default
-        # one: the terminal palette is the colour of a *terminal*, and inside
-        # this window frame a full-bleed field of it reads as one — the whole
-        # of issue #291. The web card is the window's own body colour instead,
-        # as it lands in demo.mp4. See core.INTERLUDE_CSS_WEB. On a wrapper
-        # take this dispatch is moot: the wrapper document defines its own
-        # `__demoInterlude` in the card layer (chrome.py, #360), declaring
-        # `WEB_WINDOW_BODY` uncompensated, and the init script this CSS rides
-        # never paints there.
-        self._interlude_css = INTERLUDE_CSS_WEB
+        # The caption keeps the base font size: the page is recorded at true
+        # pixel size, so there is no downscale to compensate for. (The
+        # composite path rendered captions at 34px to survive its ~0.8
+        # scale — see the module docstring's history note.)
+        #
+        # The interlude card likewise needs no per-medium stylesheet here:
+        # the wrapper document carries its own `__demoInterlude` in the card
+        # layer (chrome.py, #360), declaring `WEB_WINDOW_BODY` uncompensated,
+        # and the base init-script version never paints in it — the card
+        # element already exists in the chrome markup, so the init script
+        # only ever toggles it.
+        #
         # What spotlight() is currently pointing at, which is what a beat's
         # evidence is scoped to. Held here rather than read back out of the
         # page: `window.__spotEl` is an element handle, not a selector, and the
@@ -572,31 +414,15 @@ class Recorder(_DemoBase):
         # see `_note_navigation` for why the listener is kept anyway.
         self._navigated = False
 
-    def _frame_geometry(self) -> dict:
-        """Where the window and the app video sit in the final frame.
-        The app keeps the recording's aspect ratio; a pad leaves the window's
-        rounded corners visible around it."""
-        W, H = self._size["width"], self._size["height"]
-        pad, bar = 14, 36
-        appw = int(W * 0.80) & ~1                 # even width
-        apph = int(round(appw * H / W)) & ~1      # keep recording aspect
-        winw, winh = appw + 2 * pad, apph + 2 * pad + bar
-        winx, winy = (W - winw) // 2, (H - winh) // 2
-        return {
-            "appw": appw, "apph": apph, "winw": winw, "winh": winh,
-            "winx": winx, "winy": winy,
-            "appx": winx + pad, "appy": winy + bar + pad,
-        }
-
     def _content_rect(self) -> tuple[int, int, int, int] | None:
-        """Where the page lands inside the composited frame (issue #97).
+        """Where the app sits in the recorded frame (issue #97).
 
-        `_postprocess` scales the raw recording to `appw x apph` and overlays
-        it at `appx, appy` on the window-and-background still, so this is the
-        app's region of the *encoded* file — which is the only frame anybody
-        watches. Everything outside it is the recorder's own chrome, and that
-        chrome is exactly what made a whole-frame score rank a blank recording
-        above a healthy one (issue #17).
+        `chrome.chrome_geometry` is the single source: the app records in
+        the wrapper's content slot at true pixel size, so the slot's rect is
+        the app's region of the encoded file — which is the only frame
+        anybody watches. Everything outside it is the recorder's own chrome,
+        and that chrome is exactly what made a whole-frame score rank a
+        blank recording above a healthy one (issue #17).
         """
         geom = getattr(self, "_geom", None)
         if not geom:
@@ -609,55 +435,44 @@ class Recorder(_DemoBase):
     def app(self):
         """The app's document — where the verbs point.
 
-        On a wrapper take this is the app iframe's Playwright `Frame`; the
-        wrapper document around it is the recorder's own chrome, so
-        `rec.app.locator(...)` is the escape hatch that reaches the app the
-        way the verbs do. `rec.page` stays the wrapper `Page` — the whole
-        browser surface, chrome included — so nothing an escape hatch could
-        reach before is out of reach now.
-
-        Off the wrapper path it is the page's main frame, so a storyboard
-        written against `rec.app` records identically on both paths.
+        The app iframe's Playwright `Frame`; the wrapper document around it
+        is the recorder's own chrome, so `rec.app.locator(...)` is the
+        escape hatch that reaches the app the way the verbs do. `rec.page`
+        stays the wrapper `Page` — the whole browser surface, chrome
+        included — so nothing an escape hatch could reach before is out of
+        reach now.
         """
-        if self._wrapper:
-            if self._app_frame is None:
-                raise RuntimeError(
-                    "this wrapper take has no app frame yet — rec.app exists "
-                    "once the recorder has entered (`with Recorder(...) as "
-                    "rec:`), which is what mounts the iframe"
-                )
-            return self._app_frame
-        return self.page.main_frame
+        if self._app_frame is None:
+            raise RuntimeError(
+                "this take has no app frame yet — rec.app exists once the "
+                "recorder has entered (`with Recorder(...) as rec:`), which "
+                "is what mounts the iframe"
+            )
+        return self._app_frame
 
     def _target(self):
-        """What locator-driving verbs run against: the app frame on a wrapper
-        take, the page otherwise. `Frame` and `Page` share the whole surface
-        used here (locator/evaluate/url/title), so one call site serves both.
-        """
-        return self._app_frame if self._wrapper else self.page
+        """What locator-driving verbs run against: the app iframe's frame."""
+        return self.app
 
     def _init_context(self, context) -> None:
-        # The wrapper take's cursor lives in the wrapper document (see
-        # chrome.py) and is driven explicitly by the recorder, so the
-        # event-following dot is not injected there: context init scripts run
-        # in every frame, and the app iframe would otherwise draw a second
-        # dot on top of the chrome's.
-        if not self._wrapper:
-            context.add_init_script(_CURSOR_JS.replace("__ACCENT__", self._accent))
-        else:
-            # The opening hold (#360): frame 0 is the window's own colour
-            # over the app rect, not a white iframe waiting for the first
-            # goto. An init script for _OPENING_CARD_JS's reasons — see
-            # chrome.OPENING_HOLD_JS — and the geometry is recomputed here
-            # because init scripts are registered before the page (and
-            # therefore before `_start_wrapper` runs); `chrome_geometry` is
-            # pure, so the two calls cannot disagree.
-            context.add_init_script(
-                opening_hold_script(
-                    chrome_geometry(self._size["width"], self._size["height"]),
-                    window_body=WEB_WINDOW_BODY,
-                )
+        # The opening hold (#360): frame 0 is the window's own colour over
+        # the app rect, not a white iframe waiting for the first goto. An
+        # init script for _OPENING_CARD_JS's reasons — see
+        # chrome.OPENING_HOLD_JS — and the geometry is recomputed here
+        # because init scripts are registered before the page (and therefore
+        # before `_start` runs); `chrome_geometry` is pure, so the two calls
+        # cannot disagree.
+        #
+        # No cursor script rides along: the dot lives in the wrapper
+        # document (chrome.py) and is driven explicitly by the recorder
+        # (`_glide`), so there is no event-following overlay for the app
+        # iframe to draw a second dot with.
+        context.add_init_script(
+            opening_hold_script(
+                chrome_geometry(self._size["width"], self._size["height"]),
+                window_body=WEB_WINDOW_BODY,
             )
+        )
         context.add_init_script(
             _TERMINAL_JS.replace("__TERM_TITLE__", self._terminal_title)
             .replace("__TERM_PROMPT__", self._terminal_prompt)
@@ -680,12 +495,25 @@ class Recorder(_DemoBase):
         and empty of issues. The base now seals `_watch_page` and calls this,
         so the same mistake is a `TypeError` while the module imports.
 
-        Neither callback below calls into Playwright. Page events are
-        delivered on the same thread that is blocked inside a Playwright call,
-        so calling back into the API from one of them is a way to deadlock a
-        take — `_note_document_replaced` writes an issue and reads `page.url`,
-        which is the last URL the connection already told this process about
-        and costs no round trip.
+        The callback below never calls into Playwright. Page events are
+        delivered on the same thread that is blocked inside a Playwright
+        call, so calling back into the API from one of them is a way to
+        deadlock a take.
+
+        **Nothing here subscribes `domcontentloaded`.** The caption lives in
+        the wrapper document, `goto()` navigates the app *iframe*, and the
+        wrapper document is never replaced — a caption structurally cannot
+        be destroyed by navigation, so the #134/#180 `caption_lost` class
+        cannot exist on a web take and the recorder does not listen for it.
+        Not listening rather than listening-and-never-firing is the honest
+        shape: it makes "this issue cannot exist here" a property of the
+        code instead of an observation about one Playwright's event routing,
+        and the beats that keep reporting the caption across a mid-take goto
+        are right — the line really is still on screen (this repository's
+        `tests/smoke --wrapper-only` reads it out of the band's pixels
+        across a full document load). The in-page caption that *does* die
+        with its document survives only on the terminal path, whose page the
+        recorder owns and never navigates, until #362 moves it here too.
         """
         # **Kept deliberately when the masking went** — #142's carve-out.
         # Written for the paint gate, which is gone; nothing reads the flag.
@@ -694,70 +522,15 @@ class Recorder(_DemoBase):
         # attached after the parent's checkpoint had never been verified, which
         # is a statement about a mask and about nothing else.
         page.on("framenavigated", self._note_navigation)
-        # The caption bar is a DOM element, so a document replacing the one it
-        # lives in takes it off the screen (#134). This is the signal for that
-        # and `framenavigated` is not: Playwright fires `framenavigated` for
-        # same-document history navigation too, so an SPA route change would
-        # clear a caption that is still on screen — the same lie in the other
-        # direction. `domcontentloaded` is fired once per new document, and
-        # only for the main frame, so an iframe loading does not touch it.
-        #
-        # That last sentence was read off `playwright-core` and is now
-        # measured: `NAVIGATIONS` in `tests/unit` holds the page-event stream
-        # a real Chromium delivers for `goto`, a link click, `go_back`, a form
-        # submit, `location.href`, a meta refresh, a reload, two same-document
-        # SPA route changes and an iframe load, identical on Chromium 136, 147
-        # and 151, and the suite replays each one through this subscription
-        # (issue #179).
-        #
-        # On a **wrapper** take (#358, #360) the subscription itself is what
-        # goes: the caption lives in the wrapper document, `goto()` navigates
-        # the app *iframe*, and the wrapper document is never replaced — a
-        # caption structurally cannot be destroyed by navigation there, so
-        # `caption_lost` can never fire and the recorder does not listen for
-        # it. Not listening rather than listening-and-never-firing is the
-        # honest shape: it makes "this issue cannot exist on a wrapper take"
-        # a property of the code instead of an observation about one
-        # Playwright's event routing, and the beats that keep reporting the
-        # caption across a mid-take goto are right — the line really is
-        # still on screen (tests/smoke --wrapper-only reads it out of the
-        # band's pixels across a full document load).
-        if not self._wrapper:
-            page.on("domcontentloaded", self._note_document_replaced)
 
     def _start(self) -> None:
-        if self._wrapper:
-            self._start_wrapper()
-            return
-        # Render the window+background frame once (on a throwaway page, so the
-        # app page stays clean for goto). ffmpeg composites the recording into
-        # it in _postprocess.
-        self._geom = self._frame_geometry()
-        g = self._geom
-        # Browser-like window title: the app's host (e.g. "localhost:3000").
-        title = urlparse(self.base_url).netloc or "app"
-        html = (
-            _FRAME_HTML.replace("__BG__", _WEB_BG)
-            .replace("__WINBG__", WEB_WINDOW_BODY)
-            .replace("__WINX__", str(g["winx"])).replace("__WINY__", str(g["winy"]))
-            .replace("__WINW__", str(g["winw"])).replace("__WINH__", str(g["winh"]))
-            .replace("__TITLE__", title)
-        )
-        self._frame_png = self.out_dir / ".frame.png"
-        p = self._context.new_page()
-        p.set_content(html)
-        p.wait_for_timeout(150)
-        p.screenshot(path=str(self._frame_png))
-        p.close()
-
-    def _start_wrapper(self) -> None:
         """Build the wrapper page on the recorded page itself (issue #358).
 
         The chrome is the recording, not a still ffmpeg composites later: the
         recorded page carries the window, the caption band and the cursor
         overlay, and the app loads into an iframe sized to the app rect at
-        true pixel size. `self._geom` keeps `_frame_geometry`'s key names, so
-        `_content_rect` and every other geometry consumer reads one shape.
+        true pixel size. `self._geom` is `chrome_geometry`'s dict, the one
+        shape `_content_rect` and every other geometry consumer reads.
         """
         self._geom = chrome_geometry(self._size["width"], self._size["height"])
         title = urlparse(self.base_url).netloc or "app"
@@ -794,99 +567,6 @@ class Recorder(_DemoBase):
             )
         self._app_frame = frame
 
-    def _opening_hold(self, mp4: Path) -> Path | None:
-        """Cover this take's blank opening with the app's first painted frame.
-
-        Returns the still to composite over the app rect, or None when there is
-        nothing to cover. See "the blank opening" in `core` for why the gap is
-        covered rather than trimmed, and what it costs.
-
-        Measured on `mp4` **before** compositing, where the whole frame is the
-        app page and the window chrome does not exist yet — so there is no rect
-        to get wrong, and none of the chrome that made a whole-frame metric run
-        backwards in issue #17 is in the picture.
-        """
-        self._opening_held = 0.0
-        gap, note = opening_gap(
-            mp4, (0, 0, self._size["width"], self._size["height"])
-        )
-        if gap is None or gap <= 0:
-            return None
-        if gap > OPENING_HOLD_LIMIT_S:
-            # Deliberately nothing. `_measure_content` then measures the same
-            # gap on the encoded file and warns, which is the honest outcome:
-            # an app that takes this long to paint is showing the viewer
-            # something true about itself.
-            print(
-                f"demo-video: this take opened on {gap:.2f}s with nothing "
-                f"painted, over the {OPENING_HOLD_LIMIT_S}s the recorder will "
-                f"cover, so the opening is left as recorded"
-                + (f" ({note})" if note else ""),
-                file=sys.stderr,
-            )
-            return None
-        still = self.out_dir / ".hold.png"
-        subprocess.run(
-            ["ffmpeg", "-y", "-loglevel", "error", "-ss", f"{gap:.3f}",
-             "-i", str(mp4), "-frames:v", "1", str(still)],
-            check=True,
-        )
-        self._opening_held = gap
-        return still
-
-    def _postprocess(self, mp4: Path) -> None:
-        if self._wrapper:
-            # The recorded page already is the framed picture — one encoder,
-            # no composite, and no ffmpeg opening-hold overlay: the wrapper's
-            # opening is held in-page instead, by the frame-0 hold in
-            # chrome.OPENING_HOLD_JS (#360). `_opening_held` stays None: this
-            # path never claims the *encode* covered a gap, which is the same
-            # honest answer the terminal recorder gives about its own opening
-            # card, and `content.opening.gap` then describes the hold as the
-            # featureless stretch it really is, warning-free.
-            return
-        # Composite the recorded video into the window body on the background.
-        g = self._geom
-        hold = self._opening_hold(mp4)
-        tmp = mp4.with_suffix(".comp.mp4")
-        inputs = ["-i", str(mp4), "-i", str(self._frame_png)]
-        filt = (
-            f"[0:v]scale={g['appw']}:{g['apph']}[app];"
-            f"[1:v][app]overlay={g['appx']}:{g['appy']}"
-        )
-        if hold is None:
-            filt += "[v]"
-        else:
-            # A second overlay of the same size at the same place, switched off
-            # the moment the app painted. Content at every t >= held keeps the
-            # timestamp it already had: the video's duration does not change,
-            # the audio is copied untouched, and nothing that reads a beat time
-            # has to know this happened.
-            inputs += ["-i", str(hold)]
-            filt += (
-                f"[base];[2:v]scale={g['appw']}:{g['apph']}[held];"
-                f"[base][held]overlay={g['appx']}:{g['appy']}"
-                f":enable='lt(t,{self._opening_held:.3f})'[v]"
-            )
-        try:
-            subprocess.run(
-                ["ffmpeg", "-y", "-loglevel", "error", *inputs,
-                 "-filter_complex", filt, "-map", "[v]", "-map", "0:a?",
-                 "-c:a", "copy", "-c:v", "libx264", "-pix_fmt", "yuv420p",
-                 "-crf", "20", "-r", "25", "-movflags", "+faststart", str(tmp)],
-                check=True,
-            )
-            tmp.replace(mp4)
-        finally:
-            # In a finally because `.hold.png` is a frame of the *app*, not of
-            # the recorder's chrome: if ffmpeg raises, leaving it on disk leaves
-            # a full-size picture of whatever the app was showing sitting beside
-            # the demo.
-            self._frame_png.unlink(missing_ok=True)
-            if hold is not None:
-                hold.unlink(missing_ok=True)
-
-
     def _failure_screen(self) -> str | None:
         """The page's accessibility tree, for `failure/screen.txt` (issue #11).
 
@@ -909,9 +589,9 @@ class Recorder(_DemoBase):
     def _failure_page_text(self) -> str:
         """The ARIA tree, the URL and the title, as one document.
 
-        Read off `_target()`: on a wrapper take the page is the recorder's
-        own chrome and the crash happened in the app, so the app frame is
-        what a failure dump has to show.
+        Read off `_target()`: the page is the recorder's own chrome and the
+        crash happened in the app, so the app frame is what a failure dump
+        has to show.
         """
         target = self._target()
         aria, aria_format = self._aria(target.locator("body"))
@@ -929,59 +609,13 @@ class Recorder(_DemoBase):
 
         The flag used to mean "the next checkpoint must re-inject and re-verify
         the mask". There is no mask, so nothing consumes it. The *listener* is
-        what #142 keeps, and it fires for any frame and for same-document
-        history navigation as well, which is why it is not what invalidates the
-        caption — see `_note_document_replaced`.
+        what #142 keeps, and it fires for any frame — the app iframe's own
+        navigations included — and for same-document history navigation too.
 
         Deliberately does nothing else — see `_watch_page` for why touching
         Playwright from an event callback is not safe here.
         """
         self._navigated = True
-
-    def _note_document_replaced(self, page) -> None:
-        """A new document is in the main frame, so the caption bar is gone.
-
-        `_CAPTION_JS` builds `#__demo_caption` inside the document, and a full
-        page load destroys it. `self._caption` — which every beat that does not
-        carry its own caption is stamped with — is a Python attribute and
-        survives, so without this a mid-take `goto()` leaves every later beat
-        reporting a line that is not on screen, in a `timeline.json` this skill
-        says to commit (issue #134).
-
-        Clearing it here rather than in `goto()` covers a link click,
-        `go_back()`, a form submit, `location.href` and a meta refresh too:
-        they all replace the document and none of them goes through `goto`.
-        Measured, not assumed — see `_watch_extra` and `NAVIGATIONS` in
-        `tests/unit`.
-
-        **The line does not go quietly (issue #180).** Clearing alone leaves
-        the beat log honest and mute: a storyboard that captions, navigates
-        and then holds records an empty caption column and nothing that says
-        why, which is true and is almost certainly not what its author meant.
-        So the drop is recorded as a `caption_lost` issue naming the line and
-        the document that replaced it, and `timeline.md`'s Issues section
-        carries it. Deliberately **not** in `STRICT_KINDS`: this is the
-        storyboard's mistake, not the app saying it is broken, and strict mode
-        is a verdict on the app.
-        """
-        lost, self._caption = self._caption, ""
-        if not lost:
-            # Every take opens with a document load, and a storyboard that
-            # navigates before it says anything does it again. An issue per
-            # load with no caption up would be noise nobody reads.
-            return
-        try:
-            url = page.url
-        except Exception:  # noqa: BLE001 - a page dying still lost the caption
-            url = "(unknown)"
-        self._note_issue(
-            "caption_lost",
-            f"a new document at {url} replaced the one holding the caption "
-            f"{lost!r}, so the line left the screen — every beat after this "
-            f"reports no caption until the storyboard sets one again",
-            lost_caption=lost,
-            url=url,
-        )
 
     # -- evidence (issue #9) ------------------------------------------------
 
@@ -1002,9 +636,9 @@ class Recorder(_DemoBase):
     def _capture_page(self) -> dict:
         """One pass: the ARIA snapshot, the URL, and the spotlight target.
 
-        Captured from `_target()`: on a wrapper take (#358) the page's own
-        body is the recorder's chrome and one opaque iframe node, so evidence
-        read there would describe the recorder instead of the app.
+        Captured from `_target()` (#358): the page's own body is the
+        recorder's chrome and one opaque iframe node, so evidence read there
+        would describe the recorder instead of the app.
         """
         doc = self._target()
         aria, aria_format = self._aria(doc.locator("body"))
@@ -1016,6 +650,11 @@ class Recorder(_DemoBase):
             "aria": aria,
             "scope_aria": None,
             "html": None,
+            # The chrome's own on-screen text — the caption line, a card —
+            # read from the wrapper document, which is the other half of the
+            # screen now that the app frame no longer carries the recorder's
+            # furniture (see _CHROME_TEXT_JS).
+            "chrome": self.page.evaluate(_CHROME_TEXT_JS),
         }
         if self._spotlit:
             target = doc.locator(self._spotlit).first
@@ -1049,10 +688,9 @@ class Recorder(_DemoBase):
     @_beat_verb("goto")
     def goto(self, path: str = "") -> None:
         url = path if path.startswith("http") else self.base_url + path
-        # On a wrapper take the *iframe* navigates; the wrapper document —
-        # which holds the caption, the cursor and the chrome — never does,
-        # so a mid-take goto cannot take the caption off the screen (see
-        # `_watch_extra`).
+        # The *iframe* navigates; the wrapper document — which holds the
+        # caption, the cursor and the chrome — never does, so a mid-take
+        # goto cannot take the caption off the screen (see `_watch_extra`).
         target = self._target()
         # Asset fetches hang occasionally on a busy dev box — a reload
         # recovers, so retry rather than dying mid-recording.
@@ -1064,10 +702,10 @@ class Recorder(_DemoBase):
                 # An app that refuses framing is not a flake: Chromium
                 # cancels the iframe navigation over X-Frame-Options or CSP
                 # frame-ancestors with exactly this error, and what a retry
-                # would buy is the artifact-lie this slice must not ship — a
-                # silently blank window recorded as a demo. Refuse instead,
-                # naming the header (issue #358).
-                if self._wrapper and "ERR_BLOCKED_BY_RESPONSE" in str(exc):
+                # would buy is the artifact-lie this recorder must not ship
+                # — a silently blank window recorded as a demo. Refuse
+                # instead, naming the header (issue #358).
+                if "ERR_BLOCKED_BY_RESPONSE" in str(exc):
                     raise RuntimeError(self._frame_refusal(url)) from exc
                 if attempt == 2:
                     raise
@@ -1075,13 +713,37 @@ class Recorder(_DemoBase):
             target.wait_for_load_state("networkidle", timeout=10_000)
         except Exception:
             pass  # apps that poll never go network-idle; the page is up
-        if self._wrapper and not self._hold_cleared:
+        # A full page load used to take the recorder's cards down with the
+        # app's document — the card was an element inside it — and SKILL.md's
+        # segment pattern leans on that: interlude(...), then goto() to open
+        # on the app. The cards live in the wrapper document now (#360), so
+        # goto restores the contract deliberately: the verb that shows the
+        # app takes the recorder's own cards off it, exactly as it clears
+        # the opening hold below. Without this, a segment that opened on an
+        # interlude recorded the card over the app to the end of the take
+        # (seen red in tests/smoke --segments-only, as the recorder's own
+        # overlay-left-up warning). The caption is deliberately NOT cleared:
+        # its surviving navigation is #358/#360's whole point.
+        self.page.evaluate(
+            "() => { window.__demoInterlude(''); window.__demoBridge(''); }"
+        )
+        if not self._hold_cleared:
             # The storyboard's first content beat landed: there is an app in
             # the slot now, so the opening hold (up since frame 0 — see
             # chrome.OPENING_HOLD_JS) fades out. Inside this beat on purpose:
             # the beat log's account of when the app appeared is the goto.
             self.page.evaluate("() => window.__demoChromeHoldClear()")
             self._hold_cleared = True
+            # Written onto this beat so the review sheet can say which
+            # frames were cut inside the hold: the beat's own mid-point
+            # frame shows a flat field in the window's colour where the app
+            # will be, and a sheet that leaves that to the reader reads as a
+            # failed load (#361's reporting sweep). A video offset, like
+            # every beat timestamp; `stitch()` shifts it with the beat.
+            if self._in_beat and self._beats:
+                self._beats[-1]["opening_hold_until"] = round(
+                    time.monotonic() - self._t0, 3
+                )
 
     def _frame_refusal(self, url: str) -> str:
         """Why this app cannot be recorded through the wrapper's iframe.
@@ -1112,10 +774,10 @@ class Recorder(_DemoBase):
         )
         return (
             f"this app refuses to be framed: {url} answered with {named}, so "
-            f"Chromium blocked the wrapper take's iframe. Recording on would "
-            f"produce a silently blank window presented as a demo, so the "
-            f"take refuses instead. Record without wrapper=True, or serve "
-            f"the demo target without that header."
+            f"Chromium blocked the take's iframe. Recording on would produce "
+            f"a silently blank window presented as a demo, so the take "
+            f"refuses instead. Serve the demo target without that header, or "
+            f"record it with a target that allows framing."
         )
 
     @_beat_verb("terminal")
@@ -1123,9 +785,9 @@ class Recorder(_DemoBase):
         """Type a command in an on-screen terminal card, then perform the
         real action it describes right after this returns.
 
-        The card is raised in the app's document (`_target()`), so on a
-        wrapper take it appears over the app inside the window — the same
-        place it lands on a composite take — rather than over the chrome.
+        The card is raised in the app's document (`_target()`), so it
+        appears over the app inside the window — a prop inside the demo's
+        story, deliberately not on the chrome's card layer (see chrome.py).
         """
         self._target().evaluate("cmd => window.__demoTerminal(cmd)", command)
 
@@ -1176,8 +838,8 @@ class Recorder(_DemoBase):
         #
         # Both calls run in the app's document (`_target()`): the spotlight
         # functions are context init scripts, which Playwright evaluates in
-        # every frame, so they exist in the wrapper take's iframe too — and
-        # the element being lit lives there.
+        # every frame, so they exist in the app iframe too — and the element
+        # being lit lives there.
         self._target().evaluate("() => window.__demoSpotlightClear()")
         if selector:
             self._target().locator(selector).first.evaluate(
@@ -1193,24 +855,21 @@ class Recorder(_DemoBase):
     def _glide(self, x: float, y: float, steps: int) -> None:
         """Move the pointer to page coordinates `(x, y)`, dot included.
 
-        The legacy path is one Playwright call: the injected dot follows the
-        `mousemove` events. On a wrapper take the dot lives in the wrapper
-        document, and no wrapper listener can hear a move whose target is
-        inside the iframe — the browser delivers it to the iframe's document
-        — so the recorder drives the dot itself, one explicit update per
-        pointer step. The dot is exactly where the pointer was commanded to
-        be, by construction, which is also what makes the #186/#202 class
-        (a dot placed by an event the storyboard never sent) unreachable
-        here: nothing listens, so nothing synthetic can move it.
+        The dot lives in the wrapper document, and no wrapper listener can
+        hear a move whose target is inside the iframe — the browser delivers
+        it to the iframe's document — so the recorder drives the dot itself,
+        one explicit update per pointer step. The dot is exactly where the
+        pointer was commanded to be, by construction, which is also what
+        makes the #186/#202 class (a dot placed by an event the storyboard
+        never sent) unreachable here: nothing listens, so nothing synthetic
+        can move it. The stated cost: raw `rec.page.mouse` work moves the
+        pointer and not the dot.
 
-        Coordinates are wrapper-page coordinates either way — Playwright's
+        Coordinates are wrapper-page coordinates — Playwright's
         `bounding_box()` answers relative to the main frame's viewport even
         for elements inside an iframe, so the app-rect offset is already in
         every box the verbs read.
         """
-        if not self._wrapper:
-            self.page.mouse.move(x, y, steps=steps)
-            return
         sx, sy = self._cursor_at
         for i in range(1, steps + 1):
             xi = sx + (x - sx) * i / steps
@@ -1223,8 +882,6 @@ class Recorder(_DemoBase):
 
     def _cursor_pressed(self, down: bool) -> None:
         """Squeeze (or release) the wrapper document's cursor dot."""
-        if not self._wrapper:
-            return
         fn = "__demoChromeCursorDown" if down else "__demoChromeCursorUp"
         self.page.evaluate(f"() => window.{fn}()")
 

--- a/skills/demo-video/reference/determinism.md
+++ b/skills/demo-video/reference/determinism.md
@@ -126,26 +126,13 @@ no matter what this section does:
   screencast's frame timing is not either. Two takes match in what they *show*,
   not in their checksums — compare the stills, which are lossless PNGs and do
   reproduce exactly. The recorder's own cursor dot used to be the exception
-  ([#186](https://github.com/rogvid/skills/issues/186)): it followed the
-  movement-free `mousemove` Chromium dispatches at load, so a storyboard that
-  never touched the pointer got an 18 px dot in the corner of about half its
-  takes. It is now drawn only once the pointer is somewhere it has not been:
-  the overlay remembers the position it was last told about, starting from
-  `(0, 0)` where a fresh page's pointer sits, and ignores an event that repeats
-  it. One consequence worth knowing: a pointer verb that lands on exactly
-  `(0, 0)` draws no cursor, because "moved to the origin" and "never moved" are
-  the same state as far as the page can tell — move somewhere else first.
-- **Whether a pointer move issued before the document has loaded arrives at
-  all.** The rule above decides *where* the dot is drawn; this decides whether
-  the take has a cursor. Reaching the case takes two `rec.page` escape-hatch
-  calls in combination — `rec.page.goto(url, wait_until="commit")`, and then a
-  raw `rec.page.mouse.move(...)` before that document loads — and Chromium may
-  swallow the move outright: not delivered late, not delivered at the wrong
-  position, never delivered. No rule in the overlay can place a dot for an
-  event the page never sees, so the take records no cursor for its whole
-  length. [#230](https://github.com/rogvid/skills/issues/230) measured 12
-  `Recorder` takes per build against this repo's `tests/fixture` app: the move never reached
-  the document in 3 of 12 takes on Chromium 136, 4 of 12 on 147, 2 of 12 on 149
-  and 7 of 12 on 151. The recorder's own verbs do not reach this — `rec.goto()`
-  waits for `load` before it returns, so `move_to`, `click` and `scroll_to` are
-  never dispatched into a document that is still loading.
+  ([#186](https://github.com/rogvid/skills/issues/186)): it was an in-page
+  overlay following `mousemove` events, and the movement-free one Chromium
+  dispatches at load put an 18 px dot in the corner of about half the takes
+  of a storyboard that never touched the pointer. The class is structurally
+  gone ([#361](https://github.com/rogvid/skills/issues/361)): the dot lives
+  in the recorder's own framed page and moves only when a pointer verb
+  commands it — no listener, so no event the storyboard never sent can move
+  it. The consequence to know: raw `rec.page.mouse` work moves the pointer
+  and not the dot — wrap pointer motion in the verbs (`move_to`, `click`),
+  or accept a take whose pointer acts off-screen.

--- a/skills/demo-video/reference/failures.md
+++ b/skills/demo-video/reference/failures.md
@@ -22,7 +22,7 @@ app itself and writes what it saw into `timeline.json` as `issues`:
 | `request_failed` | a request that never got a response | no |
 | `http_error` | a response with status ≥ 400 (3xx redirects are normal) | no |
 | `nonzero_exit` | a `TerminalRecorder` `run()` whose command failed | yes |
-| `caption_lost` | a page load took the caption bar off the screen; the beat log clears with it and the issue names the line and the new URL. Composite takes only: a wrapper take's caption lives in the recorder's own document, which no app navigation can destroy, so this can never fire there — the recorder does not even subscribe the signal (#360) | no |
+| `caption_lost` | a page load took the caption bar off the screen; the beat log cleared with it and the issue names the line and the new URL. Found only in timelines recorded before the wrapper cutover (#361): a web take's caption now lives in the recorder's own document, which no app navigation can destroy, so this can never fire — the recorder does not even subscribe the signal (#360). Caption death on navigation is a terminal-take concern only (its caption is in-page, until #362), and a terminal take's page never navigates | no |
 
 Each issue is **attributed to the beat that was running when it fired** —
 `beat` (an index into `beats`), plus the beat's `verb` and `caption` copied

--- a/skills/demo-video/reference/limits.md
+++ b/skills/demo-video/reference/limits.md
@@ -17,9 +17,9 @@ carries that issue's numbers, so the evidence outlives the issue.
 Some limits live elsewhere and are not repeated. The recorder hides nothing that
 reaches the screen — the top of [SKILL.md](../SKILL.md), and the reason there
 is no masking verb. A frozen clock changes what an app does and usually does it
-silently, and every boundary about the recorder's own cursor sits beside it —
-when the dot is drawn at all, why a verb landing on exactly `(0, 0)` draws
-nothing, and when a move can be dropped outright — [determinism.md](determinism.md).
+silently, and the boundary about the recorder's own cursor sits beside it —
+the dot is verb-driven, so raw `rec.page.mouse` work never moves it —
+[determinism.md](determinism.md).
 
 ## What the recorder will not notice about your app
 

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -225,13 +225,15 @@ off.
   "aria": "- banner:\n  - heading \"Northwind Ops\" [level=1]\n- text: Revenue $128,400 …",
   "scope_aria": "- text: $128,400",
   "html": "<div id=\"kpi-rev\">$128,400</div>",
+  "chrome": "caption: A small dashboard.",
   "truncated": [], "limits": { "aria": 12000, "html": 8000 } }
 ```
 
 | Field | What it is |
 |---|---|
-| `aria` | **`Recorder`**: the page's ARIA snapshot — a compact YAML tree of roles and accessible names, the same thing `expect(...).toMatchAriaSnapshot` compares. Semantic, ~10× smaller than the markup, and stable across restyling, which is why it is preferred over raw HTML |
+| `aria` | **`Recorder`**: the app document's ARIA snapshot — a compact YAML tree of roles and accessible names, the same thing `expect(...).toMatchAriaSnapshot` compares. Semantic, ~10× smaller than the markup, and stable across restyling, which is why it is preferred over raw HTML |
 | `scope` / `scope_aria` / `html` | the current `spotlight()` target: its selector, its own ARIA tree, and its `outerHTML` with every value-bearing attribute stripped. All three are null when no spotlight is up |
+| `chrome` | **`Recorder`**: what the recorder's own chrome shows on screen — the visible caption line, and any card or bridge label that is up. Read out of the wrapper document's DOM at capture time, never copied from the beat log: the caption lives in the chrome's reserved band, not in the app document the `aria` describes, so without this field no evidence file could say which narration line the frame showed |
 | `screen` | **`TerminalRecorder`**: the rendered screen, ANSI resolved by xterm.js, scrollback included — the same text `wait_for_text()` matches against |
 | `truncated` / `limits` | which fields were cut, and at what budget. A cut field also says so inline where it stops |
 | `error` | present *instead of* the page text when reading the screen raised. Capturing evidence is a diagnostic and must not cost an otherwise fine take, so the file is written anyway, saying what went wrong — which keeps every beat's `evidence` pointer resolving. `timeline.json` is unaffected |

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -118,7 +118,7 @@ the encoded frame, and writes down what it found:
              "static_for": 21.5, "static_from": 3.5, "static_limit": 15.0,
              "static_beats": [{ "index": 6, "verb": "caption", "acting": false },
                               { "index": 7, "verb": "hold", "acting": false }],
-             "opening": { "gap": 0.0, "held": 0.4, "limit": 1.5, "note": null,
+             "opening": { "gap": 0.7, "held": null, "limit": 1.5, "note": null,
                           "card": null },
              "warnings": [] }
 ```
@@ -136,11 +136,10 @@ the encoded frame, and writes down what it found:
   from the frames at all — see *An overlay the recorder left up* below.
 - `measured` is `false`, with `note` saying why, when the check could not run.
   `content` itself is `null` only when the take encoded no mp4.
-- `opening` says what the take opened on — and, on a web take, what the
-  recorder did about it. Read the next section: `held` above zero means the
-  first frames of your video are not frames the recording captured. On a
-  terminal take `opening.card` says whether the segment's first frame was its
-  title card or a bare terminal.
+- `opening` says what the take opened on. Read the next section: on a web
+  take a short featureless `gap` is the wrapper's own opening hold, which is
+  deliberate. On a terminal take `opening.card` says whether the segment's
+  first frame was its title card or a bare terminal.
 
 **What the take says out loud, and on which stream.** Which line the take
 prints decides the stream: **anything wrong — a warning, or the note that the
@@ -152,48 +151,36 @@ nothing here at all. So capturing one stream in a script never gives you half a
 summary; it gives you the whole summary of one kind of take and silence for
 the other, which is the thing to know before redirecting either.
 
-### `opening` — the first frames of a web take are a hold
+### `opening` — a web take opens on the wrapper hold, on purpose
 
-Chromium starts recording when the page is created, and the page is
-`about:blank` until your first `goto()` returns. `about:blank` paints white, so
-a web take's recording genuinely begins with a few hundred milliseconds of flat
-white inside a correct-looking window frame — which reads as *the app loaded
-blank*, and is the most plausible-looking way a demo can misrepresent an app.
+Chromium starts recording when the page is created, before your first
+`goto()` has an app to show. A recorder that did nothing about that would
+open every demo on a flat white app rect inside a correct-looking window —
+which reads as *the app loaded blank*, and is the most plausible-looking way
+a demo can misrepresent an app.
 
-The recorder covers that gap: it finds the first frame that differs from the one
-the take opened on, and composites **that** frame over the app area for the
-seconds before it. So a web demo opens on the application, as you would want it
-to.
+So a web take's frame 0 is the **opening hold**: an opaque field in the
+window's own colour over the app rect, up before anything else paints and
+faded out by the first `goto()` — the moment there is an app to reveal. It
+is chrome the recording really captured, not a composited still, so nothing
+about the video is retouched: the duration, the audio and every beat
+timestamp are exactly what they were. The review sheet names the frames
+that were cut inside it (`frames.md`), so a flat dark window under a `goto`
+heading is documented as the hold rather than left to read as a failed
+load.
 
-**Two things follow, and neither is hidden from you:**
+`gap` is measured afterwards, off the encoded mp4: on a healthy web take it
+is the hold's own featureless stretch (a few hundred milliseconds to a
+second), and it is a description, not a warning. `held` is how many seconds
+a take's *encode* covered with a composited still; no current recorder does
+that (the exit-time composite that did went with #361), so `held` is `null`
+on every take and `limit` keeps the scale the numbers were tuned against.
+Only a recorder that claims to cover can warn about a gap it failed to
+cover.
 
-- Those opening frames show the app slightly before it painted. `held` is how
-  many seconds were covered, and it is in `timeline.json` on every take that
-  measured one. Spoken, it is a clause of the healthy `shows a picture` line —
-  **stdout**, and the only place the recorder ever says it. A take that warned
-  does not print that line, so on a take with warnings `held` is in this file
-  and nowhere else — and a take whose `held` is `0.0` gets no clause either,
-  because the clause says what was covered and nothing was, so a healthy line
-  carrying no hold is a take that opened on a painted app rather than a take
-  that hid one. Nothing else in the video is touched — the duration,
-  the audio and every beat timestamp are exactly what they were, because the
-  hold is an overlay switched off rather than a trim.
-- The video is therefore not a measurement of your app's load time, and was
-  never a good one: the gap it covers is the recorder's own startup as much as
-  the app's.
-
-`gap` is measured **afterwards**, off the encoded mp4 — so on a healthy web take
-it reads `0.0` *because* the hold landed, and a hold that silently did nothing
-shows up here as a non-zero number and a warning.
-
-Past `limit` (1.5s) nothing is held and the take warns instead. An app that
-takes that long to paint is telling the viewer something true about itself, and
-covering seconds of it would be inventing a demo rather than repairing one.
-
-`held` is `null` on a terminal take. The terminal recorder draws its own window
-inside the page, so it has no equivalent gap; open a terminal segment on a title
-card if you want its first frame to be deliberate (see *Opening a terminal
-segment on a title card*).
+On a terminal take the equivalent is the opening card; open a terminal
+segment on one if you want its first frame to be deliberate (see *Opening a
+terminal segment on a title card*).
 
 ### `opening.card` — what a terminal segment's first frame showed
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -74,25 +74,30 @@ counterpart at its definition:
   smoke's `MIN_OPENING_CARD_S`), and the corner later reads bare (≥ 150) as
   the control. Frame 0 is read by index out of one full decode, never by
   seeking a timestamp (#128).
-- **card-vs-window** (web take, #291): the criterion card and the window pad
-  read out of the composited `demo.mp4` (never a still - the two layers
-  arrive through different encoders, #301) at two instants inside the card,
-  ≤ 6 levels off the dispatched `WEB_CARD_RGB` and ≤ 2 levels apart worst
-  channel, with a card-down control that must NOT read as the card. The
-  instants are located by a luma sweep of the strip itself and tied loosely
-  to the logged beat, because this host's wall clock steps ~0.8 s mid-take
-  about one recording in five and `capture_clock`'s step position is an
-  aliased sample (#245, #250) - a beat-log fraction mapped through it landed
-  on the interlude fade on a healthy build.
+- **card-vs-window** (web take, #291/#360): the criterion card and the
+  window's bottom pad read out of `demo.mp4` at two instants inside the
+  card, ≤ 6 levels off the ONE declared colour (`core.WEB_WINDOW_BODY`,
+  uncompensated since #361) and ≤ 5 levels apart worst channel (the
+  single-declaration pair encodes 0.5-3.8 apart across healthy runs, so
+  the reading resolves repaints, not nudges - the reasoning is at the
+  constant), with a card-down control that must NOT read as the card. The
+  instants are located by a luma sweep of the strip and tied to the logged
+  beat - overlap-aware, because the opening hold is a second, deliberate
+  dark stretch in the same strip - and never by a bare beat-log fraction:
+  this host's wall clock steps ~0.8 s mid-take about one recording in five
+  and `capture_clock`'s step position is an aliased sample (#245, #250).
 - **cursor-parked** (web take, #202): the accent disc's centre, measured as
   the centroid of accent-like pixels in the last review frame, sits within
   3 px per axis (video pixels) of the park rect's centre mapped through
-  `to_video_rect`. Read from pixels, where smoke's `check_parked_pointer`
-  asks the DOM. A missing disc fails, deliberately.
-- **cursor-absence** (web take, #186; closes #193's gap): every kept review
-  frame before the marker's `no_pointer_until_beat` carries zero accent
-  pixels in the page-origin crop (x 0-8, y 0-8 - the #186 signature), with a
-  floor of 2 probed frames so the sweep cannot be vacuous.
+  `to_video_rect` - the app-rect offset, since the app records at true
+  pixel size. The wrapper dot is recorder-driven (#361), and this golden is
+  what grades the drive's pixels. A missing disc fails, deliberately.
+- **cursor-absence** (web take, #186's class; closes #193's gap): every kept
+  review frame before the marker's `no_pointer_until_beat` carries zero
+  accent pixels in the frame-origin crop (16 px - where a dot whose
+  off-screen park is lost ships visible at load), with a floor of 2 probed
+  frames so the sweep cannot be vacuous. The event race behind #186 is
+  structurally gone - nothing listens - and this keeps it gone in any form.
 
 `--dump <dir>` writes every frame the checks read (and any offending frame)
 as PNGs named by check and instant, for a pull request's before/after.
@@ -117,7 +122,7 @@ seen red under a planted recorder defect in #351's pull request.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~55 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~54 min, nightly)
 ├── unit               # the browser-free half (~6 s, 536 tests, no dependencies)
 ├── ci-unit            # the three .github/scripts helpers (~0.2 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
@@ -295,8 +300,8 @@ grades, the manifest that proves it can still fail:
 ```sh
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
-tests/smoke-inject --arm coverage # one arm's entries (~225 s)
-tests/smoke-inject                # all 73 entries, ~55 min
+tests/smoke-inject --arm coverage # one arm's entries (~195 s)
+tests/smoke-inject                # all 71 entries, ~54 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -541,23 +546,24 @@ every push.
 ### What now grades only at merge
 
 Four phases — `run_web`, `run_terminal`, `run_content` and `run_terminal_race`
-— and with them **eight check functions no other phase reaches**:
+— and with them **seven check functions no other phase reaches**:
 
 - `check_content_pair` — content/terminal; 1 `smoke-inject` entry, so nightly
 - `check_content_toured` — content/terminal; 1 entry, so nightly
 - `check_form_pacing` — web; 4 entries, so nightly
 - `_check_scored_region` — content/terminal; covered by the content entries
 - `_check_occlusion` — content/terminal; no entry, and none before this either
-- `check_opening` — web; **no entry**
 - `check_opening_gap` — web; **no entry**
 - `check_verb_classification` — content/terminal; **no entry**
 
-The last three are the real cost of the split and are written up under *Known
+The last two are the real cost of the split and are written up under *Known
 gaps*: no injection and no per-push take means nothing exercises them between a
 pull request opening and its merge, and `check_verb_classification` is the
 guard that caught `clear`/`press` going unclassified in #130.
 [#233](https://github.com/rogvid/skills/issues/233) is the entries that would
-close it.
+close it. (`check_opening` was on this list until #361 retired it with the
+composite hold it graded; the wrapper opening is `check_wrapper_opening`'s,
+which `--wrapper-only` reaches per push.)
 
 ### Why the four middle arms stayed on the push
 
@@ -613,11 +619,10 @@ window — and that bimodal spread alone scores 60–79. A fully blank web
 recording scores **61.8** that way and a healthy one **60.2**, so the metric is
 anti-correlated and no floor can work. Instead, the app's own rect is measured:
 
-- **web video** — `Recorder._geom`, the composited window position, read off the
-  live recorder rather than re-derived, so a change to the window geometry
-  carries the measurement with it
-- **web stills** — the full frame, since `shot()` captures the page full-bleed
-  before compositing
+- **web video and stills** — `Recorder._geom`, the wrapper chrome's app rect,
+  read off the live recorder rather than re-derived, so a change to the window
+  geometry carries the measurement with it. One rect for both since #361: a
+  `shot()` still is the framed page, the same picture the video records
 - **terminal** — the bounding box of `#__term_host`, the xterm.js host div
 
 The bottom 20% of each rect is dropped so the recorder's caption bar cannot
@@ -1426,14 +1431,13 @@ recorded here because nothing asserts on that gap today, and a number written
 into two closed issues as *the* check is the kind that becomes an assertion
 later — one that would look green forever.
 
-### What a web take opens on (issue #119)
+### What a web take opens on (issue #119, then #360/#361)
 
 The third defect in this file found by a human watching, and the most plausible-
-looking of the three: Chromium's screencast starts with the page, the page is
-`about:blank` until the first `goto()` returns, and `about:blank` paints white —
-so a web take opened on ~400 ms of flat white inside a *correct-looking* window
-frame. It does not read as a broken recorder. It reads as an app that loaded
-blank.
+looking of the three: Chromium's screencast starts with the page, before the
+first `goto()` has an app to show — so a web take opened on ~400 ms of flat
+white inside a *correct-looking* window frame. It does not read as a broken
+recorder. It reads as an app that loaded blank.
 
 Nothing in this file moved when that shipped, and neither did the recorder's own
 picture check: its `score` is a median, so it cannot see a leading blank shorter
@@ -1441,51 +1445,39 @@ than half the take, and `static_for` saw one 0.5 s gap against a 15 s limit.
 Both are the right design for what they grade, and both are the reason this
 needed its own assertion.
 
-`check_opening` rides on the `web/` take rather than recording a fourth one, and
-the placement is load-bearing: the fix is an overlay switched off part way
-through, so no timestamp may move, and `check_beat_frames` in that same take
-already matches each beat's frame against the caption that beat put up. A hold
-that shifted the clock lands those frames on the wrong captions.
+Two mechanisms have answered it. The composite path covered the gap at encode
+time — an ffmpeg overlay of the app's first painted frame, graded here by a
+`check_opening` that read frame zero against the take's own median. Both died
+with the composite ([#361](https://github.com/rogvid/skills/issues/361)). The
+wrapper take opens on the **in-page hold** instead: an opaque field in the
+window's own colour, up in frame 0 and cleared by the first `goto()`
+([#360](https://github.com/rogvid/skills/issues/360)) — chrome the recording
+really captured, so no frame is fabricated and no timestamp can move.
+`check_wrapper_opening` grades it twice per run, on the wrapper arm's take and
+on the long `web/` take: frame zero of the app strip reads the hold (≤ 60 mean
+luma, read with `-t` and no `fps` filter — the filter hands back a frame from
+mid-slot, which is how the first version of the old check passed on a blank
+take), and the strip later reads the bare app (≥ 150) as the control, without
+which the first claim is satisfied by a recorder that painted a rectangle and
+stopped (#91). The review sheet names the frames cut inside the hold
+(`frames.md`'s opening-hold note), so a flat dark window under a `goto`
+heading is documented rather than left to read as a failed load.
 
-Two arms, and they fail for different reasons:
+`check_opening_gap` is the surviving half of the old pair, and it exists
+because **the recorded takes cannot reach both shapes of the measurement**:
+`opening_gap` — the reading `content.opening.gap` reports on every take — has
+a blank floor that stops it firing on an app that painted immediately and then
+held still, and no take here holds that shape. Two videos are synthesised with
+ffmpeg, no browser: white until 0.6 s then colour bars (must measure 0.6 s),
+and colour bars throughout (must measure 0.0). The second is the control.
+Colour bars rather than `testsrc2` on purpose — `testsrc2` animates, so a
+video of it changes every frame and could not express "painted and holding
+still", which is the whole distinction being graded.
 
-| arm | what it grades |
-|---|---|
-| `content.opening.held` is above zero | that this take **had** a gap to cover. Without it, frame zero shows the app whatever the recorder does, and the arm below grades nothing. |
-| frame zero scores at least half the take's own median contrast | that the app is visible at t = 0, out of pixels — never through `opening_gap`, which is the code under test asking itself whether it worked. |
-
-**The first version of the second arm graded nothing, and the fault injection is
-what said so.** It sampled with `sample_fps=1` and read `frames[0]`. The `fps`
-filter quantises to its own output slots, and at 1 fps slot zero is a whole
-second wide — measured, it returns a frame from around 0.5 s, which on a broken
-take is *after* the blank has ended. It scored 17.06 on a video whose first
-frame was flat white. The window is now cut with `-t` instead, which decodes
-from the file's own first frame: 17.25 healthy against 0.00 blanked. Reading the
-assertion would not have found this; breaking the recorder did.
-
-`check_opening_gap` is the other half, and it exists because **the recorded
-takes can only ever show one of the two shapes**. A web take always opens blank,
-so nothing in this suite reaches the blank floor — the constant that stops
-`opening_gap` firing on an app that painted immediately and then held still. Two
-videos are synthesised with ffmpeg, no browser: white until 0.6 s then colour
-bars (must measure 0.6 s), and colour bars throughout (must measure 0.0). The
-second is the control. Colour bars rather than `testsrc2` on purpose —
-`testsrc2` animates, so a video of it changes every frame and could not express
-"painted and holding still", which is the whole distinction being graded.
-
-Injections caught:
-
-| break | what fires |
-|---|---|
-| the hold is composited but switched off (`enable='lt(t,0)'`) | frame zero scores 0.00 against the take's median |
-| the opening is never detected, so nothing is ever held | the premise arm — `held` comes back 0.0 |
-| the blank floor is removed | the synthetic control: a static painted picture reads as a 1.95 s opening |
-
-**What this does not cover.** Only the `web/` take is graded; the web segment
-inside `segments/` and the entropy takes hold their openings too, and nothing
-checks it there. And nothing here compares the held frames against what the app
-*would* have shown — the hold is the app's own first painted frame, so a wrong
-frame would have to come from somewhere else in the same recording.
+**What this does not cover.** Only the `web/` and `wrapper/` takes are graded;
+the web segments inside `segments/` and the entropy takes open on the same
+hold, and nothing reads their frame zero. And whether a *viewer* reads the
+hold as deliberate is the frames.md note's job, not a pixel's.
 
 ### Acceptance-criterion coverage (issue #12)
 
@@ -1852,11 +1844,16 @@ per clause and its beat numbers, and points every row at the wrong one.
   verb.
 
   **Two pixel readings are taken** (issue #291), both across the card's own
-  beat and both out of `demo.mp4`. `check_criterion_card` samples a strip of the
-  app rect and requires that it is the colour the package dispatched —
-  `#181726`, `WEB_CARD_BODY` — and it samples the pad of window body below the
-  app rect and requires the two to be **within 2 levels per channel**. The
-  shipped pair reads `(24, 21, 36)` against `(23, 22, 37)`: one level.
+  beat and both out of `demo.mp4`. `check_wrapper_card` samples a strip of
+  the app rect and requires that it is the window's declared colour as
+  encoded — `#181825`, `core.WEB_WINDOW_BODY`, the ONE declaration the card
+  and the window share since the cutover
+  ([#361](https://github.com/rogvid/skills/issues/361)) — and it samples the
+  window's bottom pad and requires the two to be **within 5 levels per
+  channel** — measured 0.5–3.8 across healthy runs (x264 settles the two
+  rects' chroma against different block histories), so what the reading
+  honestly resolves is a repaint, not a nudge: the planted 8-level repaint
+  reads ~9, the terminal-palette one ≥ 12.
 
   **What that second reading is for, and why it took four rounds to write.**
   #291 is *a web take's card is indistinguishable from the window it sits in* —
@@ -1864,26 +1861,15 @@ per clause and its beat numbers, and points every row at the wrong one.
   levels apart, which the person who found #291 rejected: they asked for the
   card to **match** the window. The round after that pinned the card's *declared*
   colour equal to the window's, and they rejected that too, by sampling a
-  shipped frame and finding the two five levels apart in blue. Both readings
-  were honest and both graded the wrong thing — one the wrong direction, one a
-  string. The window frame reaches `demo.mp4` as a screenshot and the card
-  reaches it through Chromium's VP8, so one declared colour arrives as two
-  ([#301](https://github.com/rogvid/skills/issues/301)); the card is therefore
-  declared two levels off the window *so that it lands on it*, and what is
-  graded is where the two land.
-
-  **A failure of that reading is not a flake.** The compensation is measured
-  against one encoder path — this Chromium's VP8, this ffmpeg, `yuv420p`. If any
-  of them moves, the two layers really do stop matching on screen and the bar
-  going red is correct. The fix is to re-measure `core.WEB_CARD_BODY` against
-  the window, never to widen `CARD_WINDOW_TOLERANCE`. **Where the constant was
-  measured, precisely:** one Linux developer box, sweeping 100 declared colours
-  through real takes. Two platforms then read the *shipped* value identically
-  off `demo.mp4` — that box and `ubuntu-latest` under `smoke (web, content and
-  terminal takes)`, both `(24, 21, 36)` for the card and `(23, 22, 37)` for the
-  window, not merely both under the bar. That is two hosts agreeing exactly,
-  which is evidence and not a guarantee: no Windows or macOS runner has ever
-  recorded a take here, and only this box was swept.
+  shipped frame and finding the two five levels apart in blue: the composite
+  path sent the window as a screenshot and the card through Chromium's VP8,
+  so one declared colour arrived as two
+  ([#301](https://github.com/rogvid/skills/issues/301)), and the fix was a
+  measured compensation constant. The cutover retired the class — one
+  encoder, one declaration — and the reading stays because it is the only
+  thing that grades the *result* rather than a string: a card repainted from
+  a literal still fails it in pixels, and no assertion anywhere pins two
+  declarations together or apart (#297's recorded anti-patterns).
 
   **What is still not graded: whether a viewer reads the result as a card.**
   Sameness is measurable and now measured; recognition is not. Nor is:
@@ -2221,7 +2207,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-73 entries, 14 arms, ~54.8 min of takes
+71 entries, 14 arms, ~54.3 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -2250,9 +2236,9 @@ paragraph whose job is to say what this manifest does not cover.
 |---|---|---|
 | `--lock-only` | 3 | a run the machine lock refuses goes back to building an output directory it will never write to and printing `recordings left in` under `smoke: FAILED`, naming it ([#105](https://github.com/rogvid/skills/issues/105)) — or the fix overshoots and no failing run is told where its recordings are, which the third entry is the control for |
 | `--narration-only` | 6 | the narration fixture goes back to leaving its interlude card up for the whole take, so every frame after the third beat — both captions the arm measures included — is the card and not the app, and nothing fails ([#168](https://github.com/rogvid/skills/issues/168)); or the three claims this 8 s arm is the cheapest way to reach stop grading ([#238](https://github.com/rogvid/skills/issues/238)) — the recorder reporting a healthy 2xx as a problem, which is the *only* over-reporting assertion in the file; a beat opening while the voice is still on the previous line; and every clip mixed in at zero offset, which the silent window before the first line is the control for. Two more are about *where* the voice went ([#226](https://github.com/rogvid/skills/issues/226)), which no window bar can see: the mix landing 250 ms from the second the take's own record names, and the record naming a second the mix did not use — caught only because the arm now watches the host's wall clock itself and compares |
-| `--coverage-only` | 14 | the report flatters the storyboard: nothing reported unclaimed, a claim pointing at the wrong beat or forgetting its segment, an undeclared tag accepted, the finding dropped from `timeline.md`. Or the card that puts the ticket's own sentence on screen stops carrying it ([#280](https://github.com/rogvid/skills/issues/280)): the id shown in place of the clause, the clause claimed by nothing, the beat not saying which clause was up, and — the one no reading of `timeline.json` can catch — a card logged in full and never drawn, caught only by the assertion that reads the page snapshot. The fifth is the control: with no card raised at all, the other four have nothing to grade. Four more grade the *picture* of that card ([#291](https://github.com/rogvid/skills/issues/291)) — pixels read off `demo.mp4`, not values read out of a document: a web take given the terminal's near-black card, which is the defect and which every artifact of the take describes correctly; a card dispatched in the right colour and never made visible; and two that only the card-against-window reading catches — the recorder's window repainted out from under a card that is exactly what it should be, and the card's encoder compensation dropped so that one declared colour serves both layers and they arrive five levels apart |
+| `--coverage-only` | 12 | the report flatters the storyboard: nothing reported unclaimed, a claim pointing at the wrong beat or forgetting its segment, an undeclared tag accepted, the finding dropped from `timeline.md`. Or the card that puts the ticket's own sentence on screen stops carrying it ([#280](https://github.com/rogvid/skills/issues/280)): the id shown in place of the clause, the clause claimed by nothing, the beat not saying which clause was up, and — the one no reading of `timeline.json` can catch — a card logged in full and never drawn, caught only by the assertion that reads the page snapshot. The fifth is the control: with no card raised at all, the other four have nothing to grade. Two more grade the *picture* of that card ([#291](https://github.com/rogvid/skills/issues/291), single-encoder since [#361](https://github.com/rogvid/skills/issues/361)) — pixels read off `demo.mp4`, not values read out of a document: the card's field repainted off the window body it must equal, and a card dispatched in the right colour and never made visible. The compensated-pair entries died with the composite: a window repaint carries the card with it now, by construction, and is no longer a defect anything should catch |
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
-| `--determinism-only` | 3 | a re-recording stops reproducing: the pointer parked wherever the race left it, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
+| `--determinism-only` | 3 | a re-recording stops reproducing: the cursor dot parked on-screen so it ships in every still with no pointer verb run, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
 | `--polish-only` | 4 | a terminal segment stops saying what it opened on ([#235](https://github.com/rogvid/skills/issues/235)), which is the one account of that frame a demo directory ships: the field gone entirely; the number a plausible constant instead of a reading, which every other statement about the field is happy with; the card raised 400 ms into the document, which is [#110](https://github.com/rogvid/skills/issues/110) itself and the injection that issue's acceptance criterion names; or the report forgetting that a card was asked for, without which `"bare"` cannot be told from a segment that never wanted one |
 | `--segments-only` | 14 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the sheet stops saying **which clock** it cut them on, so a reviewer cannot tell a corrected sheet from one cut on the raw beat log ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
@@ -2265,7 +2251,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **17 of `tests/smoke`'s 51 check functions have no entry**, and the harness
+- **16 of `tests/smoke`'s 49 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -2291,7 +2277,6 @@ paragraph whose job is to say what this manifest does not cover.
   | `check_determinism` | genuinely ungraded. It reads the clock, the locale and the motion setting *out of the page*, which is the whole point of it — a constructor that stored the flag and never wired it up satisfies anything asserted on the Python side |
   | `check_merge_offset` | genuinely ungraded as timing. `MergeContent` grades the merge of the content *report* (#121); the per-segment caption timing this measures against two mp4s has no browser-free half. One claim of it is graded: `LogEarlyCause` reads the AST and requires its positive-skew message to come from `log_early_causes()` rather than from its own copy of a verdict (#257) — the wording, not the measurement |
   | `check_opening_gap` | `OpeningWarning` — `held: null` against `held: 0.0`, and the blank floor that keeps the warning readable. **Merge-only since #61**: `--web-only` is the only arm that reaches it |
-  | `check_opening` | genuinely ungraded — the first frame of a web take, measured in pixels (#119). **Merge-only since #61**: `--web-only` is the only arm that reaches it, so on a pull request nothing runs it and nothing injects against it |
   | `check_opening_card` | genuinely ungraded — three statements about one sweep of one corner of a frame (#110) |
   | `check_spotlight_transitions` | genuinely ungraded — the shape of the spotlight's exit, sampled frame by frame (#111) |
   | `_check_video` | genuinely ungraded — ffprobe against the file the take wrote |
@@ -2302,14 +2287,14 @@ paragraph whose job is to say what this manifest does not cover.
   | `_check_scene_fallback` | genuinely ungraded — measured straight off `demo.mp4`, because no beat in either storyboard is long enough to provoke it |
   | `_check_unstated_holes` | `HostClockHole` — the whole of it, on a scripted `HostClock`: the complaint, the marker that silences it, the steady-host control and both edge guards (#256). Genuinely ungraded *as a check that runs*: a host that does not step its wall clock produces no hole for it to find, so no arm has ever reached its failure |
 
-  **Three rows above are worse off than the rest, and #61 is why.**
-  `check_opening`, `check_opening_gap` and `check_verb_classification` are
+  **Two rows above are worse off than the rest, and #61 is why.**
+  `check_opening_gap` and `check_verb_classification` are
   ungraded by this manifest *and* reachable only from the three arms that no
   longer run per push, so between a pull request opening and its merge nothing
   exercises them at all. The others in this table are either reached by an arm
   `--cheap` still runs or covered by a `tests/unit` class that runs in a
   second. This is the one real cost of the split, it was measured before the
-  split was made, and closing it means giving those three an entry — see
+  split was made, and closing it means giving those two an entry — see
   **When each take runs** near the top of this file, and the *Known gaps*
   entry at the bottom.
 
@@ -2319,7 +2304,7 @@ paragraph whose job is to say what this manifest does not cover.
   `tests/smoke` walked from each `run_*` phase transitively through the take
   helper, the review-frame helper, the `record_*` functions and the stitch,
   against `run_phases`' `selects()` guards and `smoke-inject`'s `ARM_SECONDS`
-  — only **four** of the sixteen cost a medium arm. The other twelve are
+  — only **three** of the sixteen cost a medium arm. The other thirteen are
   reachable from arms of 19-29 s and are ungraded because nobody wrote the
   entry:
 
@@ -2337,12 +2322,14 @@ paragraph whose job is to say what this manifest does not cover.
     [#241](https://github.com/rogvid/skills/issues/241), which supersedes
     [#200](https://github.com/rogvid/skills/issues/200) — that issue counted
     two of these eight.
-  - **The four that really are expensive** — `check_opening` and
+  - **The three that really are expensive** —
     `check_opening_gap` on `--web-only` (123 s), `check_verb_classification`
     and `_check_occlusion` on `--content-only` (148 s).
     [#233](https://github.com/rogvid/skills/issues/233) covers the first
-    three; `_check_occlusion` is PSNR between two moments of a recording and
-    has neither an issue nor a cheaper arm.
+    two; `_check_occlusion` is PSNR between two moments of a recording and
+    has neither an issue nor a cheaper arm. (The composite-opening check was
+    the fourth, retired with the ffmpeg hold it graded — #361; the wrapper
+    opening has entries of its own, reached per push by `--wrapper-only`.)
 
   An arm above is the **cheapest** phase that reaches the function, which is
   not the arm this roster's prose implies for several of them: `check_take`,
@@ -2571,63 +2558,32 @@ knows is missing is worse than one that is openly absent.
   correction scaled by one would be worse than none. Nothing about any of it
   is narration-specific and nothing in `narration.py` should chase it.
 
-- **That a real Chromium hands a click's deferred document event to
-  `evaluate("0")`.** [#214](https://github.com/rogvid/skills/issues/214) is
-  closed: a beat now forces one pump before it stamps the caption it inherited,
-  so the `domcontentloaded` a click left in the connection lands *inside* that
-  beat instead of one beat later.
-  `MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat`
-  grades it by queueing the measured late half of each stream on a page that
-  releases it when the recorder calls — which is Playwright's documented sync
-  dispatch, and is a *stand-in* for it. What no assertion here can see is a
-  build that stopped delivering the queued event on a trivial `evaluate`, or
-  delivered it later than the beat that pumped. That is a claim about a browser
-  and belongs to `tests/smoke`, which has no arm for it
-  ([#228](https://github.com/rogvid/skills/issues/228)).
+- **The caption-stamp pump's browser half is unexercised in effect.** The
+  #214 machinery survives — a beat still forces one pump before it stamps the
+  caption it inherited — but since the cutover
+  ([#361](https://github.com/rogvid/skills/issues/361)) no page event mutates
+  the caption: the clearing that pump existed to catch rode a
+  `domcontentloaded` subscription the wrapper path does not make. The pump
+  still refreshes event attribution at beat open; the re-read of
+  `self._caption` after it re-reads a value nothing can have changed, and no
+  test can make it matter without re-adding the machinery it outlived.
 
-- **The take-level sentence both cursor fixes were accepted on is ungraded.**
-  [#186](https://github.com/rogvid/skills/issues/186) and
-  [#202](https://github.com/rogvid/skills/issues/202) were accepted on "two
-  takes of a storyboard that never moves the pointer produce byte-identical
-  stills". `tests/unit`'s `CursorMotion` grades the *rule* against event shapes
-  measured off three Chromium builds; the determinism arm parks the pointer
-  before anything is photographed and is structurally blind to it. An arm was
-  built for it and removed before merge, because the only event that exercises
-  the guard in such a take — the `mousemove` Chromium dispatches at load — is
-  delivered only when the page's `load` event fires inside 22 ms: 7 of 7 takes
-  under that bar received it, 0 of 9 over it, and the reviewer's box saw 0 of
-  12. Not machine load (7/9 loaded against 8/9 idle) and not listener timing
-  (installed at `readyState: 'loading'`, 7.2-8.4 ms, 16 of 16). The full
-  measurement, and the one route that might still work, are in
-  [#210](https://github.com/rogvid/skills/issues/210).
-
-- **That a pointer move made before `DOMContentLoaded` places the dot is graded
-  as a shape, not in a browser.**
-  [#203](https://github.com/rogvid/skills/issues/203) moved the overlay's
-  pointer subscriptions to `document_start` and left only the dot's insertion
-  at `DOMContentLoaded`. What `tests/unit`'s `CursorMotion` grades is exactly
-  that: the region the script defers holds no `addEventListener(`, read out of
-  the shipped `_CURSOR_JS`. It is a **textual** claim, and a subscription
-  registered through an indirection — a `const listen = () => window.add…`
-  called from `attach` — would satisfy it while the defect was back. The
-  browser measurement is in the pull request, not in any suite: 12 `Recorder`
-  takes per build through `goto(wait_until="commit")` plus a raw
-  `page.mouse.move`, counting only the takes where a probe confirmed the move
-  was delivered at `readyState: 'loading'`. Dot placed 0 of 17 such takes
-  before, 13 of 13 after, on Chromium 136, 147 and 149. **Chromium 151 could
-  not be measured at all**: its `DOMContentLoaded` lands at 11-17 ms and
-  Playwright's move at 39-68 ms, so 0 of 24 takes reached the window. Nothing
-  re-runs any of this, and a smoke arm for it would inherit
-  [#210](https://github.com/rogvid/skills/issues/210)'s problem — the browser,
-  not the storyboard, decides whether a take exercises the path.
-
-- **The same escape hatch loses the move outright in some takes, and no suite
-  sees that either.** Measured while grading #203 and unchanged by it: the
-  document receives no `mousemove` at all in 3 of 12 takes on Chromium 136, 4
-  of 12 on 147, 2 of 12 on 149 and **7 of 12 on 151**, so the take records no
-  cursor. `check_parked_pointer` cannot catch it — the determinism storyboard
-  parks after `Recorder.goto()`, which waits for `load`. Tracked with its
-  measurement in [#230](https://github.com/rogvid/skills/issues/230).
+- **The cursor-event class (#186/#202/#203/#210/#230) is closed by
+  construction, and its browser measurements are history, not suites.** The
+  composite path's dot followed `mousemove` events, and four issues of
+  measured Chromium behaviour — the load-time hover event, the per-build
+  `movementX` semantics, the pre-`DOMContentLoaded` delivery window, the
+  dropped move — were about exactly that. The wrapper dot moves only when a
+  pointer verb commands it (`_glide`, one update per step), so no event the
+  storyboard never sent can draw or move it; `CursorDrive` in `tests/unit`
+  grades the drive, `check_undrawn_pointer` reads the no-verb park out of
+  the DOM on every determinism take, and tests/pixel's cursor-parked and
+  cursor-absence goldens read the shipped frames. What the class left
+  behind as a real limit: **raw `rec.page.mouse` work moves the pointer and
+  not the dot** — the escape hatch records a take whose pointer acts with
+  no visible cursor, stated in SKILL.md and
+  reference/determinism.md rather than graded, because the storyboard
+  author chose to leave the verb layer.
 
 - **Nothing grades the opening frame of a demo anybody ships.**
   `check_opening_card` sweeps the corner of `terminal-opening/`, a take this
@@ -3276,9 +3232,9 @@ knows is missing is worse than one that is openly absent.
   `DEMO_VIDEO_EVIDENCE=0` env var behind it, are exercised nowhere — every
   take here writes evidence
   ([#48](https://github.com/rogvid/skills/issues/48)).
-- **Three checks are exercised by nothing between a pull request and its
+- **Two checks are exercised by nothing between a pull request and its
   merge.** `--cheap` is what CI records per push since
-  [#61](https://github.com/rogvid/skills/issues/61), and `check_opening`,
+  [#61](https://github.com/rogvid/skills/issues/61), and
   `check_opening_gap` and `check_verb_classification` are reachable only from
   `--web-only`, `--content-only` and `--terminal-only`, which now run on merge.
   They also have no `tests/smoke-inject` entry, so nightly injection does not

--- a/tests/_pixels.py
+++ b/tests/_pixels.py
@@ -96,30 +96,32 @@ def frame_difference(a: bytes, b: bytes) -> float:
     return sum(abs(x - y) for x, y in zip(a, b, strict=False)) / len(a)
 
 
-def to_video_rect(rect: Rect, geom: dict, frame_size: tuple[int, int]) -> Rect:
-    """A page-space rect, mapped to where it lands in the composited mp4.
+def to_video_rect(rect: Rect, geom: dict) -> Rect:
+    """An app-document rect, mapped to where it lands in the recorded frame.
 
-    The web recorder scales the page into a window (~0.8) and overlays it on a
-    background, so a rect read off the live page is not where those pixels are
-    in demo.mp4. Derived from the recorder's own geometry rather than a
-    hardcoded factor, so a change to the window carries this with it.
+    The app records inside the wrapper's content slot at true pixel size
+    (#358, cutover #361), so the mapping is the slot's offset and no scale —
+    the deleted composite's ~0.8 factor went with it. Derived from the
+    recorder's own geometry rather than hardcoded, so a chrome change
+    carries this with it. Rects already in wrapper-page coordinates (a
+    Playwright `bounding_box()`, which answers in main-frame coordinates
+    even for iframe elements) need no mapping at all.
     """
-    width, height = frame_size
-    sx, sy = geom["appw"] / width, geom["apph"] / height
     x, y, w, h = rect
     return (
-        int(geom["appx"] + x * sx),
-        int(geom["appy"] + y * sy),
-        max(2, int(w * sx)),
-        max(2, int(h * sy)),
+        int(geom["appx"] + x),
+        int(geom["appy"] + y),
+        max(2, int(w)),
+        max(2, int(h)),
     )
 
 
 def caption_band(frame_size: tuple[int, int]) -> Rect:
-    """The strip of a full still that holds the burned-in caption bar.
+    """The strip of a full still that holds the caption.
 
-    Covers both recorders: the web caption sits 44 px off the page bottom and
-    the terminal's 88 px, and both boxes are around 70 px tall.
+    Covers both recorders: the web caption's reserved band sits ~54-150 px
+    off the frame bottom at the default viewport (chrome_geometry), and the
+    terminal's in-page bar 88 px off it, ~70 px tall.
     """
     width, height = frame_size
     return (0, max(0, height - 160), width, 140)
@@ -134,16 +136,20 @@ def caption_band(frame_size: tuple[int, int]) -> Rect:
 # the window's pad, ~2 px wide once the page is scaled into the window.
 CARD_STRIP = (0.10, 0.06, 0.80, 0.12)  # x, y, w, h as fractions of the app rect
 
-# And where the window's body is read: a band below the app rect, inset from
-# the left and right so the window's rounded corners and its drop shadow stay
-# out of the mean. Below rather than above because the title bar up there is a
-# different colour again and carries text and three coloured dots; this band is
-# flat window body and nothing else.
+# And where the window's body is read: a band of bare window body, inset
+# from the left and right so the window's rounded corners and its drop
+# shadow stay out of the mean. On a wrapper take that is the window's
+# *bottom pad*, below the caption band (each suite's `wrapper_pad_band`
+# builds the rect from these fractions): the title bar is a different
+# colour again and carries text and three coloured dots, and the strip
+# directly below the app rect is the caption band, which carries a bubble
+# whenever a line is up.
 #
-# **Nothing the card does can paint here** — the pad is part of the frame still
-# ffmpeg composites the app video *onto*, a different layer entirely. That is
-# what makes the reading worth grading against the card: the two bands are the
-# two encoder paths of #301, one each, and the claim is that they agree.
+# **Nothing the card does can paint here** — the card layer covers the app
+# rect exactly (chrome.py). That is what makes the reading worth grading
+# against the card: same encoder, two layers, and the claim is that the one
+# declared colour arrives as one (#360; the two-encoder pair this replaced
+# is #301's history).
 FRAME_BAND = (0.15, 0.70)  # x offset and width, as fractions of the app rect
 
 
@@ -194,27 +200,6 @@ def card_strip(app: Rect) -> Rect:
         max(8, int(w * fw)),
         max(8, int(h * fh)),
     )
-
-
-def frame_band(app: Rect, win: Rect) -> Rect | None:
-    """The band of the window's body this reads the frame's colour out of.
-
-    Between the bottom of the app rect and the bottom of the window — the pad
-    the recorder leaves so the window's rounded corners stay visible around the
-    video. `None` when there is no pad to read.
-
-    Graded against the card by `check_criterion_card`'s second claim, and
-    printed beside it on a healthy run.
-    """
-    ax, ay, aw, ah = app
-    _, wy, _, wh = win
-    top, bottom = ay + ah, wy + wh
-    if bottom - top < 6:
-        return None
-    fx, fw = FRAME_BAND
-    # Inset from the pad's own edges: the outermost row blends into the drop
-    # shadow, and the innermost into the video above it.
-    return (ax + int(aw * fx), top + 2, max(8, int(aw * fw)), bottom - top - 4)
 
 
 def off_card(rgb: tuple[float, float, float], card: tuple[int, int, int]) -> float:

--- a/tests/_pixels.py
+++ b/tests/_pixels.py
@@ -243,3 +243,41 @@ def psnr_db(a: Path, b: Path) -> float | None:
     if not found:
         return None
     return math.inf if found.group(1) == "inf" else float(found.group(1))
+
+
+def true_runs(flags: list[bool]) -> list[tuple[int, int]]:
+    """Every contiguous True stretch, as (start, length), in order."""
+    runs: list[tuple[int, int]] = []
+    start: int | None = None
+    for i, flag in enumerate([*flags, False]):
+        if flag and start is None:
+            start = i
+        elif not flag and start is not None:
+            runs.append((start, i - start))
+            start = None
+    return runs
+
+
+def card_run(
+    flags: list[bool], fps: int, span: tuple[float, float]
+) -> tuple[int, int] | None:
+    """The longest dark stretch that overlaps the logged card span, or None.
+
+    Not simply the longest: a wrapper take carries a *second* dark stretch
+    in the same strip — the opening hold, up from frame 0 in the window's
+    own colour and deliberately so (#360) — and on a short take it can
+    outlast the card. Overlap keeps the same 2 s of leading slack the
+    beat-tie always had (the log's clock and the video's disagree, #245);
+    a run ending earlier than that, or starting after the span's end, is
+    not the card the timeline logged.
+    """
+    start_s, end_s = span
+    best: tuple[int, int] | None = None
+    for run_start, run_len in true_runs(flags):
+        run_start_s = run_start / fps
+        run_end_s = (run_start + run_len) / fps
+        if run_end_s < start_s - 2.0 or run_start_s > end_s:
+            continue
+        if best is None or run_len > best[1]:
+            best = (run_start, run_len)
+    return best

--- a/tests/pixel
+++ b/tests/pixel
@@ -18,11 +18,12 @@ Two takes land in `tests/.pixel-cache/` (gitignored):
 
 - `terminal` - a terminal segment opened on a title card, two commands, no
   server. The shape issue #110 was measured on.
-- `web` - the recorder's web chrome against `tests/fixture/index.html` on an
-  ephemeral port: criterion card, interlude, caption, spotlight, and a cursor
-  park. Its storyboard keeps every pointer verb until late in the take, and
-  the marker says at which beat the pointer first moves, so #351 can probe
-  cursor *absence* over the front stretch without a third take.
+- `web` - the recorder's wrapper chrome (#358/#361) against
+  `tests/fixture/index.html` on an ephemeral port: criterion card, interlude,
+  caption, spotlight, and a cursor park. Its storyboard keeps every pointer
+  verb until late in the take, and the marker says at which beat the pointer
+  first moves, so #351 can probe cursor *absence* over the front stretch
+  without a third take.
 
 **Caching.** Each take carries a `.pixel-recording.json` marker naming the
 digest of everything whose bytes decide what its frames look like: every
@@ -46,14 +47,18 @@ then the four golden chrome properties, the defects humans caught by eye:
 
 - **opening-card** (terminal): frame 0 is the card, the card holds an
   unbroken prefix, and the corner later reads bare as the control (#110).
-- **card-vs-window** (web): the criterion card and the window pad around the
-  app are one colour in the composited demo.mp4, worst channel, and the app
-  strip is NOT the card's colour once the card is down (#291).
+- **card-vs-window** (web): the criterion card and the window body around
+  the app are one colour in demo.mp4, worst channel — one uncompensated
+  declaration through one encoder (#291's class, retired by #360/#361) -
+  and the app strip is NOT the card's colour once the card is down.
 - **cursor-parked** (web): the accent disc's measured centre sits at the
-  coordinate the storyboard parked it at, read out of pixels (#202).
+  coordinate the storyboard parked it at, read out of pixels (#202). The
+  wrapper dot is recorder-driven, and this is what grades its pixels — the
+  note pinned to #361.
 - **cursor-absence** (web): no frame before the take's first pointer verb
-  carries an accent pixel in the page-origin crop - #186's signature, the
-  take #193 said no suite records.
+  carries an accent pixel in the frame-origin crop, where a dot that ships
+  visible at load lands - #186's class, structurally closed by the driven
+  dot and still graded here so it cannot grow back.
 
 Each check prints one line with the numbers it measured, pass or fail.
 `--dump <dir>` writes the frames the checks read (and the offending frame,
@@ -93,7 +98,6 @@ from _pixels import (  # noqa: E402
     Rect,
     card_strip,
     channels_apart,
-    frame_band,
     gray_frames,
     off_card,
     strip_rgb,
@@ -142,30 +146,46 @@ OPENING_BARE_MIN_LUMA = 150.0  # tests/smoke OPENING_BARE_MIN_LUMA
 MIN_OPENING_CARD_S = 1.0
 MIN_OPENING_FRAMES = 40  # tests/smoke MIN_OPENING_FRAMES: the sweep floor
 
-# tests/smoke's WEB_CARD_RGB (= core.WEB_CARD_BODY, the compensated colour a
-# web card is dispatched in so it lands on the window through the app's own
-# encoder, #291/#301), with the same two bars: CARD_RGB_TOLERANCE for "the
-# card painted, in the colour dispatched" and CARD_WINDOW_TOLERANCE for "the
-# card and the window pad are one colour on screen". Neither claim reads a
-# declaration — #297's two recorded anti-patterns (pinning the declarations
-# equal, and pinning them ≥ 12 apart) were both green on builds a human
-# rejected, so both sides here are measured out of demo.mp4.
-WEB_CARD_RGB = (0x18, 0x17, 0x26)
-CARD_RGB_TOLERANCE = 6  # tests/smoke CARD_RGB_TOLERANCE
-CARD_WINDOW_TOLERANCE = 2  # tests/smoke CARD_WINDOW_TOLERANCE
-# Two instants inside the card beat (the issue's floor); smoke reads three.
-CARD_SAMPLE_FRACTIONS = (0.3, 0.7)
+# core.WEB_WINDOW_BODY in decimal — the ONE declaration the wrapper card,
+# the window body and the opening hold all paint from (#360), duplicated
+# here because the loop imports nothing from the recorder. Two bars, the
+# same two claims as tests/smoke's check_wrapper_card: CARD_RGB_TOLERANCE
+# for "the card painted, in the declared colour as encoded" and
+# CARD_WINDOW_TOLERANCE for "the card and the window body are one colour on
+# screen". Neither claim reads a declaration — #297's two recorded
+# anti-patterns (pinning declarations equal, and pinning them ≥ 12 apart)
+# were both green on builds a human rejected, so both sides here are
+# measured out of demo.mp4. There is no compensated pair left to drift:
+# #361 deleted it with the composite (see core.WEB_WINDOW_BODY's history).
+WEB_WINDOW_RGB = (0x18, 0x18, 0x25)
+CARD_RGB_TOLERANCE = 6  # smoke's CARD-family bar, kept
+# tests/smoke WRAPPER_CARD_WINDOW_TOLERANCE, same value and same measured
+# reason: the single-declaration pair encodes 0.5-3.8 apart across healthy
+# runs (2.0-3.0 on this loop's own shorter take) — x264 settles the two
+# rects' chroma against different block histories — so what the reading
+# honestly resolves is a *repaint*, not a nudge. The defect the bar exists
+# to catch, a card layer repainted away from core.WEB_WINDOW_BODY, reads
+# >= 13 (the terminal palette) — 2.6x clear of the bar.
+CARD_WINDOW_TOLERANCE = 5
+# Two instants inside the located card stretch (the issue's floor); smoke
+# reads three. Inside its middle half, because the stretch's edges carry
+# the encoder settling onto the new scene — the 0.3 fraction was measured
+# reading a blend frame 5.9 levels off while the steady card read 2.0.
+CARD_SAMPLE_FRACTIONS = (0.4, 0.75)
 
 # The card is *located in the video* before its colour is graded: a luma
-# sweep of the app strip finds the one dark stretch, and the RGB claims are
-# read inside it. Not read at beat-log fractions, because this host's wall
-# clock steps ~0.8s mid-take about one recording in five, a backward step
-# deletes that much video, and capture_clock's step position is an aliased
-# sample (#245, #250) — a beat-log fraction mapped through it was measured
-# landing on the interlude fade, 24 levels off, on a healthy build. The
-# locator is luma and the claims are colour, so nothing is circular: the
-# terminal card on a web take (#291 itself) is exactly as dark and still
-# fails the RGB reading.
+# sweep of the app strip finds the dark stretches, and the RGB claims are
+# read inside the longest one that overlaps the logged criterion beat. Not
+# read at beat-log fractions, because this host's wall clock steps ~0.8s
+# mid-take about one recording in five, a backward step deletes that much
+# video, and capture_clock's step position is an aliased sample (#245,
+# #250) — a beat-log fraction mapped through it was measured landing on the
+# interlude fade, 24 levels off, on a healthy build. Overlap-aware rather
+# than simply the longest run, because a wrapper take has a *second* dark
+# stretch in the app strip that is deliberate: the opening hold, up from
+# frame 0 in the same window colour (#360). The locator is luma and the
+# claims are colour, so nothing is circular: the terminal card on a web
+# take (#291 itself) is exactly as dark and still fails the RGB reading.
 CARD_SWEEP_FPS = 10
 # Same family as OPENING_CARD_MAX_LUMA: the card strip reads ~24, the app
 # ~236, and the fade between them (~80-150) is deliberately outside, so the
@@ -185,20 +205,22 @@ ACCENT_RGB = (235, 110, 20)
 
 # What counts as a pixel of the cursor dot. Channel *gaps* rather than a
 # distance to ACCENT_RGB, because the dot is drawn at two alphas (.45 fill,
-# .95 border, web.py's _CURSOR_JS) over whatever the page has there: the
-# blends range (122,66,25)–(246,175,149) across dark and white grounds, all
-# of them ≥ 95 red-over-blue and ≥ 56 red-over-green, while the fixture's
-# paper (245,246,249), the web card (24,23,38) and the terminal card
-# (28,26,23) are all ≤ 5 on at least one gap.
+# .95 border, chrome.py's #__demo_cursor rule) over whatever the page has
+# there: the blends range (122,66,25)–(246,175,149) across dark and white
+# grounds, all of them ≥ 95 red-over-blue and ≥ 56 red-over-green, while
+# the fixture's paper (245,246,249), the window body (24,24,37) and the
+# terminal card (28,26,23) are all ≤ 5 on at least one gap.
 ACCENT_R_MINUS_B = 60
 ACCENT_R_MINUS_G = 40
 
 # How far the disc's measured centre may sit from the park, in video pixels.
 # The healthy reading is ~1 px (centroid over a review frame downscaled 0.8,
 # plus to_video_rect's integer truncation); the defect this exists to catch —
-# a pointer placed by something other than the storyboard (#202, #186's
-# synthetic mousemove) — is tens to hundreds of pixels away. 3 px keeps an
-# order of magnitude to the defect without ever forgiving a real drift.
+# a dot drawn anywhere but where the pointer was commanded (#202's class;
+# on the wrapper path the recorder drives the dot, so this is the check
+# that reads the drive's pixels) — is tens to hundreds of pixels away.
+# 3 px keeps an order of magnitude to the defect without ever forgiving a
+# real drift.
 CURSOR_PARK_TOLERANCE_PX = 3.0
 # The half-width of the window scanned around the expected centre. Wide
 # enough that a dot a few pixels off is measured rather than missed, narrow
@@ -211,10 +233,14 @@ CURSOR_SEARCH_RADIUS_PX = 40
 # discipline exists to catch.
 CURSOR_MIN_ACCENT_PX = 40
 
-# The #186 signature: the synthetic-mousemove dot differs in x 0-8, y 0-8 of
-# the page, 69 pixels of it. The probe reads that page crop mapped into each
-# review frame.
-ORIGIN_CROP_PAGE_PX = 8
+# Where a dot that ships visible at load lands: the frame-origin corner, in
+# wrapper-page (= video) pixels. #186's signature was 69 pixels inside
+# x 0-8, y 0-8 of the app page; the wrapper dot parks off-screen at
+# (-40,-40) (chrome.py) and is 18 px wide, so a park moved on-screen — the
+# planted form of "the dot was drawn before any pointer verb" — reads in
+# this corner. 16 px covers the whole dot for a park anywhere inside the
+# first few pixels.
+ORIGIN_CROP_PX = 16
 # The absence claim needs frames to be absent from: below this many kept
 # review frames before the first pointer beat, the probe is the vacuous sweep.
 MIN_ABSENCE_FRAMES = 2
@@ -290,10 +316,14 @@ def record_terminal(out_dir: Path) -> dict:
 def record_web(out_dir: Path, base_url: str) -> dict:
     """The web chrome take: criterion card, interlude, caption, spotlight, park.
 
-    Every pointer verb is held back until the end: the whole front of the take
-    runs with a cursor that has never moved, which is the stretch #351's
-    absence probe needs. The marker records the beat index where that stretch
-    ends, read back off the take's own timeline rather than counted by hand.
+    A wrapper take (#358/#361): the recorded page is the framed picture, the
+    app lives in the iframe at true pixel size, and `rec._geom` is
+    chrome_geometry's dict — the marker's single source for where everything
+    sits. Every pointer verb is held back until the end: the whole front of
+    the take runs with a cursor that has never moved, which is the stretch
+    #351's absence probe needs. The marker records the beat index where that
+    stretch ends, read back off the take's own timeline rather than counted
+    by hand.
     """
     from demo_recording import Recorder
 
@@ -308,6 +338,12 @@ def record_web(out_dir: Path, base_url: str) -> dict:
     ) as rec:
         rec.goto("/")
         rec.wait_for("#kpi-rev")
+        # Settle the app before the card, the same distance tests/smoke's
+        # wrapper take keeps: straight off the opening hold the card's
+        # chroma is encoded against the hold's own blocks and reads ~4
+        # levels off the pad; after a settled app stretch it reads ~1, which
+        # is what the 2-level bar was measured against.
+        rec.pause(1.0)
         # -- the pointer-free stretch: nothing above or below this comment
         # moves the cursor until the move_to further down -------------------
         rec.criterion("AC-1")
@@ -333,8 +369,18 @@ def record_web(out_dir: Path, base_url: str) -> dict:
 
         geom = dict(rec._geom)
         size = (rec._size["width"], rec._size["height"])
-        park = rec.page.locator("#search").bounding_box()
-        if park is None:
+        # The park in the app document's OWN coordinates, read inside the
+        # frame — the check maps it through the app-rect offset
+        # (to_video_rect + geom), so the mapping the recorder's verbs rely
+        # on is the thing being graded rather than assumed. A
+        # `bounding_box()` here would answer in wrapper-page coordinates
+        # with the offset already applied, and the check would be comparing
+        # the recorder's arithmetic with itself.
+        park = rec.app.locator("#search").first.evaluate(
+            "el => { const r = el.getBoundingClientRect();"
+            " return [r.x, r.y, r.width, r.height]; }"
+        )
+        if not park or len(park) != 4:
             raise PixelFailure("web: #search has no box - the page never rendered")
 
     doc = json.loads((out_dir / "timeline.json").read_text(encoding="utf-8"))
@@ -356,14 +402,9 @@ def record_web(out_dir: Path, base_url: str) -> dict:
     return {
         "geom": geom,
         "size": list(size),
-        # The page-space box of the parked element; to_video_rect + geom maps
-        # it into the composite.
-        "park": [
-            int(park["x"]),
-            int(park["y"]),
-            int(park["width"]),
-            int(park["height"]),
-        ],
+        # The app-document box of the parked element; to_video_rect + geom
+        # maps it into the recorded frame.
+        "park": [int(park[0]), int(park[1]), int(park[2]), int(park[3])],
         # Beats [0, this) ran with a pointer that had never moved.
         "no_pointer_until_beat": first_pointer,
     }
@@ -535,8 +576,7 @@ def beat_spans(doc: dict, verb: str) -> list[tuple[float, float]]:
 def longest_run(flags: list[bool]) -> tuple[int, int] | None:
     """(start, length) of the longest contiguous True stretch, or None.
 
-    Ties go to the earliest stretch. This is how the card is found in the
-    sweep: the one long dark run of the app strip.
+    Ties go to the earliest stretch.
     """
     best: tuple[int, int] | None = None
     start: int | None = None
@@ -547,6 +587,44 @@ def longest_run(flags: list[bool]) -> tuple[int, int] | None:
             if best is None or i - start > best[1]:
                 best = (start, i - start)
             start = None
+    return best
+
+
+def true_runs(flags: list[bool]) -> list[tuple[int, int]]:
+    """Every contiguous True stretch, as (start, length), in order."""
+    runs: list[tuple[int, int]] = []
+    start: int | None = None
+    for i, flag in enumerate([*flags, False]):
+        if flag and start is None:
+            start = i
+        elif not flag and start is not None:
+            runs.append((start, i - start))
+            start = None
+    return runs
+
+
+def card_run(
+    flags: list[bool], fps: int, span: tuple[float, float]
+) -> tuple[int, int] | None:
+    """The longest dark stretch that overlaps the logged card span, or None.
+
+    Not simply the longest: a wrapper take carries a *second* dark stretch
+    in the same strip — the opening hold, up from frame 0 in the window's
+    own colour and deliberately so (#360) — and on a short take it can
+    outlast the card. Overlap keeps the same 2 s of leading slack the
+    beat-tie always had (the log's clock and the video's disagree, #245);
+    a run ending earlier than that, or starting after the span's end, is
+    not the card the timeline logged.
+    """
+    start_s, end_s = span
+    best: tuple[int, int] | None = None
+    for run_start, run_len in true_runs(flags):
+        run_start_s = run_start / fps
+        run_end_s = (run_start + run_len) / fps
+        if run_end_s < start_s - 2.0 or run_start_s > end_s:
+            continue
+        if best is None or run_len > best[1]:
+            best = (run_start, run_len)
     return best
 
 
@@ -752,19 +830,44 @@ def check_opening_card(
     return problems
 
 
+def wrapper_pad_band(geom: dict) -> Rect:
+    """The strip of flat window body the card is compared against.
+
+    The window's **bottom pad** — between the caption band's end and the
+    window's bottom edge — because it is the one stretch of bare window
+    body a wrapper frame always shows: the caption band above it carries a
+    bubble whenever a line is up. tests/smoke's wrapper_pad_band, duplicated
+    for the thresholds' reason: the loop and the suite must not import each
+    other. Inset from the pad's own edges — the outermost rows blend into
+    the drop shadow and the band above.
+    """
+    pad_top = geom["bandy"] + geom["bandh"]
+    pad_bottom = geom["winy"] + geom["winh"]
+    return (
+        geom["bandx"] + int(geom["bandw"] * 0.15),
+        pad_top + 2,
+        max(8, int(geom["bandw"] * 0.70)),
+        max(2, pad_bottom - pad_top - 4),
+    )
+
+
 def check_card_vs_window(
     take: Path, info: dict | None, dump: Path | None = None
 ) -> list[str]:
-    """The web card is the window's own colour, read out of demo.mp4 (#291).
+    """The card is the window's own colour, read out of demo.mp4 (#291/#360).
 
-    Never a still: `shot()` photographs the page, the layer *before* the
-    composite, and the card and the window pad reach demo.mp4 through two
-    different encoders (#301) — a still can only ever show one of them.
+    On the wrapper path the card and the window body declare ONE colour
+    (`core.WEB_WINDOW_BODY`, duplicated above) and ride one encoder — the
+    compensated pair the composite needed died with it (#361) — and the
+    claim is still read out of the encoded pixels on both sides, never out
+    of declarations (#297's two recorded anti-patterns).
 
     The instants are found in the video (see CARD_SWEEP_FPS), then tied to
     the cached timeline's one criterion beat: the located stretch must
-    overlap the logged span and be at least half its length, so a dark
-    stretch that is not the logged card cannot stand in for it.
+    overlap the logged span (`card_run` — the opening hold is a second,
+    deliberate dark stretch in the same strip) and be at least half its
+    length, so a dark stretch that is not the logged card cannot stand in
+    for it.
     """
     name = "card-vs-window"
     mp4 = take / "demo.mp4"
@@ -774,6 +877,12 @@ def check_card_vs_window(
             f"re-record (tests/pixel record --force)"
         ]
     geom = info["geom"]
+    if "bandy" not in geom:
+        return [
+            f"{take.name}/{name}: the marker's geometry has no caption band - "
+            f"it predates the wrapper cutover; re-record "
+            f"(tests/pixel record --force)"
+        ]
     doc = json.loads((take / "timeline.json").read_text(encoding="utf-8"))
     spans = beat_spans(doc, "criterion")
     if len(spans) != 1:
@@ -784,30 +893,25 @@ def check_card_vs_window(
         ]
     start, end = spans[0]
     app: Rect = (geom["appx"], geom["appy"], geom["appw"], geom["apph"])
-    win: Rect = (geom["winx"], geom["winy"], geom["winw"], geom["winh"])
     strip = card_strip(app)
-    band = frame_band(app, win)
-    if band is None:
-        return [
-            f"{take.name}/{name}: the window {win} leaves no pad around the "
-            f"app rect {app} wide enough to read - nothing can say whether "
-            f"the card is the window's own colour on screen, which is #291"
-        ]
+    band = wrapper_pad_band(geom)
 
-    # Where the card actually is in the file: the longest dark stretch of the
-    # app strip. The beat log says one exists and roughly where; the video
-    # says exactly where. See CARD_SWEEP_FPS for why the log's clock is not
-    # trusted to sub-second precision here.
+    # Where the card actually is in the file: the longest dark stretch of
+    # the app strip that overlaps the logged beat. The beat log says one
+    # exists and roughly where; the video says exactly where. See
+    # CARD_SWEEP_FPS for why the log's clock is not trusted to sub-second
+    # precision here, and card_run for why "longest overall" would find the
+    # opening hold instead.
     sweep = gray_frames(mp4, rect=strip, sample_fps=CARD_SWEEP_FPS)
     dark = [sum(f) / len(f) <= CARD_LOCATE_MAX_LUMA for f in sweep]
     media_s = len(sweep) / CARD_SWEEP_FPS
-    run = longest_run(dark)
+    run = card_run(dark, CARD_SWEEP_FPS, (start, end))
     if run is None:
         return [
-            f"{take.name}/{name}: no frame of the app strip {strip} ever "
-            f"reads <= {CARD_LOCATE_MAX_LUMA:.0f} luma across {media_s:.1f}s "
-            f"- the criterion card the timeline logs at {start:.2f}-{end:.2f}s "
-            f"never painted"
+            f"{take.name}/{name}: no dark stretch of the app strip {strip} "
+            f"(<= {CARD_LOCATE_MAX_LUMA:.0f} luma at {CARD_SWEEP_FPS} fps, "
+            f"{media_s:.1f}s of video) overlaps the criterion beat logged at "
+            f"{start:.2f}-{end:.2f}s - the card never painted"
         ]
     run_start, run_len = run
     rs, re_ = run_start / CARD_SWEEP_FPS, (run_start + run_len) / CARD_SWEEP_FPS
@@ -818,13 +922,6 @@ def check_card_vs_window(
             f"criterion beat logged {end - start:.1f}s long - the card "
             f"flashed rather than held"
         ]
-    if re_ < start - 2.0 or rs > end:
-        return [
-            f"{take.name}/{name}: the dark stretch at {rs:.2f}-{re_:.2f}s "
-            f"does not overlap the criterion beat logged at "
-            f"{start:.2f}-{end:.2f}s - whatever it is, it is not the card "
-            f"this take dispatched"
-        ]
     if media_s - re_ < MIN_CARD_DOWN_S:
         return [
             f"{take.name}/{name}: the card stretch runs to {re_:.2f}s of a "
@@ -832,9 +929,9 @@ def check_card_vs_window(
             f"there is no app stretch to tell it apart from"
         ]
 
-    # The control: after the card stretch, the strip must NOT be the card's
-    # colour — without this a fixture app that happened to be this dark blue
-    # would pass with no card in the recording at all.
+    # The control: after the card stretch, the strip must NOT be the window's
+    # colour — without this an app that happened to be this dark blue would
+    # pass with no card in the recording at all.
     control_at = re_ + (media_s - re_) * 0.5
     before = strip_rgb(mp4, control_at, strip)
     if before is None:
@@ -845,14 +942,14 @@ def check_card_vs_window(
         ]
     dump_frame(dump, name, f"card-down-control-t{control_at:.2f}s", mp4, at=control_at)
     problems: list[str] = []
-    control_off = off_card(before, WEB_CARD_RGB)
+    control_off = off_card(before, WEB_WINDOW_RGB)
     if control_off <= CARD_RGB_TOLERANCE:
         return [
             f"{take.name}/{name}: at {control_at:.2f}s, with the card down "
             f"since {re_:.2f}s, the strip reads "
             f"{tuple(round(v) for v in before)} - the card's own colour "
-            f"{WEB_CARD_RGB}. Either the app cannot be told from the card, or "
-            f"the card was never taken down"
+            f"{WEB_WINDOW_RGB}. Either the app cannot be told from the card, "
+            f"or the card was never taken down"
         ]
 
     drifts: list[float] = []
@@ -868,14 +965,14 @@ def check_card_vs_window(
             )
             continue
         dump_frame(dump, name, f"card-up-t{at:.2f}s", mp4, at=at)
-        drift = off_card(got, WEB_CARD_RGB)
+        drift = off_card(got, WEB_WINDOW_RGB)
         drifts.append(drift)
         if drift > CARD_RGB_TOLERANCE:
             problems.append(
                 f"{take.name}/{name}: {fraction * 100:.0f}% through the "
                 f"criterion beat the card reads "
                 f"{tuple(round(v) for v in got)} over {strip}, {drift:.0f} "
-                f"levels off the web card's {WEB_CARD_RGB} (bar "
+                f"levels off the declared window body {WEB_WINDOW_RGB} (bar "
                 f"{CARD_RGB_TOLERANCE}) - a web take painting the terminal "
                 f"palette here is issue #291 itself"
             )
@@ -886,18 +983,19 @@ def check_card_vs_window(
             problems.append(
                 f"{take.name}/{name}: {fraction * 100:.0f}% through the "
                 f"criterion beat the card reads "
-                f"{tuple(round(v) for v in got)} and the window pad "
+                f"{tuple(round(v) for v in got)} and the window body "
                 f"{tuple(round(v) for v in chrome)}, {gap:.0f} levels apart "
                 f"worst channel (bar {CARD_WINDOW_TOLERANCE}) - a viewer can "
-                f"tell the card from the window it sits in (#291): the "
-                f"encoder compensation is gone, one layer was repainted, or "
-                f"the encoder moved under it (#301)"
+                f"tell the card from the window it sits in (#291). The two "
+                f"declare one colour and ride one encoder here (#360), so "
+                f"one layer was repainted away from core.WEB_WINDOW_BODY"
             )
             dump_frame(dump, name, f"card-up-t{at:.2f}s-FAIL", mp4, at=at)
     detail = (
-        f"card {max(drifts):.0f} off {WEB_CARD_RGB} (bar {CARD_RGB_TOLERANCE}) "
-        f"and {max(gaps):.0f} off the window pad (bar {CARD_WINDOW_TOLERANCE}) "
-        f"over {len(drifts)} instants; card-down control {control_off:.0f} off"
+        f"card {max(drifts):.0f} off {WEB_WINDOW_RGB} (bar "
+        f"{CARD_RGB_TOLERANCE}) and {max(gaps):.0f} off the window body (bar "
+        f"{CARD_WINDOW_TOLERANCE}) over {len(drifts)} instants; card-down "
+        f"control {control_off:.0f} off"
         if drifts and gaps
         else "no instant inside the card beat could be read"
     )
@@ -911,9 +1009,12 @@ def check_cursor_parked(
     """The accent disc sits where the storyboard parked it, read from pixels.
 
     tests/smoke's check_parked_pointer asks the DOM; this reads the shipped
-    frame, which is what a viewer meets and what a compositor bug would move.
-    The parked coordinate is the marker's page-space park rect mapped through
-    to_video_rect — the recorder's own geometry, not a hardcoded scale.
+    frame, which is what a viewer meets. The wrapper dot is driven by the
+    recorder, one command per pointer step (#361) — this is the check that
+    grades the drive's *pixels*, per the note pinned on that issue. The
+    parked coordinate is the marker's app-document park rect mapped through
+    to_video_rect — the app-rect offset out of the recorder's own geometry,
+    not a hardcoded number.
     """
     name = "cursor-parked"
     if not info or not all(k in info for k in ("geom", "size", "park")):
@@ -936,7 +1037,7 @@ def check_cursor_parked(
     if dims is None:
         return [f"{take.name}/{name}: {frame.name} is not a PNG"]
     scale = dims[0] / size[0]  # review frames are downscaled (#343)
-    vx, vy, vw, vh = to_video_rect(tuple(park), geom, (size[0], size[1]))
+    vx, vy, vw, vh = to_video_rect(tuple(park), geom)
     expect = (vx + vw / 2, vy + vh / 2)
     radius = CURSOR_SEARCH_RADIUS_PX
     window = (
@@ -993,13 +1094,16 @@ def check_cursor_parked(
 def check_cursor_absence(
     take: Path, info: dict | None, dump: Path | None = None
 ) -> list[str]:
-    """No dot before the first pointer verb — #186's signature, #193's gap.
+    """No dot before the first pointer verb — #186's class, kept closed.
 
     Every kept review frame of a beat before the marker's
-    no_pointer_until_beat is probed for accent pixels in the page-origin crop
-    (x 0-8, y 0-8 — where the synthetic-mousemove dot of #186 landed, 69
-    pixels, all inside it). The take's whole front runs pointer-free by the
-    storyboard's contract, so one accent pixel there is the dot drawn at load.
+    no_pointer_until_beat is probed for accent pixels in the frame-origin
+    crop — where the wrapper dot lands if its off-screen park is lost and it
+    ships visible at load (see ORIGIN_CROP_PX). The take's whole front runs
+    pointer-free by the storyboard's contract, so one accent pixel there is
+    a dot no pointer verb commanded — the event-driven form of which was
+    #186, structurally removed by the recorder-driven dot and graded here so
+    it cannot grow back in any form.
     """
     name = "cursor-absence"
     if not info or not all(
@@ -1009,11 +1113,11 @@ def check_cursor_absence(
             f"{take.name}/{name}: the marker carries no pointer-free contract "
             f"- re-record (tests/pixel record --force)"
         ]
-    geom, size = info["geom"], info["size"]
+    size = info["size"]
     first_pointer = int(info["no_pointer_until_beat"])
-    crop = to_video_rect(
-        (0, 0, ORIGIN_CROP_PAGE_PX, ORIGIN_CROP_PAGE_PX), geom, (size[0], size[1])
-    )
+    # Wrapper-page coordinates ARE video coordinates (true pixel size, no
+    # composite), so the corner crop needs no geometry mapping.
+    crop = (0, 0, ORIGIN_CROP_PX, ORIGIN_CROP_PX)
     probed = 0
     worst = 0
     problems: list[str] = []
@@ -1050,9 +1154,9 @@ def check_cursor_absence(
         if count:
             problems.append(
                 f"{take.name}/{name}: beat {beat_index:02d}'s frame carries "
-                f"{count} accent pixels in the page-origin crop {crop}, "
-                f"before any pointer verb ran - the dot was drawn at load, "
-                f"which is #186's race shipped again"
+                f"{count} accent pixels in the frame-origin crop {crop}, "
+                f"before any pointer verb ran - the dot shipped visible at "
+                f"load, which is #186's class grown back in a new form"
             )
             dump_frame(dump, name, f"beat-{beat_index:02d}-FAIL", frame)
     if probed < MIN_ABSENCE_FRAMES:

--- a/tests/pixel
+++ b/tests/pixel
@@ -96,6 +96,7 @@ if _HERE not in sys.path:
     sys.path.insert(0, _HERE)
 from _pixels import (  # noqa: E402
     Rect,
+    card_run,
     card_strip,
     channels_apart,
     gray_frames,
@@ -587,44 +588,6 @@ def longest_run(flags: list[bool]) -> tuple[int, int] | None:
             if best is None or i - start > best[1]:
                 best = (start, i - start)
             start = None
-    return best
-
-
-def true_runs(flags: list[bool]) -> list[tuple[int, int]]:
-    """Every contiguous True stretch, as (start, length), in order."""
-    runs: list[tuple[int, int]] = []
-    start: int | None = None
-    for i, flag in enumerate([*flags, False]):
-        if flag and start is None:
-            start = i
-        elif not flag and start is not None:
-            runs.append((start, i - start))
-            start = None
-    return runs
-
-
-def card_run(
-    flags: list[bool], fps: int, span: tuple[float, float]
-) -> tuple[int, int] | None:
-    """The longest dark stretch that overlaps the logged card span, or None.
-
-    Not simply the longest: a wrapper take carries a *second* dark stretch
-    in the same strip — the opening hold, up from frame 0 in the window's
-    own colour and deliberately so (#360) — and on a short take it can
-    outlast the card. Overlap keeps the same 2 s of leading slack the
-    beat-tie always had (the log's clock and the video's disagree, #245);
-    a run ending earlier than that, or starting after the span's end, is
-    not the card the timeline logged.
-    """
-    start_s, end_s = span
-    best: tuple[int, int] | None = None
-    for run_start, run_len in true_runs(flags):
-        run_start_s = run_start / fps
-        run_end_s = (run_start + run_len) / fps
-        if run_end_s < start_s - 2.0 or run_start_s > end_s:
-            continue
-        if best is None or run_len > best[1]:
-            best = (run_start, run_len)
     return best
 
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -133,13 +133,10 @@ from _pixels import (  # noqa: E402
     card_strip,
     channels_apart,
     contrast,
-    frame_band,
     frame_difference,
     gray_frames,
-    off_card,
     psnr_db,
     strip_rgb,
-    to_video_rect,
 )
 
 # Size floors. Deliberately low, and deliberately *not* the blank-video check —
@@ -163,7 +160,7 @@ MIN_PNG_BYTES = 5_000
 # strongest blank one. See tests/README.md for what this metric cannot
 # resolve — notably a total stylesheet failure, which scores ~10 and is
 # therefore checked separately via getComputedStyle rather than by pixels.
-# "segments" is the web recorder against the same fixture, composited the same
+# "segments" is the web recorder against the same fixture, framed the same
 # way, so it takes the web numbers here and in the two dicts below.
 MIN_CONTENT_STDDEV = {
     "web": 6.0,
@@ -194,11 +191,15 @@ MIN_CONTENT_STDDEV = {
 #
 # The terminal margin is 2.7x over its floor. It was the thinnest number in
 # this file when it was written (871eac3, against 4x or better everywhere
-# else) and it is now tied: `CARD_RGB_TOLERANCE` clears the terminal card by
-# 2.7x too, since #291 put two dark palettes next to each other. Both are
-# stated where they are set, and tests/README.md calls this one out under
-# "Known gaps".
-MIN_CAPTION_BAND_DIFF = {"web": 8.0, "terminal": 1.0, "segments": 8.0}
+# else); it is stated where it is set, and tests/README.md calls it out under
+# "Known gaps". The web numbers were re-measured on the wrapper band (#361):
+# the caption is light text in a bubble over the dark band now, not a dark
+# box on a light page, and the probe rect is the band itself
+# (caption_probe_band) rather than a full-width strip — the probe caption
+# measures 4.99 on a healthy take against 0.00 undrawn (a band with no
+# caption is the same flat window body in both stills), so the floor keeps
+# a 2.5x margin under the weakest healthy reading.
+MIN_CAPTION_BAND_DIFF = {"web": 2.0, "terminal": 1.0, "segments": 2.0}
 
 # Consecutive stills must differ by at least this mean absolute luma, on the
 # 160x90 grayscale reduction. This detects a *duplicate* — a stale or copied
@@ -477,28 +478,15 @@ ENTROPY_GAP_S = 1.0
 
 # Where this storyboard parks the mouse, before anything is photographed.
 #
-# A storyboard that never moves the pointer does not thereby leave the
-# recorder's stand-in cursor undrawn. Chromium dispatches a *synthetic*
-# mousemove at its last known pointer position — (0, 0) on a fresh page — once
-# layout settles, the recorder's handler moves the dot there, and an 18 px dot
-# centred on the origin paints a 9x9 arc into the top-left corner of every
-# still. That event is not part of the storyboard, and it is not reliably
-# delivered before the first `shot()`: measured on this box under 14-way CPU
-# load, twelve takes of this storyboard left the dot at the origin eleven
-# times and off-screen (where the recorder's stylesheet parks it) once.
-#
-# Two takes that disagree about it differ by exactly 69 pixels and by nothing
-# else, which is the whole of issue #185 — three CI runs and a `main` bisect
-# spent on a difference the arm's own diagnostic could not see, because that
-# diagnostic cropped to a panel starting 160 px to the right of it.
-#
-# Parking the pointer makes the position the storyboard's rather than the
-# race's: `page.mouse.move` is awaited, and the synthetic move that follows
-# reuses the position it set (12 of 12 under the same load that lost the race
-# once in twelve). Chosen in the left gutter — the page is 1040 px wide,
-# centred in a 1280 px viewport — and low, so the dot cannot overlap the
-# entropy panel, the spinner, or anything carrying a `:hover` rule.
-PARKED_POINTER = (60, 640)
+# A storyboard that never moves the pointer leaves the cursor dot at the
+# chrome's off-screen park, in every take, by construction (#361): the dot is
+# driven by pointer verbs alone, nothing listens for mouse events, and so the
+# synthetic-mousemove coin flip that cost #185 three CI runs — eleven takes
+# in twelve with an 18 px dot in the corner of the opening stills, one
+# without — has no mechanism left. The determinism storyboard therefore
+# parks nothing; what it asserts instead is that the dot really is undrawn
+# (check_undrawn_pointer), so a recorder that grew back any way of drawing
+# it without a verb fails here on every take rather than one take in twelve.
 
 # Read as a *rect*, not as the inline `left`/`top` the recorder's own mousemove
 # handler writes. Where the pixels landed is what the still comparison asks,
@@ -997,7 +985,11 @@ ALIGN_ARRIVAL_FRACTION = 0.25
 # anything. Below this the probe caption was never drawn in the video, and the
 # right answer is a failure, not a timestamp. Same per-medium reasoning (and
 # the same numbers) as MIN_CAPTION_BAND_DIFF above.
-MIN_ALIGN_BAND_DELTA = {"web": 6.0, "terminal": 1.0, "segments": 6.0}
+# Re-measured on the wrapper band (#361), same probe rect as
+# MIN_CAPTION_BAND_DIFF: the probe caption settles at 4.96-5.17 mean luma
+# over the band on healthy takes, so the web floors keep a ~2.5x margin
+# where the legacy full-frame caption gave 6.0 a wider one.
+MIN_ALIGN_BAND_DELTA = {"web": 2.0, "terminal": 1.0, "segments": 2.0}
 
 # -- review frames (frames/, issue #8) ---------------------------------------
 #
@@ -1451,6 +1443,9 @@ EVIDENCE_LIMITS_EXPECTED = {
     "scope_aria": 12_000,
     "html": 8_000,
     "screen": 12_000,
+    # The chrome's own on-screen text (#361): the caption line and any card,
+    # read out of the wrapper document — see reference/review.md.
+    "chrome": 8_000,
 }
 EVIDENCE_MARKER = "[demo-video: truncated here,"
 # The most a marker can add past a field's budget, so "cut to the cap" can be
@@ -3201,39 +3196,37 @@ def check_determinism(b: Beats, page, when: str, on: bool = True) -> dict:
     return state
 
 
-def check_parked_pointer(b: Beats, page, when: str) -> None:
-    """The recorder's cursor dot is where the storyboard parked it.
+def check_undrawn_pointer(b: Beats, page, when: str) -> None:
+    """A take that ran no pointer verb shows no cursor dot (#185, #361).
 
-    Separate from the byte comparison it protects, and not dominated by it.
-    With `PARKED_POINTER` removed the dot lands wherever Chromium's synthetic
-    mousemove leaves it, which on this machine is the same corner in eleven
-    takes out of twelve — so the still comparison notices the unpinned pointer
-    one run in twelve, while this notices every one. An intermittent assertion
-    is how issue #185 cost three CI runs.
+    Separate from the byte comparison it protects, and not dominated by it:
+    a dot drawn without a verb is exactly the class that made two takes of
+    one storyboard differ by 69 pixels (#185), and a still comparison only
+    notices it on the run where the race goes the other way. This notices
+    every one, in the DOM, on every take of the determinism pair.
 
-    Failing on a missing dot is deliberate. A recorder that stopped drawing a
-    cursor would make this check silently unable to fail, and a check that
-    cannot fail is the thing this repo's review discipline exists to catch —
-    even though the stills would, in that one case, reproduce.
+    Failing on a *missing element* is deliberate. A chrome document that
+    stopped shipping the dot would make this check silently unable to fail,
+    and a check that cannot fail is the thing this repo's review discipline
+    exists to catch — even though the stills would, in that one case,
+    reproduce. The dot's pixels when a verb DOES drive it are tests/pixel's
+    cursor-parked golden.
     """
     box = page.evaluate(_CURSOR_BOX_JS)
     if box is None:
         b.fail_if(
             True,
-            f"{when}, the recorder drew no cursor dot (#__demo_cursor is not "
-            f"in the page) — this take can no longer tell a parked pointer "
-            f"from a synthetic mousemove, which is the difference issue #185 "
-            f"turned out to be",
+            f"{when}, the chrome ships no cursor dot (#__demo_cursor is not "
+            f"in the page) — with no element there is no off-screen park to "
+            f"assert, and no dot for any take's pointer verbs to drive",
         )
         return
-    at = (box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
     b.fail_if(
-        abs(at[0] - PARKED_POINTER[0]) > 1 or abs(at[1] - PARKED_POINTER[1]) > 1,
-        f"{when}, the cursor dot is centred at ({at[0]:.0f}, {at[1]:.0f}), not "
-        f"at the ({PARKED_POINTER[0]}, {PARKED_POINTER[1]}) this storyboard "
-        f"parked the pointer at — its position is being set by something other "
-        f"than the storyboard, and whatever that is decides whether two takes "
-        f"of this storyboard produce the same pixels",
+        box["x"] + box["width"] > 0 and box["y"] + box["height"] > 0,
+        f"{when}, the cursor dot sits at ({box['x']:.0f}, {box['y']:.0f}) "
+        f"with no pointer verb having run — a dot drawn by something other "
+        f"than the storyboard is #185's class back, and it decides whether "
+        f"two takes of this storyboard produce the same pixels",
     )
 
 
@@ -3259,12 +3252,13 @@ _TRAIL_JS = """() => {
 
 def record_web(
     out_dir: Path, base_url: str, clock: HostClock | None = None
-) -> tuple[list[str], Rect, Rect, tuple[int, int]]:
+) -> tuple[list[str], dict, tuple[int, int]]:
     """Land, read a KPI, filter the table, refresh it.
 
-    Returns the post-condition failures plus two content rects: where the app
-    sits inside the composited video, and where it sits in a still (stills are
-    captured full-bleed, before compositing).
+    Returns the post-condition failures plus the take's chrome geometry and
+    frame size. A wrapper take records the framed page itself (#358/#361),
+    so the app sits at the same rect in the video and in every still —
+    `run_web` derives one content rect from the geometry for both.
 
     A recording of a *working* app, and recorded with `strict=True` so it has
     to stay one. That is the assertion the rest of this harness structurally
@@ -3305,20 +3299,25 @@ def record_web(
         # would notice: no artifact records a navigation today.
         b.expect("goto('/') is noticed as a navigation", rec._navigated, True)
         rec.wait_for("#kpi-rev")
-        start_ticker(b, rec.page)
-        opening = check_determinism(b, rec.page, "on landing")
+        # In the app document, both of them: the ticker's opt-out control and
+        # the determinism probes are claims about what the recorder does to
+        # the *app*, and the app lives in the iframe (#358/#361). The ticker
+        # still keeps the whole page's compositor awake from in there — an
+        # iframe paint is a page paint.
+        start_ticker(b, rec.app)
+        opening = check_determinism(b, rec.app, "on landing")
         # Doubles as the run-up for the *early* timing probe: the page has
         # finished painting and the caption band does not move until the
         # first caption. See MAX_CAPTION_SKEW_S.
         rec.pause(PROBE_QUIET_S)
         b.expect(
             "goto('/'), #rows row count",
-            rec.page.locator("#rows tr").count(),
+            rec.app.locator("#rows tr").count(),
             5,
         )
         b.expect(
             "goto('/'), #status text",
-            rec.page.locator("#status").inner_text(),
+            rec.app.locator("#status").inner_text(),
             "snapshot 1 of 3",
         )
         # A stylesheet that failed to load leaves the DOM intact and the page
@@ -3326,7 +3325,7 @@ def record_web(
         # floor. This resolves that case exactly, with no pixel threshold.
         b.expect(
             "goto('/'), #refresh background (did the stylesheet apply?)",
-            rec.page.eval_on_selector("#refresh", bg),
+            rec.app.eval_on_selector("#refresh", bg),
             "rgb(235, 110, 20)",
         )
 
@@ -3337,14 +3336,14 @@ def record_web(
         rec.spotlight("#kpi-rev")
         b.expect(
             "spotlight('#kpi-rev'), computed outline-style",
-            rec.page.eval_on_selector("#kpi-rev", outline),
+            rec.app.eval_on_selector("#kpi-rev", outline),
             "solid",
         )
         rec.hold()
         rec.spotlight()
         b.expect(
             "spotlight() cleared, computed outline-style",
-            rec.page.eval_on_selector("#kpi-rev", outline),
+            rec.app.eval_on_selector("#kpi-rev", outline),
             "none",
         )
 
@@ -3354,12 +3353,12 @@ def record_web(
         rec.pause(0.8)
         b.expect(
             "type_into('#search'), field value",
-            rec.page.input_value("#search"),
+            rec.app.input_value("#search"),
             "seattle",
         )
         b.expect(
             "type_into('#search'), #rows row count",
-            rec.page.locator("#rows tr").count(),
+            rec.app.locator("#rows tr").count(),
             1,
         )
         rec.shot("02-filtered")
@@ -3371,10 +3370,13 @@ def record_web(
         # only where the cursor ends up proves nothing, because Playwright's
         # locator.click() dispatches its own mousemove to the target — that
         # measures Playwright, not move_to. Count the intermediate moves
-        # instead: a glide is many, a click is one.
-        rec.page.evaluate(_TRAIL_JS)
+        # instead: a glide is many, a click is one. Counted in the *app*
+        # document: the moves' coordinates land over the iframe (the glide
+        # runs from #search to #refresh, both inside the app rect), and no
+        # wrapper listener can hear a move whose target is inside it.
+        rec.app.evaluate(_TRAIL_JS)
         rec.move_to("#refresh")
-        trail = rec.page.evaluate("() => window.__smokeTrail.length")
+        trail = rec.app.evaluate("() => window.__smokeTrail.length")
         b.fail_if(
             trail < 10,
             f"move_to('#refresh') produced {trail} mousemove events; the glide "
@@ -3385,12 +3387,12 @@ def record_web(
         rec.pause(1.0)
         b.expect(
             "click('#refresh'), #status text",
-            rec.page.locator("#status").inner_text(),
+            rec.app.locator("#status").inner_text(),
             "snapshot 2 of 3",
         )
         b.expect(
             "click('#refresh'), #kpi-rev text",
-            rec.page.locator("#kpi-rev").inner_text(),
+            rec.app.locator("#kpi-rev").inner_text(),
             "$134,950",
         )
         rec.shot("03-refreshed")
@@ -3411,18 +3413,18 @@ def record_web(
         # sweep in wip/verified-review with a different haystack.
         b.expect(
             "before clear('#search'), #search value",
-            rec.page.input_value("#search"),
+            rec.app.input_value("#search"),
             "seattle",
         )
         rec.clear("#search")
         b.expect(
             "clear('#search'), field value",
-            rec.page.input_value("#search"),
+            rec.app.input_value("#search"),
             "",
         )
         b.expect(
             "clear('#search'), #rows row count (all four rows are back)",
-            rec.page.locator("#rows tr").count(),
+            rec.app.locator("#rows tr").count(),
             4,
         )
         # The caret stays where the viewer last saw it, which is what lets the
@@ -3431,7 +3433,7 @@ def record_web(
         # assertion meant for the other.
         b.expect(
             "clear('#search'), the focused element (the caret stays in the box)",
-            rec.page.evaluate(_FOCUSED_JS),
+            rec.app.evaluate(_FOCUSED_JS),
             "search",
         )
         rec.shot("04-cleared")
@@ -3440,19 +3442,19 @@ def record_web(
         rec.press("Enter")
         b.expect(
             "press('Enter'), #status text",
-            rec.page.locator("#status").inner_text(),
+            rec.app.locator("#status").inner_text(),
             "snapshot 3 of 3",
         )
         b.expect(
             "press('Enter'), #kpi-rev text",
-            rec.page.locator("#kpi-rev").inner_text(),
+            rec.app.locator("#kpi-rev").inner_text(),
             "$119,180",
         )
 
         rec.press("Tab")
         b.expect(
             "press('Tab'), the focused element",
-            rec.page.evaluate(_FOCUSED_JS),
+            rec.app.evaluate(_FOCUSED_JS),
             "refresh",
         )
         # ...and the half of Tab a viewer can see. `:focus-visible` in the
@@ -3460,7 +3462,7 @@ def record_web(
         # on #refresh above leaves it 'none' and this cannot pass on that.
         b.expect(
             "press('Tab'), #refresh computed outline-style (the ring)",
-            rec.page.eval_on_selector("#refresh", outline),
+            rec.app.eval_on_selector("#refresh", outline),
             "solid",
         )
 
@@ -3471,23 +3473,23 @@ def record_web(
         rec.pause(0.6)
         b.expect(
             "type_into('#search', 'harbor'), #rows row count",
-            rec.page.locator("#rows tr").count(),
+            rec.app.locator("#rows tr").count(),
             1,
         )
         rec.press("Escape")
         b.expect(
             "press('Escape'), #search value",
-            rec.page.input_value("#search"),
+            rec.app.input_value("#search"),
             "",
         )
         b.expect(
             "press('Escape'), #rows row count (all six rows are back)",
-            rec.page.locator("#rows tr").count(),
+            rec.app.locator("#rows tr").count(),
             6,
         )
         b.expect(
             "press('Escape'), the focused element (the dismiss let the box go)",
-            rec.page.evaluate(_FOCUSED_JS),
+            rec.app.evaluate(_FOCUSED_JS),
             "body",
         )
 
@@ -3509,7 +3511,7 @@ def record_web(
         # that is the one CSS animations are on. A freeze that stopped it too
         # would stop the compositor, and the recording would start losing wall
         # time again (TICKER_JS, issue #18).
-        closing = check_determinism(b, rec.page, "at the end of the take")
+        closing = check_determinism(b, rec.app, "at the end of the take")
         b.fail_if(
             closing["now"] != opening["now"],
             f"the frozen clock moved during the take: {opening['now']} at the "
@@ -3526,27 +3528,26 @@ def record_web(
         )
         rec.caption("")
 
-        # ...and again for a navigation the *storyboard did not make*, which is
-        # the harder half and the reason this is a page listener rather than a
-        # line inside goto(). A link click, a form submit, `location.href` and
-        # a meta refresh all replace the document with no verb involved, and
-        # #134 is about exactly that case leaving `self._caption` stale.
-        # `page.reload()` stands in for all of them: a real navigation, driven
-        # past the verb layer, recording no beat of its own — so this asserts
-        # the listener rather than the verb, and adds nothing to WEB_BEATS.
+        # ...and again for a navigation the *storyboard did not make* — a
+        # link click, a form submit, `location.href` all replace the app's
+        # document with no verb involved. `rec.app.goto` stands in for all
+        # of them: a real navigation of the app frame, driven past the verb
+        # layer, recording no beat of its own — so this asserts the listener
+        # rather than the verb, and adds nothing to WEB_BEATS. The wrapper
+        # page itself never navigates (#358), which is why the caption
+        # cannot be lost to any of these; the listener noticing the frame is
+        # #142's carve-out, kept.
         rec._navigated = False
-        rec.page.reload()
+        rec.app.goto(rec.app.url)
         b.expect("a navigation no verb made is noticed too", rec._navigated, True)
 
-        # Where the app lands in each medium, read off the live recorder rather
-        # than re-derived here, so a change to the window geometry carries this
+        # Where the app lands, read off the live recorder rather than
+        # re-derived here, so a change to the window geometry carries this
         # with it instead of silently scoring the wrong pixels.
-        g = rec._geom
-        video_rect: Rect = (g["appx"], g["appy"], g["appw"], g["apph"])
+        geom = dict(rec._geom)
         size = (rec._size["width"], rec._size["height"])
-        still_rect: Rect = (0, 0, size[0], size[1])
 
-    return b.problems, video_rect, still_rect, size
+    return b.problems, geom, size
 
 
 def record_terminal(
@@ -3681,7 +3682,7 @@ def record_segments(
         clock_one.rebase(rec._t0)
         rec.goto("/")
         rec.wait_for("#kpi-rev")
-        start_ticker(b, rec.page)
+        start_ticker(b, rec.app)
         # The run-up for the early timing probe: the page has finished painting
         # and nothing moves in the caption band until the caption does.
         rec.pause(PROBE_QUIET_S)
@@ -3693,7 +3694,8 @@ def record_segments(
         g = rec._geom
         video_rect: Rect = (g["appx"], g["appy"], g["appw"], g["apph"])
         size = (rec._size["width"], rec._size["height"])
-        still_rect: Rect = (0, 0, size[0], size[1])
+        # One rect for both: a wrapper still is the framed frame (#361).
+        still_rect: Rect = video_rect
     clocks.append(clock_one)
 
     with (
@@ -3701,16 +3703,18 @@ def record_segments(
         Recorder(out_dir, segment=SEGMENT_NAMES[1], **settings) as rec,
     ):
         clock_two.rebase(rec._t0)
-        # On about:blank, before anything else: the second segment's opening
-        # seconds are the ones most likely to go idle, and idle is what makes
-        # the screencast lose wall time (TICKER_JS, issue #18). The interlude
-        # card covers it while it is up — see SEGMENT_INTERLUDE_HOLD_S.
-        start_ticker(b, rec.page)
+        # Before anything else: the second segment's opening seconds are the
+        # ones most likely to go idle, and idle is what makes the screencast
+        # lose wall time (TICKER_JS, issue #18). The interlude card covers it
+        # while it is up — see SEGMENT_INTERLUDE_HOLD_S. In the app frame,
+        # which is still about:blank here — the goto below replaces that
+        # document and the ticker with it.
+        start_ticker(b, rec.app)
         rec.interlude(SEGMENT_INTERLUDE, hold=SEGMENT_INTERLUDE_HOLD_S)
         rec.goto("/")
         rec.wait_for("#kpi-rev")
         # The navigation took the first one with it.
-        start_ticker(b, rec.page)
+        start_ticker(b, rec.app)
 
         # The closing probe, in the *second* segment on purpose: its beat
         # timestamps are the ones the merge has to move, and this is where the
@@ -3728,7 +3732,9 @@ def record_segments(
     return b.problems, video_rect, still_rect, size, clocks
 
 
-def record_spotlight(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
+def record_spotlight(
+    out_dir: Path, base_url: str, clock: HostClock | None = None
+) -> tuple[list[str], dict]:
     """A spotlight put up and taken down again, with quiet either side.
 
     Recorded with the recorder's **default** (`deterministic=False`), which no
@@ -3745,6 +3751,8 @@ def record_spotlight(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
     with Recorder(
         out_dir, base_url=base_url, speech=False, strict=True, deterministic=False
     ) as rec:
+        if clock is not None:
+            clock.rebase(rec._t0)  # see HostClock
         rec.goto("/")
         rec.wait_for(SPOTLIGHT_TARGET)
         # The ticker, but not start_ticker(): that helper also asserts the
@@ -3752,9 +3760,9 @@ def record_spotlight(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
         # without it. What the ticker is for here is only that the screencast
         # keeps emitting frames through the quiet stretches, so the windows
         # below sit where the beat log says they do.
-        rec.page.evaluate(TICKER_JS)
+        rec.app.evaluate(TICKER_JS)
         b.fail_if(
-            not rec.page.evaluate("() => !!document.getElementById('__smoke_ticker')"),
+            not rec.app.evaluate("() => !!document.getElementById('__smoke_ticker')"),
             "the compositor ticker did not attach — the windows this take "
             "measures its two transitions in are not trustworthy",
         )
@@ -3762,11 +3770,11 @@ def record_spotlight(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
         # from the one before it stops meaning "the spotlight is moving".
         rec.pause(SPOTLIGHT_HOLD_S)
 
-        style_before = rec.page.locator(SPOTLIGHT_TARGET).first.evaluate(
+        style_before = rec.app.locator(SPOTLIGHT_TARGET).first.evaluate(
             "el => [el.hasAttribute('style'), el.getAttribute('style')]"
         )
         rec.spotlight(SPOTLIGHT_TARGET)
-        lit = rec.page.locator(SPOTLIGHT_TARGET).first.evaluate(
+        lit = rec.app.locator(SPOTLIGHT_TARGET).first.evaluate(
             "el => getComputedStyle(el).transform"
         )
         # Cheap, and it separates "the exit did not animate" from "the
@@ -3786,7 +3794,7 @@ def record_spotlight(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
         # #111's second half, and the one no pixel can see: the element is
         # handed back exactly as it was found, byte for byte, including having
         # no style attribute at all when it started with none.
-        style_after = rec.page.locator(SPOTLIGHT_TARGET).first.evaluate(
+        style_after = rec.app.locator(SPOTLIGHT_TARGET).first.evaluate(
             "el => [el.hasAttribute('style'), el.getAttribute('style')]"
         )
         b.fail_if(
@@ -3812,14 +3820,18 @@ def record_spotlight(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
         )
         rec.pause(SPOTLIGHT_HOLD_S)
 
-        box = rec.page.locator(SPOTLIGHT_TARGET).first.bounding_box()
+        box = rec.app.locator(SPOTLIGHT_TARGET).first.bounding_box()
         if box is None:
             raise SmokeFailure(
                 f"{SPOTLIGHT_TARGET} has no box — tests/fixture/index.html "
                 f"changed and this take is aimed at nothing"
             )
         pad = SPOTLIGHT_PAD_PX
-        page_rect: Rect = (
+        # `bounding_box()` answers in wrapper-page coordinates even for
+        # iframe elements, and the wrapper page is the video at true pixel
+        # size (#358/#361) — so the padded box is already the video rect,
+        # with no scale and no offset left to apply.
+        target_rect: Rect = (
             int(box["x"]) - pad,
             int(box["y"]) - pad,
             int(box["width"]) + 2 * pad,
@@ -3829,7 +3841,7 @@ def record_spotlight(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
         size = (rec._size["width"], rec._size["height"])
 
     return b.problems, {
-        "rect": to_video_rect(page_rect, geom, size),
+        "rect": target_rect,
         "app": (geom["appx"], geom["appy"], geom["appw"], geom["apph"]),
         "size": size,
     }
@@ -4038,7 +4050,7 @@ def record_overlay(
         rec.wait_for("#kpi-rev")
         # Without it the page goes idle behind the scrim, the screencast stops
         # emitting frames, and every timestamp below drifts (issue #18).
-        start_ticker(b, rec.page)
+        start_ticker(b, rec.app)
         rec.pause(OVERLAY_QUIET_S)
         rec.interlude(OVERLAY_LABEL, hold=OVERLAY_HOLD_S, style="light")
         if cleared:
@@ -4059,9 +4071,9 @@ class EntropyTake(NamedTuple):
     problems: list[str]
     out_dir: Path
     clock: str  # the wall clock the page printed, as text
-    still_rect: Rect  # where the entropy panel sits in a full-bleed still
-    video_rect: Rect  # ...and where it lands in the composited video
-    spin_rect: Rect  # just the spinning shape, in a full-bleed still
+    still_rect: Rect  # where the entropy panel sits in the framed frame
+    video_rect: Rect  # the same rect — stills and video share one geometry
+    spin_rect: Rect  # just the spinning shape, in the same coordinates
 
 
 def record_entropy(out_dir: Path, base_url: str, deterministic: bool) -> EntropyTake:
@@ -4088,15 +4100,12 @@ def record_entropy(out_dir: Path, base_url: str, deterministic: bool) -> Entropy
         out_dir, base_url=base_url, speech=False, strict=True, **kwargs
     ) as rec:
         rec.goto("/?entropy=1")
-        # Park the pointer before anything is photographed. Every take of this
-        # storyboard has to agree about where the recorder's cursor dot is,
-        # and left alone that is decided by a synthetic mousemove rather than
-        # by the storyboard — see PARKED_POINTER, and issue #185. Deliberately
-        # `page.mouse.move` rather than the `move_to` verb: this is the
-        # storyboard stating a precondition, not a beat worth watching, and a
-        # sixth beat would change what every other measurement in this take is
-        # taken over.
-        rec.page.mouse.move(*PARKED_POINTER)
+        # No pointer park, deliberately, where the composite path needed one
+        # (#185): the wrapper dot is driven by pointer verbs alone (#361), no
+        # event can move it, and this storyboard runs none — so every take of
+        # this storyboard agrees the dot is at the chrome's off-screen park,
+        # by construction. check_undrawn_pointer below reads that back out of
+        # the DOM rather than taking this paragraph's word for it.
         # The worker's answer lands asynchronously and is part of what the
         # stills have to reproduce, so wait for it rather than racing it. A
         # short bound rather than the 60 s default: a Worker wrapper that
@@ -4105,7 +4114,7 @@ def record_entropy(out_dir: Path, base_url: str, deterministic: bool) -> Entropy
         rec.wait_for("#entropy-worker.ready", timeout_s=15)
         rec.pause(ENTROPY_SETTLE_S)
         rec.shot(ENTROPY_SHOTS[0])
-        check_determinism(b, rec.page, f"in the {label} take", on=deterministic)
+        check_determinism(b, rec.app, f"in the {label} take", on=deterministic)
 
         # The worker line, read rather than left to the pixel comparisons.
         # They cannot see this: the fixture falls back to "worker unavailable"
@@ -4113,7 +4122,7 @@ def record_entropy(out_dir: Path, base_url: str, deterministic: bool) -> Entropy
         # across takes just as happily as a frozen timestamp does. A wrapper
         # that broke every worker on the page would pass this whole phase on
         # the strength of failing consistently.
-        worker = rec.page.locator("#entropy-worker").inner_text()
+        worker = rec.app.locator("#entropy-worker").inner_text()
         b.fail_if(
             not re.fullmatch(r"worker \d+", worker),
             f"the entropy page's worker reported {worker!r}, not a timestamp — "
@@ -4133,16 +4142,16 @@ def record_entropy(out_dir: Path, base_url: str, deterministic: bool) -> Entropy
         # would trip the "the escape-hatch take rendered the same clock as the
         # frozen ones" comparison below. An assertion that cannot be made to
         # fail is a comment.
-        clock = rec.page.locator("#entropy-readings").inner_text()
+        clock = rec.app.locator("#entropy-readings").inner_text()
         # A second still after long enough for the spinner to be somewhere
         # else entirely (it turns once every 1.7 s).
         rec.pause(ENTROPY_GAP_S)
         rec.shot(ENTROPY_SHOTS[1])
         # After both stills, so it grades the frames that were actually taken.
-        check_parked_pointer(b, rec.page, f"in the {label} take")
+        check_undrawn_pointer(b, rec.page, f"in the {label} take")
 
-        box = rec.page.locator("#entropy-panel").bounding_box()
-        spin = rec.page.locator("#entropy-spinner").bounding_box()
+        box = rec.app.locator("#entropy-panel").bounding_box()
+        spin = rec.app.locator("#entropy-spinner").bounding_box()
         if box is None or spin is None:
             raise SmokeFailure(
                 "#entropy-panel has no box — ?entropy=1 rendered nothing"
@@ -4164,17 +4173,11 @@ def record_entropy(out_dir: Path, base_url: str, deterministic: bool) -> Entropy
             int(spin["width"]),
             int(spin["height"]),
         )
-        # The recording is scaled into the window body, so the same panel sits
-        # somewhere else in the video. Map it rather than eyeballing a crop:
-        # this is the region both comparisons below actually look at.
-        g, size = rec._geom, (rec._size["width"], rec._size["height"])
-        scale_x, scale_y = g["appw"] / size[0], g["apph"] / size[1]
-        video_rect: Rect = (
-            g["appx"] + int(box["x"] * scale_x),
-            g["appy"] + int(box["y"] * scale_y),
-            max(2, int(box["width"] * scale_x)),
-            max(2, int(box["height"] * scale_y)),
-        )
+        # The page is the video at true pixel size (#358/#361), and
+        # `bounding_box()` answers in wrapper-page coordinates even for
+        # iframe elements — so the panel sits at the same rect in the video
+        # as in the still, with nothing left to map.
+        video_rect: Rect = still_rect
     return EntropyTake(b.problems, out_dir, clock, still_rect, video_rect, spin_rect)
 
 
@@ -4221,10 +4224,10 @@ def _check_video(
         return failures
 
     # Median, not max: one good frame must not excuse a blank video. Not min
-    # either — a *terminal* take legitimately opens on a frame or two of
-    # not-yet-painted page, and this runs on both media. A web take no longer
-    # does (issue #119), and `check_opening` grades that separately, on the one
-    # frame this median is deliberately insensitive to.
+    # either — both media legitimately open on the recorder's own furniture
+    # (the terminal's card, the web take's opening hold, #119/#360), which
+    # `check_opening_card`/`check_wrapper_opening` grade separately, on the
+    # frames this median is deliberately insensitive to.
     floor = MIN_CONTENT_STDDEV[label]
     score = statistics.median(contrast(f) for f in frames)
     if score < floor:
@@ -4373,147 +4376,28 @@ def check_content_healthy(label: str, out_dir: Path, app_rect: Rect) -> list[str
     return failures
 
 
-# -- what a web take opens on (issue #119) -----------------------------------
+# -- what a web take opens on (issue #119, then #360) -------------------------
 #
-# Chromium's screencast starts with the page, and the page is `about:blank`
-# until the first `goto()` returns — so every web take used to open on a flat
-# white app rect inside a correct-looking window frame, which reads as "the app
-# loaded blank". Measured at ~400 ms on the demo CI recorded for #117, and
-# found by a human watching it: none of this suite's numbers moved, and neither
-# did the recorder's own picture check, whose `score` is a *median* and whose
-# `static_for` saw one 0.5 s gap against a 15 s limit.
-#
-# The recorder now covers that gap with the app's first painted frame. What is
-# graded here is the only thing a viewer can see: **is there a picture at
-# t = 0**.
-#
-# Three things about how it is measured, each one deliberate:
-#
-#   * off `demo.mp4` with this file's own `gray_frames`/`contrast`, never
-#     through `opening_gap`. The recorder's `content.opening.gap` answers the
-#     same question, and a check that read it would be asking the code under
-#     test whether it worked.
-#   * against the take's **own** median rather than an absolute floor, so it
-#     carries no number tuned to this fixture, this app or this machine. The
-#     separation is not marginal: a covered opening scores the same as the rest
-#     of the take (measured 17.03 against a 17.01 median), and a blank one
-#     scores ~0.
-#   * with `held` asserted non-zero **first**. If this take had no gap to
-#     cover, frame zero shows the app whatever the recorder does, and the
-#     assertion below grades nothing — the exact shape of an environment-
-#     agreeing assertion. That case is reported as a failure of this check
-#     rather than passed over in silence.
-#
-# What is *not* asserted here, because something else in this take already
-# grades it: that no timestamp moved. The hold is an overlay switched off part
-# way through, so the video keeps its length and every frame keeps its time —
-# and `check_beat_frames` in the same phase reads each beat's `t` out of
-# timeline.json and matches the frame there against the caption that beat put
-# up. A hold that shifted the clock would land those frames on the wrong
-# captions.
+# Chromium's screencast starts with the page, before the first `goto()` has an
+# app to show — so a web take used to open on a flat white app rect inside a
+# correct-looking window frame, which reads as "the app loaded blank".
+# Measured at ~400 ms on the demo CI recorded for #117, and found by a human
+# watching it. The composite path covered the gap at encode time with an
+# ffmpeg overlay of the app's first painted frame, and a `check_opening` here
+# graded frame 0 against the take's own median. Both died with the composite
+# (#361): the wrapper take opens on the in-page hold instead — an opaque field
+# in the window's own colour, up in frame 0 and cleared by the first goto —
+# and `check_wrapper_opening` grades it on the long web take and the wrapper
+# arm alike. `check_opening_gap` below outlives the cutover: it grades
+# `opening_gap`, the measurement `content.opening` reports on every take.
 
-# How much of the take's own median contrast frame zero must reach. Nothing
-# subtle is being separated: the two populations are "the app" and "flat
-# white", so a half is far below anything a real opening frame scores and far
-# above what a blank one can.
-OPENING_FRAME0_SHARE = 0.5
-
-# How much of the file to read to get its first frame. Shorter than one frame
-# at any rate the recorder encodes, so what comes back is frame zero and at
-# most one neighbour — and it is read with `-t` rather than an `fps` filter for
-# the reason spelled out in check_opening().
+# How much of the file to read to get a take's first frame. Shorter than one
+# frame at any rate the recorder encodes, so what comes back is frame zero and
+# at most one neighbour — and it is read with `-t` rather than an `fps`
+# filter, because the filter answers with whichever frame lands nearest its
+# first slot's middle (the defect content.py's `_content_frames` docstring
+# records).
 OPENING_FIRST_FRAME_S = 0.03
-
-
-def check_opening(label: str, out_dir: Path, app_rect: Rect) -> list[str]:
-    """The first frame of a web take shows the app (issue #119).
-
-    **The acceptance criterion is about the picture, not about the mechanism**,
-    and the first version of this confused the two. It refused to grade a take
-    whose `held` was zero and reported that refusal as a failure — so a run
-    where Chromium's screencast happened to emit its first frame *after* the
-    page painted, which is a perfectly healthy recording and the outcome the
-    fix is trying to produce, went red. It did on CI, on a branch that had
-    nothing to do with the opening.
-
-    A take whose app painted before frame zero satisfies the criterion by
-    itself; one whose app did not satisfies it because the hold covered the
-    gap. Either way frame zero has to show the app, so that arm runs
-    unconditionally now.
-
-    What is lost is graded coverage of the hold *code* on a run that never
-    needed it, and the honest handling is to say so out loud rather than to
-    fail: the line below reports whether the hold was exercised, so a run whose
-    evidence is thinner announces it instead of looking identical to one that
-    proved something. Making that reliable needs a fixture that defers its
-    first paint on purpose — #126.
-    """
-    failures: list[str] = []
-    mp4 = out_dir / "demo.mp4"
-    content = content_of(out_dir) or {}
-    opening = content.get("opening")
-    held = opening.get("held") if isinstance(opening, dict) else None
-    exercised = isinstance(held, (int, float)) and held > 0
-
-    if held is None:
-        failures.append(
-            f"{label}: this take reports content.opening.held = null, which "
-            f"means the web recorder did not run its opening hold at all. "
-            f"Whatever frame zero shows, the mechanism is not wired in."
-        )
-
-    rect = keep_top(app_rect)
-    try:
-        # **Not `sample_fps=`.** The fps filter quantises to its own output
-        # slots, and at 1 fps slot zero is a whole second wide — measured, it
-        # returns a frame from around 0.5 s, which on a broken take is *after*
-        # the blank opening has ended. The first version of this check read
-        # that frame, scored 17.06 on a take whose first frame was flat white,
-        # and passed. A window cut with `-t` instead decodes from the file's
-        # own first frame, which is the only frame this assertion is about.
-        opening = gray_frames(mp4, rect, duration=OPENING_FIRST_FRAME_S)
-        body = gray_frames(mp4, rect, sample_fps=CONTENT_SAMPLE_FPS)
-    except RuntimeError as exc:
-        return [f"{label}: {exc}"]
-    if not opening or len(body) < 2:
-        return [
-            f"{label}: {len(opening)} opening frame(s) and {len(body)} sampled "
-            f"from {mp4.name}, too few to compare the opening against the take"
-        ]
-
-    first = contrast(opening[0])
-    median = statistics.median(contrast(f) for f in body)
-    floor = median * OPENING_FRAME0_SHARE
-    if first < floor:
-        failures.append(
-            f"{label}: {mp4.name} opens on a picture that is not there — its "
-            f"first frame scores {first:.2f} luma stddev over {rect}, under "
-            f"{floor:.2f} ({OPENING_FRAME0_SHARE:g} of this take's own "
-            f"{median:.2f} median). The recorder reports "
-            f"content.opening.held = {held!r}"
-            + (
-                "; whatever it composited, the app is not visible at t=0."
-                if exercised
-                else " — it saw nothing to cover, and the app is not there "
-                "either, so the opening was blank and went unnoticed."
-            )
-        )
-    if not failures:
-        # Which of the two ways this passed, every time, unasked. A reader who
-        # only ever sees "opens on the app" cannot tell a run that exercised
-        # the hold from one that never needed it.
-        how = (
-            f"over a {held:.2f}s hold"
-            if exercised
-            else "with no hold needed — the app had already painted when the "
-            "screencast started, so the hold code was not exercised this run "
-            "(#126)"
-        )
-        print(
-            f"smoke: {label} opens on the app (frame 0 scores {first:.2f} "
-            f"against a {median:.2f} median, {how})"
-        )
-    return failures
 
 
 def _synthetic_take(path: Path, painted_at: float | None, seconds: float) -> None:
@@ -4612,124 +4496,28 @@ COVERAGE_CARD = "AC-1"
 # the page" fire for a reason that has nothing to do with the card.
 COVERAGE_APP_MARKER = "Northwind Ops"
 
-# -- the window is still visible around the card, on a web take (issue #291) --
+# -- the card is the window's own colour, on a web take (issue #291) ----------
 #
-# The card `criterion()` and `interlude()` raise used to be one colour for both
-# media, and it was the terminal's: a near-black field, inside the web
-# recorder's own dark window frame with its title bar and traffic lights. A
-# human watching a demo read it as a terminal window rather than as a card over
-# the app, and **no artifact of that take was wrong** — the element, the beat,
-# the aria snapshot and the frames all said exactly what they should.
-#
-# **What the defect was not: geometry.** The card has always been `inset: 0`,
-# so the recorder's 14 px pad and its title bar have always been drawn around
-# it — the window frame was there the whole time. `#1c1a17` is 0.4 luma levels
-# from that frame *as encoded*, so the boundary existed and nobody could see it.
-#
-# Three fixes were rejected by the person who found it — warm paper (205 levels
-# off the window), black in a gutter of the window's colour (23.5), and then a
-# card declaring the window's own constant. What they asked for was the opposite
-# of a distance: *"I want the interlude to match the window, without a need for
-# a border of another colour, or an additional edge of a third colour."*
-#
-# **The third was rejected from a shipped frame, and that is what this file now
-# grades.** One declared colour painted in both layers arrives in `demo.mp4` as
-# two: the frame is a Playwright *screenshot* and the card is inside Playwright's
-# *video*, so the pad read `#171625` and the card `#181620`, five levels of blue
-# apart (issue #301). The reviewer sampled a frame and saw it. So the card
-# declares `WEB_CARD_BODY`, `WEB_WINDOW_BODY` compensated for that extra encoder
-# by measurement, and what is graded here is the thing they were looking at:
-#
-#   tests/unit   which stylesheet a recorder of each medium hands the page, that
-#                the terminal's is still the value #110's blend was tuned to,
-#                and that the frame is painted from the shared constant. It
-#                cannot grade the match: the two declarations differ on purpose,
-#                and a pin between them would be green on the build that was
-#                rejected.
-#   here         that the dispatched colour reached the encoded mp4 at all, and
-#                that **in that mp4 the card's field and the window's pad are
-#                within `CARD_WINDOW_TOLERANCE` levels per channel**. That is a
-#                reading of the artifact a viewer meets, and it is the check
-#                #297's 12-level bar was deleted to make room for.
-#
-# What is still graded nowhere: whether a viewer **reads the result as a card**
-# rather than as one flat surface. Sameness is measurable and now measured;
-# recognition is not. tests/README.md says so under Known gaps.
-
-# The two cards in decimal, hand-written. `tests/unit` pins the package's
-# stylesheets to the same two colours, so a palette changed in one place and
-# not the other is a failure rather than a check that grades nothing.
-#
-# `WEB_CARD_RGB` is `core.WEB_CARD_BODY` and **not** `WEB_WINDOW_BODY`: the
-# card is declared two levels off the window so that it lands on the window in
-# the encoded frame. The window body is read too, and graded against the card
-# below.
-WEB_CARD_RGB = (0x18, 0x17, 0x26)
-TERMINAL_CARD_RGB = (0x1C, 0x1A, 0x17)
-
-# How far a channel may sit from the card's own value before the strip is not
-# that card.
-#
-# Measured on this arm rather than chosen. A flat `#efe7d8` or `#000000` card
-# reads **2** levels off its own colour in this pipeline, and so does the
-# compensated `#181726` — it arrives at `(24, 21, 36)` against a declared
-# `(24, 23, 38)`. The previous round declared `#181825` here, which read **5**
-# off itself, and the bar was widened to 10 to hold it; with the card
-# compensated the reading is back to 2 and so is the bar.
-#
-# The two states the reading has to be told apart from, both injected and both
-# caught: **214** — the fixture app's own header strip, `(236, 237, 242)`, which
-# is what a card that never painted leaves there — and **16**, the terminal card
-# on a web take, `(25, 25, 22)`, which is #291 itself.
-#
-# Note the margins, because they are the honest part. Against a card that never
-# painted the bar is 36x clear. Against the *terminal* card it is 2.7x, restored
-# from 1.5x when this stood at 10 — the two cards are a dark blue and a dark
-# brown, and blue is the only channel that separates them.
-#
-# What this bar does **not** catch, and why the one below exists: a card that
-# drops the encoder compensation and declares `WEB_WINDOW_BODY` reads 6 off its
-# own declared colour, which this would let through at exactly the bound. It is
-# a defect a reviewer found by eye, and it is caught next door.
-CARD_RGB_TOLERANCE = 6
-
-# How far the card's field and the window's pad may sit apart, per channel, in
-# the encoded frame. **This is #291's own property, and it is the only check in
-# this repo that reads it.**
-#
-# The card and the window are one colour on screen by design (see the section
-# header), and this is what "on screen" is worth: a reading of `demo.mp4`, not
-# of the two constants, because the two constants differ on purpose and an
-# equality between them was green on the build a human rejected.
-#
-# Measured, not chosen. The shipped pair reads `(24, 21, 36)` against
-# `(23, 22, 37)` — **1** level per channel, at every instant sampled. The state
-# it has to rule out is the previous round's, one colour declared for both,
-# which reads **5** levels of blue apart. So the bar is 2: twice the healthy
-# reading, and 2.5x clear of the defect.
-#
-# **A failure here is not a flake and must not be widened away.** The card's
-# compensation is tuned to one encoder path, so this reading going red means
-# either the card was repainted, or the frame was, or Chromium/ffmpeg/the pixel
-# format changed under it. The first two are bugs; the third is a re-measurement
-# of `core.WEB_CARD_BODY`. None of the three is answered by a bigger number
-# here.
-CARD_WINDOW_TOLERANCE = 2
-
-# Where in the card's beat the frames are read, as fractions of its span. Three
-# rather than one: a card that arrives late, or leaves early, is a card a
-# viewer sees the wrong thing under, and one sample in the middle is true of
-# both.
-CARD_SAMPLE_FRACTIONS = (0.3, 0.5, 0.7)
+# The card `criterion()` and `interlude()` raise used to be one colour for
+# both media, and it was the terminal's: a near-black field a human read as a
+# terminal window rather than as a card over the app, with **no artifact of
+# that take wrong** (#291). The fix's history — the rejected candidates, the
+# #301 two-encoder compensation the composite needed, and the reviewer's own
+# sentence — is `core.WEB_WINDOW_BODY`'s note. Since the cutover (#361) the
+# card and the window declare ONE colour and ride ONE encoder, and the
+# `check_criterion_card` that graded the compensated pair died with it: the
+# coverage take's card is graded by `check_wrapper_card`, the same reading of
+# the encoded mp4 the wrapper arm makes — pixels on both sides, never
+# declarations (#297's two recorded anti-patterns).
 
 
-def record_coverage(out_dir: Path, base_url: str) -> tuple[list[str], Rect, Rect]:
+def record_coverage(out_dir: Path, base_url: str) -> tuple[list[str], dict]:
     """A take recorded against COVERAGE_CRITERIA, with one left undemonstrated.
 
-    Returns the app's rect and the window's rect in the encoded frame as well
-    as the problems: the card assertions read pixels of both — the card, and
-    the frame drawn around it — and where either lands in the composite is
-    something only the recorder knows (issue #17).
+    Returns the take's chrome geometry as well as the problems: the card
+    assertions read pixels of the card and of the window body around it, and
+    where either sits in the frame is something only the recorder knows
+    (issue #17).
     """
     from demo_recording import Recorder
 
@@ -4760,31 +4548,32 @@ def record_coverage(out_dir: Path, base_url: str) -> tuple[list[str], Rect, Rect
         # has to count them without any of them reaching `claimed`.
         rec.caption("")
 
-        g = rec._geom
-        app: Rect = (g["appx"], g["appy"], g["appw"], g["apph"])
-        win: Rect = (g["winx"], g["winy"], g["winw"], g["winh"])
-    return b.problems, app, win
+        geom = dict(rec._geom)
+    return b.problems, geom
 
 
 def _criterion_page_failures(out_dir: Path, card: dict, declared: str) -> list[str]:
-    """Was the clause on the page, and not only in the beat log? (issue #280)
+    """Was the clause on the screen, and not only in the beat log? (issue #280)
 
     Not a helper for tidiness — a different *source*. Every other assertion
     about the card reads `timeline.json`, which the recorder writes out of the
     same values it drew from; they agree by construction and would all pass on
     a verb that logged a perfect beat and evaluated nothing. The evidence
-    file's `aria` is Playwright's snapshot of the live document at the end of
-    the beat, so it is the one artifact in this take that can disagree.
+    file's `chrome` field is read out of the wrapper document's DOM at the
+    end of the beat (#361) — the card is the recorder's furniture and lives
+    there, not in the app's aria — so it is an artifact that can disagree.
 
-    **`aria` and not the file.** The evidence envelope also carries a copy of
-    the beat record, caption and all, so searching the whole document would
+    **`chrome` and not the file.** The evidence envelope also carries a copy
+    of the beat record, caption and all, so searching the whole document would
     find the clause on a take whose card never reached the browser — the
-    catalogue's wrong-scope search, in the file written to avoid it.
+    catalogue's wrong-scope search, in the file written to avoid it. The
+    `chrome` read is visibility-gated in the page (opacity, display), so a
+    card toggled to opacity 0 leaves the field without its line.
 
-    It still grades **presence, not legibility**: a card rendered off-frame, at
-    zero opacity, or under an app overlay puts exactly this text in exactly
-    this snapshot. That gap is stated in tests/README.md rather than papered
-    over.
+    It still grades **presence, not legibility**: a card rendered off-frame or
+    under an app overlay puts exactly this text in exactly this read. That
+    gap is stated in tests/README.md rather than papered over — and the
+    card's *pixels* are check_wrapper_card's, in the same arm.
     """
     path = card.get("evidence")
     if not path:
@@ -4796,7 +4585,8 @@ def _criterion_page_failures(out_dir: Path, card: dict, declared: str) -> list[s
     on_disk = out_dir / path
     if not on_disk.is_file():
         return [f"coverage: the criterion beat's evidence {path} was not written"]
-    aria = json.loads(on_disk.read_text()).get("aria")
+    doc = json.loads(on_disk.read_text())
+    aria = doc.get("aria")
     # The haystack, before anything is claimed about it. An empty or stubbed
     # snapshot makes "the clause is not in it" fire for the wrong reason and
     # "the clause is in it" impossible; the marker is a string the fixture page
@@ -4804,178 +4594,19 @@ def _criterion_page_failures(out_dir: Path, card: dict, declared: str) -> list[s
     if not isinstance(aria, str) or COVERAGE_APP_MARKER not in aria:
         return [
             f"coverage: the criterion beat's evidence ({path}) carries no "
-            f"snapshot of the fixture page, so whether the clause reached the "
-            f"browser cannot be read out of it either way"
+            f"snapshot of the fixture page, so whether the capture read a "
+            f"live screen cannot be established, and the chrome read below "
+            f"would prove nothing"
         ]
-    if declared not in aria:
+    chrome = doc.get("chrome")
+    if not isinstance(chrome, str) or declared not in chrome:
         return [
-            f"coverage: {declared!r} is not in the page snapshot the criterion "
-            f"beat recorded ({path}) — the beat log says a card carried the "
-            f"clause and the document the recorder was driving never had those "
-            f"words in it"
+            f"coverage: {declared!r} is not in the on-screen chrome text the "
+            f"criterion beat recorded ({path} carries chrome={chrome!r}) — "
+            f"the beat log says a card carried the clause and the screen the "
+            f"recorder was driving never showed those words"
         ]
     return []
-
-
-def check_criterion_card(out_dir: Path, app: Rect, win: Rect) -> list[str]:
-    """A web take's card is the window's own colour, in `demo.mp4` (#291).
-
-    Read off `demo.mp4` and not off a still: `shot()` screenshots the page,
-    which is the layer *before* the composite, and what a viewer meets is the
-    card once it is inside the recorder's window frame. That distinction is the
-    whole of this function — the two things compared below reach the file by
-    two different encoders (#301), and a still can only ever show one of them.
-
-    Two claims:
-
-      1. **the card painted, in the colour the package dispatched.** The strip
-         reads `WEB_CARD_RGB`. That separates a card from the app underneath it
-         — 36x from the state it has to rule out — and the two palettes at 16
-         levels against a bar of 6.
-
-      2. **the card and the window body are the same colour on screen.** The
-         strip and a band of the window's pad are within `CARD_WINDOW_TOLERANCE`
-         levels per channel, at every instant sampled. This is #291's own
-         property and the reason the fix has a compensated constant at all: a
-         human sampled a shipped frame, found the card and the window five
-         levels apart in blue, and rejected the build. Claim 1 cannot see that —
-         the card was exactly the colour it was dispatched in.
-
-    **Neither claim can be satisfied by reading a declaration.** #297 pinned
-    these two at least 12 luma levels *apart*, which the reviewer's decision
-    inverts, and the round after it pinned the card's declared colour equal to
-    the window's, which was green on the build that was rejected. Claim 2
-    replaces both, and grades the artifact instead.
-
-    What is still graded nowhere: whether a viewer reads the result as a
-    **card** rather than as one flat surface. tests/README.md says so under
-    Known gaps.
-
-    Three premises have to hold before the claims say anything:
-
-      * every strip decodes, at every instant sampled;
-      * the window leaves a pad wide enough to read, or claim 2 has nothing to
-        compare the card against and says so instead of passing quietly;
-      * the card's strip is **not** the card's colour at an instant when no card
-        is up. Without that, a fixture app that happened to be this dark blue
-        would satisfy the claim with no card in the recording at all.
-
-    That second one is read **after** the card, halfway between the end of its
-    beat and the end of the take, and not just before it. The beat log's clock
-    and the encoded video's are ~130 ms apart on this arm, so a sample a
-    quarter-second ahead of `t_start` lands on the card about as often as it
-    lands on the app — a premise that trips at random, on a healthy build, and
-    says the app is the wrong colour. After the card there is a wide margin to
-    aim at, and the reading proves something the earlier one did not: that the
-    strip goes back to the app when the card comes down.
-    """
-    mp4 = out_dir / "demo.mp4"
-    if not mp4.is_file():
-        return ["coverage: the take wrote no demo.mp4, so no frame carries a card"]
-    doc = json.loads((out_dir / "timeline.json").read_text())
-    cards = [b for b in doc.get("beats") or [] if b.get("verb") == "criterion"]
-    if len(cards) != 1:
-        return [
-            f"coverage: the take logged {len(cards)} criterion beats, expected "
-            f"1 — there is no card span to read the colour out of"
-        ]
-    start, end = float(cards[0]["t_start"]), float(cards[0]["t_end"])
-    strip = card_strip(app)
-    band = frame_band(app, win)
-
-    duration = float(doc.get("duration") or 0.0)
-    if duration - end < 1.0:
-        return [
-            f"coverage: the criterion beat ends at {end:.2f}s of a {duration:.2f}s "
-            f"take, so there is no stretch after it to read the app out of and "
-            f"nothing to tell the card apart from"
-        ]
-    if band is None:
-        return [
-            f"coverage: the window {win} leaves no pad around the app rect "
-            f"{app} wide enough to read, so nothing here can say whether the "
-            f"card is the window's own colour on screen — which is #291"
-        ]
-    before_at = end + (duration - end) * 0.5
-    before = strip_rgb(mp4, before_at, strip)
-    if before is None:
-        return [
-            f"coverage: {mp4.name} decodes no frame at {before_at:.2f}s over "
-            f"{strip}, so there is no no-card reading to compare with"
-        ]
-    if off_card(before, WEB_CARD_RGB) <= CARD_RGB_TOLERANCE:
-        return [
-            f"coverage: the strip at {strip} reads "
-            f"{tuple(round(v) for v in before)} at {before_at:.2f}s, with the "
-            f"card down since {end:.2f}s — that is the card's own colour "
-            f"{WEB_CARD_RGB}. Either this app cannot be told from the card, so "
-            f"the reading below would pass with no card in the recording, or the "
-            f"card was never taken down"
-        ]
-
-    failures: list[str] = []
-    read: list[tuple[tuple[float, float, float], float]] = []
-    apart: list[tuple[tuple[float, float, float], float]] = []
-    for fraction in CARD_SAMPLE_FRACTIONS:
-        at = start + (end - start) * fraction
-        got = strip_rgb(mp4, at, strip)
-        if got is None:
-            failures.append(
-                f"coverage: {mp4.name} decodes no frame at {at:.2f}s over {strip}"
-            )
-            continue
-        drift = off_card(got, WEB_CARD_RGB)
-        read.append((got, drift))
-        if drift > CARD_RGB_TOLERANCE:
-            failures.append(
-                f"coverage: {(fraction * 100):.0f}% through the criterion beat "
-                f"the card reads {tuple(round(v) for v in got)} over {strip}, "
-                f"{drift:.0f} levels off the web card's {WEB_CARD_RGB} (bar "
-                f"{CARD_RGB_TOLERANCE}). It reads "
-                f"{off_card(got, TERMINAL_CARD_RGB):.0f} off the *terminal* "
-                f"card's {TERMINAL_CARD_RGB} — a web take painting that one is "
-                f"issue #291, where the card reads as a terminal window inside "
-                f"the recorder's own window frame."
-            )
-        # Claim 2, at the same instant and out of the same frame: the pad the
-        # window leaves around the app video, which the card cannot paint.
-        chrome = strip_rgb(mp4, at, band)
-        if chrome is None:
-            failures.append(
-                f"coverage: {mp4.name} decodes no frame at {at:.2f}s over the "
-                f"window body {band}, so the card has nothing to be the colour of"
-            )
-            continue
-        gap = channels_apart(chrome, got)
-        apart.append((chrome, gap))
-        if gap > CARD_WINDOW_TOLERANCE:
-            failures.append(
-                f"coverage: {(fraction * 100):.0f}% through the criterion beat "
-                f"the card reads {tuple(round(v) for v in got)} over {strip} and "
-                f"the window body {tuple(round(v) for v in chrome)} over {band}, "
-                f"{gap:.0f} levels apart (bar {CARD_WINDOW_TOLERANCE}). #291 is "
-                f"that a viewer cannot tell a web take's card from the window it "
-                f"sits in, and this is the reading that says so — the card is "
-                f"declared {WEB_CARD_RGB} to land on the window through a "
-                f"different encoder (#301), so either that compensation is gone, "
-                f"one of the two was repainted, or the encoder moved under it."
-            )
-    if not failures:
-        worst = max(drift for _, drift in read)
-        print(
-            f"smoke: coverage card is the web palette {WEB_CARD_RGB} — strip "
-            f"{strip} reads {tuple(round(v) for v in read[0][0])} under it "
-            f"({worst:.0f} off over {len(read)} samples, bar "
-            f"{CARD_RGB_TOLERANCE}) and "
-            f"{tuple(round(v) for v in before)} once it is down "
-            f"({off_card(before, WEB_CARD_RGB):.0f} off); the window body {band} "
-            f"reads {tuple(round(v) for v in apart[0][0])}, "
-            f"{max(gap for _, gap in apart):.0f} off the card as encoded over "
-            f"{len(apart)} samples (bar {CARD_WINDOW_TOLERANCE}) — the two are "
-            f"one colour on screen, declared two levels apart so that they land "
-            f"there (#291, #301)"
-        )
-    return failures
 
 
 def check_coverage(out_dir: Path) -> list[str]:
@@ -6360,6 +5991,39 @@ def _scored_region_failures(
     return failures
 
 
+def caption_probe_band(
+    label: str, frame_size: tuple[int, int], factor: float = 1.0
+) -> Rect:
+    """Where this medium's caption paints, at `factor` times the frame size.
+
+    The terminal caption is an in-page lower-third and keeps `caption_band`'s
+    whole-width strip. A web (and segments) caption paints in the wrapper
+    chrome's reserved band below the app rect (#358/#361), and reading the
+    old full-width strip dilutes its change with ~7x of static chrome —
+    measured 2.68 mean luma over the strip for a caption whose own band
+    moves by an order of magnitude more. The arithmetic is
+    `chrome_geometry`'s, duplicated at native size (the loop-vs-suite rule:
+    policy is not imported), then scaled, because the geometry's even-pixel
+    rounding does not commute with scaling.
+    """
+    if label == "terminal":
+        width, height = frame_size
+        return caption_band((round(width * factor), round(height * factor)))
+    width, height = frame_size
+    appw = int(width * 0.80) & ~1
+    apph = int(height * 2 / 3) & ~1
+    winw = appw + 2 * 14
+    winh = 36 + 14 + apph + 96 + 14
+    winx = (width - winw) // 2
+    winy = (height - winh) // 2
+    return (
+        round((winx + 14) * factor),
+        round((winy + 36 + 14 + apph) * factor),
+        round(appw * factor),
+        round(96 * factor),
+    )
+
+
 def caption_appearance_s(
     label: str, mp4: Path, band: Rect, expect_at: float
 ) -> tuple[float | None, str]:
@@ -6677,10 +6341,30 @@ def check_timeline(
                 f"{where} ends at {t_end:.3f}s, before it starts ({t_start:.3f}s)"
             )
         if t_start < previous_end - BEAT_ORDER_SLACK_S:
-            failures.append(
-                f"{where} starts at {t_start:.3f}s, before the previous beat "
-                f"ended ({previous_end:.3f}s) — the log is not monotonic"
+            # A stitched log is allowed to run backwards at a capture seam
+            # exactly as loudly as its own artifact says (issue #263): a
+            # backward step deletes wall time from a part's video without
+            # touching its beat log, the merge lays the next part out by the
+            # real file duration, and the recorder REPORTS the overlap in
+            # `overlaps` rather than clamping timestamps to instants neither
+            # clock has. So a seam the document publishes — this beat, seam
+            # flagged, published size covering the observed one — is the
+            # documented healthy shape on a stepping host, and an overlap
+            # anywhere else, or bigger than published, still fails.
+            published = any(
+                rec.get("seam") is True
+                and rec.get("beat") == position
+                and isinstance(rec.get("overlap"), (int, float))
+                and previous_end - t_start <= rec["overlap"] + BEAT_ORDER_SLACK_S
+                for rec in doc.get("overlaps") or []
             )
+            if not published:
+                failures.append(
+                    f"{where} starts at {t_start:.3f}s, before the previous "
+                    f"beat ended ({previous_end:.3f}s) — the log is not "
+                    f"monotonic, and timeline.json publishes no seam overlap "
+                    f"covering it (#263)"
+                )
         previous_end = max(previous_end, t_end)
         if first_start is None:
             first_start = t_start
@@ -6881,7 +6565,7 @@ def check_timeline(
         shift = stepped(t_start)
         expect_at = t_start + shift
         seen_at, note = caption_appearance_s(
-            label, mp4, caption_band(frame_size), expect_at
+            label, mp4, caption_probe_band(label, frame_size), expect_at
         )
         if seen_at is None:
             failures.append(
@@ -7596,7 +7280,7 @@ def _check_frame_captions(
     # native size would crop a region the smaller picture does not have.
     width, height = frame_size
     factor = min(1024, width) / width
-    band = caption_band((round(width * factor), round(height * factor)))
+    band = caption_probe_band(label, frame_size, factor)
     stepped = clock.before if clock is not None else (lambda _t: 0.0)
     reference: bytes | None = None
     graded: list[tuple[int, str, bytes]] = []
@@ -7622,12 +7306,36 @@ def _check_frame_captions(
         # the whole interval between the two accounts of where it is clears
         # every caption change by the guard.
         at = float(frame["t"])
-        shows = at - stepped(at)
-        lo, hi = min(at, shows), max(at, shows)
-        near = min(
-            (0.0 if lo <= c <= hi else min(abs(lo - c), abs(hi - c)) for c in changes),
-            default=math.inf,
+        # Two accounts of where this frame sits, each kept on ITS OWN clock
+        # and measured against the change on that same clock: the beat's
+        # midpoint on the log's, and the cut instant on the video's (the
+        # change moved there by `before(c)`, whose argument really is a
+        # log-clock second). The previous form fed `at` — a video-clock
+        # instant since #229 — into `before()`, and on a take whose step
+        # landed inside a caption stretch the video instant read as inside
+        # the hole on the wrong axis: the corrected interval missed the
+        # change by ~1 s and a frame cut 60 ms from a caption clear was
+        # graded (measured on a --cheap run of #361: beat 4 cut at video
+        # 3.974 s = log 5.09 s, change at log 5.151 s, step -1.119 s at
+        # 3.768 s). A change the two accounts straddle is distance zero —
+        # that is the ambiguous case the guard exists for.
+        beat_record = beats.get(int(frame["beat"])) or {}
+        t_start, t_end = beat_record.get("t_start"), beat_record.get("t_end")
+        log_mid = (
+            (float(t_start) + float(t_end)) / 2
+            if isinstance(t_start, (int, float)) and isinstance(t_end, (int, float))
+            else at
         )
+        near = math.inf
+        for c in changes:
+            log_side = log_mid - c
+            video_side = at - (c + stepped(c))
+            near = min(
+                near,
+                0.0
+                if min(log_side, video_side) <= 0.0 <= max(log_side, video_side)
+                else min(abs(log_side), abs(video_side)),
+            )
         if near < FRAME_CAPTION_GUARD_S:
             continue
         try:
@@ -8194,12 +7902,20 @@ def _transition_shape(frames: list[bytes], fps: float, t_start: float) -> dict:
     return {"frames": len(window), "total": total, "mid": mid}
 
 
-def check_spotlight_transitions(out_dir: Path, info: dict) -> list[str]:
+def check_spotlight_transitions(
+    out_dir: Path, info: dict, clock: HostClock | None = None
+) -> list[str]:
     """The spotlight leaves the way it arrived (issue #111).
 
     Both spotlight beats are measured the same way, and the enter is the
     control: it eased before this change and eases after it, so a reading where
     only the exit passes through nothing is a reading about the exit.
+
+    Each window is placed at its beat's timestamp moved onto the video's
+    clock by the harness's own wall-clock watcher (#215) — the same
+    correction every other timing reading in this file applies, added here
+    after a mid-take backward step was measured sliding the exit window off
+    the fade entirely.
     """
     failures: list[str] = []
     mp4 = out_dir / "demo.mp4"
@@ -8224,6 +7940,7 @@ def check_spotlight_transitions(out_dir: Path, info: dict) -> list[str]:
     # seeks into the same file would each carry their own rounding, and the two
     # windows would then be measured on grids that do not agree.
     frames = gray_frames(mp4, rect=info["rect"])
+    stepped = clock.before if clock is not None else (lambda _t: 0.0)
     readings: dict[str, dict] = {}
     for name, beat in (("enter", enter), ("exit", clear)):
         t_start = beat.get("t_start")
@@ -8233,7 +7950,8 @@ def check_spotlight_transitions(out_dir: Path, info: dict) -> list[str]:
                 f"window cannot be placed in the video"
             )
             continue
-        readings[name] = _transition_shape(frames, fps, float(t_start))
+        at = float(t_start) + stepped(float(t_start))
+        readings[name] = _transition_shape(frames, fps, at)
     span = sum(SPOTLIGHT_WINDOW_S)
     for name, shape in readings.items():
         # Two ways the reading below can be about nothing, each with its own
@@ -8453,7 +8171,7 @@ def check_reported_opening_card(out_dir: Path, info: dict) -> list[str]:
 
     # The number against the file. Read here, off frame zero, over the
     # strip this harness worked out for itself — `-t` and no `fps` filter, for
-    # the reason check_opening() spells out.
+    # the reason OPENING_FIRST_FRAME_S spells out.
     try:
         first = gray_frames(
             out_dir / "demo.mp4", info["corner"], duration=OPENING_FIRST_FRAME_S
@@ -8597,7 +8315,8 @@ def evidence_screen_text(doc: dict) -> str:
     what the page said, not about the log quoting itself.
     """
     return "\n".join(
-        str(doc.get(field) or "") for field in ("aria", "scope_aria", "html", "screen")
+        str(doc.get(field) or "")
+        for field in ("aria", "scope_aria", "html", "screen", "chrome")
     )
 
 
@@ -8844,7 +8563,7 @@ def check_take(
             f"{CAPTION_PROBE[1]}.png were not both captured"
         )
     else:
-        band = caption_band(frame_size)
+        band = caption_probe_band(label, frame_size)
         try:
             before = gray_frames(off, band)
             after = gray_frames(on, band)
@@ -8896,11 +8615,14 @@ def run_web(out_root: Path) -> list[str]:
             # recording. demo.mp4 is on that clock and the beat log is not, so
             # every timing reading below is corrected by this (issue #215).
             with watch_wall_clock() as clock:
-                problems, video_rect, still_rect, size = record_web(
-                    out_dir, base_url, clock
-                )
+                problems, geom, size = record_web(out_dir, base_url, clock)
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"web: Recorder raised {type(exc).__name__}: {exc}"]
+    # One rect for video and stills alike: the wrapper page is the recording
+    # (#358/#361), so a still is the framed frame and the app sits at the
+    # same place in both — the "stills are full-bleed, video is windowed"
+    # mismatch died with the composite.
+    app_rect: Rect = (geom["appx"], geom["appy"], geom["appw"], geom["apph"])
     return (
         problems
         + check_take(
@@ -8909,8 +8631,8 @@ def run_web(out_root: Path) -> list[str]:
             WEB_SHOTS,
             WEB_DURATION_S,
             started,
-            video_rect,
-            still_rect,
+            app_rect,
+            app_rect,
             size,
         )
         + check_capture_clock("web", out_dir, clock)
@@ -8924,10 +8646,13 @@ def run_web(out_root: Path) -> list[str]:
         # The form verbs' pacing (issue #130), read off the same beat log the
         # two checks above read for their contents.
         + check_form_pacing("web", out_dir)
-        # Here rather than in its own phase: the opening hold has to leave every
-        # beat where it was, and this is the take whose beat/frame alignment is
-        # already graded above (issue #119).
-        + check_opening("web", out_dir, video_rect)
+        # What the take opens on (#119 → #360): frame 0 must be the opening
+        # hold and the app must show later — the same claims the wrapper arm
+        # grades, on the long take whose beat/frame alignment is already
+        # graded above. The deleted composite's ffmpeg hold had its own
+        # check here; the in-page hold is graded by the same pixel reading
+        # on every path now.
+        + check_wrapper_opening(out_dir, {"geom": geom})
         # No browser and no recording — two synthesised videos, run here
         # because this is the phase whose acceptance criterion it belongs to.
         + check_opening_gap(out_root)
@@ -8940,7 +8665,14 @@ def run_spotlight(out_root: Path) -> list[str]:
     out_dir = fresh_take_dir(out_root, "spotlight")
     with fixture_server() as base_url:
         try:
-            problems, info = record_spotlight(out_dir, base_url)
+            # Watched for the same reason the web take is (#215): the two
+            # transition windows below are placed at beat timestamps, and a
+            # backward step between the enter and the exit deletes its own
+            # width of video out from under the later window — measured on
+            # this arm, a -1.07 s step at 0.789 s of a 6 s take left the exit
+            # window reading a stretch the fade had already left.
+            with watch_wall_clock() as clock:
+                problems, info = record_spotlight(out_dir, base_url, clock)
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"spotlight: Recorder raised {type(exc).__name__}: {exc}"]
     mp4 = out_dir / "demo.mp4"
@@ -8949,7 +8681,7 @@ def run_spotlight(out_root: Path) -> list[str]:
     return (
         problems
         + _check_video("spotlight", mp4, SPOTLIGHT_DURATION_S, keep_top(info["app"]))
-        + check_spotlight_transitions(out_dir, info)
+        + check_spotlight_transitions(out_dir, info, clock)
         + check_healthy("spotlight", out_dir)
     )
 
@@ -9098,7 +8830,7 @@ def run_coverage(out_root: Path) -> list[str]:
     out_dir = fresh_take_dir(out_root, "coverage")
     with fixture_server() as base_url:
         try:
-            problems, app, win = record_coverage(out_dir, base_url)
+            problems, geom = record_coverage(out_dir, base_url)
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
             return [f"coverage: Recorder raised {type(exc).__name__}: {exc}"]
     if not (out_dir / "timeline.json").is_file():
@@ -9106,7 +8838,9 @@ def run_coverage(out_root: Path) -> list[str]:
     return (
         problems
         + check_coverage(out_dir)
-        + check_criterion_card(out_dir, app, win)
+        # The card's colour, single-encoder (#360/#361): the same reading the
+        # wrapper arm makes, on the take that raises a criterion card anyway.
+        + check_wrapper_card(out_dir, {"geom": geom})
         + check_coverage_refusals(out_root)
         + check_coverage_merge()
     )
@@ -9131,12 +8865,15 @@ def run_web_problems(out_root: Path) -> list[str]:
 
                 # No beat is open here. Whatever this logs must come back with
                 # `beat: null` rather than the closed `wait_for` above it.
-                rec.page.evaluate(BETWEEN_BEATS_JS)
+                # In the app document: the problems have to be the app's, and
+                # page-level listeners hear an iframe's console errors and
+                # failed requests exactly as they heard the page's own.
+                rec.app.evaluate(BETWEEN_BEATS_JS)
 
                 rec.caption(LATE_BOOM_CAPTION)
                 # Armed *before* the hold, fired one second into it. Nothing
                 # else in the take reaches Playwright during that second.
-                rec.page.evaluate(LATE_BOOM_JS)
+                rec.app.evaluate(LATE_BOOM_JS)
                 rec.pause(LATE_BOOM_HOLD_S)
                 rec.caption("The caption after the boom.")
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
@@ -9339,9 +9076,11 @@ def run_strict_terminal(out_root: Path) -> list[str]:
 
 # -- the wrapper take (issues #358, #360) --------------------------------------
 #
-# The opt-in wrapper path: chrome in the recorded page, the app in an iframe
-# at true pixel size, the caption in a reserved band BELOW the app rect. Two
-# takes: one healthy — every locator verb driven through the frame, the band,
+# The wrapper path — since #361 the only web path: chrome in the recorded
+# page, the app in an iframe at true pixel size, the caption in a reserved
+# band BELOW the app rect. This arm is the fast, dedicated grading of the
+# chrome's own behaviour (the long web take exercises the same recorder
+# end-to-end). Two takes: one healthy — every locator verb driven through the frame, the band,
 # the opening hold, the criterion card and a caption surviving a real
 # mid-take goto all graded out of the pixels — and one against a fixture
 # served with X-Frame-Options: DENY, which the recorder must refuse by name
@@ -9409,11 +9148,21 @@ WRAPPER_FIRST_FRAME_S = 0.05
 
 # The card-vs-window bar (#360): on the wrapper path the criterion card and
 # the window body declare ONE colour and ride ONE encoder, so as encoded
-# they sit within this, worst channel — measured 1.0 on a healthy take.
-# There is no compensated pair here to compare declarations of, and the
-# check deliberately reads pixels rather than declarations either way
-# (#297's two recorded anti-patterns).
-WRAPPER_CARD_WINDOW_TOLERANCE = 2.0
+# they sit within this, worst channel. **Measured 0.5-3.8 across healthy
+# runs** — x264 settles the two rects' chroma against different block
+# histories, and the blue channel wanders up to ~4 levels with the take's
+# own content, so a bar of 2.0 went red twice on healthy takes the week
+# the compensation died (#361). What this check can honestly resolve on
+# this encoder is a *repaint*, not a nudge: the planted defect is an
+# 8-level shift (reads ~9 as encoded) and the real one — the terminal
+# palette, #291 itself — reads >= 12, so the bar keeps ~1.8x to the
+# nearest planted defect while clearing its own worst healthy reading. A
+# nudge under ~5 declared levels is inside the encoder's own noise on
+# these rects and is not a claim this check makes. There is no compensated
+# pair here to compare declarations of, and the check deliberately reads
+# pixels rather than declarations either way (#297's two recorded
+# anti-patterns).
+WRAPPER_CARD_WINDOW_TOLERANCE = 5.0
 # Where inside the criterion beat the card is sampled, and how far past its
 # end the no-card control is read. Fractions well inside the beat because
 # the beat log's clock and the video's sit ~130 ms apart (#245); the control
@@ -9516,7 +9265,6 @@ def record_wrapper(out_dir: Path, base_url: str) -> dict:
         speech=False,
         strict=True,
         deterministic=True,
-        wrapper=True,
         criteria={"AC-1": WRAPPER_CLAUSE},
     ) as rec:
         rec.goto("/")
@@ -9565,7 +9313,14 @@ def record_wrapper(out_dir: Path, base_url: str) -> dict:
         # (check_wrapper_caption_survives).
         rec.caption(WRAPPER_SURVIVES)
         rec.goto("/second.html")
-        rec.pause(1.0)
+        # 2.5 s, not 1.0: check_wrapper_caption_survives samples the band up
+        # to 0.8 s after the second document's pixel-located arrival, and a
+        # backward wall-clock step between the load and the clear deletes
+        # its own width of video from that gap — measured, a -1.05 s step at
+        # 28.1 s of a --cheap run pulled the caption clear to ~0.4 s after
+        # arrival and the +0.5/+0.8 samples read a dark band on a healthy
+        # take. The margin outlasts one step of this box's ~1 s cadence.
+        rec.pause(2.5)
         rec.caption("")
         rec.pause(0.6)
         geom = dict(rec._geom)
@@ -9688,10 +9443,10 @@ def wrapper_pad_band(geom: dict) -> Rect:
 
     The window's **bottom pad** — between the caption band's end and the
     window's bottom edge — because it is the one stretch of bare window body
-    a wrapper frame always shows: the pad `frame_band` reads on a composite
-    take is the caption band here, which carries a bubble whenever a line is
-    up. Inset from the pad's own edges for `frame_band`'s reasons — the
-    outermost rows blend into the drop shadow and the band above.
+    a wrapper frame always shows: the pad between the app rect and the
+    window's bottom is the caption band here, which carries a bubble
+    whenever a line is up. Inset from the pad's own edges — the outermost
+    rows blend into the drop shadow and the band above.
     """
     pad_top = geom["bandy"] + geom["bandh"]
     pad_bottom = geom["winy"] + geom["winh"]
@@ -10100,7 +9855,6 @@ def run_wrapper(out_root: Path) -> list[str]:
                 base_url=base_url,
                 speech=False,
                 strict=False,
-                wrapper=True,
             ) as rec:
                 rec.goto("/")
                 rec.caption(WRAPPER_UNREACHED)
@@ -10530,7 +10284,7 @@ def check_merge_offset(
     would be the harness re-doing the recorder's arithmetic and agreeing with
     it. This reads pixels out of two videos.
     """
-    band = caption_band(frame_size)
+    band = caption_probe_band("segments", frame_size)
     demo = out_dir / "demo.mp4"
     merged_json = out_dir / "timeline.json"
     failures: list[str] = []
@@ -11093,11 +10847,11 @@ def run_evidence(out_root: Path) -> list[str]:
                 # iframe. Injected rather than added to the fixture: what is
                 # being graded is the serializer, and the fixture has no
                 # element of this shape that a spotlight can name.
-                rec.page.evaluate(EVIDENCE_SOURCE_JS, EVIDENCE_SOURCE_ID)
+                rec.app.evaluate(EVIDENCE_SOURCE_JS, EVIDENCE_SOURCE_ID)
                 rec.spotlight(f"#{EVIDENCE_SOURCE_ID}")
                 rec.pause(0.3)
                 # 3 — the caps.
-                rec.page.evaluate(EVIDENCE_BLOAT_JS, EVIDENCE_BLOAT_ITEMS)
+                rec.app.evaluate(EVIDENCE_BLOAT_JS, EVIDENCE_BLOAT_ITEMS)
                 rec.spotlight(f"#{EVIDENCE_BLOAT_ID}")
                 rec.pause(0.3)
         except Exception as exc:  # noqa: BLE001 - a raising take is a failure
@@ -13168,8 +12922,8 @@ def open_output(args: argparse.Namespace) -> tuple[Path, bool]:
 # `--cheap` is to be reachable from *nothing but* these three, which is the
 # same sentence as "this phase costs two minutes".
 #
-# What that costs is written down rather than implied: eight check functions —
-# `check_opening`, `check_opening_gap`, `check_verb_classification`,
+# What that costs is written down rather than implied: seven check functions —
+# `check_opening_gap`, `check_verb_classification`,
 # `check_content_pair`, `check_content_toured`, `check_form_pacing`,
 # `_check_occlusion` and `_check_scored_region` — are reachable only from these
 # arms, so under `--cheap` they grade on merge and not on push. Three of them

--- a/tests/smoke
+++ b/tests/smoke
@@ -130,6 +130,7 @@ from _pixels import (  # noqa: E402
     FRAME_BAND,
     Rect,
     caption_band,
+    card_run,
     card_strip,
     channels_apart,
     contrast,
@@ -9163,12 +9164,33 @@ WRAPPER_FIRST_FRAME_S = 0.05
 # pixels rather than declarations either way (#297's two recorded
 # anti-patterns).
 WRAPPER_CARD_WINDOW_TOLERANCE = 5.0
-# Where inside the criterion beat the card is sampled, and how far past its
-# end the no-card control is read. Fractions well inside the beat because
-# the beat log's clock and the video's sit ~130 ms apart (#245); the control
-# lands in the storyboard's deliberate pause after `interlude("")`.
+# The card is located in the video before anything is measured: the longest
+# dark stretch of the app strip that overlaps the logged criterion span
+# (`card_run`, shared with the pixel loop's golden), sampled only in its
+# interior. Beat-log fractions were how this check first shipped, and they
+# are the aliasing #245 warns about: on a stepping host the video slides
+# under the log, so a fixed fraction of the *logged* span lands on the
+# card's fade — measured on a kept take, the gap read 0.0 from 10% to 50%
+# through the logged beat, 5.6 at 60% (mid-fade) and 205 at 70% (card
+# gone). Those 5.x readings were reported as healthy encoder noise when
+# the bar was set; with the fade excluded the healthy band is 0.5-3.8.
+WRAPPER_CARD_SWEEP_FPS = 10
+# One classification bar with the opening card: at or under this mean luma
+# the strip is the card (or the hold), above ~150 it is the app.
+WRAPPER_CARD_LOCATE_MAX_LUMA = 60.0
+# Sweep frames skipped at each end of the located run before sampling. The
+# dark flag admits the first frames of the 0.45 s fade (a mid-fade frame
+# reads ~28-40 mean luma, still under the locate bar, while its colour is
+# already blended toward the app) — the kept take's 5.6 was exactly such a
+# frame.
+WRAPPER_CARD_EDGE_TRIM = 2
+# Where inside the trimmed run the card is sampled.
 WRAPPER_CARD_FRACTIONS = (0.3, 0.6)
-WRAPPER_CARD_CONTROL_AFTER_S = 1.2
+# The located run must hold at least this long AND at least half the logged
+# span, or the card flashed rather than held; and the video must go on past
+# the run long enough for a no-card control to exist.
+WRAPPER_CARD_MIN_STRETCH_S = 1.0
+WRAPPER_CARD_MIN_DOWN_S = 0.8
 # Under this separation between the no-card control and the window body, the
 # app cannot be told from the card and the readings above prove nothing.
 WRAPPER_CARD_CONTROL_MIN_GAP = 12.0
@@ -9532,6 +9554,12 @@ def check_wrapper_card(out_dir: Path, info: dict) -> list[str]:
     alternatives (pinned equal, pinned apart) as anti-patterns, and neither
     is asserted here or anywhere.
 
+    The instants are found in the video, then tied to the log by overlap
+    (`card_run`, the pixel golden's locator): a fixed fraction of the
+    *logged* span lands on the card's fade when the host's clock steps
+    (#245) — see the note over WRAPPER_CARD_SWEEP_FPS for the take that
+    proved it.
+
     The premise the readings need: after the card is down, the strip must
     read as something *other* than the window body, or an app the colour of
     the card would pass with no card in the recording at all.
@@ -9550,7 +9578,40 @@ def check_wrapper_card(out_dir: Path, info: dict) -> list[str]:
     strip = card_strip(app)
     pad = wrapper_pad_band(geom)
 
-    control_at = end + WRAPPER_CARD_CONTROL_AFTER_S
+    sweep = gray_frames(mp4, rect=strip, sample_fps=WRAPPER_CARD_SWEEP_FPS)
+    dark = [
+        sum(f) / len(f) <= WRAPPER_CARD_LOCATE_MAX_LUMA for f in sweep if len(f)
+    ]
+    media_s = len(sweep) / WRAPPER_CARD_SWEEP_FPS
+    run = card_run(dark, WRAPPER_CARD_SWEEP_FPS, (start, end))
+    if run is None:
+        return [
+            f"wrapper-card: no dark stretch of the app strip {strip} "
+            f"(<= {WRAPPER_CARD_LOCATE_MAX_LUMA:.0f} mean luma at "
+            f"{WRAPPER_CARD_SWEEP_FPS} fps, {media_s:.1f}s of video) overlaps "
+            f"the criterion beat logged at {start:.2f}-{end:.2f}s — the card "
+            f"never painted"
+        ]
+    run_start, run_len = run
+    rs = run_start / WRAPPER_CARD_SWEEP_FPS
+    re_ = (run_start + run_len) / WRAPPER_CARD_SWEEP_FPS
+    if run_len / WRAPPER_CARD_SWEEP_FPS < max(
+        WRAPPER_CARD_MIN_STRETCH_S, 0.5 * (end - start)
+    ):
+        return [
+            f"wrapper-card: the card stretch in the video is only "
+            f"{run_len / WRAPPER_CARD_SWEEP_FPS:.1f}s ({rs:.2f}-{re_:.2f}s) "
+            f"against a criterion beat logged {end - start:.1f}s long — the "
+            f"card flashed rather than held"
+        ]
+    if media_s - re_ < WRAPPER_CARD_MIN_DOWN_S:
+        return [
+            f"wrapper-card: the card stretch runs to {re_:.2f}s of a "
+            f"{media_s:.1f}s video — the card is never taken down, and there "
+            f"is no app stretch to tell it apart from"
+        ]
+
+    control_at = re_ + (media_s - re_) * 0.5
     control = strip_rgb(mp4, control_at, strip)
     control_pad = strip_rgb(mp4, control_at, pad)
     if control is None or control_pad is None:
@@ -9561,7 +9622,7 @@ def check_wrapper_card(out_dir: Path, info: dict) -> list[str]:
     control_gap = channels_apart(control, control_pad)
     if control_gap <= WRAPPER_CARD_CONTROL_MIN_GAP:
         return [
-            f"wrapper-card: with the card down since {end:.2f}s the strip "
+            f"wrapper-card: with the card down since {re_:.2f}s the strip "
             f"{strip} reads {tuple(round(v) for v in control)} at "
             f"{control_at:.2f}s, only {control_gap:.0f} levels off the window "
             f"body {tuple(round(v) for v in control_pad)} (premise bar "
@@ -9569,10 +9630,14 @@ def check_wrapper_card(out_dir: Path, info: dict) -> list[str]:
             f"from the card, or the card was never taken down"
         ]
 
+    trim = WRAPPER_CARD_EDGE_TRIM / WRAPPER_CARD_SWEEP_FPS
+    lo, hi = rs + trim, re_ - trim
+    if hi <= lo:
+        lo = hi = (rs + re_) / 2
     failures: list[str] = []
     gaps: list[float] = []
     for fraction in WRAPPER_CARD_FRACTIONS:
-        at = start + (end - start) * fraction
+        at = lo + (hi - lo) * fraction
         card = strip_rgb(mp4, at, strip)
         body = strip_rgb(mp4, at, pad)
         if card is None or body is None:
@@ -9585,20 +9650,22 @@ def check_wrapper_card(out_dir: Path, info: dict) -> list[str]:
         gaps.append(gap)
         if gap > WRAPPER_CARD_WINDOW_TOLERANCE:
             failures.append(
-                f"wrapper-card: {(fraction * 100):.0f}% through the criterion "
-                f"beat the card reads {tuple(round(v) for v in card)} over "
-                f"{strip} and the window body "
-                f"{tuple(round(v) for v in body)} over {pad}, {gap:.1f} levels "
-                f"apart, worst channel (bar {WRAPPER_CARD_WINDOW_TOLERANCE}). "
-                f"On the wrapper path the two declare one colour and ride one "
-                f"encoder (#360), so this gap means the card's field was "
-                f"repainted away from core.WEB_WINDOW_BODY — the #291 mismatch "
-                f"a human once had to spot by eye"
+                f"wrapper-card: {at:.2f}s, inside the card's own stretch of "
+                f"the video ({rs:.2f}-{re_:.2f}s), the card reads "
+                f"{tuple(round(v) for v in card)} over {strip} and the window "
+                f"body {tuple(round(v) for v in body)} over {pad}, {gap:.1f} "
+                f"levels apart, worst channel (bar "
+                f"{WRAPPER_CARD_WINDOW_TOLERANCE}). On the wrapper path the "
+                f"two declare one colour and ride one encoder (#360), so this "
+                f"gap means the card's field was repainted away from "
+                f"core.WEB_WINDOW_BODY — the #291 mismatch a human once had "
+                f"to spot by eye"
             )
     if not failures:
         print(
             f"wrapper-card: card and window body sit {max(gaps):.1f} apart, "
-            f"worst channel over {len(gaps)} samples (bar "
+            f"worst channel over {len(gaps)} samples inside the card's "
+            f"{rs:.2f}-{re_:.2f}s stretch (bar "
             f"{WRAPPER_CARD_WINDOW_TOLERANCE}); the no-card control reads "
             f"{control_gap:.0f} off the body (premise bar "
             f"{WRAPPER_CARD_CONTROL_MIN_GAP}) — one declared colour, one "

--- a/tests/smoke
+++ b/tests/smoke
@@ -9579,9 +9579,7 @@ def check_wrapper_card(out_dir: Path, info: dict) -> list[str]:
     pad = wrapper_pad_band(geom)
 
     sweep = gray_frames(mp4, rect=strip, sample_fps=WRAPPER_CARD_SWEEP_FPS)
-    dark = [
-        sum(f) / len(f) <= WRAPPER_CARD_LOCATE_MAX_LUMA for f in sweep if len(f)
-    ]
+    dark = [sum(f) / len(f) <= WRAPPER_CARD_LOCATE_MAX_LUMA for f in sweep if len(f)]
     media_s = len(sweep) / WRAPPER_CARD_SWEEP_FPS
     run = card_run(dark, WRAPPER_CARD_SWEEP_FPS, (start, end))
     if run is None:

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -470,16 +470,21 @@ INJECTIONS = [
         # The card raised at zero opacity: the element is in the tree with the
         # right text and the right stylesheet, so the aria snapshot, the beat
         # log and the coverage table are all exactly as they should be, and the
-        # app is what a viewer sees. Every other assertion in this arm passes.
-        # Injected into the chrome document's own `__demoInterlude` — the one
-        # a wrapper take's criterion() reaches (chrome.py).
+        # app is what a viewer sees. Injected into the chrome document's own
+        # `__demoInterlude` — the one a wrapper take's criterion() reaches
+        # (chrome.py). Since the check learned to locate the card in the video
+        # before measuring it (the #245 fade-aliasing fix), an invisible card
+        # is caught one step earlier: the only dark stretch overlapping the
+        # logged beat is the 0.6 s opening hold, and the length gate names it
+        # a card that never held. The colour comparison is unreachable — there
+        # is nothing to read the colour of, which is the defect.
         name="the card is built with the right colour and never shown",
         module="chrome.py",
         old="    card.style.opacity = text ? '1' : '0';",
         new="    card.style.opacity = '0';",
         arm="--coverage-only",
         sites=("check_wrapper_card",),
-        must_contain=("levels apart, worst channel (bar",),
+        must_contain=("the card flashed rather than held",),
     ),
     # -- what strict=True refuses (issue #3), 21 s an entry -------------------
     #

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -375,7 +375,7 @@ INJECTIONS = [
         sites=("check_coverage",),
         must_contain=(
             "The card reads the criteria map so that a second wording",
-            "the document the recorder was driving never had those",
+            "the screen the recorder was driving never showed those words",
         ),
     ),
     Injection(
@@ -389,7 +389,7 @@ INJECTIONS = [
         new="            pass",
         arm="--coverage-only",
         sites=("check_coverage",),
-        must_contain=("the document the recorder was driving never had those",),
+        must_contain=("the screen the recorder was driving never showed those words",),
     ),
     Injection(
         name="the card claims nothing, so coverage never lists the clause it showed",
@@ -441,110 +441,45 @@ INJECTIONS = [
         must_contain=("states a finding about unclaimed criteria",),
     ),
     # -- the card is the window's own colour, in demo.mp4 (issue #291) --------
-    #
-    # Four entries against the two claims in the one assertion here that reads
-    # *pixels* out of the encoded frame. `tests/unit` grades the dispatch —
-    # which stylesheet each medium hands the page — at 0.2 s an injection; what
-    # it cannot see is what the composite did with it, which is the half a
-    # viewer meets, and after #301 it is the *only* half that can say whether
-    # the card and the window are one colour on screen.
-    #
-    # The first entry is the defect as it shipped: a terminal card on a web
-    # take, caught as a wrong *colour* at 16 levels against a bar of 6. The
-    # second is a card dispatched perfectly and never painted, at 214. The last
-    # two carry the claim that the card and the window body agree in the
-    # encoded frame, one from each side — the frame repainted under a card that
-    # is exactly what it should be, and the card's encoder compensation
-    # removed. Note what the second of those means for the bar next door: the
-    # uncompensated card is 6 levels off its own declared colour, which
-    # `CARD_RGB_TOLERANCE` lets through at exactly the bound, so the entry is
-    # caught by the window reading and by nothing else.
+    # *pixels* out of the encoded frame. `tests/unit` grades the wiring — the
+    # card's rule painting from the `window_body` substitution, the base
+    # stylesheet unable to paint where the chrome ships the element — at
+    # 0.2 s an injection; what it cannot see is what the encoder did with it,
+    # which is the half a viewer meets. Since #361 the card and the window
+    # declare ONE colour on ONE encoder, so the compensated-pair entries died
+    # with `check_criterion_card`: a window repaint carries the card with it
+    # now, deliberately, and is not a defect anything should catch. What is
+    # left to break is the card's own field (a literal instead of the
+    # substitution) and a card that never shows — both read out of demo.mp4
+    # by `check_wrapper_card` on the coverage take.
     Injection(
-        # #291 restored. Injected at the import so the module still loads: a
-        # `NameError` here would fail the arm before it recorded anything, and
-        # the entry would be graded by an exception rather than by the pixels.
-        name="a web take is painted the terminal's card",
-        module="web.py",
-        old="from .core import (\n"
-        "    INTERLUDE_CSS_WEB,\n"
-        "    WEB_WINDOW_BODY,\n"
-        "    _beat_verb,\n"
-        "    _DemoBase,\n"
-        "    _env,\n"
-        "    _env_flag,\n"
-        ")",
-        new="from .core import (  # noqa: I001\n"
-        "    INTERLUDE_CSS_TERMINAL as INTERLUDE_CSS_WEB,\n"
-        "    WEB_WINDOW_BODY,\n"
-        "    _beat_verb,\n"
-        "    _DemoBase,\n"
-        "    _env,\n"
-        "    _env_flag,\n"
-        ")",
+        # #291 wearing new clothes: the card's field repainted off the window
+        # body it must equal — the single declaration replaced by a second,
+        # slightly different one. The same defect the wrapper arm plants; here
+        # it is caught on the coverage take, whose card is the one a real
+        # storyboard raises (#280).
+        name="the coverage take's card is repainted off the window body",
+        module="chrome.py",
+        old="    background: __WINBG__; color: #f2f0ec; z-index: 3; }",
+        new="    background: #202030; color: #f2f0ec; z-index: 3; }",
         arm="--coverage-only",
-        sites=("check_criterion_card",),
-        must_contain=("off the *terminal* card's",),
+        sites=("check_wrapper_card",),
+        must_contain=("the card's field was repainted away from core.WEB_WINDOW_BODY",),
     ),
     Injection(
         # The card raised at zero opacity: the element is in the tree with the
         # right text and the right stylesheet, so the aria snapshot, the beat
         # log and the coverage table are all exactly as they should be, and the
         # app is what a viewer sees. Every other assertion in this arm passes.
+        # Injected into the chrome document's own `__demoInterlude` — the one
+        # a wrapper take's criterion() reaches (chrome.py).
         name="the card is built with the right colour and never shown",
-        module="core.py",
-        # The card's own two lines and not the caption bar's: `__demoCaption`
-        # ends in the same pair, so a shorter search string matches twice and
-        # the harness refuses the entry.
-        old="    el.style.cssText = '__CSS__';\n"
-        "    document.body.appendChild(el);\n"
-        "  }\n"
-        "  el.textContent = text;\n"
-        "  el.style.opacity = text ? '1' : '0';",
-        new="    el.style.cssText = '__CSS__';\n"
-        "    document.body.appendChild(el);\n"
-        "  }\n"
-        "  el.textContent = text;\n"
-        "  el.style.opacity = '0';",
+        module="chrome.py",
+        old="    card.style.opacity = text ? '1' : '0';",
+        new="    card.style.opacity = '0';",
         arm="--coverage-only",
-        sites=("check_criterion_card",),
-        must_contain=(" levels off the web card's ",),
-    ),
-    Injection(
-        # **The window is repainted under a card that is exactly right.** This
-        # is the entry #297 had and the round after it deleted with the check it
-        # existed for. It is back because there is a check again: the card's own
-        # colour claim passes here — the strip really is `WEB_CARD_RGB` — and
-        # the *only* thing that fires is the reading that says the card and the
-        # window body are one colour on screen, which is #291's own property.
-        name="the window frame is repainted out from under the card",
-        module="core.py",
-        old='WEB_WINDOW_BODY = "#181825"',
-        new='WEB_WINDOW_BODY = "#050505"',
-        arm="--coverage-only",
-        sites=("check_criterion_card",),
-        must_contain=(
-            "levels apart (bar",
-            "that a viewer cannot tell a web take's card",
-        ),
-    ),
-    Injection(
-        # **The compensation is removed**, which is the third rejected fix
-        # restored: one declared colour for both, the thing a reader expects
-        # "the card is the window's colour" to mean. Every stylesheet is
-        # consistent, `tests/unit` is green, and the card lands 5 levels of blue
-        # off the window in `demo.mp4` because it went through Chromium's VP8
-        # and the window did not (#301). A human found this by sampling a
-        # shipped frame; this is the entry that says a machine can now find it.
-        name="the card drops its encoder compensation and declares the window's colour",
-        module="core.py",
-        old='WEB_CARD_BODY = "#181726"',
-        new='WEB_CARD_BODY = "#181825"',
-        arm="--coverage-only",
-        sites=("check_criterion_card",),
-        must_contain=(
-            "levels apart (bar",
-            "that a viewer cannot tell a web take's card",
-        ),
+        sites=("check_wrapper_card",),
+        must_contain=("levels apart, worst channel (bar",),
     ),
     # -- what strict=True refuses (issue #3), 21 s an entry -------------------
     #
@@ -582,19 +517,19 @@ INJECTIONS = [
     # for the difference it was describing, and 1.07 and 0.98 for the two real
     # breaks below. A number that cannot separate those three grades nothing.
     Injection(
-        # The cause of #185. The recorder's cursor dot follows the pointer, and
-        # a storyboard that never places the pointer gets whatever Chromium's
-        # synthetic mousemove leaves — the origin, eleven takes in twelve under
-        # load, and off-screen the twelfth. The still comparison sees that one
-        # take in twelve; this assertion sees every one of them, which is the
-        # difference between a check and a coin.
-        name="the storyboard leaves the pointer where the race puts it",
-        module="tests/smoke",
-        old="        rec.page.mouse.move(*PARKED_POINTER)",
-        new="        pass  # the pointer is left to the synthetic mousemove",
+        # #185's class, in the only form left to it: the chrome's off-screen
+        # park moved on-screen, so a dot no verb commanded ships in every
+        # still of a storyboard that never touched the pointer. The event
+        # race that used to produce this one take in twelve is structurally
+        # gone (#361 — nothing listens); the DOM check sees a park defect on
+        # every take, which is the difference between a check and a coin.
+        name="the chrome parks the cursor dot on-screen",
+        module="chrome.py",
+        old="  #__demo_cursor { position: fixed; top: -40px; left: -40px; width: 18px;",
+        new="  #__demo_cursor { position: fixed; top: 8px; left: 8px; width: 18px;",
         arm="--determinism-only",
-        sites=("check_parked_pointer",),
-        must_contain=("this storyboard parked the pointer at",),
+        sites=("check_undrawn_pointer",),
+        must_contain=("with no pointer verb having run",),
     ),
     Injection(
         # The claim the byte comparison exists for: a frozen clock. Both takes
@@ -1120,14 +1055,12 @@ INJECTIONS = [
         name="a frame-refused app fails with an error naming no header",
         module="web.py",
         old=(
-            "                if self._wrapper and "
-            '"ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
+            '                if "ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
             "                    raise RuntimeError(self._frame_refusal(url)) "
             "from exc"
         ),
         new=(
-            "                if self._wrapper and "
-            '"ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
+            '                if "ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
             "                    pass"
         ),
         arm="--wrapper-only",
@@ -1175,16 +1108,19 @@ INJECTIONS = [
         must_contain=("was not opaque in frame 0",),
     ),
     Injection(
-        # #360's colour claim: the wrapper card's field nudged four levels off
-        # the window body it must equal — the single declared colour replaced
-        # by a second, slightly different one, which is the #291 mismatch a
-        # human once had to spot by eye in a shipped frame. Read out of the
-        # encoded mp4, card strip against window pad, never out of the
-        # declarations (#297's anti-patterns).
-        name="the wrapper card's palette is nudged four levels off the window",
+        # #360's colour claim: the wrapper card's field repainted eight levels
+        # off the window body it must equal — the single declared colour
+        # replaced by a second one, which is the #291 mismatch a human once
+        # had to spot by eye in a shipped frame. Eight levels rather than the
+        # four this entry used to plant: the healthy pair encodes up to 3.8
+        # apart on this box (the bar's own comment has the band), so a
+        # 4-level nudge is inside the encoder's noise and no honest bar can
+        # resolve it. Read out of the encoded mp4, card strip against window
+        # pad, never out of the declarations (#297's anti-patterns).
+        name="the wrapper card's palette is repainted eight levels off the window",
         module="chrome.py",
         old="    background: __WINBG__; color: #f2f0ec; z-index: 3; }",
-        new="    background: #1c1c29; color: #f2f0ec; z-index: 3; }",
+        new="    background: #202030; color: #f2f0ec; z-index: 3; }",
         arm="--wrapper-only",
         sites=("check_wrapper_card",),
         must_contain=("the card's field was repainted away from core.WEB_WINDOW_BODY",),
@@ -1196,11 +1132,10 @@ INJECTIONS = [
         # only the band's pixels across the load can say it left the screen.
         name="a mid-take goto kills the caption band",
         module="web.py",
-        old="        if self._wrapper and not self._hold_cleared:",
+        old="        if not self._hold_cleared:",
         new=(
-            "        if self._wrapper:\n"
-            "            self.page.evaluate(\"() => window.__demoCaption('')\")\n"
-            "        if self._wrapper and not self._hold_cleared:"
+            "        self.page.evaluate(\"() => window.__demoCaption('')\")\n"
+            "        if not self._hold_cleared:"
         ),
         arm="--wrapper-only",
         sites=("check_wrapper_caption_survives",),
@@ -1213,15 +1148,13 @@ INJECTIONS = [
         name="a frame-refused app is recorded as a silently blank demo",
         module="web.py",
         old=(
-            "                if self._wrapper and "
-            '"ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
+            '                if "ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
             "                    raise RuntimeError(self._frame_refusal(url)) "
             "from exc\n"
             "                if attempt == 2:"
         ),
         new=(
-            "                if self._wrapper and "
-            '"ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
+            '                if "ERR_BLOCKED_BY_RESPONSE" in str(exc):\n'
             "                    break\n"
             "                if attempt == 2:"
         ),

--- a/tests/unit
+++ b/tests/unit
@@ -177,7 +177,7 @@ from demo_recording.core import (  # noqa: E402
     _DemoBase,
 )
 from demo_recording.terminal import TerminalRecorder  # noqa: E402
-from demo_recording.web import _CURSOR_JS, Recorder  # noqa: E402
+from demo_recording.web import Recorder  # noqa: E402
 
 # --------------------------------------------------------------------------
 # Helpers — deliberately hand-written
@@ -3609,6 +3609,24 @@ class PixelChecks(unittest.TestCase):
         # A tie goes to the earliest, so the answer is deterministic.
         self.assertEqual(px.longest_run([True, False, True]), (0, 1))
 
+    def test_card_run_picks_the_overlapping_stretch_not_the_longest(self):
+        # The wrapper take's opening hold is a longer dark stretch in the
+        # same strip, deliberate and earlier (#360) — a locator that took
+        # the longest run outright would grade the hold's colour and call
+        # it the card. At 10 fps: hold frames 0-39 (0-4 s), card frames
+        # 60-79 (6-8 s), criterion beat logged 6.0-8.0 s.
+        px = self.px
+        flags = [True] * 7 + [False] * 53 + [True] * 20 + [False] * 10
+        self.assertEqual(px.card_run(flags, 10, (6.0, 8.0)), (60, 20))
+        # The 2 s leading slack the beat-tie always had (#245): a run ending
+        # up to 2 s before the logged start still counts...
+        lone = [False] * 45 + [True] * 5 + [False] * 40
+        self.assertEqual(px.card_run(lone, 10, (6.5, 8.0)), (45, 5))
+        # ...but one ending further back than the slack does not, and no
+        # overlapping run at all is None rather than the nearest one.
+        self.assertIsNone(px.card_run([True] * 10 + [False] * 80, 10, (6.0, 8.0)))
+        self.assertIsNone(px.card_run([False] * 90, 10, (6.0, 8.0)))
+
     def test_accent_like_matches_the_dot_blends_and_not_the_chrome(self):
         px = self.px
         # The dot's own colours: full accent, the .45 fill over white and
@@ -4364,10 +4382,16 @@ def first_string_parameter(cls: type, name: str) -> str | None:
 class CaptionTruth(unittest.TestCase):
     """What a beat reports was on screen, across a navigation (issue #134).
 
-    The caption bar is a DOM element (`#__demo_caption`), so a document
-    replacing the one it lives in takes it off the screen. `self._caption` is
-    a Python attribute and does not notice, and every beat that does not carry
-    its own caption is stamped with it.
+    Until #361 the web caption was a DOM element inside the app's document,
+    a full page load destroyed it, and this class graded the machinery that
+    kept the beat log honest about the loss. The wrapper cutover inverted
+    the truth to hold: the caption lives in the wrapper document (chrome.py),
+    `goto()` navigates the app *iframe*, and no way of leaving a page can
+    take the line off the screen — so a beat after a document load must keep
+    reporting it, and the recorder must not even subscribe the signal that
+    used to clear it (the structural half; `WrapperChrome` pins the
+    non-subscription, `tests/smoke --wrapper-only` reads the surviving line
+    out of the band's pixels across a real load).
     """
 
     def prepared(self):
@@ -4376,10 +4400,9 @@ class CaptionTruth(unittest.TestCase):
         rec._watch_page(rec.page)
         rec.caption(STALE_CAPTION)
         rec.pause(0)
-        # The control. Everything below is a claim about a caption going
-        # *away*, and none of it means anything unless a beat was carrying the
-        # caption in the first place — a recorder that stamped "" on every
-        # beat would satisfy the assertions and record nothing true.
+        # The control. Everything below is a claim about a caption staying
+        # *up*, and none of it means anything unless a beat was carrying the
+        # caption in the first place.
         self.assertEqual(
             rec._beats[-1]["caption"],
             STALE_CAPTION,
@@ -4388,39 +4411,31 @@ class CaptionTruth(unittest.TestCase):
         )
         return rec
 
-    def test_a_beat_after_a_document_load_reports_no_caption(self):
+    def test_a_beat_after_a_document_load_still_reports_the_line(self):
+        # The app document was replaced; the wrapper document — which holds
+        # the caption — was not. Zero handlers is the claim, not a gap: the
+        # clearing rode a `domcontentloaded` subscription, and not listening
+        # is what makes "the caption cannot be lost" a property of the code.
         rec = self.prepared()
         before = len(rec._beats)
-        self.assertGreaterEqual(
+        self.assertEqual(
             rec.page.fire("domcontentloaded", rec.page),
-            1,
-            "no handler took the document-load event, so nothing was tested",
+            0,
+            "something subscribed the document-load signal — the #134 "
+            "clearing machinery grew back, and the beat log would report a "
+            "line as lost that is still on screen",
         )
         rec.pause(0)
-        after = rec._beats[before:]
-        self.assertEqual([b["caption"] for b in after], [""])
-        # Broader than the field, deliberately: the claim is that a reader of
-        # this take's timeline cannot recover the pre-navigation line from a
-        # beat recorded after it, whichever key it might have travelled under.
-        self.assertNotIn(STALE_CAPTION, json.dumps(after))
+        self.assertEqual([b["caption"] for b in rec._beats[before:]], [STALE_CAPTION])
 
     def test_an_spa_route_change_keeps_the_caption(self):
-        # The bar survives history navigation, so clearing on every
-        # `framenavigated` — which Playwright also fires for same-document
-        # navigation — would be the same lie pointing the other way: a beat
-        # reporting no caption while one is on screen.
+        # `framenavigated` still has a listener (#142's carve-out) and it
+        # must keep changing nothing about the caption.
         rec = self.prepared()
         before = len(rec._beats)
         self.assertGreaterEqual(rec.page.fire("framenavigated", None), 1)
         rec.pause(0)
         self.assertEqual([b["caption"] for b in rec._beats[before:]], [STALE_CAPTION])
-
-    def test_a_caption_set_after_the_load_is_reported_again(self):
-        rec = self.prepared()
-        rec.page.fire("domcontentloaded", rec.page)
-        rec.caption("The order was accepted.")
-        rec.pause(0)
-        self.assertEqual(rec._beats[-1]["caption"], "The order was accepted.")
 
     def test_a_take_watches_its_page_before_the_medium_starts(self):
         # `__enter__` needs Chromium, so what is graded is that it reaches the
@@ -4440,14 +4455,7 @@ class CaptionTruth(unittest.TestCase):
 # What Chromium really sends for each way of leaving a page (issue #179)
 # --------------------------------------------------------------------------
 #
-# `CaptionTruth` above fires `domcontentloaded` itself. That grades the handler
-# and the subscription and takes the *event name* on trust — and the name is
-# the whole of the decision, because `framenavigated` fires for same-document
-# history navigation as well, so clearing there would take a caption off the
-# beat log while it is still on screen. A check that fires the event it is
-# unsure about is the catalogue's *check that shares the bug's blind spot*.
-#
-# So the streams below were **measured**. A probe served a fixture with a link,
+# The streams below were **measured**. A probe served a fixture with a link,
 # a GET form, a `location.href` button, a `history.pushState` button, an iframe
 # and a `<meta http-equiv=refresh>`, put the shipped `Recorder._watch_page`
 # subscription on a real page, and recorded the ordered page events each way of
@@ -4456,18 +4464,19 @@ class CaptionTruth(unittest.TestCase):
 #
 # **Measured on three Chromium builds, byte-identical on all three:**
 # 136.0.7103.25 (Playwright 1.52), 147.0.7727.15 (1.59) and 151.0.7922.34
-# (1.62) — the same three #202 is about, where one build disagreeing with the
-# others is exactly what this is written to notice. The probe is not committed;
-# a re-measurement lands in this table.
+# (1.62). The probe is not committed; a re-measurement lands in this table.
 #
-# What the tests do with it is replay each measured stream through the
-# production subscription and read the *beat log* — never `rec._caption`,
-# which is the field #134 was about. The table is data, not code shared with
-# `web.py`: an author who changes the event the clear hangs off has to change
-# the browser to make these agree again.
+# The table was measured for #134's clearing machinery, which #361 deleted —
+# the caption lives in the wrapper document now and no app navigation reaches
+# it. The table stays because the claim it grades survived the inversion:
+# every one of these streams is delivered to the wrapper page's subscription,
+# and none of them may touch the beat log's caption. Replaying them through
+# the production `_watch_page` and reading the *beat log* — never
+# `rec._caption` — is what holds "the caption cannot be lost" against every
+# measured way of leaving, not only the one `CaptionTruth` fires by hand.
 #
 # (name, what the storyboard did, stream, events delivered by the time the
-#  driving call returned, does the caption survive it)
+#  driving call returned, does the page's document survive it)
 _MAIN, _CHILD, _PAGE = "main", "child", None
 NAVIGATIONS = [
     (
@@ -4539,8 +4548,8 @@ NAVIGATIONS = [
         False,
     ),
     (
-        # The three that must NOT clear. The bar is still in the document, so
-        # a beat reporting no caption here is #134 pointing the other way.
+        # The three where the page's document stands still — measured as
+        # `framenavigated` with no document event.
         "spa_push_state",
         "history.pushState to a new route, no document loaded",
         [("framenavigated", _MAIN)],
@@ -4555,9 +4564,10 @@ NAVIGATIONS = [
         True,
     ),
     (
-        # The "only for the main frame" half: an iframe loading a document
-        # produces a child-frame `framenavigated` and no page-level
-        # `domcontentloaded` at all.
+        # An iframe loading a document produces a child-frame
+        # `framenavigated` and no page-level `domcontentloaded` at all —
+        # measured for #179, and since #358 it is the shape of every wrapper
+        # take's own `goto()`.
         "iframe_load",
         "an iframe loading a document while the page stands still",
         [("framenavigated", _CHILD)],
@@ -4624,273 +4634,89 @@ class MeasuredNavigations(unittest.TestCase):
     def prepared(self):
         return CaptionTruth.prepared(self)  # the same control, same reasons
 
-    def test_every_measured_document_load_takes_the_line_off_the_beat_log(self):
-        for name, did, stream, _, keeps in NAVIGATIONS:
-            if keeps:
-                continue
+    def test_no_measured_way_of_leaving_a_page_touches_the_beat_log(self):
+        # Every row, document-replacing or not: the caption is the wrapper
+        # document's and the wrapper never navigates, so every stream a real
+        # Chromium delivers must leave the next beat reporting the line and
+        # file no issue. Non-vacuous because every measured stream carries a
+        # `framenavigated` and #142's kept listener takes it — a subscription
+        # pass that attached nothing would fail the floor below.
+        for name, did, stream, _, _survives in NAVIGATIONS:
             with self.subTest(navigation=name):
                 rec = self.prepared()
                 before = len(rec._beats)
                 self.assertGreaterEqual(
                     replay(rec, stream),
                     1,
-                    f"nothing was subscribed to any event {name} delivers, so "
-                    f"this replayed a stream at nobody",
-                )
-                rec.pause(0)
-                after = rec._beats[before:]
-                self.assertEqual(
-                    [b["caption"] for b in after],
-                    [""],
-                    f"{did} replaced the document, and a beat after it still "
-                    f"reports a caption",
-                )
-                # Broader than the field on purpose: what a reader of this
-                # take's timeline can recover, whichever key it travelled in.
-                self.assertNotIn(STALE_CAPTION, json.dumps(after))
-
-    def test_every_measured_same_document_navigation_keeps_the_line(self):
-        for name, did, stream, _, keeps in NAVIGATIONS:
-            if not keeps:
-                continue
-            with self.subTest(navigation=name):
-                rec = self.prepared()
-                before = len(rec._beats)
-                self.assertGreaterEqual(
-                    replay(rec, stream),
-                    1,
-                    f"nothing took any event {name} delivers — with the whole "
-                    f"subscription gone this test would pass on silence",
+                    f"nothing took any event {name} delivers — the whole "
+                    f"subscription is gone, and this replayed a stream at "
+                    f"nobody",
                 )
                 rec.pause(0)
                 self.assertEqual(
                     [b["caption"] for b in rec._beats[before:]],
                     [STALE_CAPTION],
-                    f"{did} left the caption bar in the document, and the "
-                    f"beat log says it went away",
+                    f"{did} cannot reach the wrapper document's caption, and "
+                    f"the beat log says the line went away",
+                )
+                self.assertEqual(
+                    rec._issues,
+                    [],
+                    f"{did} left an issue behind — a loss was recorded that "
+                    f"cannot have happened on a wrapper take",
                 )
 
     def test_the_measured_table_covers_every_way_issue_179_names(self):
-        # The vacuous half of both sweeps above. Each loop is over whatever
-        # rows carry its flag, so a table that lost the SPA rows would leave
-        # "an SPA route change keeps the caption" graded over nothing at all.
+        # The vacuous half of the sweep above: a table that lost rows would
+        # leave "no way of leaving a page touches the beat log" graded over
+        # almost nothing. Spelled out rather than counted, and every stream
+        # must carry the `framenavigated` that makes the replay land on a
+        # subscribed handler.
         measured = {row[0] for row in NAVIGATIONS}
         self.assertEqual(sorted(NAVIGATIONS_REQUIRED - measured), [])
-        kept = [row[0] for row in NAVIGATIONS if row[4]]
-        replaced = [row[0] for row in NAVIGATIONS if not row[4]]
-        self.assertGreaterEqual(len(kept), 3, kept)
-        self.assertGreaterEqual(len(replaced), 5, replaced)
-        # And the streams have to disagree in the way the fix depends on:
-        # every same-document navigation is `framenavigated` with no document
-        # event, and every replacement carries one. If that stopped being
-        # true, no subscription could tell them apart and the tests above
-        # would be grading a coincidence.
-        for name, _, stream, _, keeps in NAVIGATIONS:
-            loads = [e for e, _t in stream if e == "domcontentloaded"]
-            self.assertEqual(
-                bool(loads),
-                not keeps,
-                f"{name} was measured with {len(loads)} document-load "
-                f"event(s), which does not match what it does to the page",
-            )
+        for name, _, stream, _, _survives in NAVIGATIONS:
             self.assertTrue(
                 any(e == "framenavigated" for e, _t in stream),
-                f"{name} produced no framenavigated at all, so it cannot show "
-                f"that the two signals are distinguishable",
+                f"{name} was measured with no framenavigated at all — the "
+                f"sweep above would replay it at nobody and call that green",
             )
 
-    def deferring(self):
-        """A prepared recorder on a page that holds events until it is called.
-
-        The timing a click really has (issue #214): `goto()` waits for the
-        load, so the clear has already happened when it returns, but a link
-        click, a form submit and a `location.href` button all return after
-        `framenavigated` alone — measured, all three builds — and the
-        `domcontentloaded` that takes the caption off the screen is still
-        sitting in the connection. It lands on the next round trip somebody
-        makes, and the beat that follows the click is what has to make it.
-        """
-        rec = recorder(self, page=NoisyPage())
-        rec._watch_page(rec.page)
-        rec.caption(STALE_CAPTION)
-        rec.pause(0)
-        self.assertEqual(
-            rec._beats[-1]["caption"],
-            STALE_CAPTION,
-            "the beat before the navigation does not carry the caption, so "
-            "this test is not exercising the stamping it grades",
-        )
-        return rec
-
-    def test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat(self):
-        # Issue #214's acceptance criterion, one navigation at a time:
-        # `caption(...)`, a click, `pause(3)` — and no beat after the click
-        # carrying the line the load took away.
-        #
-        # The late half of each measured stream is *queued* on the page rather
-        # than fired at the recorder, so the only thing that can deliver it is
-        # a round trip the recorder makes for itself. That is the whole claim:
-        # a beat stamps its caption when it opens, before its verb touches the
-        # browser, so unless the beat asks the page first it inherits a line
-        # that is no longer on screen.
-        for name in ("link_click", "form_submit", "location_href"):
-            with self.subTest(navigation=name):
-                row = next(r for r in NAVIGATIONS if r[0] == name)
-                _, did, stream, at_return, _ = row
-                self.assertLess(
-                    at_return,
-                    len(stream),
-                    "this navigation was measured as fully delivered before "
-                    "its verb returned, so there is no late half to grade",
-                )
-                rec = self.deferring()
-                before = len(rec._beats)
-                replay(rec, stream[:at_return])
-                # The control for the queueing: what the click itself
-                # delivered leaves the caption alone, so anything the beat
-                # below reports comes from the half that had not arrived yet.
-                self.assertEqual(
-                    rec._caption,
-                    STALE_CAPTION,
-                    f"{did} cleared the caption before its late half was "
-                    f"delivered at all, so the deferral grades nothing",
-                )
-                rec.page.queued = payloads(rec.page, stream[at_return:])
-                # As a click leaves the clock: `click()` holds for 0.4 s
-                # before it clicks, so the last pump is about a millisecond
-                # old when the next beat opens and a rate-limited pump would
-                # skip exactly this beat. Stamped rather than left to how fast
-                # this suite happens to run.
-                rec._pumped_at = time.monotonic() - rec._t0
-                # `pause(0)`, not the criterion's `pause(3)`: the hold length
-                # is not part of the claim — the caption is stamped when the
-                # beat *opens* — and three seconds times three navigations is
-                # nine seconds this suite would spend proving nothing.
-                rec.pause(0)
-                after = rec._beats[before:]
-                # One claim, with the reason in its message rather than in a
-                # second assertion: what is still queued can only be non-empty
-                # when this one fails, so asserting it separately would be a
-                # check that cannot fire on its own.
-                self.assertEqual(
-                    [b["caption"] for b in after],
-                    [""],
-                    f"{did} replaced the document, and the beat right after "
-                    f"it still reports the line the load took off the screen "
-                    f"(never delivered: {[e for e, _a in rec.page.queued]})",
-                )
-                # Broader than the field on purpose: what a reader of this
-                # take's timeline can recover, whichever key it travelled in.
-                self.assertNotIn(STALE_CAPTION, json.dumps(after))
-
 
 # --------------------------------------------------------------------------
-# What the log says about the line it dropped (issue #180)
+# The retired `caption_lost` kind (#180, ended by #358/#361)
 # --------------------------------------------------------------------------
 #
-# Clearing the caption made the timeline honest and mute. A storyboard that
-# captions, navigates and holds for eight seconds records eight seconds of
-# empty caption column and nothing naming the cause, and the recorder knew
-# both the line and the document at the moment it dropped it.
+# The issue existed because the composite path's caption died with the app's
+# document and the beat log had to say so (#134/#180). On the wrapper path
+# there is no way for the line to leave the screen, no subscription for the
+# machinery to ride, and therefore no recorder left that can file the kind.
+# What survives it: committed timelines carry the kind, so it stays
+# published; and it must never become fatal retroactively.
 
 
-class CaptionLost(unittest.TestCase):
-    """The issue a page load records for the caption it took away (#180)."""
+class CaptionLostRetired(unittest.TestCase):
+    """What remains of `caption_lost` after the cutover (#361)."""
 
-    def dropped(self, url: str = LOADED_URL):
-        """A recorder that captioned, then had its document replaced."""
-        rec = recorder(self, page=FakePage(url))
+    def test_the_kind_stays_published_for_committed_timelines(self):
+        # Timelines recorded before #361 carry the kind, reference/failures.md
+        # still documents the row for their readers, and stitch() merges old
+        # segments' issues as-is — unpublishing it would turn those artifacts
+        # into records nothing can name.
+        self.assertIn("caption_lost", ISSUE_KINDS)
+        self.assertNotIn("caption_lost", STRICT_KINDS)
+
+    def test_no_recorder_files_it_any_more(self):
+        # A caption up, the full document-load signal fired at the page: no
+        # handler takes it (the subscription is gone, not merely quiet) and
+        # no issue is recorded — the line is still on screen, in the wrapper
+        # document the load cannot reach.
+        rec = recorder(self, page=FakePage(LOADED_URL))
         rec._watch_page(rec.page)
         rec.caption(STALE_CAPTION)
-        self.assertEqual(
-            rec._issues,
-            [],
-            "something else was already recorded, so the "
-            "assertions below are not about the caption",
-        )
-        self.assertGreaterEqual(rec.page.fire("domcontentloaded", rec.page), 1)
-        return rec
-
-    def test_the_line_a_load_took_off_the_screen_is_recorded_as_a_problem(self):
-        rec = self.dropped()
-        self.assertEqual(len(rec._issues), 1, f"recorded {rec._issues!r}")
-        issue = rec._issues[0]
-        self.assertEqual(issue["kind"], "caption_lost")
-        # Both facts the recorder had and neither of which reached anything
-        # before: which line, and which document took it.
-        self.assertEqual(issue["lost_caption"], STALE_CAPTION)
-        self.assertEqual(issue["url"], LOADED_URL)
-        # …and in the one field a reader of timeline.md's Issues section sees,
-        # because that list renders `message` and nothing else.
-        self.assertIn(STALE_CAPTION, issue["message"])
-        self.assertIn(LOADED_URL, issue["message"])
-
-    def test_the_kind_is_one_the_package_publishes(self):
-        # `check_issues` in tests/smoke refuses a kind outside this tuple, and
-        # a take that recorded one would fail on the artifact rather than on
-        # the defect.
-        self.assertIn("caption_lost", ISSUE_KINDS)
-
-    def test_a_load_with_no_caption_up_records_nothing(self):
-        # Every take begins with a document load and most storyboards navigate
-        # before they caption anything. An issue for each would be a log
-        # nobody reads.
-        rec = recorder(self)
-        rec._watch_page(rec.page)
-        rec.page.fire("domcontentloaded", rec.page)
-        rec.pause(0)
-        rec.page.fire("domcontentloaded", rec.page)
+        self.assertEqual(rec.page.fire("domcontentloaded", rec.page), 0)
         self.assertEqual(rec._issues, [])
         self.assertEqual(rec._issue_count, 0)
-
-    def test_a_second_load_does_not_report_the_line_a_second_time(self):
-        # The caption is gone after the first one. A recorder that logged the
-        # same lost line once per document would bury a real one under a
-        # storyboard that navigates six times.
-        rec = self.dropped()
-        rec.page.fire("domcontentloaded", rec.page)
-        self.assertEqual(len(rec._issues), 1, f"recorded {rec._issues!r}")
-
-    def test_losing_a_caption_does_not_fail_a_strict_take(self):
-        # A storyboard mistake is not the app saying it is broken, and strict
-        # mode is a verdict on the app. Asserted on the counter `__exit__`
-        # reads, not on the tuple, so moving the kind into STRICT_KINDS is
-        # what this notices.
-        rec = self.dropped()
-        self.assertNotIn("caption_lost", STRICT_KINDS)
-        self.assertEqual(rec._fatal_count, 0)
-
-    def test_a_page_too_far_gone_to_name_still_reports_the_line(self):
-        # The catalogue's clean-path-only assertion. The URL is read off a
-        # page that is, by definition, in the middle of replacing itself, and
-        # a diagnostic that threw here would surface inside an unrelated
-        # Playwright call and cost the take. What must not happen is the
-        # *line* being lost with it: which caption went away is the half the
-        # recorder alone knows.
-        rec = recorder(self, page=UnreadablePage())
-        rec._watch_page(rec.page)
-        rec.caption(STALE_CAPTION)
-        rec.page.fire("domcontentloaded", rec.page)
-        self.assertEqual(len(rec._issues), 1, f"recorded {rec._issues!r}")
-        self.assertEqual(rec._issues[0]["lost_caption"], STALE_CAPTION)
-        self.assertIn(STALE_CAPTION, rec._issues[0]["message"])
-        # …and says so, rather than naming a URL it never had.
-        self.assertEqual(rec._issues[0]["url"], "(unknown)")
-        self.assertEqual(rec._caption, "", "the caption survived the load")
-
-    def test_the_lost_line_reaches_the_document_a_reviewer_reads(self):
-        # The consumer's side, end to end: the envelope a take writes, then
-        # the markdown rendered off it. Neither is asked what the recorder
-        # thinks; both are searched for the line that went missing.
-        rec = self.dropped()
-        rec.pause(0)
-        with contextlib.redirect_stderr(io.StringIO()):
-            doc = rec._timeline_doc()
-        self.assertEqual([i["kind"] for i in doc["issues"]], ["caption_lost"])
-        md = render_timeline_md(doc)
-        body = md[md.index("## Issues") :]
-        self.assertIn(STALE_CAPTION, body)
-        self.assertIn(LOADED_URL, body)
+        self.assertEqual(rec._caption, STALE_CAPTION)
 
 
 class WatchedEvents(unittest.TestCase):
@@ -4926,11 +4752,14 @@ class WatchedEvents(unittest.TestCase):
     def test_the_web_recorder_only_adds_to_what_the_base_watches(self):
         # The same claim from the other side, and the one that survives a
         # listener being renamed: the terminal recorder does not override
-        # `_watch_page`, so what it subscribes *is* the base's set.
+        # `_watch_page`, so what it subscribes *is* the base's set. The web
+        # recorder adds exactly #142's kept `framenavigated` — and nothing
+        # else, which since #361 includes *not* the `domcontentloaded` the
+        # caption-clearing machinery used to ride (see CaptionTruth).
         base = set(self.subscribed(TermRec))
         self.assertEqual(
             set(self.subscribed(WebRec)),
-            base | {"framenavigated", "domcontentloaded"},
+            base | {"framenavigated"},
         )
 
     def test_no_page_event_is_subscribed_twice(self):
@@ -5279,23 +5108,21 @@ class WrapperChrome(unittest.TestCase):
             f"unsubstituted chrome tokens reached the page: {sorted(set(leftover))}",
         )
 
-    def test_a_wrapper_take_keeps_the_base_caption_font(self):
-        # The 34px compensation exists because the composite scales the page
-        # by ~0.8; the wrapper page is recorded at true size, so inheriting
-        # it would put visibly oversized captions in the band.
-        self.assertEqual(recorder(self, wrapper=True)._caption_font_px, 26)
-        self.assertEqual(recorder(self)._caption_font_px, 34)
+    def test_a_web_take_keeps_the_base_caption_font(self):
+        # The page is recorded at true pixel size, so the caption is the
+        # declared 26px on screen. The deleted composite compensated its
+        # ~0.8 downscale with 34px (web.py's history note); a web recorder
+        # that grew that back would put visibly oversized captions in the
+        # band, and nothing else pins it.
+        self.assertEqual(recorder(self)._caption_font_px, 26)
 
-    def test_rec_app_is_the_main_frame_until_a_wrapper_take_mounts_its_iframe(self):
-        legacy = recorder(self)
-        legacy.page = types.SimpleNamespace(main_frame="the main frame")
-        self.assertEqual(legacy.app, "the main frame")
-        wrapped = recorder(self, wrapper=True)
+    def test_rec_app_refuses_until_the_take_mounts_its_iframe(self):
+        rec = recorder(self)
         with self.assertRaises(RuntimeError) as caught:
-            wrapped.app  # noqa: B018 - the property's refusal is the claim
+            rec.app  # noqa: B018 - the property's refusal is the claim
         self.assertIn("no app frame yet", str(caught.exception))
-        wrapped._app_frame = "the app frame"
-        self.assertEqual(wrapped.app, "the app frame")
+        rec._app_frame = "the app frame"
+        self.assertEqual(rec.app, "the app frame")
 
     class CaptionSurface(FakePage):
         """A page whose `__demoCaption` reports what the band could not show.
@@ -5322,7 +5149,7 @@ class WrapperChrome(unittest.TestCase):
         # a strict take stayed green — the artifact claiming a line the
         # pixels do not show. The text is deliberately not capped or
         # reflowed; the record is the fix.
-        rec = recorder(self, wrapper=True, page=self.CaptionSurface(34))
+        rec = recorder(self, page=self.CaptionSurface(34))
         rec.caption("a caption far too tall for the band")
         clipped = [i for i in rec._issues if i["kind"] == "caption_clipped"]
         self.assertEqual(len(clipped), 1, rec._issues)
@@ -5335,17 +5162,18 @@ class WrapperChrome(unittest.TestCase):
         self.assertEqual(rec._fatal_count, 0)
 
     def test_a_caption_that_fits_its_band_records_nothing(self):
-        # Both quiet answers: the wrapper surface measuring zero overflow,
-        # and the legacy overlay returning nothing at all.
-        fits = recorder(self, wrapper=True, page=self.CaptionSurface(0))
+        # Both quiet answers: the band measuring zero overflow, and a caption
+        # surface that answers nothing at all (the terminal's in-page overlay
+        # grows with its text and returns no number).
+        fits = recorder(self, page=self.CaptionSurface(0))
         fits.caption("short")
-        legacy = recorder(self)  # FakePage.evaluate returns None
-        legacy.caption("short")
+        silent = recorder(self)  # FakePage.evaluate returns None
+        silent.caption("short")
         self.assertEqual(
             [i for i in fits._issues if i["kind"] == "caption_clipped"], []
         )
         self.assertEqual(
-            [i for i in legacy._issues if i["kind"] == "caption_clipped"], []
+            [i for i in silent._issues if i["kind"] == "caption_clipped"], []
         )
 
     def test_the_card_layer_sits_on_the_slot_and_carries_card_and_scrim(self):
@@ -5413,24 +5241,16 @@ class WrapperChrome(unittest.TestCase):
             f"unsubstituted hold tokens would reach the page: {sorted(set(leftover))}",
         )
 
-    def test_a_wrapper_take_registers_the_hold_script_and_a_legacy_take_none(self):
+    def test_a_web_take_registers_the_opening_hold_script(self):
         # The hold is an init script for _OPENING_CARD_JS's reasons — it has
         # to exist on the wrapper page's initial document, before set_content
-        # — and the legacy composite path must not gain one: its opening is
-        # covered by the ffmpeg overlay, byte-untouched until #361.
-        wrapped = recorder(self, wrapper=True)
+        # replaces it. Exactly one: two registrations would be two elements
+        # racing for one id.
+        rec = recorder(self)
         context = _RecordingContext()
-        wrapped._init_context(context)
+        rec._init_context(context)
         holds = [s for s in context.scripts if "__chrome_hold" in s]
-        self.assertEqual(len(holds), 1, "the wrapper take registers no opening hold")
-        legacy = recorder(self)
-        legacy_context = _RecordingContext()
-        legacy._init_context(legacy_context)
-        self.assertEqual(
-            [s for s in legacy_context.scripts if "__chrome_hold" in s],
-            [],
-            "the legacy path gained an opening-hold init script",
-        )
+        self.assertEqual(len(holds), 1, "the web take registers no opening hold")
 
     class HoldPage(FakePage):
         """A page that remembers every script `evaluate` was handed."""
@@ -5460,7 +5280,7 @@ class WrapperChrome(unittest.TestCase):
         # clear is already down and a re-clear on every goto would be the
         # verb quietly depending on chrome state it does not own.
         page = self.HoldPage()
-        rec = recorder(self, wrapper=True, page=page)
+        rec = recorder(self, page=page)
         rec._app_frame = self.app_frame()
         rec.goto("/")
         self.assertEqual(
@@ -5472,31 +5292,63 @@ class WrapperChrome(unittest.TestCase):
         rec.goto("/second.html")
         self.assertEqual(len(self.clears(page)), 1, "a later goto re-cleared the hold")
 
-    def test_a_legacy_goto_never_touches_the_hold(self):
+    def test_every_goto_takes_the_recorders_cards_down(self):
+        # A full page load used to destroy the card with the app's document,
+        # and SKILL.md's segment pattern leans on it: interlude(...), then
+        # goto() to open on the app. The cards live in the wrapper document
+        # now, so goto clears them deliberately — every goto, because any
+        # full load took a card down on the old path. Seen red in pixels
+        # first: a segment that opened on an interlude recorded the card
+        # over the app to the end of the take (tests/smoke --segments-only,
+        # the recorder's own overlay-left-up warning firing on a take this
+        # suite grades as healthy).
         page = self.HoldPage()
-        page.goto = lambda url, timeout=None: None
-        page.wait_for_load_state = lambda *args, **kwargs: None
-        legacy = recorder(self, page=page)
-        legacy.goto("/")
-        self.assertEqual(self.clears(page), [])
+        rec = recorder(self, page=page)
+        rec._app_frame = self.app_frame()
 
-    def test_a_wrapper_take_does_not_listen_for_a_replaced_document(self):
-        # #360's beat-log honesty: the wrapper document holds the caption and
-        # never navigates, so `caption_lost` cannot happen there — and the
-        # recorder must not even subscribe the signal. Not listening is the
-        # structural form of "this issue can never fire"; a listener that
-        # merely happens never to fire would be an observation about one
-        # Chromium's event routing, one engine bump away from a false loss.
-        wrapped = recorder(self, wrapper=True)
+        def card_clears():
+            return [
+                s
+                for s in page.evaluated
+                if "__demoInterlude('')" in s and "__demoBridge('')" in s
+            ]
+
+        rec.goto("/")
+        self.assertEqual(len(card_clears()), 1, page.evaluated)
+        rec.goto("/second.html")
+        self.assertEqual(len(card_clears()), 2, "a later goto left a card up")
+
+    def test_the_hold_clearing_goto_stamps_the_instant_on_its_own_beat(self):
+        # What the review sheet's opening-hold note reads (frames.py, #361):
+        # the clear's video offset, on the beat that cleared it, and on no
+        # other — a second goto stamping it again would move the note onto
+        # frames recorded long after the hold came down.
+        page = self.HoldPage()
+        rec = recorder(self, page=page)
+        rec._app_frame = self.app_frame()
+        rec.goto("/")
+        rec.goto("/second.html")
+        stamped = [b for b in rec._beats if "opening_hold_until" in b]
+        self.assertEqual(len(stamped), 1, rec._beats)
+        self.assertEqual(stamped[0]["index"], 0)
+        until = stamped[0]["opening_hold_until"]
+        self.assertIsInstance(until, float)
+        self.assertGreaterEqual(until, stamped[0]["t_start"])
+
+    def test_a_web_take_does_not_listen_for_a_replaced_document(self):
+        # #360's beat-log honesty, unconditional since #361: the wrapper
+        # document holds the caption and never navigates, so `caption_lost`
+        # cannot happen — and the recorder must not even subscribe the
+        # signal. Not listening is the structural form of "this issue can
+        # never fire"; a listener that merely happens never to fire would be
+        # an observation about one Chromium's event routing, one engine bump
+        # away from a false loss.
+        rec = recorder(self)
         page = FakePage()
-        wrapped._watch_extra(page)
+        rec._watch_extra(page)
         self.assertNotIn("domcontentloaded", page.subscribed)
-        # #142's kept listener stays on both paths.
+        # #142's kept listener stays.
         self.assertIn("framenavigated", page.subscribed)
-        legacy = recorder(self)
-        legacy_page = FakePage()
-        legacy._watch_extra(legacy_page)
-        self.assertIn("domcontentloaded", legacy_page.subscribed)
 
 
 class VerbTarget(unittest.TestCase):
@@ -5642,6 +5494,9 @@ class ActBeat(unittest.TestCase):
         with target_env(), contextlib.redirect_stderr(io.StringIO()):
             rec = WebRec(tmp.name, speech=False, evidence=True)
         rec.page = EvidencePage()
+        # Evidence reads the app frame, not the wrapper page (#358) — wire
+        # the same surface in as the frame, the way `_start` would.
+        rec._app_frame = rec.page
         rec._t0 = time.monotonic()
         with rec.act(self.LABEL):
             rec.page.evaluate("0")
@@ -5979,54 +5834,35 @@ class CriterionHold(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
-# core.py — which card each medium raises (issue #291)
+# core.py — the interlude card each medium shows (issue #291, then #361)
 # --------------------------------------------------------------------------
 #
 # One stylesheet used to serve both media and it was the terminal's, so on a
-# **web** take the full-screen card was a near-black field inside the recorder's
-# own dark window frame and read as a terminal window rather than as a card over
-# the app. Found by a human watching a demo; no artifact could have said so,
-# because every artifact was right.
+# **web** take the full-screen card was a near-black field inside the
+# recorder's own dark window frame and read as a terminal window rather than
+# as a card over the app (#291) — the fix's history, including the rejected
+# candidates and the #301 encoder compensation the composite needed, is
+# `core.WEB_WINDOW_BODY`'s note. Since #361 there is no per-medium CSS
+# dispatch left to grade: the web card is an element the wrapper document
+# ships in its own card layer, painted from the same `window_body`
+# substitution as the window (`WrapperChrome` pins that wiring; `tests/smoke
+# --wrapper-only`'s check_wrapper_card reads the sameness out of demo.mp4).
+# Core's `_INTERLUDE_JS` only ever *finds* that element and toggles it —
+# the create-if-missing guard below is what keeps the terminal stylesheet it
+# still carries from ever painting on a web take.
 #
-# **The web card is the window's own body colour on screen — and that sentence
-# is about `demo.mp4`, not about these strings, which is why the match is not
-# graded in this file.** Three rounds of candidates were put in front of the
-# person who found #291, and what they asked for was *"the interlude to match
-# the window, without a need for a border of another colour, or an additional
-# edge of a third colour."*
-#
-# The round that answered it by declaring **one** constant for both was rejected
-# too, from a shipped frame: the frame is a Playwright screenshot and the card
-# is inside Playwright's video, so one declared colour arrives in `demo.mp4` as
-# two, five levels of blue apart (#301). So the card declares `WEB_CARD_BODY` —
-# `WEB_WINDOW_BODY` compensated for that extra encoder, by measurement — and
-# **the two declarations differ on purpose**. An equality pinned between them
-# here would have been green on the build the reviewer rejected, which is the
-# whole reason it is gone.
-#
-# What replaces it is a reading of the encoded video, in `tests/smoke`'s
-# `check_criterion_card`: the card's field and the window's pad within 2 levels
-# per channel in `demo.mp4`. That is the property #291 is about, and no
-# browser-free test can hold it.
-#
-# What is graded here is the dispatch and the two palettes — which card a
-# recorder of each medium hands the page, that the terminal's is the value the
-# #110 blend was tuned to, and that the frame is painted from the constant the
-# card's compensation is measured against. **Whether a card reads as a card is
-# not graded anywhere and cannot be**: the same element, text and snapshot are
-# produced either way, and the only difference is a colour a person recognises.
+# What is graded here is what remains browser-free: the terminal palette the
+# #110 blend was tuned to, the init-script/verb agreement a terminal segment
+# opens on, and the guard that makes the base stylesheet inert on a page
+# whose card already exists. **Whether a card reads as a card is not graded
+# anywhere and cannot be**: the same element, text and snapshot are produced
+# either way, and the only difference is a colour a person recognises.
 
-# The two palettes and the window body, hand-written. A bound read off the code
-# being graded agrees with that code whatever it says, and these are the numbers
-# other things were chosen against: `tests/smoke`'s opening-card sweep calls
-# anything under 60 luma "the card" (the terminal one measures 26), and the same
-# file's `WEB_CARD_RGB` is the web one in decimal.
-#
-# `WEB_CARD_PALETTE` is two levels off `WINDOW_BODY` and that is not a typo —
-# see the section header, and `core.WEB_CARD_BODY`.
+# The terminal palette, hand-written. A bound read off the code being graded
+# agrees with that code whatever it says, and this is the number other
+# things were chosen against: `tests/smoke`'s opening-card sweep calls
+# anything under 60 luma "the card", and the terminal one measures 26.
 TERMINAL_CARD_PALETTE = "background: #1c1a17; color: #f7f4ee;"
-WEB_CARD_PALETTE = "background: #181726; color: #f2f0ec;"
-WINDOW_BODY = "#181825"
 
 
 class _RecordingContext:
@@ -6078,27 +5914,31 @@ class InterludePalette(unittest.TestCase):
         """
         return card_css(recorder(self, cls=cls, **settings)._interlude_script())
 
-    def test_a_web_take_raises_the_palette_smoke_grades_in_pixels(self):
-        # The pin, in both directions. `tests/smoke`'s `check_criterion_card`
-        # compares an encoded frame against this colour in decimal, and a
-        # palette changed here and not there turns that check into a reading of
-        # nothing at all.
-        self.assertIn(WEB_CARD_PALETTE, self.css_for(WebRec))
-
-    def test_a_web_take_does_not_raise_the_terminals_card(self):
-        # The defect, exactly: the string the *page* was handed on a web take
-        # carried the terminal palette, so the card was painted the colour of
-        # the recorder's own terminal widgets.
-        self.assertNotIn(TERMINAL_CARD_PALETTE, self.css_for(WebRec))
-
     def test_a_terminal_take_still_raises_the_card_110_was_tuned_to(self):
         # The blend `eca42c5` added is load-bearing on this medium: the card is
         # what a terminal segment *opens* on, covering the recorder's own setup,
-        # and it has to be dark for the same reason the terminal is. This is the
-        # regression half of #291 — the fix is only correct if it left this one
-        # exactly where it was.
+        # and it has to be dark for the same reason the terminal is.
         self.assertIn(TERMINAL_CARD_PALETTE, self.css_for(TermRec))
-        self.assertNotIn(WEB_CARD_PALETTE, self.css_for(TermRec))
+
+    def test_the_base_stylesheet_cannot_paint_where_the_card_already_exists(self):
+        # The wiring that makes `_INTERLUDE_JS`'s terminal stylesheet inert on
+        # a web take: the script builds (and styles) the element only when the
+        # id is missing, and the wrapper document ships it in the card layer
+        # (`WrapperChrome`), so on a web page the script only ever toggles
+        # text and opacity. Drop the guard and every interlude would repaint
+        # the wrapper card as a full-viewport terminal-black field — the #291
+        # regression wearing #361's clothes.
+        script = recorder(self, cls=WebRec)._interlude_script()
+        create = script.index("createElement")
+        guard = script.index("if (!el)")
+        self.assertLess(
+            guard,
+            create,
+            "the interlude script creates its element unguarded, so the "
+            "stylesheet it carries would repaint a card the chrome document "
+            "already ships",
+        )
+        self.assertIn("getElementById", script[:guard])
 
     def test_the_card_a_terminal_segment_opens_on_is_that_same_card(self):
         # Two things build this element, and only one of them is the verb.
@@ -6115,578 +5955,130 @@ class InterludePalette(unittest.TestCase):
         )
         self.assertEqual(card_css(opening[0]), card_css(rec._interlude_script()))
 
-    def test_the_window_body_the_card_is_compensated_against_is_the_one_drawn(self):
-        # **No test in this file asserts that the card matches the window** —
-        # they are two declarations, two levels apart, and equal only after two
-        # different encoders have had them (see the section header). What this
-        # file can hold is the other half: that the window the card was measured
-        # against is still the window `_FRAME_HTML` paints, from the shared
-        # constant rather than from a literal of its own.
-        #
-        # Without it, `tests/smoke`'s card-against-window reading would still be
-        # the check — but a frame repainted from a literal would drift away from
-        # a compensation nobody re-measured, and the only thing to notice would
-        # be a 15-minute arm.
-        import inspect
-
-        import demo_recording.web as web_module
-        from demo_recording.core import WEB_WINDOW_BODY
-        from demo_recording.web import _FRAME_HTML
-
-        self.assertEqual(WEB_WINDOW_BODY, WINDOW_BODY)
-        self.assertIn("background: __WINBG__", _FRAME_HTML)
-        # ...and that the placeholder is filled from the shared constant. A
-        # frame painted from a literal would satisfy both lines above while
-        # drifting away from the card on the next edit, which is the drift the
-        # constant was introduced to close.
-        self.assertIn(
-            '.replace("__WINBG__", WEB_WINDOW_BODY)',
-            inspect.getsource(web_module),
-        )
-
-    def test_the_web_card_is_one_colour_and_draws_no_edge_of_its_own(self):
-        # The reviewer's sentence has three clauses and this is the last two:
-        # *"without a need for a border of another colour, or an additional edge
-        # of a third colour."* #297 shipped an 18 px border in the window's
-        # colour and it was rejected — measured in the encoded frame, that
-        # border and the recorder's own pad are two different colours (#301),
-        # so what reads as one gutter in the stylesheet is two bands on screen.
-        # Neither card declares a border now.
-        self.assertEqual(card_declaration(self.css_for(WebRec), "border"), "")
-        self.assertEqual(card_declaration(self.css_for(TermRec), "border"), "")
-
     def test_the_web_card_is_not_painted_like_the_skills_terminal_widgets(self):
-        # #291's own sentence, and the colour the card collided with is not only
-        # the other card's: `Recorder.terminal()` draws an on-screen terminal
-        # prop *inside a web demo*, and a card matching it reads as that widget
-        # having taken the whole screen over.
+        # #291's own sentence, held on the card the wrapper document ships:
+        # `Recorder.terminal()` draws an on-screen terminal prop *inside a web
+        # demo*, and a card matching it reads as that widget having taken the
+        # whole screen over. The wrapper card paints the window's own body —
+        # asserted here against the prop's palette, wiring-side; the
+        # sameness-with-the-window half is pixels (check_wrapper_card).
+        from demo_recording.core import WEB_WINDOW_BODY
         from demo_recording.web import _TERMINAL_JS
 
-        web = card_background(self.css_for(WebRec))
         self.assertNotIn(
-            web,
+            WEB_WINDOW_BODY,
             _TERMINAL_JS,
-            f"the web interlude card is painted {web}, which is a colour the "
-            f"web recorder's own terminal prop draws with",
+            f"the web card is painted {WEB_WINDOW_BODY}, which is a colour "
+            f"the web recorder's own terminal prop draws with",
         )
 
-    def test_both_cards_are_opaque_and_cover_the_frame_above_the_caption(self):
-        # Not decoration, and not a restatement of the CSS: reference/limits.md
-        # reasons from all three of these — a card that is translucent, inset,
-        # or under the caption bar changes what the picture check can see and
-        # what a caption swap does to it. The two other candidate fixes for #291
-        # (a scrim over the still-visible app; a card inset from the viewport
-        # edge) are ruled out here rather than in a commit message.
-        for medium, cls in (("web", WebRec), ("terminal", TermRec)):
-            with self.subTest(medium=medium):
-                css = self.css_for(cls)
-                self.assertIn("inset: 0", css)
-                self.assertIn("z-index: 2147483647", css)
-                # A flat `#rrggbb` and nothing else: `rgba(...)`, a gradient
-                # with a transparent stop, or a `background` left to the page
-                # are all ways for the app to show through.
-                self.assertRegex(card_background(css), r"^#[0-9a-f]{6}$")
-                # And no rounded corners. Neither card declares a border any
-                # more (the test above), but `border-radius` needs one of its
-                # own: it clips the *background* too, so a radius here puts the
-                # app back on screen at the four corners of the app rect while
-                # the card is up.
-                self.assertEqual(card_declaration(css, "border-radius"), "")
+    def test_the_terminal_card_is_opaque_and_covers_the_frame(self):
+        # Not decoration, and not a restatement of the CSS:
+        # reference/limits.md reasons from all three of these — a card that
+        # is translucent, inset, or under the caption bar changes what the
+        # picture check can see and what a caption swap does to it. The web
+        # card's geometry is the chrome document's card layer, pinned by
+        # `WrapperChrome`; this is the terminal's, the one still built from
+        # this stylesheet.
+        css = self.css_for(TermRec)
+        self.assertIn("inset: 0", css)
+        self.assertIn("z-index: 2147483647", css)
+        # A flat `#rrggbb` and nothing else: `rgba(...)`, a gradient with a
+        # transparent stop, or a `background` left to the page are all ways
+        # for the app to show through.
+        self.assertRegex(card_background(css), r"^#[0-9a-f]{6}$")
+        # No border and no rounded corners: a radius clips the *background*
+        # too, so it would put the app back on screen at the four corners
+        # while the card is up (#297's rejected bordered card).
+        self.assertEqual(card_declaration(css, "border"), "")
+        self.assertEqual(card_declaration(css, "border-radius"), "")
 
 
 # --------------------------------------------------------------------------
-# web.py — which mousemove moves the cursor dot (issue #186)
+# web.py — the recorder drives the cursor dot (#186/#202/#203, class retired)
 # --------------------------------------------------------------------------
 #
-# `Recorder(deterministic=True)` announces "re-recording reproduces the take",
-# and for a storyboard that never moves the pointer that was false about the
-# opening stills. Chromium dispatches one `mousemove` of its own per document,
-# at the widget's initial pointer position — `(0, 0)` on a fresh page — when it
-# recomputes hover state after the first layout. The overlay's handler
-# subscribes at `DOMContentLoaded`, because it needs `document.body`, and which
-# of the two comes first is decided by machine load: eleven takes in twelve
-# under 14-way load had an 18 px dot in the corner of the still and one did
-# not, and two stills that disagree differ in 69 of 921 600 pixels, all of them
-# inside x 0-8, y 0-8 (#185, #186, #188).
-#
-# The overlay refuses a `mousemove` that reports the pointer at the position
-# it was already known to be at. It remembers that position — seeded at
-# `(0, 0)`, where a fresh page's pointer sits and where Chromium's load-time
-# event lands — so the settle event says nothing new and is dropped, while any
-# move the storyboard makes is somewhere the pointer has not been and is drawn.
-#
-# **It reads positions rather than `movementX`/`movementY`, and that is issue
-# #202.** The rule shipped for #186 read the browser's movement delta, which
-# for the *first* mouse event in a page has no previous event to be measured
-# against, and what Chromium substitutes there is a build detail: Chromium 136
-# and 151 measure it from the origin, so a park at (60, 640) reports (60, 640),
-# and Chromium 147 measures it from the event's own position, so the same park
-# reports (0, 0) — identical to the load-time event. On 147 the movement rule
-# therefore threw away the storyboard's own park: `tests/smoke`'s determinism
-# arm went red three ways while CI, which installs whatever Chromium the newest
-# Playwright ships (151 the day this was written), stayed green.
-#
-# What is graded here is the **rule**, read out of the shipped script and run
-# over event *sequences* measured off Chromium rather than imagined. Sequences
-# rather than single events because the rule is now stateful, and because the
-# claim that matters is about a sequence: the two orders in which the load-time
-# event and a storyboard's first move can arrive have to leave the dot in the
-# same place, which is what "the dot's position does not depend on delivery
-# timing" means. A check that restated the rule in Python would agree with
-# itself while the take shipped something else, so the guard is extracted; the
-# JS-to-Python translation is hand-written and deliberately narrow, so a guard
-# written in a form it does not model fails the extraction loudly instead of
-# passing silently, and the two statements the harness *does* model (the seed
-# and the update) are pinned to the shipped text by
-# `test_nothing_moves_the_dot_except_through_the_rule`. What this suite cannot
-# grade — that Chromium's events still look like this, and that two takes
-# therefore produce the same bytes — is stated at the bottom of the file.
+# The composite path's dot was an in-page overlay following `mousemove`
+# events, and #185/#186/#188/#202/#203 were one class: an event the
+# storyboard never sent deciding where the dot is drawn. This file carried a
+# JS-extraction harness that replayed event streams measured off three
+# Chromium builds through the shipped guard. The wrapper cutover (#361)
+# removed the listener wholesale: the dot lives in the wrapper document
+# (chrome.py) and moves only when `_glide` commands it, one explicit update
+# per pointer step — nothing listens, so nothing synthetic can move it, and
+# there is no event rule left to extract. What stays gradeable without a
+# browser is the drive itself, below. The dot's *pixels* — parked where the
+# storyboard parked it, absent before the first pointer verb — are graded by
+# tests/pixel's cursor-parked and cursor-absence goldens on a recorded take.
 
 
-def event(**over: object) -> dict:
-    """One `mousemove` as Chromium delivered it, with every field a guard
-    might plausibly read.
+class CursorDrive(unittest.TestCase):
+    """The wrapper dot is exactly where the storyboard commanded (#202)."""
 
-    Measured with a Playwright probe against `tests/fixture`, not imagined:
-    the settle event arrives at (0, 0) with `movementX`/`movementY` 0,
-    `isTrusted` true, and a `pointermove` and `mouseover` beside it exactly as
-    a real move has. Nothing but the position it reports tells the two apart.
-    """
-    doc = {
-        "type": "mousemove",
-        "isTrusted": True,
-        "clientX": 0,
-        "clientY": 0,
-        "screenX": 0,
-        "screenY": 0,
-        "pageX": 0,
-        "pageY": 0,
-        "movementX": 0,
-        "movementY": 0,
-        "buttons": 0,
-        "detail": 0,
-    }
-    doc.update(over)
-    return doc
+    class PointerPage(FakePage):
+        """A page that remembers the pointer moves and the dot commands."""
 
-
-# The event the race is about, and the only one the storyboard did not ask for.
-SETTLE_EVENT = event()
-
-# Where `tests/smoke`'s determinism storyboard parks the pointer with a raw
-# `page.mouse.move`, and the position the same event reports when Chromium's
-# hover recompute arrives *after* the park instead of before it.
-PARKED = (60, 640)
-
-# The same park, as the three browsers this was measured on report it when it
-# is the first mouse event in the page. The dot has to end up at PARKED in all
-# three: what the movement fields say about a move the storyboard actually made
-# is the browser's business, and #202 is what reading them cost.
-FIRST_MOVE_SHAPES = [
-    (
-        "Chromium 136 and 151, which measure the first delta from the origin",
-        event(clientX=60, clientY=640, movementX=60, movementY=640),
-    ),
-    (
-        "Chromium 147, which measures it from the event's own position",
-        event(clientX=60, clientY=640, movementX=0, movementY=0),
-    ),
-    (
-        "an engine that implements no movementX at all",
-        event(clientX=60, clientY=640, movementX=None, movementY=None),
-    ),
-]
-
-# What a real glide is made of. The diagonal is the first step of `move_to`'s
-# 30-step move; the axis-aligned two are what a glide along a row or a column
-# produces, and they are why the rule is "the same position on *both* axes"
-# rather than "on one of them" — a guard joined with `||` would freeze the dot
-# for every horizontal drag across a toolbar.
-REAL_MOVES = [
-    (
-        "a diagonal glide step",
-        event(clientX=150, clientY=150, movementX=150, movementY=150),
-    ),
-    (
-        "a horizontal glide step",
-        event(clientX=310, clientY=150, movementX=160, movementY=0),
-    ),
-    (
-        "a vertical glide step",
-        event(clientX=310, clientY=400, movementX=0, movementY=250),
-    ),
-]
-
-# The JS the guard may be written in, translated one form at a time. `!==`
-# before `!`, or the `!=` it just produced would become `not =`.
-_JS_GUARD_RE = re.compile(r"if \((?P<cond>[^)]*(?:\([^)]*\))?[^)]*)\) return;")
-_JS_TOKEN = re.compile(
-    r"e\.[A-Za-z]+|at[XY]\b|-?\d+(?:\.\d+)?|==|!=|and\b|or\b|not\b|[()\s]"
-)
-# The remembered position, as the overlay declares it. Read rather than
-# assumed: a seed anywhere other than where the pointer starts would either
-# let the load-time event through (#186) or swallow a real move.
-_JS_SEED_RE = re.compile(r"let atX = (-?\d+), atY = (-?\d+);")
-# What the overlay puts off until the document has a `<body>` to hang the dot
-# on. Everything else in the script runs at `document_start`, and issue #203 is
-# the difference: a rule about `mousemove` grades nothing while nothing is
-# subscribed, and a move dispatched before `DOMContentLoaded` has no
-# replacement — the pointer is where it was asked to be, so the browser never
-# reports it again.
-_JS_DEFER_RE = re.compile(r"document\.addEventListener\('DOMContentLoaded', (\w+)\)")
-
-
-class _JsEvent:
-    """An event object the translated guard can read fields off."""
-
-    def __init__(self, fields: dict) -> None:
-        self.__dict__.update(fields)
-
-
-def cursor_mousemove_body() -> str:
-    """The body of the overlay's `mousemove` listener, as shipped."""
-    opening = "window.addEventListener('mousemove'"
-    if opening not in _CURSOR_JS:
-        raise AssertionError(
-            "the cursor overlay no longer subscribes to mousemove under the "
-            "name this suite looks for, so nothing below graded the rule that "
-            "decides where the dot is drawn"
-        )
-
-    start = _CURSOR_JS.index(opening)
-    return _CURSOR_JS[start : _CURSOR_JS.index("}, true);", start)]
-
-
-def cursor_guard_py() -> str:
-    """The condition the overlay refuses a `mousemove` under, in Python."""
-    found = _JS_GUARD_RE.findall(cursor_mousemove_body())
-    if len(found) != 1:
-        raise AssertionError(
-            f"the mousemove handler holds {len(found)} early-return guards, "
-            f"expected exactly 1 — with none, every event Chromium dispatches "
-            f"moves the dot, including the one it sends at load (#186)"
-        )
-    expr = found[0].replace("!==", "!=").replace("===", "==")
-    expr = re.sub(r"!(?!=)", "not ", expr)
-    expr = expr.replace("&&", " and ").replace("||", " or ")
-    residue = _JS_TOKEN.sub("", expr).strip()
-    if residue:
-        raise AssertionError(
-            f"the guard {found[0]!r} is written in a form this suite cannot "
-            f"evaluate (left over: {residue!r}). Extend the translation, or "
-            f"grade the new form in a browser — do not delete the check"
-        )
-    return expr
-
-
-def cursor_seed() -> tuple[int, int]:
-    """The pointer position the overlay starts a document believing in."""
-    found = _JS_SEED_RE.findall(_CURSOR_JS)
-    if len(found) != 1:
-        raise AssertionError(
-            f"the cursor overlay declares its remembered pointer position "
-            f"{len(found)} times, expected exactly 1 — this suite reads the "
-            f"seed out of the script rather than assuming it, because a seed "
-            f"anywhere but where the pointer starts either lets Chromium's "
-            f"load-time event through (#186) or swallows a real move (#202)"
-        )
-    return int(found[0][0]), int(found[0][1])
-
-
-def _js_block(text: str, start: int) -> str:
-    """The source between an already-opened `{` and the `}` that closes it.
-
-    Template literals are skipped whole rather than scanned: the overlay's
-    stylesheet lives in one, and a counter that read its braces would close
-    the function early and hand every assertion below a slice of CSS.
-    """
-    depth, i = 1, start
-    while i < len(text):
-        ch = text[i]
-        if ch in "'\"":
-            i += 1
-            while i < len(text) and text[i] != ch:
-                i += 2 if text[i] == "\\" else 1
-        elif ch == "`":
-            i += 1
-            while i < len(text) and text[i] != "`":
-                if text[i] == "$" and text[i + 1 : i + 2] == "{":
-                    raise AssertionError(
-                        "the cursor overlay interpolates into a template "
-                        "literal; this reader skips template literals whole "
-                        "and would mis-count the braces inside one"
-                    )
-                i += 2 if text[i] == "\\" else 1
-        elif ch == "{":
-            depth += 1
-        elif ch == "}":
-            depth -= 1
-            if depth == 0:
-                return text[start:i]
-        i += 1
-    raise AssertionError(
-        "the cursor overlay has an unbalanced block, so nothing below could "
-        "read what it defers to DOMContentLoaded"
-    )
-
-
-def cursor_deferred_body() -> str:
-    """The part of the overlay that does not run until `DOMContentLoaded`."""
-    found = _JS_DEFER_RE.findall(_CURSOR_JS)
-    if len(found) != 1:
-        raise AssertionError(
-            f"the cursor overlay defers {len(found)} functions to "
-            f"DOMContentLoaded, expected exactly 1 — this suite reads the "
-            f"deferred region out of the script rather than assuming it, "
-            f"because what is inside it is unreachable to a pointer move "
-            f"dispatched earlier in the document (#203)"
-        )
-    opening = f"const {found[0]} = () => {{"
-    if opening not in _CURSOR_JS:
-        raise AssertionError(
-            f"the overlay defers {found[0]!r} to DOMContentLoaded but does not "
-            f"declare it as `{opening}`, so this suite cannot say what runs "
-            f"late and what runs at document_start (#203)"
-        )
-    return _js_block(_CURSOR_JS, _CURSOR_JS.index(opening) + len(opening))
-
-
-class CursorMotion(unittest.TestCase):
-    """Which `mousemove` moves the recorder's cursor dot (#186, #202)."""
-
-    def dot_trail(self, events: list[dict]) -> list[tuple[int, int] | None]:
-        """Run a document's `mousemove` stream through the shipped rule.
-
-        Returns where the dot stands after *each* event — `None` while the
-        overlay has never moved it, which is the stylesheet's off-screen park
-        and what a take that never moves the pointer has to show. Per event
-        rather than at the end: a rule that drops a glide's middle steps and
-        catches up on the last one lands the dot in the right place having
-        shown the wrong motion, and the cursor exists to be watched moving.
-        """
-        expr = cursor_guard_py()
-        at_x, at_y = cursor_seed()
-        drawn: tuple[int, int] | None = None
-        trail: list[tuple[int, int] | None] = []
-        for fields in events:
-            scope = {"e": _JsEvent(fields), "atX": at_x, "atY": at_y}
-            try:
-                refused = bool(eval(expr, {"__builtins__": {}}, scope))
-            except AttributeError as exc:
-                self.fail(
-                    f"the guard {expr!r} reads an event field this suite does "
-                    f"not model ({exc}) — add it to `event()` with the value "
-                    f"Chromium measured, rather than dropping the assertion"
-                )
-            if not refused:
-                # The two statements the shipped handler runs next, and the
-                # only part of it this harness restates. `test_nothing_moves_
-                # the_dot_except_through_the_rule` pins them to the script's
-                # own text.
-                at_x, at_y = fields["clientX"], fields["clientY"]
-                drawn = (at_x, at_y)
-            trail.append(drawn)
-        return trail
-
-    def test_the_rule_is_one_condition_that_reads_the_event(self):
-        # The control. Every assertion below is "the dot ended up at X after
-        # this stream", and all of them are satisfied by a guard that says
-        # nothing about the event — so what the guard is, and that it reads
-        # both the event and the position the overlay remembers, is graded
-        # first and separately.
-        expr = cursor_guard_py()
-        self.assertIn(
-            "e.",
-            expr,
-            f"the guard {expr!r} never reads the event, so which mousemove "
-            f"moves the dot is not decided by the mousemove",
-        )
-        self.assertTrue(
-            "atX" in expr or "atY" in expr,
-            f"the guard {expr!r} never reads the position the overlay "
-            f"remembers, so it cannot be telling an event that reports a new "
-            f"position from one that repeats the old one (#186, #202)",
-        )
-
-    def test_what_the_overlay_defers_to_domcontentloaded_is_the_insertion(self):
-        # The control for the assertion below, which is "X is *not* in this
-        # string" and would be satisfied just as happily by an extraction that
-        # returned an empty one. What is legitimately late is putting the dot
-        # and its stylesheet in the document, because neither can happen
-        # before there is a `<body>` and a `<head>` to put them in.
-        deferred = cursor_deferred_body()
-        for statement in (
-            "document.head.appendChild(style);",
-            "document.body.appendChild(dot);",
-        ):
-            self.assertIn(
-                statement,
-                deferred,
-                f"the overlay never runs `{statement}` at DOMContentLoaded, so "
-                f"either the dot is never put on the page — no cursor in any "
-                f"take — or this suite is reading the wrong region and the "
-                f"assertion below grades nothing (#203)",
+        def __init__(self) -> None:
+            super().__init__()
+            self.pointer: list[tuple[float, float]] = []
+            self.dot: list[tuple[float, float]] = []
+            self.squeezed: list[str] = []
+            self.mouse = types.SimpleNamespace(
+                move=lambda x, y, steps=1: self.pointer.append((x, y))
             )
 
-    def test_the_pointer_is_listened_for_before_the_document_has_loaded(self):
-        # #203. `attach` cannot run before `document.body` exists, so a
-        # `mousemove` dispatched earlier in the document is delivered to
-        # whatever was subscribed *then* — and with the subscription inside
-        # `attach` that was nothing at all. Nothing replaces it either: the
-        # pointer is already where the storyboard put it, so the browser has
-        # no reason to report it again, and the dot sits at the stylesheet's
-        # off-screen park for the rest of the document. Reachable only by
-        # combining `goto(..., wait_until="commit")` with a raw
-        # `page.mouse.move`, and neither of those two is documented — what
-        # SKILL.md documents is `rec.page` itself, as the escape hatch. #202's
-        # determinism arm uses the raw move but parks *after* `Recorder.goto()`,
-        # which waits for `load`, so that arm never reaches this.
-        #
-        # So the subscription is established while the init script is
-        # evaluated, and the element it writes to is created there too; only
-        # the insertion waits. A detached div keeps the inline `left`/`top` a
-        # handler wrote on it, so the dot enters the document already standing
-        # where the pointer went.
-        deferred = cursor_deferred_body()
-        self.assertNotIn(
-            "addEventListener(",
-            deferred,
-            "the overlay subscribes to pointer events inside the function it "
-            "defers to DOMContentLoaded, so a move dispatched before the "
-            "document finished loading is delivered to no handler and no later "
-            "event replaces it — the dot stays off screen for the whole take "
-            "(#203)",
-        )
+        def evaluate(self, script, *args):
+            text = str(script)
+            if "__demoChromeCursor(" in text and args:
+                self.dot.append(tuple(args[0]))
+            elif "__demoChromeCursorDown" in text:
+                self.squeezed.append("down")
+            elif "__demoChromeCursorUp" in text:
+                self.squeezed.append("up")
+            return None
 
-    def test_chromiums_load_time_hover_event_does_not_move_the_dot(self):
-        self.assertEqual(
-            self.dot_trail([SETTLE_EVENT]),
-            [None],
-            "the overlay draws the dot for the mousemove Chromium dispatches "
-            "at load, at the position the pointer already had, so whether an "
-            "18 px dot is burned into the corner of a take's opening stills is "
-            "decided by machine load and not by the storyboard (#186)",
-        )
+    def glided(self, *to, steps):
+        page = self.PointerPage()
+        rec = recorder(self, page=page)
+        for target in to:
+            rec._glide(*target, steps=steps)
+        return rec, page
 
-    def test_the_storyboards_own_park_moves_the_dot_on_every_engine(self):
-        # #202. A raw `page.mouse.move` — the documented escape hatch, and what
-        # smoke's determinism arm uses — is often the first mouse event in the
-        # page, and what the browser reports for its movement is a build
-        # detail. Whether the cursor appears in the recording at all must not
-        # be.
-        #
-        # The second shape is the same event a park *after a navigation*
-        # produces on every build: the pointer is already where the storyboard
-        # is putting it, so nothing moves, but the new document's dot is a new
-        # element parked off screen that nothing else will ever place. There is
-        # no separate test for it because the overlay sees the same event, and
-        # an assertion that cannot fail independently is decoration; it was
-        # measured in a browser instead — Chromium 151, movement rule, dot off
-        # screen in 4 takes of 4.
-        for engine, park in FIRST_MOVE_SHAPES:
-            with self.subTest(engine):
-                self.assertEqual(
-                    self.dot_trail([park]),
-                    [PARKED],
-                    f"on {engine}, the overlay drops the storyboard's own park "
-                    f"at {PARKED} because of what that engine reports about "
-                    f"it — so every take driving page.mouse directly records "
-                    f"no cursor at all (#202)",
-                )
+    def test_the_dot_rides_every_pointer_step_and_ends_at_the_target(self):
+        # One dot command per pointer step, at the same coordinate — the dot
+        # cannot trail the pointer or jump ahead of it, because the recorder
+        # is the only writer of both.
+        rec, page = self.glided((60, 640), steps=4)
+        self.assertEqual(len(page.pointer), 4)
+        self.assertEqual(page.dot, page.pointer)
+        self.assertEqual(page.dot[-1], (60.0, 640.0))
+        self.assertEqual(rec._cursor_at, (60.0, 640.0))
 
-    def test_both_orders_of_the_load_event_leave_the_dot_in_one_place(self):
-        # The determinism claim in the rule's own terms, and the reason the
-        # race is *removed* rather than made less likely: Chromium's hover
-        # recompute can land before the park (at the origin) or after it (at
-        # the position the park moved the pointer to), and the storyboard
-        # cannot control which. Both have to end at the parked position.
-        _, park = FIRST_MOVE_SHAPES[1]
-        settled_after = event(clientX=60, clientY=640, movementX=0, movementY=0)
-        for order, stream in (
-            ("the settle event first", [SETTLE_EVENT, park]),
-            ("the park first", [park, settled_after]),
-        ):
-            with self.subTest(order):
-                self.assertEqual(
-                    self.dot_trail(stream)[-1],
-                    PARKED,
-                    f"with {order}, the dot ends up somewhere other than the "
-                    f"{PARKED} the storyboard parked the pointer at — so which "
-                    f"of the two arrives first decides what the take shows, "
-                    f"which is the race itself (#186, #202)",
-                )
+    def test_a_second_glide_starts_from_the_last_commanded_position(self):
+        # `_cursor_at` is the seed: a glide that forgot it would sweep in
+        # from the origin on every move, which is motion the storyboard
+        # never asked for.
+        rec, page = self.glided((60.0, 640.0), (100.0, 640.0), steps=2)
+        self.assertEqual(page.dot[-2], (80.0, 640.0))
+        self.assertEqual(page.dot[-1], (100.0, 640.0))
 
-    def test_every_real_move_moves_the_dot(self):
-        # A glide as one stream, graded step by step: a rule that dropped the
-        # steps along a row would leave the dot in the right final place having
-        # skipped half the motion, and the cursor exists to be watched moving.
-        self.assertEqual(
-            self.dot_trail([fields for _, fields in REAL_MOVES]),
-            [(f["clientX"], f["clientY"]) for _, f in REAL_MOVES],
-            "the overlay drops steps of a glide "
-            f"({', '.join(what for what, _ in REAL_MOVES)}), so the cursor "
-            f"stops following the pointer it exists to stand in for",
-        )
+    def test_nothing_but_a_glide_moves_the_dot(self):
+        # The structural end of the #186 class: with no glide commanded, no
+        # dot command reaches the page whatever events the browser delivers —
+        # there is no subscription for them to land in.
+        page = self.PointerPage()
+        rec = recorder(self, page=page)
+        rec._watch_page(page)
+        page.fire("framenavigated", FakeFrame())
+        self.assertEqual(page.dot, [])
+        self.assertEqual(rec._cursor_at, (0.0, 0.0))
 
-    def test_the_remembered_position_is_where_the_pointer_starts(self):
-        # The seed is the whole of why the load-time event is ignorable. At
-        # anything else, either that event reports a "new" position and the
-        # dot lands in the corner (#186), or a real move to the seed is
-        # swallowed.
-        self.assertEqual(
-            cursor_seed(),
-            (0, 0),
-            f"the overlay starts a document believing the pointer is at "
-            f"{cursor_seed()}, but a fresh page's pointer is at (0, 0) and "
-            f"that is where Chromium's load-time mousemove reports it (#186)",
-        )
-
-    def test_nothing_moves_the_dot_except_through_the_rule(self):
-        # A second positioning path — a `pointermove` listener added beside
-        # this one, a `mouseover` that snaps the dot into place — would restore
-        # the race while every assertion above stayed green. The update of the
-        # remembered position is pinned here too, because `dot_trail` models
-        # it: if the script stopped doing it, the harness would keep simulating
-        # a rule the take no longer ships.
-        body = cursor_mousemove_body()
-        for statement in ("atX = e.clientX;", "atY = e.clientY;"):
-            self.assertIn(
-                statement,
-                body,
-                f"the mousemove handler never runs `{statement}`, so the "
-                f"position it compares the next event against is not the "
-                f"position this event reported — the rule this suite "
-                f"evaluates is not the rule the take ships (#202)",
-            )
-            self.assertLess(
-                body.index("return;"),
-                body.index(statement),
-                f"`{statement}` runs before the rule decides whether this "
-                f"event should move the dot, so an ignored event still "
-                f"rewrites the position every later event is compared to",
-            )
-        for property_ in ("dot.style.left", "dot.style.top"):
-            self.assertEqual(
-                _CURSOR_JS.count(property_),
-                1,
-                f"{property_} is written in {_CURSOR_JS.count(property_)} "
-                f"places in the cursor overlay; only the guarded mousemove "
-                f"handler may position the dot (#186)",
-            )
-            self.assertIn(property_, body)
-            self.assertIn(
-                "return;",
-                body,
-                "the mousemove handler positions the dot with no early return "
-                "in front of it, so every event Chromium dispatches moves it — "
-                "including the one it sends at load (#186)",
-            )
-            self.assertLess(
-                body.index("return;"),
-                body.index(property_),
-                "the dot is positioned before the rule that decides whether "
-                "this event should move it, so the rule changes nothing",
-            )
+    def test_the_dot_squeezes_on_press_and_releases_after(self):
+        page = self.PointerPage()
+        rec = recorder(self, page=page)
+        rec._cursor_pressed(True)
+        rec._cursor_pressed(False)
+        self.assertEqual(page.squeezed, ["down", "up"])
 
 
 # --------------------------------------------------------------------------
@@ -7381,6 +6773,50 @@ def reader_correction(doc: dict, beat: dict) -> float:
         for step in record.get("steps") or []
         if step.get("segment") == beat.get("segment") and step["t"] <= beat["t_start"]
     )
+
+
+class StitchedHold(unittest.TestCase):
+    """The hold-clear instant rides the merge with its beat (#361).
+
+    `opening_hold_until` is a video offset like `t_start`, and the review
+    sheet's opening-hold note reads it (frames.py) — a merged timeline that
+    kept it on the segment's own clock would name part one's frames as
+    sitting under part two's hold.
+    """
+
+    def test_the_hold_instant_is_shifted_with_its_beat(self):
+        names = ["part1", "part2"]
+        docs = [
+            {
+                "recorder": "Recorder",
+                "segment": name,
+                "beats": [
+                    {
+                        "index": 0,
+                        "segment": name,
+                        "verb": "goto",
+                        "t_start": 0.2,
+                        "t_end": 1.4,
+                        "opening_hold_until": 1.4,
+                    }
+                ],
+            }
+            for name in names
+        ]
+        doc = _merged_timeline(
+            names,
+            [Path(f"{name}.seg.mp4") for name in names],
+            docs,
+            [10.0, 8.0],
+            Path("demo.mp4"),
+        )
+        stamped = [b for b in doc["beats"] if "opening_hold_until" in b]
+        self.assertEqual(
+            [(b["segment"], b["opening_hold_until"]) for b in stamped],
+            [("part1", 1.4), ("part2", 11.4)],
+        )
+        # …and on the same clock as the beat that carries it.
+        self.assertEqual(stamped[1]["t_end"], 11.4)
 
 
 class MergedCaptureClock(unittest.TestCase):
@@ -8609,6 +8045,126 @@ class FrameDedupe(unittest.TestCase):
         self.assertEqual(len(argv), 1)
         self.assertIn("scale='min(1024,iw)':-1", argv[0])
         self.assertEqual(argv[0][argv[0].index("scale='min(1024,iw)':-1") - 1], "-vf")
+
+
+class OpeningHoldOnTheSheet(unittest.TestCase):
+    """The sheet names the frames cut inside the wrapper's opening hold (#361).
+
+    A web take's first `goto()` clears the opening hold at its end and stamps
+    `opening_hold_until` on its own beat (web.py), so that beat's mid-point
+    review frame shows a flat field in the window's colour where the app will
+    be. A sheet that leaves that to the reader reads as a failed load — the
+    #367 review met exactly that frame. Same named-not-counted style as
+    `scene_search_skipped`: the reader's question is which frame is the hold,
+    and a count does not answer it.
+    """
+
+    def sheet(self, doc: dict) -> dict:
+        def extract(mp4: Path, at: float, path: Path) -> bool:
+            path.write_bytes(path.name.encode())
+            return True
+
+        out_dir = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, out_dir, ignore_errors=True)
+        (out_dir / "demo.mp4").write_bytes(b"a stand-in for a recording")
+        was = (
+            frames_module._extract,
+            frames_module.scene_times,
+            frames_module._frame_mse,
+        )
+        frames_module._extract = extract
+        frames_module.scene_times = lambda *a, **k: []
+        frames_module._frame_mse = lambda kept, candidate: 1e6
+        try:
+            return beat_frames(out_dir, doc)
+        finally:
+            (
+                frames_module._extract,
+                frames_module.scene_times,
+                frames_module._frame_mse,
+            ) = was
+
+    def test_the_frames_cut_inside_the_hold_are_named_on_the_sheet(self):
+        # The goto runs 0.2-3.0s and clears the hold at its end; its mid-point
+        # frame (1.6s) is inside the hold, the later caption's is not.
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record(),
+            beats=[
+                beat(0, "goto", 0.2, t_end=3.0, opening_hold_until=3.0),
+                beat(1, "caption", 5.0),
+            ],
+        )
+        manifest = self.sheet(doc)
+        self.assertEqual(
+            manifest["opening_hold"],
+            [{"until": 3.0, "frames": ["beat-00.png"]}],
+        )
+        text = render_frames_md(manifest)
+        self.assertIn("`beat-00.png`", text)
+        self.assertIn("opening hold", text)
+        self.assertIn("until 3.00s", text)
+        # Named, not counted — the caption's frame is not swept into it.
+        hold_line = next(line for line in text.splitlines() if "opening hold" in line)
+        self.assertNotIn("beat-01.png", hold_line)
+
+    def test_a_take_with_no_hold_says_nothing(self):
+        # The healthy silence: a note on every sheet is a note nobody reads.
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record(),
+            beats=[beat(0, "goto", 0.2), beat(1, "caption", 5.0)],
+        )
+        manifest = self.sheet(doc)
+        self.assertEqual(manifest["opening_hold"], [])
+        self.assertNotIn("opening hold", render_frames_md(manifest))
+
+    def test_a_frame_after_the_hold_cleared_is_not_flagged(self):
+        # The goto's own frame lands after the clear (mid-point 2.0s, hold
+        # gone by 1.5s): nothing on the sheet is inside the hold, and a note
+        # naming no frame would be the confident wrong caption in miniature.
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record(),
+            beats=[
+                beat(0, "goto", 1.5, t_end=2.5, opening_hold_until=1.5),
+                beat(1, "caption", 5.0),
+            ],
+        )
+        manifest = self.sheet(doc)
+        self.assertEqual(manifest["opening_hold"], [])
+
+    def test_a_merged_sheet_scopes_each_hold_to_its_own_segment(self):
+        # stitch() shifts opening_hold_until with the beat, so part2's hold
+        # ends at 12.0s of the joined video — and part1's 5.0s frame, though
+        # earlier than that instant, was never under part2's hold.
+        doc = envelope(
+            duration=20.0,
+            capture_clock=clock_record(),
+            beats=[
+                beat(
+                    0, "goto", 0.2, t_end=1.0, opening_hold_until=1.0, segment="part1"
+                ),
+                beat(1, "caption", 5.0, segment="part1"),
+                beat(
+                    2,
+                    "goto",
+                    10.5,
+                    t_end=12.0,
+                    opening_hold_until=12.0,
+                    segment="part2",
+                ),
+                beat(3, "caption", 14.0, segment="part2"),
+            ],
+        )
+        manifest = self.sheet(doc)
+        self.assertEqual(
+            manifest["opening_hold"],
+            [
+                {"until": 1.0, "frames": ["beat-00.png"]},
+                {"until": 12.0, "frames": ["beat-02.png"]},
+            ],
+        )
 
 
 class TimelineClockNote(unittest.TestCase):
@@ -11394,73 +10950,6 @@ class ExitStatus(_GradeCase):
 
 # --------------------------------------------------------------------------
 
-# Issue #203, as the overlay shipped before it was fixed and after it was.
-# Nothing below is rewritten by hand: the two are the same region of
-# `_CURSOR_JS` — from the dot's creation to its insertion — in the two orders,
-# and swapping them puts the pointer subscriptions back inside the function
-# that cannot run until `document.body` exists. A `mousemove` dispatched
-# before that is then delivered to no handler, and no later event replaces it:
-# measured against `tests/fixture` with `goto(wait_until="commit")` and a raw
-# `page.mouse.move`, Chromium 147 placed the dot in 2 takes of 4 and left it
-# off screen in the other 2.
-#
-# Written out in full rather than as a one-line edit because there is no
-# one-line version: the fix *is* the order, and an injection that only looked
-# like it would leave the suite grading a script nobody ships.
-_CURSOR_LISTENS_AT_DOCUMENT_START = """\
-  const dot = document.createElement('div');
-  dot.id = '__demo_cursor';
-  let atX = 0, atY = 0;
-  window.addEventListener('mousemove', (e) => {
-    if (e.clientX === atX && e.clientY === atY) return;
-    atX = e.clientX;
-    atY = e.clientY;
-    dot.style.left = e.clientX + 'px';
-    dot.style.top = e.clientY + 'px';
-  }, true);
-  window.addEventListener('mousedown', () => dot.classList.add('__down'), true);
-  window.addEventListener('mouseup', () => dot.classList.remove('__down'), true);
-  const attach = () => {
-    if (document.getElementById('__demo_cursor')) return;
-    const style = document.createElement('style');
-    style.textContent = `
-      #__demo_cursor { position: fixed; top: -40px; left: -40px; width: 18px;
-        height: 18px; border-radius: 50%; background: rgba(__ACCENT__,.45);
-        border: 2px solid rgba(__ACCENT__,.95); pointer-events: none;
-        z-index: 2147483647; transform: translate(-50%,-50%);
-        transition: width .1s, height .1s; }
-      #__demo_cursor.__down { width: 12px; height: 12px; }
-    `;
-    document.head.appendChild(style);
-    document.body.appendChild(dot);"""
-
-_CURSOR_LISTENS_AT_DOMCONTENTLOADED = """\
-  const attach = () => {
-    if (document.getElementById('__demo_cursor')) return;
-    const style = document.createElement('style');
-    style.textContent = `
-      #__demo_cursor { position: fixed; top: -40px; left: -40px; width: 18px;
-        height: 18px; border-radius: 50%; background: rgba(__ACCENT__,.45);
-        border: 2px solid rgba(__ACCENT__,.95); pointer-events: none;
-        z-index: 2147483647; transform: translate(-50%,-50%);
-        transition: width .1s, height .1s; }
-      #__demo_cursor.__down { width: 12px; height: 12px; }
-    `;
-    document.head.appendChild(style);
-    const dot = document.createElement('div');
-    dot.id = '__demo_cursor';
-    document.body.appendChild(dot);
-    let atX = 0, atY = 0;
-    window.addEventListener('mousemove', (e) => {
-      if (e.clientX === atX && e.clientY === atY) return;
-      atX = e.clientX;
-      atY = e.clientY;
-      dot.style.left = e.clientX + 'px';
-      dot.style.top = e.clientY + 'px';
-    }, true);
-    window.addEventListener('mousedown', () => dot.classList.add('__down'), true);
-    window.addEventListener('mouseup', () => dot.classList.remove('__down'), true);"""
-
 # (name, module, exact text to replace, replacement, tests that must then fail)
 INJECTIONS = [
     # -- the pixel loop's cache key (tests/pixel, #350) -----------------------
@@ -13959,121 +13448,24 @@ INJECTIONS = [
         ],
     ),
     (
-        # Issue #134: the caption bar dies with the document, the recorder's
-        # copy of it does not, and every later beat reports a line that is not
-        # on screen into a committed timeline.
-        "a document load stops invalidating the caption",
+        # #134's clearing machinery grown back: a document-load subscription
+        # that clears the recorder's caption again. On the wrapper path the
+        # line is still on screen — the wrapper document never navigated —
+        # so every beat after the load would report an empty caption over
+        # pixels that show one, which is the old lie pointing the other way
+        # (#361).
+        "the caption-clearing document-load subscription grows back",
         "web.py",
-        '        lost, self._caption = self._caption, ""',
-        "        lost = self._caption  # the recorder keeps what the document took",
+        '        page.on("framenavigated", self._note_navigation)',
+        '        page.on("framenavigated", self._note_navigation)\n'
+        "        page.on(\n"
+        '            "domcontentloaded",\n'
+        '            lambda page: setattr(self, "_caption", ""),\n'
+        "        )",
         [
-            "CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption",
-            "MeasuredNavigations.test_every_measured_document_load_takes_the_line_off_the_beat_log",
-            "MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat",
-        ],
-    ),
-    (
-        # Issue #214: the clear is right and lands one beat too late. A click
-        # returns after `framenavigated` alone, so the beat that follows it
-        # inherits a caption the document event — still in the connection —
-        # is about to take away.
-        "a beat stops asking the page before it stamps the line it inherited",
-        "core.py",
-        "            self._pump_events(force=True)\n"
-        '            record["caption"] = self._caption\n',
-        "            pass  # the beat keeps whatever line it inherited\n",
-        [
-            "MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat"
-        ],
-    ),
-    (
-        # The `force` on its own, which is the whole difference between the
-        # pump landing and not: `click()` holds for 0.4 s before it clicks, so
-        # the interval `_idle` pumps on is a millisecond old when the next
-        # beat opens and would skip exactly the beat that needed it.
-        "the pump at beat open goes back to being rate-limited",
-        "core.py",
-        "            self._pump_events(force=True)",
-        "            self._pump_events()",
-        [
-            "MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat"
-        ],
-    ),
-    (
-        # The measured fact the whole of #214 rests on, graded from its own
-        # side: a click returns *before* the document event. A table that said
-        # otherwise would leave the deferral in the test delivering nothing
-        # late, and "the beat after the click is clean" would be graded
-        # against a caption that was already gone when the beat opened.
-        "a click is filed as having delivered the document event before it returned",
-        "tests/unit",
-        '        "link_click",\n'
-        "        'click(\"#link\") on an <a href> to another document',\n"
-        '        [("framenavigated", _MAIN), ("domcontentloaded", _PAGE), ("load", _PAGE)],\n'
-        "        1,\n",
-        '        "link_click",\n'
-        "        'click(\"#link\") on an <a href> to another document',\n"
-        '        [("framenavigated", _MAIN), ("domcontentloaded", _PAGE), ("load", _PAGE)],\n'
-        "        2,\n",
-        [
-            "MeasuredNavigations.test_a_load_the_verb_did_not_wait_for_reaches_the_log_in_the_same_beat"
-        ],
-    ),
-    (
-        # The handler can be right and reachable by nothing.
-        "nothing subscribes to the document being replaced",
-        "web.py",
-        '        page.on("domcontentloaded", self._note_document_replaced)',
-        "        pass  # no subscription",
-        # Not the same-document sweep: `framenavigated` is still subscribed,
-        # so its control (`replay` reached a handler) still holds and the
-        # caption still survives. Listing it here would be a claim this
-        # injection does not support.
-        [
-            "CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption",
-            "MeasuredNavigations.test_every_measured_document_load_takes_the_line_off_the_beat_log",
-        ],
-    ),
-    (
-        # **Issue #179's injection.** The event name is the whole decision,
-        # and until the streams in `NAVIGATIONS` were measured off a browser
-        # nothing here could tell the two apart: `CaptionTruth` fires the
-        # event it is unsure about, so it goes green against either name.
-        # This is caught now because a real Chromium sends `framenavigated`
-        # for a pushState route change and no document event at all, so the
-        # clear lands on a caption still on screen.
-        "the caption clear hangs off the navigation signal, not the document one",
-        "web.py",
-        '        page.on("domcontentloaded", self._note_document_replaced)',
-        '        page.on("framenavigated", self._note_document_replaced)',
-        # Deliberately *not* the document-load sweep: every stream that
-        # replaces a document carries a `framenavigated` too, so the caption
-        # still clears there and that sweep stays green. Only the
-        # same-document half can tell the two names apart, which is the whole
-        # reason it had to be measured.
-        [
-            "MeasuredNavigations.test_every_measured_same_document_navigation_keeps_the_line",
+            "CaptionTruth.test_a_beat_after_a_document_load_still_reports_the_line",
+            "MeasuredNavigations.test_no_measured_way_of_leaving_a_page_touches_the_beat_log",
             "WatchedEvents.test_the_web_recorder_only_adds_to_what_the_base_watches",
-        ],
-    ),
-    (
-        # The measured table graded from its own side. Each sweep loops over
-        # whichever rows carry its flag, so a row that changed sides would
-        # quietly move out of one sweep and into the other — and the SPA rows
-        # are the half that decides the event name.
-        "a same-document route change is filed as a document replacement",
-        "tests/unit",
-        '        "history.pushState to a new route, no document loaded",\n'
-        '        [("framenavigated", _MAIN)],\n'
-        "        1,\n"
-        "        True,",
-        '        "history.pushState to a new route, no document loaded",\n'
-        '        [("framenavigated", _MAIN)],\n'
-        "        1,\n"
-        "        False,",
-        [
-            "MeasuredNavigations.test_every_measured_document_load_takes_the_line_off_the_beat_log",
-            "MeasuredNavigations.test_the_measured_table_covers_every_way_issue_179_names",
         ],
     ),
     (
@@ -14092,82 +13484,25 @@ INJECTIONS = [
     ),
     # -- the line the load took away (issue #180) --------------------------
     (
-        # #180 itself: the clear on its own leaves a true, mute timeline.
-        "a caption lost to a page load goes unrecorded",
-        "web.py",
-        '        self._note_issue(\n            "caption_lost",',
-        '        return\n        self._note_issue(\n            "caption_lost",',
-        [
-            "CaptionLost.test_the_line_a_load_took_off_the_screen_is_recorded_as_a_problem",
-            "CaptionLost.test_the_lost_line_reaches_the_document_a_reviewer_reads",
-        ],
-    ),
-    (
-        # The other direction: every take opens with a document load, so a
-        # recorder that logged one per load buries the real one.
-        "every document load records a lost caption, including the ones with none",
-        "web.py",
-        "        if not lost:\n",
-        "        if False:\n",
-        [
-            "CaptionLost.test_a_load_with_no_caption_up_records_nothing",
-            "CaptionLost.test_a_second_load_does_not_report_the_line_a_second_time",
-        ],
-    ),
-    (
-        # The Issues section renders `message` and nothing else, so an issue
-        # whose extra keys carry the line and whose message does not is one a
-        # reviewer reading timeline.md cannot act on.
-        "the recorded problem stops naming the line that was lost",
-        "web.py",
-        '            f"{lost!r}, so the line left the screen — every beat after this "',
-        '            f"so the line left the screen — every beat after this "',
-        [
-            "CaptionLost.test_the_line_a_load_took_off_the_screen_is_recorded_as_a_problem",
-            "CaptionLost.test_the_lost_line_reaches_the_document_a_reviewer_reads",
-        ],
-    ),
-    (
-        "the recorded problem stops naming the document that replaced it",
-        "web.py",
-        '            f"a new document at {url} replaced the one holding the caption "',
-        '            f"a new document replaced the one holding the caption "',
-        [
-            "CaptionLost.test_the_line_a_load_took_off_the_screen_is_recorded_as_a_problem",
-            "CaptionLost.test_the_lost_line_reaches_the_document_a_reviewer_reads",
-        ],
-    ),
-    (
-        # The exception path, which is where a guard usually is not tested:
-        # the URL is read off a page in the middle of replacing itself, and a
-        # diagnostic that threw there would surface inside an unrelated
-        # Playwright call and take the whole recording with it.
-        "reading the new document's URL is allowed to throw out of the callback",
-        "web.py",
-        "        try:\n"
-        "            url = page.url\n"
-        "        except Exception:  # noqa: BLE001 - a page dying still lost the caption\n"
-        '            url = "(unknown)"\n',
-        "        url = page.url\n",
-        ["CaptionLost.test_a_page_too_far_gone_to_name_still_reports_the_line"],
-    ),
-    (
-        # A kind the package does not publish fails `check_issues` on the
-        # artifact instead of on the defect, which is a worse bug report.
-        "the new kind is not one the timeline contract declares",
+        # A committed timeline's vocabulary unpublished out from under it:
+        # `check_issues` in tests/smoke refuses a kind outside the tuple, so
+        # a pre-#361 timeline carrying the kind would fail on the artifact
+        # instead of reading as the record it is.
+        "the retired kind is unpublished out from under committed timelines",
         "timeline.py",
         '    "caption_lost",     # a page load took the caption bar off the screen\n',
         "",
-        ["CaptionLost.test_the_kind_is_one_the_package_publishes"],
+        ["CaptionLostRetired.test_the_kind_stays_published_for_committed_timelines"],
     ),
     (
-        # A storyboard mistake made into a verdict on the app: every demo that
-        # navigates away from a captioned screen stops recording under strict.
+        # A storyboard-era mistake made into a verdict on the app,
+        # retroactively: stitch() carries old segments' issues into merged
+        # demos, and strict reads the kind tuple.
         "losing a caption becomes something strict mode refuses a take over",
         "timeline.py",
         'STRICT_KINDS = ("console_error", "page_error", "nonzero_exit")',
         'STRICT_KINDS = ("console_error", "page_error", "nonzero_exit", "caption_lost")',
-        ["CaptionLost.test_losing_a_caption_does_not_fail_a_strict_take"],
+        ["CaptionLostRetired.test_the_kind_stays_published_for_committed_timelines"],
     ),
     (
         # …and the subscription can be right and never made, because
@@ -14189,7 +13524,7 @@ INJECTIONS = [
         "        pass  # the medium's own subscriptions never happen",
         [
             "WatchedEvents.test_the_web_recorder_only_adds_to_what_the_base_watches",
-            "CaptionTruth.test_a_beat_after_a_document_load_reports_no_caption",
+            "MeasuredNavigations.test_no_measured_way_of_leaving_a_page_touches_the_beat_log",
         ],
     ),
     (
@@ -14321,100 +13656,50 @@ INJECTIONS = [
         '        self._navigated = True\n        self._caption = ""',
         [
             "CaptionTruth.test_an_spa_route_change_keeps_the_caption",
-            "MeasuredNavigations.test_every_measured_same_document_navigation_keeps_the_line",
+            "MeasuredNavigations.test_no_measured_way_of_leaving_a_page_touches_the_beat_log",
         ],
     ),
     (
-        # Issue #186 exactly as it shipped before it was fixed: every mousemove
-        # moves the dot, including the one Chromium dispatches at load, so a
-        # deterministic take's opening stills are a coin flip.
-        "the cursor dot follows every mousemove again",
+        # The dot left behind by the glide: the pointer moves through
+        # Playwright and the wrapper document's dot is never told. Every take
+        # then shows a parked dot while the pointer clicks elsewhere — the
+        # pixel form is tests/pixel's cursor-parked golden; this is the
+        # browser-free half of the same drive.
+        "the glide moves the pointer and never the dot",
         "web.py",
-        "    if (e.clientX === atX && e.clientY === atY) return;\n",
-        "",
-        [
-            "CursorMotion.test_the_rule_is_one_condition_that_reads_the_event",
-            "CursorMotion.test_chromiums_load_time_hover_event_does_not_move_the_dot",
-            "CursorMotion.test_nothing_moves_the_dot_except_through_the_rule",
-        ],
+        "            self.page.evaluate(\n"
+        '                "([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi]\n'
+        "            )",
+        "            pass  # the dot is never told",
+        ["CursorDrive.test_the_dot_rides_every_pointer_step_and_ends_at_the_target"],
     ),
     (
-        # Issue #202: the rule as #194 wrote it, reading the browser's movement
-        # delta. Green on the Chromium CI installs, and on Chromium 147 it
-        # throws away the storyboard's own park — so a take recorded there has
-        # no cursor in it at all, which no still comparison notices because it
-        # makes every take agree.
-        "the cursor rule reads the browser's movement delta again",
+        # The dot commanded somewhere the pointer is not — #202's class with
+        # the event machinery gone: the recorder is the only writer of both,
+        # so an offset here is the one way left for them to disagree.
+        "the dot is commanded off the pointer's own path",
         "web.py",
-        "if (e.clientX === atX && e.clientY === atY) return;",
-        "if (e.movementX === 0 && e.movementY === 0) return;",
-        [
-            "CursorMotion.test_the_rule_is_one_condition_that_reads_the_event",
-            "CursorMotion.test_the_storyboards_own_park_moves_the_dot_on_every_engine",
-            "CursorMotion.test_both_orders_of_the_load_event_leave_the_dot_in_one_place",
-        ],
+        '                "([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi]',
+        '                "([x, y]) => window.__demoChromeCursor(x, y)", [xi + 30, yi]',
+        ["CursorDrive.test_the_dot_rides_every_pointer_step_and_ends_at_the_target"],
     ),
     (
-        # The rule pointing the other way, and the reason it is `&&`: a guard
-        # that drops a move repeating *either* coordinate freezes the dot for
-        # every horizontal glide, which no still comparison would ever notice
-        # because it makes takes agree.
-        "the cursor rule drops a move that is along one axis",
+        # The seed forgotten: every glide sweeps in from the origin, which is
+        # motion the storyboard never asked for, on every move of every take.
+        "a glide forgets where the pointer last was",
         "web.py",
-        "if (e.clientX === atX && e.clientY === atY) return;",
-        "if (e.clientX === atX || e.clientY === atY) return;",
-        ["CursorMotion.test_every_real_move_moves_the_dot"],
+        "        sx, sy = self._cursor_at",
+        "        sx, sy = (0.0, 0.0)",
+        ["CursorDrive.test_a_second_glide_starts_from_the_last_commanded_position"],
     ),
     (
-        # The seed, which is the whole of why the load-time event can be
-        # ignored: at any position other than where the pointer starts, that
-        # event reports a "new" position and #186 is back.
-        "the overlay starts out believing the pointer is somewhere else",
+        # The squeeze inverted: the dot enlarges on press and shrinks at
+        # rest, so every click reads backwards.
+        "the press squeeze runs backwards",
         "web.py",
-        "  let atX = 0, atY = 0;",
-        "  let atX = -1, atY = -1;",
-        [
-            "CursorMotion.test_chromiums_load_time_hover_event_does_not_move_the_dot",
-            "CursorMotion.test_the_remembered_position_is_where_the_pointer_starts",
-        ],
-    ),
-    (
-        # Issue #203: the overlay does not start listening until the document
-        # has a body, so the pointer move a storyboard makes before that is
-        # heard by nothing. Silent everywhere else — the rule is unchanged, the
-        # seed is unchanged, and a take recorded this way looks exactly like a
-        # take whose storyboard never moved the pointer.
-        "the cursor overlay waits for the document before it listens",
-        "web.py",
-        _CURSOR_LISTENS_AT_DOCUMENT_START,
-        _CURSOR_LISTENS_AT_DOMCONTENTLOADED,
-        [
-            "CursorMotion.test_the_pointer_is_listened_for_before_the_document_has_loaded",
-        ],
-    ),
-    (
-        # The control under the assertion above, and a real defect on its own:
-        # a dot that is built and positioned but never inserted is no cursor at
-        # all, in every take. It is also what an extraction that returned the
-        # wrong slice of the script would look like.
-        "the dot is built and positioned but never put on the page",
-        "web.py",
-        "    document.body.appendChild(dot);\n",
-        "",
-        [
-            "CursorMotion.test_what_the_overlay_defers_to_domcontentloaded_is_the_insertion",
-        ],
-    ),
-    (
-        # The state update, which the harness models rather than extracts: if
-        # the script stopped running it, `dot_trail` would go on simulating a
-        # rule the take no longer ships, and every assertion above would grade
-        # a fiction.
-        "the overlay never records where it last saw the pointer",
-        "web.py",
-        "    atX = e.clientX;\n    atY = e.clientY;\n",
-        "",
-        ["CursorMotion.test_nothing_moves_the_dot_except_through_the_rule"],
+        '        fn = "__demoChromeCursorDown" if down else "__demoChromeCursorUp"',
+        '        fn = "__demoChromeCursorUp" if down else "__demoChromeCursorDown"',
+        ["CursorDrive.test_the_dot_squeezes_on_press_and_releases_after"],
     ),
     # -- the scored region (issue #135) ------------------------------------
     #
@@ -15133,51 +14418,20 @@ INJECTIONS = [
         ["CriterionHold.test_the_criterion_beat_covers_the_whole_spoken_line"],
     ),
     (
-        # **Issue #291, restored.** The web recorder takes the card the terminal
-        # recorder needs, and every artifact of the take stays correct: the
-        # element, the beat, the aria snapshot and the coverage row are all
-        # right, and the video shows what a viewer read as a terminal window.
-        # Injected at the import rather than at the assignment, so the module
-        # still imports: a `NameError` would fail every test that builds a web
-        # recorder, and the entry would be graded by an exception instead of by
-        # the assertions it names.
-        "a web take is given the terminal's card",
-        "web.py",
-        "from .core import (\n"
-        "    INTERLUDE_CSS_WEB,\n"
-        "    WEB_WINDOW_BODY,\n"
-        "    _beat_verb,\n"
-        "    _DemoBase,\n"
-        "    _env,\n"
-        "    _env_flag,\n"
-        ")",
-        "from .core import (  # noqa: I001\n"
-        "    INTERLUDE_CSS_TERMINAL as INTERLUDE_CSS_WEB,\n"
-        "    WEB_WINDOW_BODY,\n"
-        "    _beat_verb,\n"
-        "    _DemoBase,\n"
-        "    _env,\n"
-        "    _env_flag,\n"
-        ")",
-        [
-            "InterludePalette.test_a_web_take_raises_the_palette_smoke_grades_in_pixels",
-            "InterludePalette.test_a_web_take_does_not_raise_the_terminals_card",
-            "InterludePalette."
-            "test_the_web_card_is_not_painted_like_the_skills_terminal_widgets",
-        ],
-    ),
-    (
-        # The dispatch removed while both palettes stay in the file: the fix
-        # looks present at every site a reader would check, and no take reaches
-        # the web one. This is what makes the medium tests above readings about
-        # a recorder rather than about a constant.
-        "the card is chosen once for every medium instead of per take",
+        # **#291 wearing #361's clothes.** The wrapper document ships the
+        # card element, so core's `_INTERLUDE_JS` — which still carries the
+        # terminal stylesheet — must only ever find and toggle it. Drop the
+        # ask-the-page half and the script styles a fresh full-viewport
+        # element on every interlude: the web card repaints as a
+        # terminal-black field over the whole chrome.
+        "the interlude script stops asking the page before it builds a card",
         "core.py",
-        '            "__CSS__", self._interlude_css',
-        '            "__CSS__", INTERLUDE_CSS_TERMINAL',
+        "window.__demoInterlude = (text) => {\n"
+        "  let el = document.getElementById('__ID__');",
+        "window.__demoInterlude = (text) => {\n  let el = null;",
         [
-            "InterludePalette.test_a_web_take_raises_the_palette_smoke_grades_in_pixels",
-            "InterludePalette.test_a_web_take_does_not_raise_the_terminals_card",
+            "InterludePalette."
+            "test_the_base_stylesheet_cannot_paint_where_the_card_already_exists",
         ],
     ),
     (
@@ -15209,94 +14463,44 @@ INJECTIONS = [
         ],
     ),
     (
-        # **The card's compensation moved by one level, and every layer of the
-        # render still agrees.** `#181727` arrives in `demo.mp4` at
-        # `(24, 21, 38)` where `#181726` arrives at `(24, 21, 36)`, so both are
-        # inside `tests/smoke`'s bar against the window and the pixel check
-        # cannot see the difference. What can is the hand-written palette in
-        # this file — and that is the whole job of the pin, now that the value
-        # it holds is a measured constant rather than a colour anyone can
-        # re-derive by reading the window's.
-        "the card's compensated colour moves by one level",
-        "core.py",
-        'WEB_CARD_BODY = "#181726"',
-        'WEB_CARD_BODY = "#181727"',
-        [
-            "InterludePalette.test_a_web_take_raises_the_palette_smoke_grades_in_pixels",
-        ],
-    ),
-    (
-        # **The window is repainted and the card's compensation is left
-        # behind.** The card no longer follows this constant — it is measured
-        # against it — so this moves one of the two and not both. `tests/smoke`
-        # catches it in pixels, at 32 levels; what catches it here, in 0.2 s, is
-        # that `WEB_WINDOW_BODY` is pinned to a `WINDOW_BODY` written out by
-        # hand. Without that pin the compensated card would sit in the file
-        # looking deliberate while the thing it compensates for had moved.
-        "the window body is repainted out from under the card's compensation",
-        "core.py",
-        'WEB_WINDOW_BODY = "#181825"',
-        'WEB_WINDOW_BODY = "#050505"',
-        [
-            "InterludePalette.test_the_window_body_the_card_is_compensated_against_is_the_one_drawn",
-        ],
-    ),
-    (
-        # The window painted from a literal again, with the shared constant
-        # left in the file and still correct. Every value a reader would check
-        # agrees; the two are simply no longer the same value, which is how
-        # they drifted apart in the first place.
-        "the window frame is painted from a literal, not the shared constant",
-        "web.py",
-        '            .replace("__WINBG__", WEB_WINDOW_BODY)',
-        '            .replace("__WINBG__", "#181825")',
-        [
-            "InterludePalette.test_the_window_body_the_card_is_compensated_against_is_the_one_drawn",
-        ],
-    ),
-    (
         # A border put back on the card. This is #297's second rejected
-        # candidate: the field matches the window, the dispatch is right, and
-        # the card draws an edge of its own between itself and the recorder's
-        # pad — the "additional edge of a third colour" the reviewer refused.
-        "the card draws an edge of its own around the field",
+        # candidate: the field matches the window, and the card draws an edge
+        # of its own between itself and the recorder's pad — the "additional
+        # edge of a third colour" the reviewer refused.
+        "the terminal card draws an edge of its own around the field",
         "core.py",
-        '    _INTERLUDE_LAYOUT + f" background: {WEB_CARD_BODY}; color: #f2f0ec;"',
-        '    _INTERLUDE_LAYOUT + f" background: {WEB_CARD_BODY}; color: #f2f0ec;"\n'
+        '    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"',
+        '    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"\n'
         '    + " border: 18px solid #b45309;"',
         [
-            "InterludePalette.test_the_web_card_is_one_colour_and_draws_no_edge_of_its_own",
+            "InterludePalette.test_the_terminal_card_is_opaque_and_covers_the_frame",
         ],
     ),
     (
-        # A card that lets the app show through. The colour is right, the
-        # dispatch is right, and reference/limits.md's account of what the
-        # picture check can see — which rests on this card being opaque — stops
-        # being true of a web take.
-        "the web card is a scrim over the app rather than a card",
+        # A card that lets the app show through. The colour is right, and
+        # reference/limits.md's account of what the picture check can see —
+        # which rests on this card being opaque — stops being true of a
+        # terminal take.
+        "the terminal card is a scrim over the app rather than a card",
         "core.py",
-        '    _INTERLUDE_LAYOUT + f" background: {WEB_CARD_BODY}; color: #f2f0ec;"',
-        '    _INTERLUDE_LAYOUT + " background: rgba(24,23,38,.72); color: #f2f0ec;"',
+        '    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"',
+        '    _INTERLUDE_LAYOUT + " background: rgba(28,26,23,.72); color: #f7f4ee;"',
         [
-            "InterludePalette."
-            "test_both_cards_are_opaque_and_cover_the_frame_above_the_caption",
-            "InterludePalette.test_a_web_take_raises_the_palette_smoke_grades_in_pixels",
+            "InterludePalette.test_the_terminal_card_is_opaque_and_covers_the_frame",
         ],
     ),
     (
-        # The card's corners rounded off the app rect. `border-radius` clips the
-        # background of an `inset: 0` element, so the four corners of the app
-        # rect stop being painted and the app shows through them while the card
-        # is up — full-bleed lost to a styling flourish, with the colour and the
-        # dispatch both correct.
-        "the card's outer corners are rounded off the app rect",
+        # The card's corners rounded off the frame. `border-radius` clips the
+        # background of an `inset: 0` element, so the four corners stop being
+        # painted and the app shows through them while the card is up —
+        # full-bleed lost to a styling flourish, with the colour correct.
+        "the terminal card's outer corners are rounded off the frame",
         "core.py",
-        '    _INTERLUDE_LAYOUT + f" background: {WEB_CARD_BODY}; color: #f2f0ec;"',
-        '    _INTERLUDE_LAYOUT + f" background: {WEB_CARD_BODY}; color: #f2f0ec;"\n'
+        '    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"',
+        '    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"\n'
         '    + " border-radius: 14px;"',
         [
-            "InterludePalette."
-            "test_both_cards_are_opaque_and_cover_the_frame_above_the_caption",
+            "InterludePalette.test_the_terminal_card_is_opaque_and_covers_the_frame",
         ],
     ),
     (
@@ -15905,16 +15109,15 @@ INJECTIONS = [
         ],
     ),
     (
-        # The composite's caption compensation inherited by the path that has
-        # no composite: a wrapper take is recorded at true pixel size, so
-        # 34px in the band is visibly oversized, and nothing else pins it.
-        "a wrapper take inherits the composite's 34px caption compensation",
+        # The deleted composite's caption compensation grown back: the page
+        # is recorded at true pixel size, so 34px in the band is visibly
+        # oversized, and nothing else pins it.
+        "the web take grows the composite's 34px caption compensation back",
         "web.py",
-        "        if not self._wrapper:\n"
-        "            # The recording is composited into a window and scaled down\n",
-        "        if True:\n"
-        "            # The recording is composited into a window and scaled down\n",
-        ["WrapperChrome.test_a_wrapper_take_keeps_the_base_caption_font"],
+        "        # What spotlight() is currently pointing at, which is what a beat's",
+        "        self._caption_font_px = 34\n"
+        "        # What spotlight() is currently pointing at, which is what a beat's",
+        ["WrapperChrome.test_a_web_take_keeps_the_base_caption_font"],
     ),
     (
         # The PR #366 review's blocking finding, restored: the band shaves a
@@ -15982,14 +15185,11 @@ INJECTIONS = [
         # The hold never registered: the wrapper take opens on the slot's
         # white canvas. The pixel form is smoke's check_wrapper_opening; this
         # is the browser-free half of the same seam.
-        "the wrapper take registers no opening-hold init script",
+        "the web take registers no opening-hold init script",
         "web.py",
-        "            context.add_init_script(\n                opening_hold_script(",
-        "            _unused = (\n                opening_hold_script(",
-        [
-            "WrapperChrome."
-            "test_a_wrapper_take_registers_the_hold_script_and_a_legacy_take_none"
-        ],
+        "        context.add_init_script(\n            opening_hold_script(",
+        "        _unused = (\n            opening_hold_script(",
+        ["WrapperChrome.test_a_web_take_registers_the_opening_hold_script"],
     ),
     (
         # The reveal never runs: the first content beat lands and the viewer
@@ -15997,47 +15197,111 @@ INJECTIONS = [
         # opening cover.
         "no goto ever clears the opening hold",
         "web.py",
-        "        if self._wrapper and not self._hold_cleared:",
-        "        if self._wrapper and False:",
+        "        if not self._hold_cleared:",
+        "        if False:",
         [
             "WrapperChrome."
             "test_the_first_goto_clears_the_opening_hold_and_only_the_first"
         ],
     ),
     (
-        # The once-guard dropped: every wrapper goto re-clears chrome state
-        # it does not own, and a legacy-shaped reading of the same line —
-        # `if not self._hold_cleared:` alone — would clear it on the
-        # composite path too.
+        # The once-guard dropped: every goto re-clears chrome state it does
+        # not own, and re-stamps the hold-clear instant onto beats recorded
+        # long after the hold came down — which would move the review
+        # sheet's opening-hold note onto frames that show the app.
         "every goto re-clears the opening hold",
         "web.py",
-        "        if self._wrapper and not self._hold_cleared:",
-        "        if self._wrapper:",
+        "        if not self._hold_cleared:",
+        "        if True:",
         [
             "WrapperChrome."
-            "test_the_first_goto_clears_the_opening_hold_and_only_the_first"
+            "test_the_first_goto_clears_the_opening_hold_and_only_the_first",
+            "WrapperChrome."
+            "test_the_hold_clearing_goto_stamps_the_instant_on_its_own_beat",
         ],
     ),
     (
-        # ...and the other half of the same line: the wrapper guard dropped,
-        # so a legacy goto evaluates wrapper chrome that is not in its page.
-        "a legacy goto clears a hold its page never had",
+        # The segment pattern's card left over the app: SKILL.md says
+        # interlude(...) then goto(), and a full load used to destroy the
+        # card with the app's document. Drop the deliberate clear and every
+        # such take records the card over the app to its end, with only an
+        # end-of-take warning to say so.
+        "a goto leaves the recorder's cards up over the app",
         "web.py",
-        "        if self._wrapper and not self._hold_cleared:",
-        "        if not self._hold_cleared:",
-        ["WrapperChrome.test_a_legacy_goto_never_touches_the_hold"],
+        "        self.page.evaluate(\n"
+        "            \"() => { window.__demoInterlude(''); "
+        "window.__demoBridge(''); }\"\n"
+        "        )",
+        "        pass  # the cards stay up over the app",
+        ["WrapperChrome.test_every_goto_takes_the_recorders_cards_down"],
     ),
     (
-        # The #134 listener re-subscribed on the wrapper path: one engine
-        # bump in event routing away from recording a caption_lost that
-        # cannot happen — the timeline claiming a loss the band's pixels
-        # disprove (#360).
-        "the wrapper take listens for a document replacement again",
+        # The sheet's note reads the instant off the beat (frames.py, #361);
+        # a goto that clears the hold and writes nothing down leaves the
+        # first review frame a flat dark window with nothing anywhere saying
+        # it is deliberate — the confusion the note exists to end.
+        "the hold-clearing goto stops writing the instant on its beat",
         "web.py",
-        "        if not self._wrapper:\n"
-        '            page.on("domcontentloaded", self._note_document_replaced)',
-        '        page.on("domcontentloaded", self._note_document_replaced)',
-        ["WrapperChrome.test_a_wrapper_take_does_not_listen_for_a_replaced_document"],
+        '                self._beats[-1]["opening_hold_until"] = round(',
+        "                _unwritten = round(",
+        [
+            "WrapperChrome."
+            "test_the_hold_clearing_goto_stamps_the_instant_on_its_own_beat",
+        ],
+    ),
+    (
+        # The #134 listener re-subscribed: one engine bump in event routing
+        # away from clearing a caption that is still on screen — the
+        # timeline claiming a loss the band's pixels disprove (#360).
+        "the web take listens for a document replacement again",
+        "web.py",
+        '        page.on("framenavigated", self._note_navigation)',
+        '        page.on("framenavigated", self._note_navigation)\n'
+        '        page.on("domcontentloaded", self._note_navigation)',
+        ["WrapperChrome.test_a_web_take_does_not_listen_for_a_replaced_document"],
+    ),
+    # -- the review sheet's opening-hold note (#361) -------------------------
+    (
+        # The note dropped whole: the manifest stops carrying the hold and
+        # the sheet stops naming the frames cut inside it, so the first
+        # goto's flat dark frame reads as a failed load again.
+        "the sheet stops naming the frames cut inside the opening hold",
+        "frames.py",
+        '    manifest["opening_hold"] = holds',
+        '    manifest["opening_hold"] = []',
+        [
+            "OpeningHoldOnTheSheet."
+            "test_the_frames_cut_inside_the_hold_are_named_on_the_sheet",
+            "OpeningHoldOnTheSheet."
+            "test_a_merged_sheet_scopes_each_hold_to_its_own_segment",
+        ],
+    ),
+    (
+        # The over-reporting direction: every kept frame swept into the note
+        # whatever its segment, so a merged sheet names part one's frames as
+        # under part two's hold — a confident wrong caption in miniature.
+        "the hold note sweeps in frames from other segments",
+        "frames.py",
+        '            and by_index.get(int(frame["beat"]), {}).get("segment")\n'
+        '            == hold_beat.get("segment")',
+        "            and True",
+        [
+            "OpeningHoldOnTheSheet."
+            "test_a_merged_sheet_scopes_each_hold_to_its_own_segment",
+        ],
+    ),
+    (
+        # stitch() forgetting to shift the instant with its beat: part two's
+        # hold note then points at the merged video's opening seconds, which
+        # are part one's frames.
+        "a merged timeline keeps the hold instant on the segment's own clock",
+        "stitching.py",
+        '            if "opening_hold_until" in merged:\n'
+        '                merged["opening_hold_until"] = _shift(\n'
+        '                    beat.get("opening_hold_until"), offset\n'
+        "                )",
+        "            pass",
+        ["StitchedHold.test_the_hold_instant_is_shifted_with_its_beat"],
     ),
 ]
 


### PR DESCRIPTION
Slice 3 of #355's structural half (design record there). Built on #358 (fc32e01) and #360 (5a40204). Fixes #361.

## Acceptance, per the issue

- **The wrapper is the only web path.** The transitional `wrapper=` flag and `DEMO_VIDEO_WRAPPER` are gone; `Recorder` records wrapper takes unconditionally. `rec.app` is always the app iframe's frame, `rec.page` the framed page.
- **The exit-time composite is deleted** — the full list below.
- **Grep acceptance**: `_postprocess` survives only as the no-op base hook (the medium seam a future transforming medium would use; both shipped recorders leave it alone); `WEB_CARD_BODY` appears only inside history notes (core.py's `WEB_WINDOW_BODY` note, web.py's module docstring, tests/README's history paragraphs). No compensation constant exists.
- **Full `tests/smoke` green on the wrapper-only path**, `--web-only` and `--cheap` included — gate below.
- **The retake measurement shows one encode saved** — table below.

## The deletion list

| deleted | where | size |
|---|---|---|
| `_FRAME_HTML` + `_WEB_BG` + the screenshot render half of `_start` | web.py | ~55 lines |
| `_postprocess` composite + `_opening_hold` + the `enable='lt(t,held)'` overlay | web.py | ~91 lines |
| `_CURSOR_JS` + the #186/#202/#203 rationale block (the event-following dot) | web.py | ~133 lines |
| `_note_document_replaced` + the web `domcontentloaded` subscription (#134/#180 machinery) | web.py | ~75 lines |
| `wrapper=` flag, `_wrapper` dispatches, the 34px caption compensation | web.py | ~40 lines |
| `WEB_CARD_BODY`, `INTERLUDE_CSS_WEB`, and the compensated-palette essays, condensed into history notes pointing at #291/#301/#355 | core.py | 113− / 57+ |
| `check_opening` (composite-hold check) + its section; `check_criterion_card` + `WEB_CARD_RGB`/`CARD_RGB_TOLERANCE`/`CARD_WINDOW_TOLERANCE`; `check_parked_pointer`; legacy `caption_band` probes | tests/smoke | 627− / 321+ |
| `CursorMotion` + the JS-extraction harness; the caption-clearing halves of `CaptionTruth`/`MeasuredNavigations`; `CaptionLost`; `InterludePalette`'s web-palette tests; 15 fault-inject entries for the deleted machinery | tests/unit | 1450− / 696+ |

Branch total: **+1,900 / −3,365** across 19 files. web.py alone: 182+/525−.

## caption_lost semantics

Web takes no longer subscribe the document-load signal at all — unconditional since this PR (`_watch_extra` keeps only #142's `framenavigated` carve-out). `caption_lost` stays a published issue kind: committed timelines carry it and `stitch()` merges old segments' issues as-is (`CaptionLostRetired` in tests/unit pins both, with two injections). SKILL.md's caption row and reference/failures.md now say caption death on navigation is a terminal-take concern only (its caption is in-page, until #362) — and a terminal take's page never navigates.

The measured `NAVIGATIONS` table (Chromium event streams, #179) stays as data; its sweep inverted: every measured way of leaving a page must now leave the caption on the beat log and file no issue, non-vacuously (every stream lands on the kept `framenavigated` listener). `tests/smoke --wrapper-only`'s check_wrapper_caption_survives keeps the pixel half.

## Geometry consumers moved

- `_content_rect` reads `chrome.chrome_geometry`'s dict as the single source.
- `to_video_rect` is now the app-rect **offset**, no scale — the ~0.8 factor died with the composite. Most call sites dropped mapping outright: `bounding_box()` answers in wrapper-page = video coordinates (spotlight rect, entropy panel/spinner rects).
- Stills and video share one geometry: `check_take` gets one rect for both; the "stills are full-bleed, video is windowed" mismatch is gone, and `shot()` stills match the video frame for frame.
- Caption probes read the chrome's band rect (`caption_probe_band`, chrome_geometry's arithmetic duplicated per the loop-vs-suite rule), not a full-width bottom strip. Floors re-measured on the band: probe caption 4.99 healthy vs 0.00 undrawn → `MIN_CAPTION_BAND_DIFF`/`MIN_ALIGN_BAND_DELTA` web/segments 8.0/6.0 → 2.0 (2.5x margin).
- Determinism/ticker probes target `rec.app` — the claims are about what the recorder does to the *app*, and the wrapper document's init-script re-run is racy on `set_content` (measured: the motion-CSS control read 0.18s in the wrapper doc on one run).

### Legacy-only checks: moved or died, one reason each

| check | fate |
|---|---|
| `check_opening` (held>0 + frame-0-vs-median) | **died** — it graded the deleted ffmpeg hold. The same take now runs `check_wrapper_opening` (frame 0 = hold ≤ 60 luma, bare app ≥ 150 later), so the wrapper opening is graded on the 28 s web take and the wrapper arm alike |
| `check_opening_gap` | **stays** — it grades `opening_gap`, the measurement `content.opening` reports on every take, on synthesised videos |
| `check_criterion_card` (compensated pair) | **died** — no pair left. The coverage take's card is graded by `check_wrapper_card`: one declaration, one encoder, pixels on both sides |
| `check_parked_pointer` (DOM == parked coordinate) | **moved** → `check_undrawn_pointer`: the determinism storyboard parks nothing (nothing but a verb can draw the dot), so it asserts the dot is off-viewport with no verb run — failing on a missing element, so it cannot go silent |
| `CaptionLost` + the caption-clearing sweeps + the #214 late-half test | **died/inverted** — the machinery is gone; see caption_lost above |
| `CursorMotion` + JS extraction | **died** — no event rule left to extract. Replaced by `CursorDrive` (one dot command per pointer step, seeded from `_cursor_at`, squeeze on press; 4 injections) and the two pixel goldens |
| `InterludePalette` web tests | **died** — no per-medium CSS dispatch. Kept: the terminal palette, the #110 opening-card agreement, and the create-if-missing guard that keeps the base stylesheet inert where the chrome ships the card element (1 new injection) |

## Pixel goldens migrated (the pinned requirement)

The web reference storyboard records a wrapper take; the marker's geometry is `chrome_geometry`'s dict, and the park is the app-document rect mapped through the app-rect offset (`to_video_rect`) — so the mapping the verbs rely on is graded rather than assumed. `card-vs-window` reads the uncompensated declaration (`WEB_WINDOW_RGB` = `core.WEB_WINDOW_BODY`), locating the card by the dark run that **overlaps the logged beat** (`card_run`) because the opening hold is a second, deliberate dark stretch in the same strip. `opening-card` (terminal) is untouched.

Seen red by the issue's two planted defects, the digest re-recording automatically both times:

**cursor offset edit** (web.py, `__demoChromeCursor(x, y)", [xi, yi]` → `[xi + 30, yi]`):

```
web/cursor-parked: FAIL - disc centre (620.5, 401.3) vs park (590.5, 401.0), off (+30.0, +0.3)px (bar 3.0), 235 accent px
```

**dot-at-load edit** (chrome.py, `#__demo_cursor { ... top: -40px; left: -40px` → `top: 8px; left: 8px`):

```
web/cursor-absence: FAIL - 9 frames before beat 11 probed, worst frame 144 accent px in the 16x16px origin crop (bar 0)
```

Both reverted; re-recorded; `pixel: 6 checks, 0 failing`. Healthy: disc centre off (+0.6, +0.1)px, card 3 off the window body (bar 5, shared with smoke — see the stated limit on what this reading resolves).

## The reporting sweep (#367's stated limit, inherited)

The first goto's review frame shows the opening hold — a flat dark window under a heading that says `goto`. The goto that clears the hold now stamps the instant on its own beat (`opening_hold_until`; `stitch()` shifts it with the beat), and `frames.md` names the frames cut inside it, in `scene_search_skipped`'s named-not-counted style. Live, from the web take:

> `beat-00.png` was cut inside the take's opening hold: until 0.63s the app rect is an opaque field in the window's own colour, up from frame 0 and cleared when the first `goto` had an app to reveal. A flat dark window under this heading is the hold, not an app that failed to load.

Seen red, exactly-once, in `tests/unit --fault-inject` (4 entries): the note dropped whole, the note sweeping in other segments' frames, the goto not stamping the instant, and stitch keeping the instant on the segment's own clock:

```
PASS  break: the sheet stops naming the frames cut inside the opening hold
      in frames.py: manifest["opening_hold"] = holds…
      FAIL: test_the_frames_cut_inside_the_hold_are_named_on_the_sheet (OpeningHoldOnTheSheet)
      FAIL: test_a_merged_sheet_scopes_each_hold_to_its_own_segment (OpeningHoldOnTheSheet)
```

## Viewer-visible changes, and one for evidence readers

- **Captions render at the base 26px.** The 34px compensation existed for the composite's ~0.8 downscale; the page records at true pixel size now. (Card text stays the declared 30/34px from #360.)
- **`goto()` takes the recorder's cards down.** A full page load used to destroy the card with the app's document, and SKILL.md's segment pattern (interlude, then goto) leans on it; the cards live in the wrapper document now, so goto clears them deliberately — every goto, as any full load did. Seen red in pixels first: `--segments-only` went red with the recorder's own overlay-left-up warning on a take the suite grades as healthy, which is exactly the take a user's segmented demo would have recorded. The caption is *not* cleared — its survival is the point.
- **Evidence gains a `chrome` field** — the visible caption line and any card, read out of the wrapper document's DOM at capture time, never copied from the beat log. The caption left the app document with the band, so without it no evidence file could say which narration line the frame showed (#9): `check_evidence`'s caption facts and the coverage arm's clause-on-screen check both read it now. Documented in reference/review.md; `EVIDENCE_LIMITS` gains `chrome: 8000`; schema stays 1 (additive key).

## Measurements

Method: the pixel loop's web reference storyboard, recorded 3x per tree against `tests/fixture` on an ephemeral port, ffmpeg shimmed to log argv (`libx264` occurrences = video encodes). Before = main (5a40204) via `git archive`; after = this branch. The after-storyboard holds one extra `pause(1.0)` (the card needs a settled app stretch), so the saving is understated by ~1 s.

| | before (composite) | after (wrapper) |
|---|---|---|
| x264 video encodes per retake | **2** (`_convert` + `_postprocess` composite; the take's 0.45 s opening hold rode the composite pass) | **1** (`_convert`) |
| wall-clock per retake | 24.4 / 23.3 / 23.5 s | 22.6 / 22.2 / 22.2 s |

## The gate

- `./tests/unit` — 534 tests OK
- `./tests/unit --fault-inject` — **All 341 injections were caught** (was 355: −21 with the deleted machinery, +7 new — the four hold-note/stamp entries, the goto card clear, the clearing-subscription-grows-back, the interlude create-guard; the four `CursorDrive` entries replace six `CursorMotion` ones)
- `./tests/ci-unit` (147 OK), `./tests/lint`, mypy 1.18.2 per ci.yml — clean
- `./tests/unit --budget` — SKILL.md 630/630 (in-place edits only)
- `./tests/pixel` — re-recorded from these source edits, 6 checks, 0 failing
- `./tests/smoke --cheap` — PASSED
- `./tests/smoke --web-only` — PASSED (the expensive arm, on the unified checks)
- `./tests/smoke --segments-only`, `--polish-only`, `--determinism-only`, `--overlay-only`, `--coverage-only`, `--evidence-only`, `--issues-only`, `--strict-only`, `--wrapper-only` — PASSED individually while unifying
- `./tests/smoke-inject --self-test` — every guard holds; README figures re-synced (71 entries, 14 arms, 16 of 49 check functions ungraded)

Four harness fixes rode along, all pre-existing stepping-host defects this box's ~1 s/32 s clock cadence surfaced while gating the branch, each with the failing run's numbers in its comment:

- `check_spotlight_transitions` now applies the suite's own wall-clock correction (#215) to its two windows — a −1.07 s step at 0.789 s of a 6 s take slid the exit window off the fade entirely; the arm was the only timing check left uncorrected.
- `_check_frame_captions`' guard compared clocks across domains: it fed the frame's *video*-clock instant into `HostClock.before()`, which takes log-clock seconds. On a take whose step landed inside a caption stretch, the corrected interval missed the change by ~1 s and a frame cut 60 ms from a caption clear was graded (beat 4 at video 3.974 s = log 5.09 s, change at log 5.151 s, step −1.119 s at 3.768 s). Each account now measures against the change on its own clock, with a straddled change reading zero.
- `check_timeline`'s monotonic sweep now honours the seam overlaps a stitched timeline *publishes* (#263 — "reported, not clamped" is the recorder's documented design): a backward step deletes wall time from a part's video without touching its log, so the next part's offset lands before the previous log's end. A seam the document reports — same beat, `seam: true`, published size covering the observed one — is the healthy shape on a stepping host; an unreported overlap, or one bigger than published, still fails, anywhere.
- The wrapper arm's survives-storyboard holds 2.5 s (was 1.0 s) between the mid-take goto and the caption clear: a −1.05 s step in that gap deleted it from the video and pulled the clear into the check's +0.5/+0.8 s samples on a healthy take.
- `check_wrapper_card` adopted the pixel golden's locate-then-measure (`card_run` moved to tests/_pixels.py, shared): it sampled at fixed fractions of the *logged* criterion span, and on a stepping host the video slides under the log, so 60% of the span landed on the card's fade — measured on a kept healthy take: gap 0.0 from 10–50%, 5.6 at 60% (mid-fade, still under the ≤ 60 locate bar), 205 at 70% (card gone). Those fade readings are what the bar-raise to 5 had explained as encoder noise. The check now finds the card's own dark stretch overlapping the logged beat, trims two sweep frames off each end, and samples inside it: the same take reads 0.1, `--web-only` went from 2 failures in 4 runs to 3/3 green, and the opacity-0 planted card is caught one gate earlier (the only overlapping dark stretch is the 0.6 s opening hold — "flashed rather than held").

## Stated limits

- **#362 owns the terminal mount and the shared caption path**: `core._CAPTION_JS`, `_caption_bottom_px` and `INTERLUDE_CSS_TERMINAL` survive for the terminal recorder only.
- **The #214 caption re-read is unexercised in effect**: a beat still pumps before stamping its inherited caption, but no page event can change the caption any more; the pump stays for event-attribution freshness. Its two fault-inject entries died with the tests that watched them (tests/README's Known gaps says so).
- **Raw `rec.page.mouse` moves the pointer and not the dot** — the escape-hatch limit inherited from #366, now the stated limit of the only path (SKILL.md, reference/determinism.md).
- **`content.opening.held` is null on every take**; the field, `limit` and `opening_warning` stay for committed timelines and any future encode-time-cover medium (content.py's history note).
- **Nothing reads frame zero of the segments or entropy takes** — they open on the same hold; only `web/` and `wrapper/` are graded (tests/README states it).
- **The card-vs-window reading resolves repaints, not nudges.** With one declaration on one encoder, the healthy card/pad pair encodes 0.5–3.8 apart (x264 settles the two rects' chroma against different block histories). Both suites' bars sit at 5, and the planted defect is an 8-level repaint (reads ~9; the terminal palette reads ≥ 12) — a nudge under ~5 declared levels is inside the encoder's own noise and is not a claim either check makes. Stated at both constants. The 5.6–5.9 readings once reported as healthy noise were not noise — see harness fix 5.
- **`check_wrapper_card` prints `wrapper-card:`-prefixed failures on the coverage arm** — the check names itself, not the arm.
- **The wrapper document's init-script re-run on `set_content` is racy** (measured: motion CSS absent from the wrapper doc in one run of three): the chrome carries its own copies of everything load-bearing (#360's pattern), and the harness probes the app document, but chrome fades can run unflattened on a deterministic take. Cosmetic; no check reads a chrome fade's duration.
- **Evidence schema stays 1** with the additive `chrome` field; pre-#361 readers see one extra key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
