### PR TITLE
Terminal takes mount the shared chrome: one window, one caption band, one opening hold on both media

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -63,11 +63,11 @@ segments, and verification all work identically. This document leads with
 the web recorder; the **Terminal demos** section below covers what differs,
 and is **Unix-only** because it uses a PTY.
 
-Both record into a **framed window on a soft pastel background** (rounded
-window, title bar, traffic lights), framed in-page: the web app records in
-an iframe at true pixel size, caption in a reserved band **below** the app
-rect, so the page is the finished picture — no exit composite, one encode
-per take, and `shot()` stills match the video exactly, chrome included.
+Both record into the **same framed window on a soft pastel background** (rounded
+window, title bar, traffic lights): one recorder-owned chrome whose content slot
+holds the web app in an iframe at true pixel size, or the terminal's xterm.js
+screen, with the caption in a reserved band **below** the app rect. The page is
+the finished picture — one encode per take, and `shot()` stills match the video.
 `rec.page` is the framed page; `rec.app` is the app's document. Two edges:
 an app answering `X-Frame-Options`/CSP `frame-ancestors` refuses the take
 by name, and the dot is verb-driven — raw `rec.page.mouse` never moves it.
@@ -264,7 +264,7 @@ exception, or a non-zero exit. Both are
 |---|---|
 | `goto(path)` | Navigate (relative to base_url); waits for networkidle, but gives up after 10 s for apps that poll |
 | `pause(s)` / `shot(name)` | Hold the frame / capture `images/<name>.png` |
-| `caption(text)` | Narrator line in the caption band below the app; `""` clears. The band is the recorder's own document, so the line survives full page loads and SPA routing alike and `caption_lost` cannot fire on a web take — caption death on navigation is a terminal-take concern only (its caption is in-page, until #362). A line taller than the two-line band is shaved at the band's edges and recorded as a `caption_clipped` issue: shorten it, or split it over two captions |
+| `caption(text)` | Narrator line in the caption band below the app; `""` clears. Both media draw it in the same band, which is the recorder's own document — so the line survives full page loads and SPA routing alike, and `caption_lost` cannot fire at all any more. A line taller than the two-line band is shaved at the band's edges and recorded as a `caption_clipped` issue: shorten it, or split it over two captions |
 | `caption(text, ac="AC-3")` / `shot(name, ac="AC-3")` | Tag this beat with the acceptance criterion it is there to demonstrate. Needs `Recorder(criteria={...})`; a tag naming an undeclared criterion is refused. See [reference/review.md](reference/review.md). |
 | `criterion("AC-3")` | Raise a card carrying **AC-3's own declared sentence**, read out of `criteria={...}` rather than retyped — so the viewer meets the clause and then watches it happen. The beat claims AC-3 and nothing else; the beats after it are untagged. Held to reading speed, and cleared by `interlude("")` like any card. |
 | `hold(min_s=1.5)` | Keep the current frame up until the current caption's narration finishes (min `min_s`). Use after a spotlight/action so the emphasis rides the whole spoken line instead of flashing. See **Pacing and perception** below. |

--- a/skills/demo-video/helpers/demo_recording/chrome.py
+++ b/skills/demo-video/helpers/demo_recording/chrome.py
@@ -3,8 +3,9 @@
 Issue #358 (design record: #355). A wrapper take records a recorder-owned
 page carrying the window chrome: the pastel background, the dark rounded
 window with its title bar and traffic lights, a **content slot** the medium
-fills (the web recorder mounts the app iframe in it; #362 mounts xterm.js in
-the same slot), a **caption band** reserved BELOW the slot, and a **card
+fills (the web recorder mounts the app iframe in it; the terminal recorder
+mounts xterm.js in the same slot, #362), a **caption band** reserved BELOW
+the slot, and a **card
 layer** over the slot (#360). By construction the slot and the band share no
 pixels — `chrome_geometry` is the arithmetic behind that sentence. This
 repository's `tests/unit` (not shipped with the installed skill) grades it,
@@ -22,29 +23,31 @@ page — which is why its card sat above the caption bar and this one sits
 beside it. The decorative terminal prop (`Recorder.terminal()`) is deliberately
 **not** here: it is content, a styled element inside the demo's story that
 rides over the app the way an app dialog would, and the card layer stays
-reserved for the recorder's own furniture — #362 mounts a *real* terminal in
+reserved for the recorder's own furniture — #362 mounted a *real* terminal in
 the slot, and a prop living on the chrome layer would blur exactly that line.
 
 **The wrapper card declares the window's own colour — no compensation.** The
 card and the window body reach `demo.mp4` through one encoder on this path,
 so both paint the `window_body` the document was built with
-(`core.WEB_WINDOW_BODY` for the web recorder). The compensated pair the
-deleted composite needed (#291/#301) is recorded in that constant's history
-note; #361 deleted it with the composite.
+(`core.WEB_WINDOW_BODY` for the web recorder, `terminal.TERM_WINDOW_BODY` —
+the Catppuccin theme's own background — for the terminal). The compensated
+pair the deleted composite needed (#291/#301) is recorded in
+`core.WEB_WINDOW_BODY`'s history note; #361 deleted it with the composite.
 
 The visual constants here were ported from the composite's window frame
-(retired with it in #361) and from `terminal._TERM_HOST_JS`, whose copy
-stays until #362 mounts the terminal in this chrome too.
+(retired with it in #361) and from `terminal._TERM_HOST_JS`, the second
+hand-maintained copy of this window, retired when #362 mounted the terminal
+in this chrome too.
 """
 
 from __future__ import annotations
 
-# The pastel gradient behind the window. terminal.py still paints its own
-# copy (`_TERM_BG`) until #362; this one is the web recorder's since #361.
+# The pastel gradient behind the window — both media's, since #362 retired
+# terminal.py's own copy (`_TERM_BG`).
 CHROME_BG = "linear-gradient(135deg, #f6d5f0 0%, #d7e3fb 52%, #cdeede 100%)"
 
 # Title bar: height, fill and text colour, and the three traffic lights —
-# the frame both media share; `_TERM_HOST_JS` (terminal) still matches it.
+# the frame both media share.
 CHROME_BAR_PX = 36
 CHROME_BAR_BG = "#232334"
 CHROME_BAR_FG = "#9399b2"
@@ -69,13 +72,14 @@ CAPTION_FONT_PX = 26
 
 # Element ids. The slot is what a medium fills; the band holds the caption
 # element; the card layer holds the interlude/criterion card and the bridge
-# scrim (#360). The caption element deliberately keeps the id
-# `core._CAPTION_JS` uses, so "the caption element" is one selector whichever
-# medium drew it. The cursor dot keeps the id the composite path's overlay
-# used (`__demo_cursor`, so committed selectors keep working), and the card
-# and scrim keep `core.INTERLUDE_ID`/`core.BRIDGE_ID` — that is what lets
-# `interlude("")` and core's end-of-take overlay probe (`_OVERLAY_PROBE_JS`,
-# issue #163) find them with no wrapper-specific dispatch.
+# scrim (#360). The caption element keeps the id the retired in-page overlay
+# used (see core's history note over INTERLUDE_ID), so "the caption element"
+# is one selector in committed timelines old and new. The cursor dot keeps
+# the id the composite path's overlay used (`__demo_cursor`, so committed
+# selectors keep working), and the card and scrim keep
+# `core.INTERLUDE_ID`/`core.BRIDGE_ID` — that is what lets `interlude("")`
+# and core's end-of-take overlay probe (`_OVERLAY_PROBE_JS`, issue #163)
+# find them with no wrapper-specific dispatch.
 SLOT_ID = "__chrome_slot"
 BAND_ID = "__chrome_band"
 CARD_ID = "__chrome_card"
@@ -361,7 +365,8 @@ def chrome_html(
 # blank opening behind, so the blank opening is never on screen instead.
 #
 # An **init script**, and appended **already opaque** — both halves are
-# `terminal._OPENING_CARD_JS`'s pattern, kept for its reasons: an init script
+# the retired `terminal._OPENING_CARD_JS`'s pattern, kept for its reasons
+# (and since #362 this script is that card's one successor): an init script
 # runs on the wrapper page's *initial empty document*, which is earlier than
 # any Python statement or `set_content` can reach; and an element whose
 # computed opacity has been 1 since it entered the tree has no fade-in to run
@@ -378,9 +383,10 @@ def chrome_html(
 # iframe painting a copy of the hold over its own content would be the hold
 # covering the thing it exists to reveal.
 #
-# The pastel paint on the document element is `terminal._init_context`'s
-# issue-#25 guard, for the same white flash: the initial document is up
-# before the chrome document replaces it, and an unpainted document is white.
+# The pastel paint on the document element is the issue-#25 guard (born in
+# the terminal recorder's own init script, now living only here), for the
+# same white flash: the initial document is up before the chrome document
+# replaces it, and an unpainted document is white.
 OPENING_HOLD_JS = """
 (() => {
   if (window !== window.top) return;

--- a/skills/demo-video/helpers/demo_recording/content.py
+++ b/skills/demo-video/helpers/demo_recording/content.py
@@ -267,6 +267,10 @@ CONTENT_STATIC_WARN_S = 15.0
 # is how a dead member reached a shipped document in the first place.
 CONTENT_ACTING_VERBS = frozenset(
     {
+        # `act` is the escape-hatch block (#344): the storyboard drives the
+        # app with raw Playwright inside it, so by construction it changed
+        # the picture — the verb exists because that work was invisible.
+        "act",
         "clear",
         "click",
         "click_fast",
@@ -517,20 +521,20 @@ def opening_report(
 # it. A demo directory commits `record.py`, `timeline.json`, `timeline.md` and
 # `images/`; it does not commit `demo.mp4` or the `.seg.mp4` parts, so no
 # committed artifact carries the frame the question is about. `tests/smoke`'s
-# `check_opening_card` sweeps this same corner and grades a take that suite
+# `check_opening_card` sweeps this same strip and grades a take that suite
 # records itself, which is a claim about the *recorder* rather than about
 # anything anybody ships.
 #
 # So the recorder reads it, at the one moment the video exists: after the
-# segment is encoded, off that segment's own first frame, over a strip of the
-# background beside the terminal window. Outside the window on purpose —
-# inside it the card and the terminal are both dark and telling them apart
-# means reading text, which is not a robust thing to measure. Outside it the
-# two are an order of magnitude apart, and neither number is a threshold
-# anybody tuned; they are two constants in the recorder's own styling:
+# segment is encoded, off that segment's own first frame, over a strip of
+# the app rect (`terminal.OPENING_STRIP` — until #362 it was a strip of
+# background beside the recorder's bespoke window, which the shared chrome's
+# app-rect-only card layer made blind). The two states of frame 0 are an
+# order of magnitude apart there, and neither number is a threshold anybody
+# tuned; they are two constants in the recorder's own styling:
 #
-#   the card         a full-bleed #1c1a17 rectangle          luma ~26
-#   bare terminal    the _TERM_BG pastel gradient            luma ~226
+#   covered   the opening hold / clause card, the window's own body   luma ~26
+#   bare      the unheld slot canvas or chrome background             luma ~225+
 #
 # **Reported, never enforced**, and the measurement behind that decision is
 # [#128]: one CI run in nine read **128** and 0.00 s of cover on a loaded
@@ -586,9 +590,11 @@ def opening_card_report(
 ) -> dict:
     """`content.opening.card`: what this segment's **first frame** showed.
 
-    `rect` is the strip beside the terminal window, in video pixels; `raised`
-    is whether this take asked the recorder for an opening card at all, which
-    is what tells a reader whether `"bare"` is the defect or the arrangement.
+    `rect` is the strip of the app rect the cover paints (#362 moved it
+    inside the window — see the section header), in video pixels; `raised`
+    is whether this take asked the recorder for an opening card at all.
+    Since the opening hold is unconditional, `"bare"` is the defect either
+    way; `raised` says whether a clause was on the cover.
 
     `state` is derived from the **rounded** `luma` this dict publishes, so the
     number and the word can never disagree with each other.

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -87,54 +87,24 @@ from .timeline import (
     write_timeline,
 )
 
-# Caption bar: a narrator line burned into the recording (and stills), so
-# the video explains itself to someone watching with no other context.
-_CAPTION_JS = """
-window.__demoCaption = (text) => {
-  let el = document.getElementById('__demo_caption');
-  if (!el) {
-    el = document.createElement('div');
-    el.id = '__demo_caption';
-    el.style.cssText = `
-      position: fixed; left: 50%; bottom: __CAPBOTTOM__px; transform: translateX(-50%);
-      max-width: 90%; padding: 12px 30px; border-radius: 12px;
-      background: rgba(22,20,16,.72); backdrop-filter: blur(3px);
-      color: #f7f4ee; text-align: center;
-      font: 600 __CAPFONT__px/1.36 system-ui, sans-serif; letter-spacing: .01em;
-      pointer-events: none; z-index: 2147483646; opacity: 0;
-      transition: opacity .3s ease; box-shadow: 0 6px 24px rgba(0,0,0,.28);
-    `;
-    document.body.appendChild(el);
-  }
-  el.textContent = text;
-  el.style.opacity = text ? '1' : '0';
-};
-"""
-
-# Interlude: a full-screen title card for jumps over real-world time the
-# recording skips (minutes of background work between two segments).
+# The caption, the interlude card and the bridge scrim all render in the
+# wrapper chrome's own document (chrome.py): the caption in its reserved
+# band below the app rect, the cards in the card layer over it. Both media
+# mount that chrome — the web recorder since #358/#361, the terminal since
+# #362 — so the chrome document's inline `__demoCaption`/`__demoInterlude`/
+# `__demoBridge` are the only renderers left, and this module keeps only the
+# element ids they share with the verbs and the end-of-take probe.
 #
-# The card's styling is a module constant because a *second* thing builds this
-# same element: a segment that opens on a card raises it from an init script,
-# before the recorder's own setup and before the page has painted at all
-# (issue #110, and see terminal.py's `_OPENING_CARD_JS`). Both have to produce
-# an element `__demoInterlude` will then recognise and fade out, which means
-# one id and one stylesheet, in one place.
+# History: until #362 this module carried the in-page overlay path — a
+# `_CAPTION_JS` init script drawing a fixed-bottom caption bar inside the
+# recorded page (`_caption_bottom_px` placed it), an `_INTERLUDE_JS` builder
+# with a per-medium stylesheet (`INTERLUDE_CSS_TERMINAL`, the #110/#291
+# palette work), and a `_BRIDGE_JS` builder — because the terminal page was
+# its own document with no chrome to host them. The terminal now records the
+# shared chrome, the last consumer went with it, and a caption that dies
+# with its document died as a class: no recorded page navigates its own
+# chrome.
 INTERLUDE_ID = "__demo_interlude"
-
-# Everything about the card except its two colours. Split out so the palettes
-# below cannot drift apart in the properties other things depend on: the card
-# is **opaque**, it covers the viewport, and it sits one level above the
-# caption bar (2147483646) so no caption is drawn while it is up. All three are
-# load-bearing outside this file — reference/limits.md reasons from them about
-# what the picture check can and cannot see.
-_INTERLUDE_LAYOUT = (
-    "position: fixed; inset: 0; display: flex; align-items: center;"
-    " justify-content: center;"
-    " font: 500 30px/1.5 system-ui, sans-serif; text-align: center;"
-    " padding: 0 12%; z-index: 2147483647; opacity: 0;"
-    " transition: opacity .45s ease; pointer-events: none;"
-)
 
 # The web window's body — the fill chrome.py paints the dark rounded window
 # with, and with it the pad around the app rect, the opening hold, and the
@@ -156,37 +126,6 @@ _INTERLUDE_LAYOUT = (
 # level off the window (#301). #355's structural half retired the class:
 # one encoder, one declaration, and #361 deleted the compensated pair.
 WEB_WINDOW_BODY = "#181825"
-
-# The interlude card's stylesheet. One consumer today: the terminal
-# recorder, whose segments can *open* on this card (#110) — raised from an
-# init script before the recorder's own setup, so the id and the stylesheet
-# live here where both builders can reach them. The near-black terminal
-# palette is the feature there: the card blends with the terminal it covers.
-#
-# The web recorder's card is deliberately **not** built from this. The
-# wrapper document carries its own `__demoInterlude` element in the card
-# layer over the app rect (chrome.py, #360), declaring `WEB_WINDOW_BODY`
-# uncompensated — `_INTERLUDE_JS` below only ever finds that element already
-# in the tree and toggles it, so the stylesheet here never paints on a web
-# take. The per-medium CSS split this replaces (`INTERLUDE_CSS_WEB`, painted
-# in the compensated `WEB_CARD_BODY`) died with the composite in #361; see
-# WEB_WINDOW_BODY's history note.
-INTERLUDE_CSS_TERMINAL = (
-    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"
-)
-_INTERLUDE_JS = """
-window.__demoInterlude = (text) => {
-  let el = document.getElementById('__ID__');
-  if (!el) {
-    el = document.createElement('div');
-    el.id = '__ID__';
-    el.style.cssText = '__CSS__';
-    document.body.appendChild(el);
-  }
-  el.textContent = text;
-  el.style.opacity = text ? '1' : '0';
-};
-"""
 
 # How long a `criterion()` card stays up when the storyboard does not say.
 #
@@ -210,34 +149,9 @@ CRITERION_HOLD_MAX_S = 9.0
 
 # Lightweight bridge: a centered label over a soft scrim, with the scene
 # still visible behind it. For short segment transitions where a full-screen
-# interlude card would feel heavy.
+# interlude card would feel heavy. Rendered by the chrome document's own
+# `__demoBridge` (chrome.py) — see the history note over INTERLUDE_ID.
 BRIDGE_ID = "__demo_bridge"
-_BRIDGE_JS = """
-window.__demoBridge = (text) => {
-  let el = document.getElementById('__ID__');
-  if (!el) {
-    el = document.createElement('div');
-    el.id = '__ID__';
-    el.style.cssText = `
-      position: fixed; inset: 0; display: flex; align-items: center;
-      justify-content: center; z-index: 2147483647; opacity: 0;
-      transition: opacity .4s ease; pointer-events: none;
-      background: radial-gradient(ellipse at center,
-        rgba(18,15,28,.58) 0%, rgba(18,15,28,.16) 70%, rgba(18,15,28,0) 100%);
-    `;
-    const t = document.createElement('div');
-    t.id = '__demo_bridge_t';
-    t.style.cssText = `
-      color: #fff; font: 600 34px/1.4 system-ui, sans-serif; text-align: center;
-      max-width: 72%; text-shadow: 0 2px 22px rgba(0,0,0,.65);
-    `;
-    el.appendChild(t);
-    document.body.appendChild(el);
-  }
-  document.getElementById('__demo_bridge_t').textContent = text;
-  el.style.opacity = text ? '1' : '0';
-};
-"""
 
 # The two overlays this module puts on the page, by element id.
 #
@@ -451,9 +365,12 @@ _FROZEN_CLOCK_JS = """
 # frame; a finite one ends where it would have ended.
 #
 # Two things are spared, and both matter:
-#   * the recorder's own overlays (`#__demo…`, `#__term…`) — their motion is
-#     triggered by the storyboard, so it is already as repeatable as the
-#     storyboard is, and killing it would only make captions pop;
+#   * the recorder's own furniture (`#__demo…`, `#__term…`, `#__chrome…`) —
+#     its motion is triggered by the storyboard, so it is already as
+#     repeatable as the storyboard is, and killing it would only make
+#     captions pop. `#__chrome…` joined the list in #362, when the rule
+#     first reached the chrome document at all: the hold's 450 ms reveal is
+#     recorder motion by the same reading as a caption's fade;
 #   * anything carrying `data-demo-video-animate` — the documented opt-out for
 #     an element that must keep painting. Chromium's screencast emits a frame
 #     when the page paints (issue #18), so "no motion at all" is not a free
@@ -462,7 +379,8 @@ _FROZEN_CLOCK_JS = """
 _FREEZE_MOTION_JS = """
 (() => {
   const KEEP =
-    ':not([data-demo-video-animate]):not([id^="__demo"]):not([id^="__term"])';
+    ':not([data-demo-video-animate]):not([id^="__demo"]):not([id^="__term"])'
+    + ':not([id^="__chrome"])';
   // The pseudo-element arms are not padding: an animated ::after is the most
   // common spinner on the web.
   const CSS = ['', '::before', '::after'].map((p) => '*' + KEEP + p).join(',') + `{
@@ -1043,22 +961,12 @@ class _DemoBase:
             "SPEECH_MODEL", "eleven_multilingual_v2"
         )
         self._tts_dir = self.out_dir / ".tts"
-        # Caption font size in px. Both media record at true pixel size now,
-        # so this is the size on screen: the web recorder's band caption and
-        # the terminal's in-page bar both render it as declared. (The deleted
+        # Caption font size in px, handed to `chrome_html` by each medium's
+        # `_start`. Both media record at true pixel size, so this is the
+        # size on screen in the chrome's caption band. (The deleted
         # composite scaled the web page ~0.8 and compensated with 34px — see
         # web.py's history note.)
         self._caption_font_px = 26
-        # Caption distance from the frame bottom, in px — `_CAPTION_JS`'s
-        # in-page overlay only, which today means the terminal recorder (the
-        # web caption lives in the wrapper chrome's own band and never reads
-        # this). The terminal raises it so the bar clears its window's edge.
-        self._caption_bottom_px = 44
-        # The interlude card's stylesheet, read only when `_INTERLUDE_JS` has
-        # to *build* the element — which today means the terminal page: the
-        # web recorder's wrapper document ships the card element in its own
-        # card layer (chrome.py, #360), so the script only toggles it there.
-        self._interlude_css = INTERLUDE_CSS_TERMINAL
         self._lines: list[tuple[float, Path]] = []  # (video offset s, clip)
         # Both are readings of time.monotonic(). Nothing in this package
         # measures elapsed time any other way — not the beat log, not narration
@@ -1178,18 +1086,29 @@ class _DemoBase:
                 file=sys.stderr,
             )
 
-    def _interlude_script(self) -> str:
-        """`__demoInterlude`, carrying **this medium's** card (issue #291).
+    def _freeze_motion_here(self) -> None:
+        """Re-attach the motion rule to a document `set_content` just wrote.
 
-        A method rather than an expression inside `__enter__` because that is
-        where the dispatch would otherwise be, and `__enter__` needs a browser:
-        this is the whole of the per-medium choice, and it is the largest part
-        of it a browser-free test can reach. `tests/unit` reads what it returns
-        for a recorder of each medium.
+        `page.set_content` writes a new document into the same window. The
+        `<style>` the context init script appended goes with the old one,
+        and the init script does **not** run again — measured directly: a
+        probe init script's counter stays at 1 across `set_content` while
+        its style element is gone. Globals survive (same realm), which is
+        why the frozen clock needs nothing here and this does.
+
+        It went unnoticed until #362, because until then the only document
+        either medium wrote its chrome into was the web wrapper, whose app
+        is an iframe with a document of its own where the init script does
+        run. The terminal's content is *in* the written document, so every
+        animation probe in this repository's `tests/smoke --terminal-only`
+        read its authored duration — 2 s where the rule says 1 ms.
+
+        A no-op unless `deterministic=True`, like the init script it
+        repeats: the rule is opt-in and this does not widen that.
         """
-        return _INTERLUDE_JS.replace("__ID__", INTERLUDE_ID).replace(
-            "__CSS__", self._interlude_css
-        )
+        if not self.deterministic:
+            return
+        self.page.evaluate("() => {" + _FREEZE_MOTION_JS + "}")
 
     # -- subclass hooks -----------------------------------------------------
 
@@ -1259,14 +1178,11 @@ class _DemoBase:
                     _FROZEN_CLOCK_JS.replace("__EPOCH_MS__", str(self._clock_ms))
                 )
                 self._context.add_init_script(_FREEZE_MOTION_JS)
-            # Overlays common to every medium.
-            self._context.add_init_script(
-                _CAPTION_JS.replace("__CAPFONT__", str(self._caption_font_px))
-                .replace("__CAPBOTTOM__", str(self._caption_bottom_px))
-            )
-            self._context.add_init_script(self._interlude_script())
-            self._context.add_init_script(_BRIDGE_JS.replace("__ID__", BRIDGE_ID))
-            # Medium-specific init scripts (cursor, spotlight, ...).
+            # No caption/card init scripts ride along: the chrome document
+            # each medium's `_start` builds carries its own renderers
+            # (chrome.py), and nothing calls them before it is up — see the
+            # history note over INTERLUDE_ID.
+            # Medium-specific init scripts (opening hold, spotlight, ...).
             self._init_context(self._context)
             self.page = self._context.new_page()
             # Chromium's screencast starts with the page, so this — not the
@@ -2266,12 +2182,13 @@ take with fewer beats than the last one would otherwise leave the
         and the medium seam's whole rule is that a medium extends by
         implementing a hook it was offered.
 
-        Only `TerminalRecorder` answers. Its segments open on a card raised
-        before capture starts, and the strip of background beside its window
-        says in one number whether the card was up when the recording began.
-        The web recorder answers None — its opening is the wrapper hold, up
-        in frame 0 and cleared by the first `goto()` (#360), which the
-        review sheet names on the frames cut inside it (frames.py) rather
+        Only `TerminalRecorder` answers. Its takes open on the chrome's hold
+        (or the clause card `interlude=` raised over it), and a strip of the
+        app rect says in one number whether that cover was up when the
+        recording began (#362 moved the strip inside the window — see
+        `terminal.OPENING_STRIP`). The web recorder answers None — its
+        opening hold is graded by `tests/smoke --wrapper-only` and named by
+        the review sheet on the frames cut inside it (frames.py) rather
         than this field claiming a card the medium did not measure — so None
         lands in the artifact as `content.opening.card: null`.
         """
@@ -2297,15 +2214,16 @@ take with fewer beats than the last one would otherwise leave the
                 f"frame ({type(exc).__name__}: {exc}), so nothing about the "
                 f"picture was measured"
             )
-            # The opening frame is *not* measured over the app rect — a medium
-            # that can read its own window still knows where to look — so a
-            # take that lost one measurement does not have to lose the other
-            # (issue #235). Without this the whole `opening` block was null on
-            # this path, which is an absence with no reason in it: a terminal
-            # take that could read `#__term_win` and not `#__term_host` said
-            # nothing at all about the frame it opened on, and nothing said
-            # why. `gap` genuinely could not be measured here, and the note is
-            # where that is written down.
+            # The opening frame is *not* measured over `_content_rect`'s
+            # answer — a medium whose chrome geometry survived still knows
+            # where to look — so a take that lost one measurement does not
+            # have to lose the other (issue #235). Without this the whole
+            # `opening` block was null on this path, which is an absence
+            # with no reason in it: a terminal take that had its geometry
+            # and not its `#__term_host` box said nothing at all about the
+            # frame it opened on, and nothing said why. `gap` genuinely
+            # could not be measured here, and the note is where that is
+            # written down.
             self._content["opening"] = opening_report(
                 None,
                 "the app rect could not be worked out, so the opening gap was "
@@ -2552,16 +2470,19 @@ take with fewer beats than the last one would otherwise leave the
     def _note_caption_clipped(self, text: str, clipped: object) -> None:
         """A caption surface that measured itself clipped gets written down.
 
-        Only the wrapper chrome's `__demoCaption` (chrome.py, #358) returns a
-        number: its caption band has a fixed height and `overflow: hidden` —
-        the construction that keeps the app rect caption-free — so a caption
+        The chrome's `__demoCaption` (chrome.py, #358) returns the number:
+        its caption band has a fixed height and `overflow: hidden` — the
+        construction that keeps the app rect caption-free — so a caption
         too tall for the band is shaved at the band's edges while the beat
         log records the full sentence. Without this, that is `timeline.json`
         claiming a line the pixels do not show: measured on a 174-character
         caption, the band's flex centring shaved ~17 px off the top of the
         first line and the bottom of the third, `warnings` stayed empty and a
-        strict take stayed green. The in-page overlay `_CAPTION_JS` grows
-        with its text and returns nothing, so nothing fires off this path.
+        strict take stayed green. Both media share the band since #362, so
+        this fires on a terminal take exactly as on a web one. (The retired
+        in-page overlay grew with its text and returned nothing — the None
+        guard below is also what keeps a scripted page that answers nothing
+        from minting an issue.)
 
         The text is deliberately **not** capped or reflowed — the honest
         artifact is the point. An issue rather than a refusal, and not in

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import codecs
 import fcntl
-import json
 import os
 import pty
 import re
@@ -35,13 +34,17 @@ import time
 from collections import deque
 from pathlib import Path
 
+from .chrome import chrome_geometry, chrome_html, opening_hold_script
 from .content import content_rect, opening_card_report
-from .core import INTERLUDE_ID, _beat_verb, _DemoBase, _env
+from .core import _beat_verb, _DemoBase, _env
 
 _ASSETS = Path(__file__).parent.parent / "assets" / "xterm"
 
 # Terminal window theme (Catppuccin Mocha) — a cohesive, well-loved palette
-# that reads as a polished dev terminal rather than a bare console.
+# that reads as a polished dev terminal rather than a bare console. This is
+# the *content's* colour, a parameter of the chrome's slot, not chrome
+# (#355's design record): the window frame around it comes from chrome.py,
+# shared with the web recorder since #362.
 _TERM_THEME = {
     "background": "#181825", "foreground": "#cdd6f4",
     "cursorAccent": "#181825",
@@ -55,44 +58,38 @@ _TERM_THEME = {
     "brightWhite": "#a6adc8",
 }
 
-# Host page: render the terminal inside a floating, rounded window with a
-# title bar and traffic-light buttons, centered on a soft pastel gradient so
-# the eye has an obvious frame to follow (full-bleed is hard to read). The
-# fit addon derives cols/rows from the window's inner size; they are read
-# back to size the PTY so TUIs lay out correctly.
-_TERM_HOST_JS = """
+# The terminal window's body — the fill the shared chrome paints the window,
+# the opening hold and the card layer with on a terminal take, and the
+# xterm.js slot content's own background. One name so the four cannot drift:
+# it is the theme's background on purpose, because the old bespoke window
+# (`_TERM_HOST_JS`, retired by #362) painted its body from the theme too and
+# the seam between window pad and terminal screen is invisible only while
+# the two agree. Numerically equal to `core.WEB_WINDOW_BODY` today; kept as
+# its own name because it is the *theme's* colour, a content parameter.
+TERM_WINDOW_BODY = _TERM_THEME["background"]
+
+# Mounts xterm.js in the shared chrome's content slot (#362) — the same
+# `#__chrome_slot` the web recorder mounts its app iframe into. The window
+# around it (background, title bar, pads, caption band, card layer) is
+# chrome.py's; this script only fills the slot. The host div keeps the id
+# `__term_host` so every geometry consumer that reads the live element
+# (issue #97) reads the same one it always has. The fit addon derives
+# cols/rows from the slot's size; they are read back to size the PTY so
+# TUIs lay out correctly.
+#
+# History: until #362 this file carried `_TERM_HOST_JS`, a second
+# hand-maintained copy of the window chrome (bar 40 px against the shared
+# 36, radius 12 against 14, its own gradient and shadow, fixed 70/74 insets
+# against computed pads). #355's addendum retired it: one chrome, two
+# mounts.
+_TERM_MOUNT_JS = """
 window.__demoTermInit = (opts) => {
-  document.documentElement.style.height = '100%';
-  document.body.style.cssText =
-    'margin:0; height:100%; overflow:hidden; background:' + opts.bg + ';';
-
-  const win = document.createElement('div');
-  win.id = '__term_win';
-  win.style.cssText = `
-    position: fixed; top: 70px; left: 74px; right: 74px; bottom: 70px;
-    display: flex; flex-direction: column; border-radius: 12px;
-    overflow: hidden; background: ${opts.theme.background};
-    box-shadow: 0 30px 80px rgba(20,16,40,.38), 0 6px 18px rgba(20,16,40,.28);
-  `;
-  const bar = document.createElement('div');
-  bar.style.cssText = `
-    display: flex; align-items: center; gap: 8px; height: 40px;
-    padding: 0 14px; background: #232334; flex: 0 0 auto;
-    font: 13px/1 ui-monospace, monospace; color: #9399b2;
-  `;
-  const dot = (c) => `<span style="width:12px;height:12px;border-radius:50%;
-    display:inline-block;background:${c}"></span>`;
-  bar.innerHTML =
-    dot('#ff5f57') + dot('#febc2e') + dot('#28c840') +
-    `<span style="flex:1;text-align:center;letter-spacing:.02em">${opts.title}</span>` +
-    `<span style="width:44px"></span>`;
-  win.appendChild(bar);
-
+  const slot = document.getElementById('__chrome_slot');
   const host = document.createElement('div');
   host.id = '__term_host';
-  host.style.cssText = 'flex: 1 1 auto; min-height: 0; padding: 12px 14px;';
-  win.appendChild(host);
-  document.body.appendChild(win);
+  host.style.cssText = 'position: absolute; inset: 0; padding: 12px 14px;'
+    + ' box-sizing: border-box; background: ' + opts.theme.background + ';';
+  slot.appendChild(host);
 
   const term = new Terminal({
     fontSize: opts.fontSize,
@@ -121,94 +118,56 @@ window.__demoTermInit = (opts) => {
 };
 """
 
-# Soft, low-saturation pastel gradient behind the window — present enough to
-# frame the terminal, calm enough not to pull focus.
-_TERM_BG = "linear-gradient(135deg, #f6d5f0 0%, #d7e3fb 52%, #cdeede 100%)"
-
-# -- opening on a card (issue #110) ------------------------------------------
+# -- opening on a card (issue #110, re-based on the shared chrome by #362) ----
 #
 # A terminal segment that opens with `interlude()` shows a flash of bare
 # terminal first, and it is structural rather than a pacing mistake:
 # `__enter__` starts Chromium's screencast when it creates the page, and a
 # storyboard cannot paint anything before its own first statement. Measured on
 # the reference demo: six frames — ~0.30 s — of an empty window with a lone
-# prompt at the head of part2. The web recorder does not show it only because
-# it has nothing on screen until `goto()` — there is no "before" to flash.
+# prompt at the head of part2 (#110, #207).
 #
-# Measured in *frames*, and not in the timeline, which is where #110 first
-# wrote it down (part2's offset at 37.76 s against the interlude beat at
-# 38.05 s). That gap is this recorder's own setup cost — `_t0` is set before
-# `_start()`, which goes to about:blank, injects xterm.js, opens the PTY and
-# waits for the first prompt before `_open_on_card` runs — so it survives the
-# fix: 0.358 s before and 0.365 s after, on the same storyboard one line
-# apart, while the first part2 frame went 226.5 (bare) to 25.8 (card). See
-# issue #207. A beat's timestamp says when the card was *logged*; only the
-# pixels say when it was up.
+# What covers that gap since #362 is the chrome's **opening hold**
+# (chrome.OPENING_HOLD_JS): an opaque field in the window's own colour over
+# the app rect, up in frame 0 from an init script — earlier than any Python
+# statement can reach, earlier than `pty.openpty()`, earlier than xterm.js is
+# injected — exactly the web recorder's #360 pattern, one implementation for
+# both media. The whole of the recorder's setup happens behind it, and the
+# hold is cleared when the terminal has something to show (the shell's first
+# prompt), the same contract as the web path's first `goto()`.
 #
-# So the card stops being something a storyboard has to remember to do first
-# and becomes a property of the recorder: `TerminalRecorder(interlude="…")`
-# paints it from an **init script**, which runs before the page's own scripts
-# on every document including Chromium's initial one. That is earlier than any
-# Python statement can reach — earlier than `pty.openpty()`, earlier than
-# xterm.js is injected — so the card is up in the recording's first frame and
-# the whole of the recorder's own setup happens behind it.
+# `TerminalRecorder(interlude="…")` still opens the segment on intent rather
+# than on a covered pause: the clause is raised in the chrome's card layer
+# (`__demoInterlude`, over the hold — chrome.py's stacking puts the card
+# above it) as the first thing `_start()` does after the chrome document is
+# up, so its 450 ms fade runs over the hold's flat field, never over the
+# recorder's setup. The card renders on the app rect in the window's own
+# body colour — the shared card layer, not the full-bleed `#1c1a17` field
+# the retired `_OPENING_CARD_JS` init script used to build (#362 states the
+# visual change; #291's palette history is on `core.WEB_WINDOW_BODY`).
 #
-# It is also the answer to the *other* end of the same seam. #91 was this card
-# left up for the rest of a take, because a storyboard remembered
-# `interlude(text)` and not `interlude("")`. A card the recorder raises is a
-# card the recorder clears — see `_open_on_card`.
-#
-# It builds the element rather than calling `__demoInterlude`, and the whole
-# difference is one line: the card is appended **already opaque**.
-# `__demoInterlude` creates it at `opacity: 0` and raises it, which is a 450 ms
-# fade — and a card that fades in over the recorder's setup is showing exactly
-# what it exists to cover. An element whose computed opacity has been 1 since
-# it entered the tree has no transition to run, so that is structural here
-# rather than a flag somebody could turn off. Everything else about it — the
-# id, the styling — is core's, so `interlude("")` finds this element and fades
-# it out like any other.
-#
-# (What the suite can say about that last point is limited, and tests/README.md
-# says where: on this box the fade-in variant is invisible in the recording
-# too, because injecting xterm.js takes longer than 450 ms and Chromium's
-# screencast has emitted nothing by then. Being opaque by construction is what
-# keeps that from being the thing holding the fix up.)
-_OPENING_CARD_JS = """
-(() => {
-  const build = () => {
-    // `document.body` is null on Chromium's initial empty document, where init
-    // scripts first run — the same guard the background paint above needs, and
-    // for the same reason (issue #25).
-    if (!document.body || document.getElementById('__ID__')) return;
-    const el = document.createElement('div');
-    el.id = '__ID__';
-    el.style.cssText = '__CSS__';
-    el.style.opacity = '1';
-    el.textContent = __TEXT__;
-    document.body.appendChild(el);
-  };
-  if (document.body) build();
-  else addEventListener('DOMContentLoaded', build);
-})();
-"""
-
-# How long the opening card is held before it fades, when nothing says
-# otherwise. The same default `interlude()` uses, because it is the same card
-# doing the same job.
+# The other end of the seam is unchanged: #91 was this card left up for the
+# rest of a take. A card the recorder raises is a card the recorder clears —
+# see `_open_on_card`.
 OPENING_CARD_HOLD_S = 2.8
 
-# Where the card is read back off the finished video (issue #235): a strip of
-# the background beside the terminal window, in the top corner opposite the
-# caption bar. See `_opening_card_rect`, and "the frame a terminal segment
-# opens on" in `content` for why it is outside the window rather than in it.
+# Where the opening frame is read back off the finished video (issue #235):
+# a strip of the **app rect**, as fractions of it. A band across the top,
+# where a shell's first rows land, starting near the left edge — terminal
+# text hugs the left column, and a strip inset the way the web card strip
+# is (`tests/_pixels.CARD_STRIP`) was measured missing every glyph of a
+# short command (travel 0.01 against frame 0 on a healthy take). Inset a
+# slot-padding's worth from the left and top so the strip never reads the
+# slot's own edge blend, and kept above the centred clause card's text.
 #
-# The margin clears the window's rounded corner and the near side of its drop
-# shadow; the height keeps the strip well above the window's top inset (70 px),
-# so nothing but the background — or whatever is covering it — is in the read.
-# `_TERM_HOST_JS` insets the window by 74 px, so this is a 58x50 strip on the
-# stock geometry, and that is the rect `tests/smoke` has swept since #110.
-OPENING_CARD_MARGIN_PX = 8
-OPENING_CARD_STRIP_PX = 50
+# Inside the app rect, where until #362 it was a strip of background beside
+# the bespoke window: the shared chrome's card layer covers the app rect and
+# nothing else, so the background beside the window never changes and can no
+# longer say what the take opened on. What frame 0 shows there now is the
+# opening hold (or the clause card over it) — the window's own dark body —
+# against the defect's reading: the slot's white canvas, or the unheld
+# pastel background, both an order of magnitude of luma away.
+OPENING_STRIP = (0.01, 0.04, 0.90, 0.16)  # x, y, w, h as fractions of the app rect
 
 # Named keys -> the bytes a terminal program expects. Ctrl-<letter> is
 # handled generically (C-a..C-z -> 0x01..0x1a).
@@ -275,11 +234,13 @@ class TerminalRecorder(_DemoBase):
     fit addon; the resulting cols/rows are pushed to the PTY winsize so TUIs
     render correctly. `font_size` tunes how much fits on screen.
 
-    `interlude="…"` opens the segment on a full-screen title card, raised
-    before capture starts and cleared by the recorder when `interlude_hold`
-    seconds are up. Use it instead of an `interlude()` as the storyboard's
-    first statement: the storyboard's first statement is already ~290 ms too
-    late, and the viewer sees an empty terminal before the card (issue #110).
+    `interlude="…"` opens the segment on a title card in the chrome's card
+    layer, raised over the opening hold before any storyboard statement runs
+    and cleared by the recorder when `interlude_hold` seconds are up. Use it
+    instead of an `interlude()` as the storyboard's first statement: the
+    storyboard's first statement is already ~290 ms too late (issue #110).
+    Either way the take opens covered — the hold is up in frame 0 (#360's
+    pattern, shared since #362) — so a bare terminal is never on screen.
     """
 
     def __init__(
@@ -320,11 +281,6 @@ class TerminalRecorder(_DemoBase):
             timezone_id=timezone_id, locale=locale, evidence=evidence,
             criteria=criteria, ticket=ticket, allow_private=allow_private,
         )
-        # Match the web recorder's effective caption height. Web composites
-        # its page into a scaled, centered window, lifting its bottom:44px
-        # caption to ~89px in the final frame; the terminal isn't composited,
-        # so raise its caption to the same height for uniform placement.
-        self._caption_bottom_px = 88
         self._shell = shell or _env("TERMINAL_SHELL") or "/bin/bash"
         fs = font_size
         if fs is None:
@@ -346,57 +302,60 @@ class TerminalRecorder(_DemoBase):
         self._exit_tail = ""
         # When the PTY last produced a byte.
         self._last_data_at = time.monotonic()
-        # The card this segment opens on, if it opens on one. See
-        # _OPENING_CARD_JS.
+        # The card this segment opens on, if it opens on one. See the
+        # "opening on a card" section header above.
         self._opening = interlude
         self._opening_hold = interlude_hold
         # Where the xterm.js screen sits in the frame, read off the live
         # element once the terminal exists (issue #97). See `_content_rect`.
         self._host_box: tuple[int, int, int, int] | None = None
-        # Where the window's right edge is, which is what says where the
-        # background stops being the window (issue #235). See
-        # `_opening_card_rect`.
-        self._win_right: int | None = None
 
     # -- setup / teardown ---------------------------------------------------
 
     def _init_context(self, context) -> None:
-        # Paint the background from the very first frame, so the brief
-        # about:blank + xterm-injection period isn't a white flash (it would
-        # otherwise show between a preceding segment and the terminal).
-        # `documentElement` is null on Chromium's initial empty document, where
-        # init scripts first run — dereferencing it there threw an uncaught
-        # TypeError on every single take, and took the background paint this
-        # exists to apply down with it (issue #25). Guarded like `body` below
-        # it, and applied again once the document is real.
+        # The shared chrome's opening hold (#360, mounted here by #362): it
+        # paints the chrome background on the initial document — the #25
+        # white-flash guard, now one script for both media — and holds an
+        # opaque field in the window's own colour over the app rect from
+        # frame 0, so the whole of this recorder's setup (the PTY, the
+        # xterm.js injection, the shell's first prompt) happens behind it.
+        # An init script because that runs on Chromium's initial empty
+        # document, earlier than any Python statement can reach.
         context.add_init_script(
-            "(() => { const bg = '__BG__';"
-            " const paint = (el) => { if (el) el.style.background = bg; };"
-            " paint(document.documentElement);"
-            " const b = () => { paint(document.documentElement); paint(document.body); };"
-            " if (document.body) b(); else addEventListener('DOMContentLoaded', b); })();"
-            .replace("__BG__", _TERM_BG)
-        )
-        # After the background paint and before anything else: the card is
-        # opaque and covers the whole viewport, so what is behind it only has
-        # to be the right colour for the fade *out*. Registered here rather
-        # than evaluated in `_start()` because `_start()` navigates
-        # (`goto("about:blank")`), and an init script is the only thing that
-        # survives a navigation and precedes the first paint of what follows
-        # it.
-        if self._opening is not None:
-            context.add_init_script(
-                _OPENING_CARD_JS.replace("__ID__", INTERLUDE_ID)
-                # `self._interlude_css`, not the constant it defaults to: the
-                # opening card and the card `interlude()` raises later in the
-                # same take are the same element, and reading them off one
-                # attribute is what keeps a per-medium palette (#291) from
-                # arriving in one of the two places.
-                .replace("__CSS__", self._interlude_css)
-                .replace("__TEXT__", json.dumps(self._opening))
+            opening_hold_script(
+                chrome_geometry(self._size["width"], self._size["height"]),
+                window_body=TERM_WINDOW_BODY,
             )
+        )
 
     def _start(self) -> None:
+        # The chrome document first, so the recorded pixels are the shared
+        # window from the earliest paint after frame 0's hold. `self._geom`
+        # is `chrome_geometry`'s dict — the one shape every geometry consumer
+        # reads, web and terminal alike (#362).
+        self._geom = chrome_geometry(self._size["width"], self._size["height"])
+        self.page.set_content(
+            chrome_html(
+                self._geom,
+                title=self._terminal_title,
+                window_body=TERM_WINDOW_BODY,
+                accent=self._accent,
+                caption_font_px=self._caption_font_px,
+            )
+        )
+        # `set_content` wrote a new document, which took the motion rule with
+        # it — and this medium's content lives in that document. See
+        # `_freeze_motion_here`.
+        self._freeze_motion_here()
+        if self._opening is not None:
+            # The clause, in the chrome's card layer, raised before anything
+            # else this method does: its fade runs over the opening hold's
+            # flat field (the card layer stacks above the hold), never over
+            # the recorder's setup — #110's point, on #360's machinery.
+            self.page.evaluate(
+                "t => window.__demoInterlude(t)", self._opening
+            )
+
         master, slave = pty.openpty()
         self._fd = master
         env = os.environ.copy()
@@ -421,8 +380,7 @@ class TerminalRecorder(_DemoBase):
         flags = fcntl.fcntl(master, fcntl.F_GETFL)
         fcntl.fcntl(master, fcntl.F_SETFL, flags | os.O_NONBLOCK)
 
-        # Build the xterm.js terminal in the page and read back its geometry.
-        self.page.goto("about:blank")
+        # Mount xterm.js in the chrome's content slot and read back its grid.
         self.page.add_style_tag(content=(_ASSETS / "xterm.css").read_text())
         self.page.add_script_tag(content=(_ASSETS / "xterm.js").read_text())
         self.page.add_script_tag(content=(_ASSETS / "addon-fit.js").read_text())
@@ -435,34 +393,38 @@ class TerminalRecorder(_DemoBase):
         # take, and a reader of this method reasonably assumed it did something.
         # A serialized dump of the buffer beside `timeline.json` is a feature
         # somebody can propose on its own; it was never this.
-        self.page.add_script_tag(content=_TERM_HOST_JS)
+        self.page.add_script_tag(content=_TERM_MOUNT_JS)
         dims = self.page.evaluate(
             "o => window.__demoTermInit(o)",
-            {"bg": _TERM_BG, "theme": _TERM_THEME,
-             "title": self._terminal_title,
+            {"theme": _TERM_THEME,
              "cursor": f"rgb({self._accent})",
              "fontSize": self._font_size},
         )
         self._set_winsize(int(dims["rows"]), int(dims["cols"]))
         self._read_host_box()
-        self._read_win_edge()
-        # Just enough to catch the shell's first prompt. It used to be kept
-        # short so a segment opening on a transition would not dwell on a bare
-        # terminal; with `interlude=` that dwell happens behind the card, and
-        # without it there is no card for the length of this to matter to.
+        # Just enough to catch the shell's first prompt. The dwell happens
+        # behind the opening hold (and the clause card, when there is one),
+        # so nothing bare is on screen for the length of this to matter to.
         self._idle(0.15)
         if self._opening is not None:
             self._open_on_card()
+        else:
+            # The terminal has something to show — the shell's prompt — so
+            # the opening hold comes down, exactly as the web recorder's
+            # first goto() clears it: the hold is up from frame 0 and the
+            # medium's first content is what takes it down (#360, #362).
+            self.page.evaluate("() => window.__demoChromeHoldClear()")
 
     def _read_host_box(self) -> None:
         """Remember where `#__term_host` is, for the picture check (issue #97).
 
-        Read here, off the live element, rather than derived from the window
-        CSS: `_TERM_HOST_JS` positions the window with fixed insets and the
-        xterm.js fit addon decides the rest, so a change to either would
-        silently move the rect a hardcoded copy claimed to describe. Read
-        **once**, at `_start()`, because nothing after this resizes it and the
-        page is gone by the time the mp4 exists.
+        Read here, off the live element, rather than derived from
+        `chrome_geometry`: the host fills the chrome's content slot, but its
+        own padding and the slot's placement both live in stylesheets, so a
+        change to either would silently move the rect a hardcoded copy
+        claimed to describe. Read **once**, at `_start()`, because nothing
+        after this resizes it and the page is gone by the time the mp4
+        exists.
 
         Failure is not fatal and not silent: `content_report` says the picture
         was not measured, which is a truthful artifact. Refusing a take because
@@ -485,80 +447,51 @@ class TerminalRecorder(_DemoBase):
                 int(box["width"]), int(box["height"]),
             )
 
-    def _read_win_edge(self) -> None:
-        """Remember where `#__term_win` ends, for the opening card (#235).
-
-        Read off the live element for the reason `_read_host_box` is: the
-        window's insets are in `_TERM_HOST_JS` and the strip beside it is
-        derived from them, so a hardcoded copy would go on describing a
-        geometry somebody had already changed. Read **once**, here, because
-        nothing after this moves the window and the page is gone by the time
-        there is an mp4 to measure.
-
-        **`int(x + width)`, not `int(x) + int(width)`.** Two truncations of a
-        fractional box land a column apart from one truncation of their sum,
-        and this rect is compared against `tests/smoke`'s own reading of the
-        same strip. One column out of 58 moves the mean by a fraction of a
-        luma level — not enough to change the answer, easily enough to be a
-        latent flake in an agreement check with a 1.0 bar. So the two derive
-        the edge the same way, and the harness's way is the truer one.
-
-        Not fatal and not silent, again like `_read_host_box`: without it the
-        card report says it could not be measured, which is a truthful
-        artifact. Losing a recording over a strip of background would be the
-        measurement costing somebody the thing it exists to describe.
-        """
-        try:
-            box = self.page.locator("#__term_win").bounding_box()
-        except Exception as exc:  # noqa: BLE001 - a measurement is not a take
-            print(
-                f"demo-video: WARNING — could not read the terminal window's "
-                f"box ({type(exc).__name__}: {exc}), so this take's timeline "
-                f"will say the opening frame was not measured.",
-                file=sys.stderr,
-            )
-            return
-        if box:
-            self._win_right = int(box["x"] + box["width"])
-
     def _opening_card_rect(self) -> tuple[int, int, int, int] | None:
-        """The strip of background the opening card is read off (issue #235).
+        """The strip of the app rect the opening frame is read off (#235).
 
-        Beside the window, not inside it: an opening card and a bare terminal
-        are both dark inside the window and are told apart there by their text.
-        Outside it they are the card's flat `#1c1a17` against the pastel
-        `_TERM_BG`, which is an order of magnitude of luma and needs no
-        threshold anybody had to choose.
+        `OPENING_STRIP` of `chrome_geometry`'s app rect — inside the window,
+        where until #362 it was a strip of background beside the bespoke
+        one. The section header over `OPENING_STRIP` says why it moved: the
+        shared chrome's card layer covers the app rect and nothing else, so
+        the background outside the window never changes and frame 0 is told
+        apart *here* — the hold or the clause card (the window's own dark
+        body) against the slot's unheld canvas, an order of magnitude of
+        luma away.
 
-        None when the window's edge was never read, or when the geometry
-        leaves no strip worth reading — a take whose window fills the frame has
-        no background to measure, and inventing a rect there would produce a
-        confident number about the wrong pixels.
+        None when the chrome geometry was never built — a take that died
+        before `_start()` has no frame worth describing, and inventing a
+        rect there would produce a confident number about the wrong pixels.
         """
-        if self._win_right is None:
+        geom = getattr(self, "_geom", None)
+        if not geom:
             return None
-        left = self._win_right + OPENING_CARD_MARGIN_PX
-        width = self._size["width"] - left - OPENING_CARD_MARGIN_PX
-        if left < 0 or width < OPENING_CARD_MARGIN_PX:
-            return None
-        return (left, 0, width, OPENING_CARD_STRIP_PX)
+        fx, fy, fw, fh = OPENING_STRIP
+        return (
+            geom["appx"] + int(geom["appw"] * fx),
+            geom["appy"] + int(geom["apph"] * fy),
+            max(8, int(geom["appw"] * fw)),
+            max(8, int(geom["apph"] * fh)),
+        )
 
     def _opening_card(self) -> dict | None:
         """What this segment's first frame showed (issue #235).
 
         The medium's half of `_DemoBase._opening_card`, and the reason the
-        hook exists here rather than in the base: the strip it reads is
-        defined by *this* recorder's window, and the card it looks for is this
-        recorder's own opening. A web take has neither.
+        hook exists here rather than in the base: the opening this take
+        reads is its own — the hold, or the clause card the constructor's
+        `interlude=` raised over it. The web recorder answers None; its
+        opening hold is graded by this repository's `tests/smoke
+        --wrapper-only` instead.
 
         Reported and not enforced — nothing here appends to `warnings`, raises
         or refuses. See "the frame a terminal segment opens on" in `content`
         for the loaded-runner reading that decided that.
 
         Answered on **every** terminal take, not only one opened with
-        `interlude=`: a segment that opens on a bare prompt is exactly what
-        three people reported by watching, and `raised` is what tells a reader
-        whether `"bare"` is the defect or the arrangement.
+        `interlude=`: since #362 both arrangements open dark (the hold is
+        unconditional), so `"bare"` here is always the defect — a hold that
+        never painted — and `raised` says whether a clause was on it.
         """
         return opening_card_report(
             self._media_path(),
@@ -581,17 +514,22 @@ class TerminalRecorder(_DemoBase):
         return content_rect(self._host_box)
 
     def _open_on_card(self) -> None:
-        """Hold the card the init script raised, then take it down.
+        """Hold the card `_start()` raised, then take it down.
 
-        Everything before this ran behind it — the PTY, the xterm.js
-        injection, the shell's first prompt — which is the point: the segment
-        opens on intent rather than on an empty window (issue #110).
+        Everything before this ran behind the opening hold and the clause
+        card over it — the PTY, the xterm.js injection, the shell's first
+        prompt — which is the point: the segment opens on intent rather than
+        on an empty window (issue #110).
 
         Taking it down is the other half of the same seam. #91 was this card
         left up for the rest of a take because a storyboard remembered
         `interlude(text)` and not `interlude("")`; a card the recorder raises
         is a card the recorder clears, and there is no ordering left for a
         storyboard to get wrong.
+
+        The hold beneath goes down in the same breath — invisible under the
+        opaque card, so the card's fade reveals the terminal rather than a
+        second flat field a viewer would read as a stuck screen.
 
         It records an ordinary `interlude` beat, so a merged timeline reads the
         same whether the card came from here or from the verb.
@@ -601,7 +539,10 @@ class TerminalRecorder(_DemoBase):
         with self._beat("interlude", selector="card", caption=text):
             self._start_line(clip)
             self.pause(self._opening_hold)
-            self.page.evaluate("() => window.__demoInterlude('')")
+            self.page.evaluate(
+                "() => { window.__demoChromeHoldClear();"
+                " window.__demoInterlude(''); }"
+            )
             self.pause(0.6)
 
     def _stop(self) -> None:

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -511,9 +511,10 @@ class Recorder(_DemoBase):
         and the beats that keep reporting the caption across a mid-take goto
         are right — the line really is still on screen (this repository's
         `tests/smoke --wrapper-only` reads it out of the band's pixels
-        across a full document load). The in-page caption that *does* die
-        with its document survives only on the terminal path, whose page the
-        recorder owns and never navigates, until #362 moves it here too.
+        across a full document load). Since #362 the terminal caption lives
+        in the same chrome band, so caption death on navigation is no
+        medium's concern — the `caption_lost` issue kind survives only in
+        timelines committed before the cutovers.
         """
         # **Kept deliberately when the masking went** — #142's carve-out.
         # Written for the paint gate, which is gone; nothing reads the flag.
@@ -543,10 +544,15 @@ class Recorder(_DemoBase):
                 caption_font_px=self._caption_font_px,
             )
         )
+        # The chrome document is written, not navigated to, so it never got
+        # the motion rule (`_freeze_motion_here`). The app iframe below has
+        # a document of its own and does get it from the init script; this
+        # is for the chrome around it, so both media are one behaviour.
+        self._freeze_motion_here()
         # Mounted here rather than shipped in the chrome document because the
-        # iframe is the *web* medium's content — #362 mounts xterm.js in the
-        # same slot. Size comes from the slot's CSS (chrome.py), which is the
-        # app rect exactly.
+        # iframe is the *web* medium's content — the terminal recorder mounts
+        # xterm.js in the same slot (#362). Size comes from the slot's CSS
+        # (chrome.py), which is the app rect exactly.
         self.page.evaluate(
             "() => {"
             " const frame = document.createElement('iframe');"

--- a/skills/demo-video/reference/failures.md
+++ b/skills/demo-video/reference/failures.md
@@ -22,7 +22,7 @@ app itself and writes what it saw into `timeline.json` as `issues`:
 | `request_failed` | a request that never got a response | no |
 | `http_error` | a response with status ≥ 400 (3xx redirects are normal) | no |
 | `nonzero_exit` | a `TerminalRecorder` `run()` whose command failed | yes |
-| `caption_lost` | a page load took the caption bar off the screen; the beat log cleared with it and the issue names the line and the new URL. Found only in timelines recorded before the wrapper cutover (#361): a web take's caption now lives in the recorder's own document, which no app navigation can destroy, so this can never fire — the recorder does not even subscribe the signal (#360). Caption death on navigation is a terminal-take concern only (its caption is in-page, until #362), and a terminal take's page never navigates | no |
+| `caption_lost` | a page load took the caption bar off the screen; the beat log cleared with it and the issue names the line and the new URL. Found only in timelines recorded before the cutovers (#361 for web, #362 for terminal). Every caption now lives in the recorder's own document, which no app navigation can destroy, so this can never fire — the recorder does not even subscribe the signal (#360). The kind stays published so an old committed timeline still reads | no |
 
 Each issue is **attributed to the beat that was running when it fired** —
 `beat` (an index into `beats`), plus the beat's `verb` and `caption` copied

--- a/skills/demo-video/reference/terminal.md
+++ b/skills/demo-video/reference/terminal.md
@@ -35,21 +35,30 @@ with TerminalRecorder(
 The recorder starts capturing when it creates the page, which is before any
 storyboard statement can paint anything — so a card raised by the first verb
 arrives ~290 ms late and the segment opens on an empty terminal with a lone
-prompt. `interlude=` raises the card from a context init script instead,
-before the page has painted at all, and the PTY, the terminal's own setup and
-the shell's first prompt all happen behind it. The recorder also **takes it
-down** when `interlude_hold` is up, so there is no `interlude("")` to forget.
+prompt.
 
-It records an ordinary `interlude` beat, so `timeline.json` reads the same
-either way. `Recorder` (web) has no such argument and does not need one: its
-page is blank until `goto()`, so there is no "before" to flash — and a card
-painted before that first `goto()` would be destroyed by it.
+Nothing bare is on screen either way, because every take opens on the
+recorder's **opening hold**: an opaque field in the window's own colour, up in
+frame 0 from an init script, cleared when the medium has something to show
+(here, the shell's first prompt). The PTY, the xterm.js injection and that
+first prompt all happen behind it. Both media work this way.
+
+What `interlude=` adds is *intent*: the clause is raised in the window's card
+layer over the hold, so the viewer reads a sentence instead of a blank window.
+The recorder also **takes it down** when `interlude_hold` is up, so there is no
+`interlude("")` to forget. It records an ordinary `interlude` beat, so
+`timeline.json` reads the same as a mid-take card.
+
+`Recorder` (web) has no such argument. Its hold is cleared by the first
+`goto()`; if you want a clause over a web segment's opening, use `interlude()`
+as its first statement.
 
 **Check it in the timeline rather than by watching.** Every terminal take reads
 its own first frame after the encode and writes the answer into
 `content.opening.card`: `state` is `"card"`, `"bare"` or `"between"`, beside
-the luma it came from and whether this take asked for a card. `demo.mp4` is not
-a file anybody commits, so this is the only account of that frame a demo
+the luma it came from and whether this take asked for a clause. The hold is
+unconditional, so `"bare"` is a defect however the take was written. `demo.mp4`
+is not a file anybody commits, so this is the only account of that frame a demo
 directory carries — and the same flash has been reported three times by people
 watching. Nothing enforces it; read it. See *`opening.card`* in
 [timeline.md](timeline.md).

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -188,27 +188,27 @@ A terminal take reads its own frame zero after the encode and writes down what
 was there:
 
 ```json
-"card": { "luma": 25.8, "state": "card", "raised": true,
-          "rect": [1214, 0, 58, 50],
+"card": { "luma": 24.0, "state": "card", "raised": true,
+          "rect": [138, 109, 921, 76],
           "card_max": 60.0, "bare_min": 150.0, "note": null }
 ```
 
-- `luma` is the mean luma of a strip of background **beside** the terminal
-  window on the segment's first frame. Outside the window on purpose: inside
-  it a title card and a terminal are both dark and telling them apart means
-  reading text. Outside it the card (`#1c1a17`, full bleed) reads ~26 and the
-  recorder's pastel background reads ~226.
+- `luma` is the mean luma of a strip **inside the window**, across the top of
+  the app rect, on the segment's first frame. The cover — the opening hold, or
+  the clause card over it — paints the window's own dark body and reads ~26
+  there. Uncovered, the strip reads the terminal slot's white canvas at ~255.
+  Two constants in the recorder's own styling, an order of magnitude apart.
 - `state` is that number as a word: `"card"`, `"bare"`, or `"between"`. The gap
   between the two bars is wide and deliberately empty — a frame that lands in
-  it is a card still becoming opaque, and calling that either thing would be
+  it is a cover still becoming opaque, and calling that either thing would be
   this file claiming something nobody measured.
-- `raised` says whether the take asked for an opening card
-  (`TerminalRecorder(interlude=…)`). It is what makes `"bare"` readable: on a
-  take that asked, `"bare"` is the flash issue #110 is about; on a take that
-  did not, it is simply what the segment opens on.
+- `raised` says whether the take asked for an opening clause
+  (`TerminalRecorder(interlude=…)`). The hold is unconditional, so `"bare"` is
+  the defect either way; `raised` only says whether a sentence was on the cover.
 - `note` says why when there is no reading. `luma` and `state` are then `null`
   rather than a guess.
-- `card` itself is `null` on a web take — there is no window to read beside.
+- `card` itself is `null` on a web take. Its hold is graded from the pixels by
+  this repository's `tests/smoke --wrapper-only`, not claimed in the artifact.
 
 **Nothing enforces it.** No warning, no refusal, no failed take: one CI run in
 nine has read a value in the empty band on a loaded runner, and a bar that
@@ -258,7 +258,7 @@ inside the stretch?**
 | beats inside the held stretch | verdict |
 |---|---|
 | `caption`, `criterion`, `hold`, `interlude`, `pause`, `shot`, `wait_for`, `wait_for_prompt`, `wait_for_text` | narrated hold — silent |
-| `clear`, `click`, `click_fast`, `goto`, `key`, `move_to`, `press`, `run`, `scroll_to`, `send`, `spotlight`, `terminal`, `terminal_close`, `terminal_output`, `type_into` | worth looking at — warns |
+| `act`, `clear`, `click`, `click_fast`, `goto`, `key`, `move_to`, `press`, `run`, `scroll_to`, `send`, `spotlight`, `terminal`, `terminal_close`, `terminal_output`, `type_into` | worth looking at — warns |
 
 Both rows are the whole of `content.py`'s `CONTENT_PASSIVE_VERBS` and
 `CONTENT_ACTING_VERBS`, written out name by name rather than summarised. This

--- a/tests/README.md
+++ b/tests/README.md
@@ -1343,22 +1343,35 @@ after it is 300 ms too late to see a restore that was still pending. A lower
 bound on a wait is also the one timing bar contention cannot turn red.
 
 `terminal-opening/` records a segment opened with
-`TerminalRecorder(interlude=…)` and reads **one corner of the frame**, outside
-the terminal window, at 20 fps for the whole take:
+`TerminalRecorder(interlude=…)` and reads **a strip across the top of the app
+rect** at 20 fps for the whole take. The strip moved inside the window when
+[#362](https://github.com/rogvid/skills/issues/362) mounted the terminal in the
+shared chrome: the card layer covers the app rect and nothing else, so the
+background beside the window no longer changes and can no longer say what the
+take opened on.
 
 | | mean luma |
 |---|---|
-| the card (`#1c1a17`, full bleed) | 26 |
-| bare terminal (the recorder's pastel gradient) | 226 |
+| the cover — the opening hold, or the clause card over it | 24 |
+| the slot's bare canvas | 255 |
 
 Neither number is a threshold anybody tuned — they are two constants in the
-recorder's own styling, an order of magnitude apart, and the corner is read off
-the live `#__term_win` box rather than hardcoded. Three statements, each broken
-by a different mistake: the recording's **first** frame is card; the card
-covers at least the first second (it is held 2.5); and the corner **does** end
-up bare, which is the control — without it, the first two are equally true of a
-recorder that painted a black rectangle and stopped, and that is exactly
+recorder's own styling, an order of magnitude apart, and the strip is derived
+from `chrome_geometry`'s app rect rather than hardcoded. Three statements, each
+broken by a different mistake: the recording's **first** frame is the cover; no
+frame of the strip is ever bare, which a cover cleared before xterm.js painted
+would break; and the strip **does** stop being a flat field, which is the
+control — without it, the first two are equally true of a recorder that painted
+a rectangle and stopped, and that is exactly
 [#91](https://github.com/rogvid/skills/issues/91).
+
+The control is read as **structure, not brightness**: the revealed terminal is
+as dark as the cover it replaces, so luma cannot separate them, and the strip's
+own standard deviation can — a flat cover reads 0.11-0.15, one line of terminal
+text reads 2.1, a settled screen 13.9. Change against frame 0 was measured first
+and rejected: the covered stretch reads 0.00 on one box and 1.68 on another,
+against 1.86 for the first revealed command, so the bar would have picked a host
+rather than a defect.
 
 Nine injections, each one exact string in one file, with a driver that refuses
 to run unless the pattern matched exactly once:
@@ -1371,14 +1384,14 @@ to run unless the pattern matched exactly once:
 | the enter's `transform` removed | "the highlight never went on, so the exit measurement is about nothing" |
 | the clear leaves `style=""` on an element that had no attribute | the before/after style comparison |
 | the clear's promise resolves before the transition ends | the 0.45 s bar |
-| the card raised 400 ms into the document instead of at document start | first frame is bare, and the prefix is 0.00 s |
-| the card built at `opacity: 0` like `interlude()` builds it | the same two, plus the content floor |
-| the card never cleared | "the corner never reaches 150 mean luma — the card is never taken down" |
+| the cover painted a colour that is not the window body | first frame is bare |
+| the cover built at `opacity: 0` like `interlude()` builds it | the same, plus the content floor |
+| the cover never cleared | "the strip is a flat field for the whole take — the cover is never taken down" |
 
 **The same frame, from the other side (issue #235).** Everything above grades
 the video, and no demo directory ships one. So the recorder reads its own first
-frame after the encode — the same strip, off the live `#__term_win` box, on the
-segment's own frame zero — and writes it into `content.opening.card`:
+frame after the encode — the same strip, derived from the same chrome geometry,
+on the segment's own frame zero — and writes it into `content.opening.card`:
 `luma`, `state` (one of `card`, `bare`, `between`), `raised` (whether this take
 asked for a card at all), the two bars it was classified against, and a `note`
 when there was no reading. **Reported, never enforced**: nothing warns, refuses
@@ -1390,21 +1403,24 @@ would be flaky on the runner it most needs to be trusted on.
 and complete, it says `card`, it says the card was asked for, and — the one
 that keeps the rest from being a document agreeing with itself — the number in
 it is within `OPENING_CARD_AGREEMENT` (1.0) of frame zero re-read here. Both
-readings came out at **25.8** on this box, which is [#207](https://github.com/rogvid/skills/issues/207)'s
-number for the fixed take. Four `tests/smoke-inject` entries, one per statement,
+readings came out at **24.0** on this box — the window body the shared chrome
+paints the cover with, where before #362 it was 25.8 over the strip of
+background beside the bespoke window ([#207](https://github.com/rogvid/skills/issues/207)'s
+number for the fixed take). Four `tests/smoke-inject` entries, one per statement,
 and the third of them is the injection #235's acceptance criterion names.
 
 **What this does not catch**, and is a stated limit rather than an oversight: a
 card that *fades in* over 450 ms rather than being painted opaque is invisible
 here. Measured — a faded-in card and a painted one produce byte-identical
-corner readings for the first 14 frames, because the recorder spends longer
+strip readings for the first 14 frames, because the recorder spends longer
 than the fade injecting xterm.js before Chromium's screencast emits anything.
 The recorder has no fade-in path (the element is appended already opaque, so no
 transition can run), but the suite is relying on setup cost for that and would
 not notice if it changed.
 
-**The corner is the discriminator; the timeline gap is not, and it was written
-down twice as though it were.** [#110](https://github.com/rogvid/skills/issues/110)
+**The pixels are the discriminator; the timeline gap is not, and it was written
+down twice as though it were.** (The readings below are the pre-#362 corner,
+kept as the history they are.) [#110](https://github.com/rogvid/skills/issues/110)
 measured the flash as part2's offset against the interlude beat's timestamp
 (37.76 s against 38.05 s), and
 [#206](https://github.com/rogvid/skills/issues/206) restated that gap as the
@@ -1425,7 +1441,7 @@ check would have reported the fixed take as marginally worse. The gap is
 which goes to `about:blank`, injects xterm.js, opens the PTY and waits for the
 first prompt before it raises the card, so the first beat lands ~0.36 s into
 the segment either way. A beat's timestamp says when the card was *logged*;
-only the pixels say when it was up. The corner sweep discriminates it 226 → 26
+only the pixels say when it was up. The sweep discriminates it 226 → 26
 at the boundary frame, across four re-records including one under load. This is
 recorded here because nothing asserts on that gap today, and a number written
 into two closed issues as *the* check is the kind that becomes an assertion
@@ -2240,7 +2256,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the cursor dot parked on-screen so it ships in every still with no pointer verb run, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
-| `--polish-only` | 4 | a terminal segment stops saying what it opened on ([#235](https://github.com/rogvid/skills/issues/235)), which is the one account of that frame a demo directory ships: the field gone entirely; the number a plausible constant instead of a reading, which every other statement about the field is happy with; the card raised 400 ms into the document, which is [#110](https://github.com/rogvid/skills/issues/110) itself and the injection that issue's acceptance criterion names; or the report forgetting that a card was asked for, without which `"bare"` cannot be told from a segment that never wanted one |
+| `--polish-only` | 4 | a terminal segment stops saying what it opened on ([#235](https://github.com/rogvid/skills/issues/235)), which is the one account of that frame a demo directory ships: the field gone entirely; the number a plausible constant instead of a reading, which every other statement about the field is happy with; the cover painted a colour that is not the window body, so frame 0 is not the cover at all — #110's own defect, the card raised late, can no longer be planted here: since [#362](https://github.com/rogvid/skills/issues/362) the shared chrome covers frame 0 twice, independently, and breaking either cover alone leaves frame 0 reading 24.0; or the report forgetting that a card was asked for, without which `"bare"` cannot be told from a segment that never wanted one |
 | `--segments-only` | 14 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the sheet stops saying **which clock** it cut them on, so a reviewer cannot tell a corrected sheet from one cut on the raw beat log ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
 | `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |

--- a/tests/_pixels.py
+++ b/tests/_pixels.py
@@ -116,17 +116,6 @@ def to_video_rect(rect: Rect, geom: dict) -> Rect:
     )
 
 
-def caption_band(frame_size: tuple[int, int]) -> Rect:
-    """The strip of a full still that holds the caption.
-
-    Covers both recorders: the web caption's reserved band sits ~54-150 px
-    off the frame bottom at the default viewport (chrome_geometry), and the
-    terminal's in-page bar 88 px off it, ~70 px tall.
-    """
-    width, height = frame_size
-    return (0, max(0, height - 160), width, 140)
-
-
 # Where in the app rect the strip is read: a band across the top, inset from
 # every edge. Above the centred text on purpose — glyphs move the mean by ~5
 # levels and by however many words the clause has, which is a reading of the

--- a/tests/pixel
+++ b/tests/pixel
@@ -45,8 +45,9 @@ own. This file never opens the lock path.
 check over a take with no frames would fail for a reason it does not name),
 then the four golden chrome properties, the defects humans caught by eye:
 
-- **opening-card** (terminal): frame 0 is the card, the card holds an
-  unbroken prefix, and the corner later reads bare as the control (#110).
+- **opening-card** (terminal): frame 0 is the cover, no frame of the strip
+  ever shows the slot's bare canvas, and the strip later stops being a flat
+  field as the control - the terminal appeared (#110).
 - **card-vs-window** (web): the criterion card and the window body around
   the app are one colour in demo.mp4, worst channel — one uncompensated
   declaration through one encoder (#291's class, retired by #360/#361) -
@@ -77,6 +78,7 @@ import os
 import re
 import shutil
 import socket
+import statistics
 import struct
 import subprocess
 import sys
@@ -135,17 +137,37 @@ SERVER_START_TIMEOUT_S = 10.0
 # that applies it. Each constant names its smoke counterpart so a retuning
 # there is a prompt to retune here — and a divergence is a decision, not drift.
 
-# tests/smoke's OPENING_* family. Card and bare are deliberately far apart with
-# a deliberately empty gap: a frame between the two is the card mid-fade, and
-# nothing here calls that either one.
+# tests/smoke's OPENING_* family, re-based with the terminal's move into the
+# shared chrome (#362): the sweep reads a strip of the app rect (the shared
+# card layer covers the app rect and nothing else, so the old strip of
+# background beside the bespoke window never changes any more). Covered and
+# bare are deliberately far apart with a deliberately empty gap: a frame
+# between the two is a fade, and nothing here calls that either one.
 OPENING_SAMPLE_FPS = 20  # tests/smoke OPENING_SAMPLE_FPS
 OPENING_CARD_MAX_LUMA = 60.0  # tests/smoke OPENING_CARD_MAX_LUMA
 OPENING_BARE_MIN_LUMA = 150.0  # tests/smoke OPENING_BARE_MIN_LUMA
 # The value of tests/smoke's MIN_OPENING_CARD_S: the take holds its card 2.5 s,
-# the bar is 1.0 s — room for a stalled screencast (#18), none for a card that
-# arrives after the terminal does (#110).
+# the bar is 1.0 s — room for a stalled screencast (#18), none for a cover
+# that comes down before the card was read (#110).
 MIN_OPENING_CARD_S = 1.0
 MIN_OPENING_FRAMES = 40  # tests/smoke MIN_OPENING_FRAMES: the sweep floor
+# terminal.OPENING_STRIP, duplicated (the loop imports nothing from the
+# recorder): the strip of the app rect the opening claims read — a top band
+# starting near the left edge, where a shell's first rows land (CARD_STRIP's
+# web-tuned inset was measured missing every glyph of a short command).
+OPENING_STRIP_FRACTIONS = (0.01, 0.04, 0.90, 0.16)
+# What counts as the terminal having appeared in that strip: the strip's own
+# luma standard deviation. The cover is a flat field by construction and
+# terminal text is not, so the two are told apart on structure rather than
+# on brightness — the revealed terminal is as dark as the cover it replaces.
+# Change against frame 0 was measured first and does not grade: the covered
+# stretch reads 0.00 here but 1.68 on tests/smoke's own take, where the
+# chrome document arrives after frame 0 and shifts the whole flat field,
+# against 1.86 for the first revealed command. Standard deviation over both
+# takes: covered 0.105-0.147, chrome-arrival transient at worst 0.686, first
+# revealed command 2.10-2.12, settled terminal 13.7-13.9. tests/smoke
+# TERMINAL_REVEAL_MIN_STDDEV is the same number for the same measurement.
+TERMINAL_REVEAL_MIN_STDDEV = 1.2
 
 # core.WEB_WINDOW_BODY in decimal — the ONE declaration the wrapper card,
 # the window body and the opening hold all paint from (#360), duplicated
@@ -293,13 +315,13 @@ def record_terminal(out_dir: Path) -> dict:
         rec.pause(0.4)
         rec.caption("")
 
-        win = rec.page.locator("#__term_win").bounding_box()
         host = rec.page.locator("#__term_host").bounding_box()
-        if win is None or host is None:
+        if host is None:
             raise PixelFailure(
-                "terminal: #__term_win/#__term_host has no box - the terminal "
-                "window never rendered"
+                "terminal: #__term_host has no box - the terminal never "
+                "rendered in the chrome's slot"
             )
+        geom = dict(rec._geom)
         size = (rec._size["width"], rec._size["height"])
     return {
         "card": card,
@@ -309,7 +331,10 @@ def record_terminal(out_dir: Path) -> dict:
             int(host["width"]),
             int(host["height"]),
         ],
-        "win": [int(win["x"]), int(win["y"]), int(win["width"]), int(win["height"])],
+        # The shared chrome's geometry (#362) - the same dict the web take's
+        # marker carries, so the opening check derives its strip from the
+        # one shape every geometry consumer reads.
+        "geom": geom,
         "size": list(size),
     }
 
@@ -543,23 +568,15 @@ def recorded(take: Path) -> bool:
 def opening_kind(value: float) -> str:
     """card / bare / between, tests/smoke's classifier with the same bars.
 
-    `between` is the card mid-fade; it is deliberately neither, and a prefix
-    counter that treated it as card would call #128's half-faded frame 'the
-    card was still up'.
+    `between` is a fade caught mid-way; it is deliberately neither, so a
+    check never calls #128's half-faded frame either the cover or the bare
+    canvas.
     """
     if value <= OPENING_CARD_MAX_LUMA:
         return "card"
     if value >= OPENING_BARE_MIN_LUMA:
         return "bare"
     return "between"
-
-
-def card_prefix(luma: list[float]) -> int:
-    """How many leading frames read card — ends at the first that does not."""
-    prefix = 0
-    while prefix < len(luma) and opening_kind(luma[prefix]) == "card":
-        prefix += 1
-    return prefix
 
 
 def beat_spans(doc: dict, verb: str) -> list[tuple[float, float]]:
@@ -701,94 +718,139 @@ def _verdict(name: str, take: Path, problems: list[str], detail: str) -> None:
     print(f"{take.name}/{name}: {state} - {detail}")
 
 
+def opening_strip(geom: dict) -> Rect:
+    """`OPENING_STRIP_FRACTIONS` of the app rect - the recorder's own strip.
+
+    The same arithmetic `terminal._opening_card_rect` runs, duplicated (the
+    loop-vs-recorder rule), so the frames graded here are the frames the
+    take's own `content.opening.card` describes.
+    """
+    fx, fy, fw, fh = OPENING_STRIP_FRACTIONS
+    return (
+        geom["appx"] + int(geom["appw"] * fx),
+        geom["appy"] + int(geom["apph"] * fy),
+        max(8, int(geom["appw"] * fw)),
+        max(8, int(geom["apph"] * fh)),
+    )
+
+
 def check_opening_card(
     take: Path, info: dict | None, dump: Path | None = None
 ) -> list[str]:
-    """The terminal take opens on its card, holds it, then clears it (#110).
+    """The terminal take opens covered, holds the cover, then shows a
+    terminal (#110, re-based on the shared chrome by #362).
 
     tests/smoke's check_opening_card, on the cached take: one sweep of the
-    background strip beside the terminal window, three statements each broken
-    by a different mistake. Frame 0 is read by frame index out of the same
-    decode — never by seeking a timestamp, which is how #128 caught a fade
-    mid-way and called it neither.
+    opening strip inside the app rect, three statements each broken by a
+    different mistake. Terminal content is as dark as the hold, so "the
+    cover came down" is read as *change against frame 0* rather than as
+    luma — the revealed terminal puts prompt and command rows through the
+    strip, a hold left up changes nothing (#91). Frame 0 is read by frame
+    index out of the same decode — never by seeking a timestamp, which is
+    how #128 caught a fade mid-way and called it neither.
     """
     name = "opening-card"
     mp4 = take / "demo.mp4"
-    if not info or "win" not in info or "size" not in info:
+    if not info or "geom" not in info or "size" not in info:
         return [
-            f"{take.name}/{name}: the marker carries no window geometry - "
+            f"{take.name}/{name}: the marker carries no chrome geometry - "
+            f"it predates the terminal's move into the shared chrome (#362); "
             f"re-record (tests/pixel record --force)"
         ]
-    win, size = info["win"], info["size"]
-    # The strip of background to the right of the terminal window — outside
-    # it on purpose, same as tests/smoke: inside, the card and the terminal
-    # are both dark and are told apart by their text.
-    right = int(win[0]) + int(win[2])
-    corner: Rect = (right + 8, 0, max(8, int(size[0]) - right - 16), 50)
-    frames = gray_frames(mp4, rect=corner, sample_fps=OPENING_SAMPLE_FPS)
+    strip = opening_strip(info["geom"])
+    frames = gray_frames(mp4, rect=strip, sample_fps=OPENING_SAMPLE_FPS)
     luma = [sum(f) / len(f) for f in frames]
     if len(luma) < MIN_OPENING_FRAMES:
         return [
-            f"{take.name}/{name}: the corner sweep decoded {len(luma)} frames "
-            f"at {OPENING_SAMPLE_FPS} fps over {corner}, under the "
+            f"{take.name}/{name}: the strip sweep decoded {len(luma)} frames "
+            f"at {OPENING_SAMPLE_FPS} fps over {strip}, under the "
             f"{MIN_OPENING_FRAMES} floor - every statement below would be "
             f"satisfied by a video too short to hold the card at all"
         ]
 
     problems: list[str] = []
+    # Frame 0 is the cover - the opening hold, or the clause card over it -
+    # not the slot's white canvas (~255) or the unheld chrome (~225).
     if opening_kind(luma[0]) != "card":
         problems.append(
-            f"{take.name}/{name}: frame 0 reads {luma[0]:.1f} mean luma in the "
-            f"corner at {corner} ({opening_kind(luma[0])!r}, card <= "
-            f"{OPENING_CARD_MAX_LUMA:.0f}) - the take opens on the terminal "
-            f"and the card arrives afterwards, issue #110"
+            f"{take.name}/{name}: frame 0 reads {luma[0]:.1f} mean luma over "
+            f"the app strip {strip} ({opening_kind(luma[0])!r}, cover <= "
+            f"{OPENING_CARD_MAX_LUMA:.0f}) - the take opens on the slot's "
+            f"canvas and the cover arrives afterwards, issue #110"
         )
         dump_frame(dump, name, "frame-0-FAIL", mp4, frame_index=0)
-    prefix = card_prefix(luma)
-    prefix_s = prefix / OPENING_SAMPLE_FPS
-    if prefix_s < MIN_OPENING_CARD_S:
-        problems.append(
-            f"{take.name}/{name}: the card covers only the first "
-            f"{prefix_s:.2f}s ({prefix} frames at {OPENING_SAMPLE_FPS} fps), "
-            f"under the {MIN_OPENING_CARD_S}s bar - frame {prefix} reads "
-            f"{luma[min(prefix, len(luma) - 1)]:.1f}, the viewer sees the "
-            f"terminal before the card that should be covering it"
-        )
-        dump_frame(
-            dump, name, f"prefix-end-frame-{prefix}-FAIL", mp4, frame_index=prefix
-        )
-    bare = next(
+    # The slot's canvas never shows: a cover cleared before xterm.js painted
+    # is a white flash in the window, and no healthy frame of this strip is
+    # ever bare - the terminal is as dark as the hold.
+    flash = next(
         (i for i, value in enumerate(luma) if opening_kind(value) == "bare"), None
     )
-    if bare is None:
+    if flash is not None:
         problems.append(
-            f"{take.name}/{name}: the corner never reaches "
-            f"{OPENING_BARE_MIN_LUMA:.0f} mean luma in "
-            f"{len(luma) / OPENING_SAMPLE_FPS:.1f}s (range "
-            f"{min(luma):.1f}..{max(luma):.1f}) - without a bare control the "
-            f"first two statements are equally true of a recorder that "
-            f"painted a black rectangle and stopped (#91)"
+            f"{take.name}/{name}: frame {flash} "
+            f"({flash / OPENING_SAMPLE_FPS:.2f}s) reads {luma[flash]:.1f} "
+            f"mean luma over {strip} (bare >= {OPENING_BARE_MIN_LUMA:.0f}) - "
+            f"the slot's canvas showed through, so the cover came down "
+            f"before the terminal painted"
+        )
+        dump_frame(dump, name, f"flash-frame-{flash}-FAIL", mp4, frame_index=flash)
+    # The cover holds, then the terminal appears: the first frame that has
+    # moved against frame 0 is the reveal, it must exist (#91 - a hold left
+    # up changes nothing, ever) and it must not come before the card was
+    # readable (#110's other half).
+    spread = [statistics.pstdev(f) for f in frames]
+    revealed = next(
+        (i for i, v in enumerate(spread) if v >= TERMINAL_REVEAL_MIN_STDDEV), None
+    )
+    if revealed is None:
+        problems.append(
+            f"{take.name}/{name}: no frame of {len(frames)} at "
+            f"{OPENING_SAMPLE_FPS} fps ever reaches "
+            f"{TERMINAL_REVEAL_MIN_STDDEV} luma stddev over "
+            f"{strip} (worst {max(spread):.2f}) - the cover is never taken "
+            f"down (#91), and the frame-0 statement above would be satisfied "
+            f"by a recorder that painted a rectangle and stopped"
         )
         dump_frame(
-            dump, name, "last-frame-no-bare-FAIL", mp4, frame_index=len(luma) - 1
+            dump, name, "last-frame-no-reveal-FAIL", mp4, frame_index=len(luma) - 1
         )
+    else:
+        revealed_s = revealed / OPENING_SAMPLE_FPS
+        if revealed_s < MIN_OPENING_CARD_S:
+            problems.append(
+                f"{take.name}/{name}: the strip stops being a flat field "
+                f"at {revealed_s:.2f}s ({spread[revealed]:.2f} luma stddev, "
+                f"floor {TERMINAL_REVEAL_MIN_STDDEV}), under the "
+                f"{MIN_OPENING_CARD_S}s bar - the viewer sees the terminal "
+                f"before the card could be read, issue #110"
+            )
+            dump_frame(
+                dump,
+                name,
+                f"reveal-frame-{revealed}-FAIL",
+                mp4,
+                frame_index=revealed,
+            )
+        else:
+            dump_frame(
+                dump,
+                name,
+                f"revealed-from-{revealed_s:.2f}s",
+                mp4,
+                frame_index=revealed,
+            )
     dump_frame(dump, name, "frame-0", mp4, frame_index=0)
-    if bare is not None:
-        dump_frame(
-            dump,
-            name,
-            f"bare-from-{bare / OPENING_SAMPLE_FPS:.2f}s",
-            mp4,
-            frame_index=bare,
-        )
-    bare_s = f"{bare / OPENING_SAMPLE_FPS:.2f}s" if bare is not None else "never"
+    reveal_s = (
+        f"{revealed / OPENING_SAMPLE_FPS:.2f}s" if revealed is not None else "never"
+    )
     _verdict(
         name,
         take,
         problems,
-        f"frame 0 luma {luma[0]:.1f} (card <= {OPENING_CARD_MAX_LUMA:.0f}), "
-        f"card prefix {prefix_s:.2f}s (bar {MIN_OPENING_CARD_S:.1f}s), bare "
-        f">= {OPENING_BARE_MIN_LUMA:.0f} from {bare_s}",
+        f"frame 0 luma {luma[0]:.1f} over {strip} (cover <= "
+        f"{OPENING_CARD_MAX_LUMA:.0f}), no bare frame (max {max(luma):.1f}), "
+        f"terminal revealed from {reveal_s} (bar {MIN_OPENING_CARD_S:.1f}s, "
+        f"stddev floor {TERMINAL_REVEAL_MIN_STDDEV})",
     )
     return problems
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -129,7 +129,6 @@ if _HERE not in sys.path:
 from _pixels import (  # noqa: E402
     FRAME_BAND,
     Rect,
-    caption_band,
     card_run,
     card_strip,
     channels_apart,
@@ -199,8 +198,10 @@ MIN_CONTENT_STDDEV = {
 # (caption_probe_band) rather than a full-width strip — the probe caption
 # measures 4.99 on a healthy take against 0.00 undrawn (a band with no
 # caption is the same flat window body in both stills), so the floor keeps
-# a 2.5x margin under the weakest healthy reading.
-MIN_CAPTION_BAND_DIFF = {"web": 2.0, "terminal": 1.0, "segments": 2.0}
+# a 2.5x margin under the weakest healthy reading. The terminal caption
+# paints in the same chrome band since #362 (measured 4.87 on the terminal
+# arm's probe stills), so it carries the web floor for the web reason.
+MIN_CAPTION_BAND_DIFF = {"web": 2.0, "terminal": 2.0, "segments": 2.0}
 
 # Consecutive stills must differ by at least this mean absolute luma, on the
 # 160x90 grayscale reduction. This detects a *duplicate* — a stale or copied
@@ -989,8 +990,9 @@ ALIGN_ARRIVAL_FRACTION = 0.25
 # Re-measured on the wrapper band (#361), same probe rect as
 # MIN_CAPTION_BAND_DIFF: the probe caption settles at 4.96-5.17 mean luma
 # over the band on healthy takes, so the web floors keep a ~2.5x margin
-# where the legacy full-frame caption gave 6.0 a wider one.
-MIN_ALIGN_BAND_DELTA = {"web": 2.0, "terminal": 1.0, "segments": 2.0}
+# where the legacy full-frame caption gave 6.0 a wider one. The terminal
+# rides the same band since #362 and carries the same floor.
+MIN_ALIGN_BAND_DELTA = {"web": 2.0, "terminal": 2.0, "segments": 2.0}
 
 # -- review frames (frames/, issue #8) ---------------------------------------
 #
@@ -1372,39 +1374,74 @@ MIN_SPOTLIGHT_CLEAR_S = 0.45
 # transparent, and it says nothing about a card painted late, because a beat's
 # timestamp is when the recorder logged the card, not when a viewer saw it.
 #
-# The discriminator is one corner of the frame, outside the terminal window:
+# The discriminator is a strip of the app rect, re-based when #362 mounted
+# the terminal in the shared chrome (until then it was a corner of
+# background beside the bespoke window, which the shared card layer — app
+# rect only — made blind):
 #
-#   the card         a full-bleed #1c1a17 rectangle          luma ~26
-#   bare terminal    the recorder's pastel gradient          luma ~225
+#   the cover     the opening hold / clause card, window body    luma ~24
+#   the defect    the slot's unheld white canvas                 luma ~255
 #
-# An order of magnitude apart, and neither number is a threshold anybody tuned
-# — they are two constants in the recorder's own styling. The corner is read
-# off the live `#__term_win` box rather than hardcoded, so a change to the
-# window chrome carries it.
+# An order of magnitude apart, and neither number is a threshold anybody
+# tuned — they are two constants in the recorder's own styling. The strip is
+# OPENING_STRIP_FRACTIONS of `rec._geom`'s app rect, this file's own copy of
+# `terminal.OPENING_STRIP`'s arithmetic. Terminal content is as dark as the
+# cover, so "the cover came down" is graded as the strip **ceasing to be a
+# flat field** (TERMINAL_REVEAL_MIN_STDDEV) rather than as luma — the
+# revealed terminal puts prompt and command rows through the strip, a cover
+# left up stays flat (#91).
 OPENING_CARD = "…and the same thing, on the command line."
 
-# Held long enough that the dark prefix below has 2.5x of margin over its bar,
-# and short enough that this take stays a few seconds.
+# Held long enough that the covered stretch below has 2.5x of margin over
+# its bar, and short enough that this take stays a few seconds.
 OPENING_HOLD_S = 2.5
 
 # 20 fps is plenty for a card that is up for seconds, and keeps the sweep to a
 # few hundred frames.
 OPENING_SAMPLE_FPS = 20
 
-# What counts as the card, and what counts as the gradient behind it. The gap
-# between them is deliberately enormous and deliberately empty: a frame that
-# lands between the two is the card mid-fade, and the assertions below refuse
-# to call that either one.
+# What counts as the cover, and what counts as the slot's canvas showing
+# through it. The gap between them is deliberately enormous and deliberately
+# empty: a frame that lands between the two is a fade, and the assertions
+# below refuse to call that either one.
 OPENING_CARD_MAX_LUMA = 60.0
 OPENING_BARE_MIN_LUMA = 150.0
 
-# How much of the video must be card before anything else. The card is held for
-# OPENING_HOLD_S, so a healthy take reads ~2.5 s here; the bar is at 1.0 s,
-# which leaves room for a screencast that stalls (issue #18) without leaving
-# room for a card that arrives after the terminal does.
+# terminal.OPENING_STRIP, this file's own copy (the suite imports no policy
+# from the recorder): the strip of the app rect the opening claims read — a
+# top band starting near the left edge, where a shell's first rows land.
+OPENING_STRIP_FRACTIONS = (0.01, 0.04, 0.90, 0.16)
+
+# What counts as the terminal having appeared in the strip: the strip's own
+# luma **standard deviation**. The cover is a flat field by construction and
+# terminal text is not, so this separates the two on their structure rather
+# than on their brightness — which is the whole difficulty, since the
+# revealed terminal is as dark as the cover it replaces.
+#
+# Change-against-frame-0 was tried first and does not grade. Measured over
+# two takes of this strip: the covered stretch reads 0.00 against frame 0 on
+# the pixel loop's reference take but 1.68 on this suite's, because the
+# chrome document arrives *after* frame 0 on a slower host and the whole
+# flat field shifts by that much when it does. The first revealed command
+# reads 1.86. A bar between 1.68 and 1.86 grades nothing; it just picks a
+# host.
+#
+# Standard deviation over the same two takes: covered 0.105-0.147, the
+# chrome-arrival transient at worst 0.686, the first revealed command
+# 2.10-2.12, the settled terminal 13.7-13.9. 1.2 is the geometric middle of
+# 0.686 and 2.10 — 1.75x clear of the worst covered reading and 1.75x under
+# the weakest revealed one. tests/pixel TERMINAL_REVEAL_MIN_STDDEV is the
+# same number for the same measurement.
+TERMINAL_REVEAL_MIN_STDDEV = 1.2
+
+# How long the take must stay covered before the terminal first shows. The
+# card is held for OPENING_HOLD_S, so a healthy take reveals at ~3 s; the
+# bar is at 1.0 s, which leaves room for a screencast that stalls (issue
+# #18) without leaving room for a cover that comes down before the card
+# could be read.
 MIN_OPENING_CARD_S = 1.0
 
-# Frames the corner sweep must produce before anything is concluded from it. A
+# Frames the strip sweep must produce before anything is concluded from it. A
 # sweep of three frames would satisfy every assertion below by accident.
 MIN_OPENING_FRAMES = 40
 
@@ -1414,13 +1451,13 @@ MIN_OPENING_FRAMES = 40
 # Not a tolerance for the answer being roughly right. The two readings are the
 # same crop of the same frame of the same file, reduced the same way, and they
 # come out equal to the rounding the timeline publishes (0.05) — the strip is
-# computed twice, once by the recorder off `#__term_win` and once by
-# `record_terminal_opening` off the same live box, and both then read frame
-# zero with `-t` and no `fps` filter. What this has to be far under is the
-# thing it exists to catch: a number that describes something other than this
-# video, which is 200 luma levels away when the card is not up. An order of
-# magnitude either side, which is the shape to prefer over a comfortable
-# margin.
+# computed twice, once by the recorder off its `_geom` and once by
+# `record_terminal_opening` off this file's own copy of the fractions, and
+# both then read frame zero with `-t` and no `fps` filter. What this has to
+# be far under is the thing it exists to catch: a number that describes
+# something other than this video, which is 200 luma levels away when the
+# cover is not up. An order of magnitude either side, which is the shape to
+# prefer over a comfortable margin.
 OPENING_CARD_AGREEMENT = 1.0
 
 OPENING_DURATION_S = (5.0, 30.0)
@@ -3879,12 +3916,12 @@ def record_terminal_opening(out_dir: Path) -> tuple[list[str], dict]:
         rec.pause(0.6)
         rec.caption("")
 
-        win = rec.page.locator("#__term_win").bounding_box()
         host = rec.page.locator("#__term_host").bounding_box()
-        if win is None or host is None:
+        if host is None:
             raise SmokeFailure(
-                "#__term_win/#__term_host has no box — the terminal window "
-                "never rendered, so there is no margin to read the card out of"
+                "#__term_host has no box — the terminal never rendered in "
+                "the chrome's slot, so there is no strip to read the cover "
+                "out of"
             )
         app: Rect = (
             int(host["x"]),
@@ -3892,16 +3929,21 @@ def record_terminal_opening(out_dir: Path) -> tuple[list[str], dict]:
             int(host["width"]),
             int(host["height"]),
         )
+        geom = dict(rec._geom)
         size = (rec._size["width"], rec._size["height"])
 
-    # The strip of background to the right of the terminal window. Outside the
-    # window on purpose — inside it the card and the terminal are both dark and
-    # the two are told apart by their text, which is not a robust thing to
-    # measure. Also the opposite corner from TICKER_JS's 8x8 element, so the
-    # ticker cannot contribute a single level to this.
-    right = int(win["x"] + win["width"])
-    corner: Rect = (right + 8, 0, max(8, size[0] - right - 16), 50)
-    return b.problems, {"corner": corner, "app": app, "size": size}
+    # The opening strip: this file's own fractions of the shared chrome's
+    # app rect (#362) — where the cover and, later, the shell's first rows
+    # are. Far from TICKER_JS's 8x8 corner element, so the ticker cannot
+    # contribute a single level to this.
+    fx, fy, fw, fh = OPENING_STRIP_FRACTIONS
+    strip: Rect = (
+        geom["appx"] + int(geom["appw"] * fx),
+        geom["appy"] + int(geom["apph"] * fy),
+        max(8, int(geom["appw"] * fw)),
+        max(8, int(geom["apph"] * fh)),
+    )
+    return b.problems, {"strip": strip, "app": app, "size": size}
 
 
 def record_content(out_dir: Path, cleared: bool) -> tuple[list[str], dict]:
@@ -5997,19 +6039,18 @@ def caption_probe_band(
 ) -> Rect:
     """Where this medium's caption paints, at `factor` times the frame size.
 
-    The terminal caption is an in-page lower-third and keeps `caption_band`'s
-    whole-width strip. A web (and segments) caption paints in the wrapper
-    chrome's reserved band below the app rect (#358/#361), and reading the
-    old full-width strip dilutes its change with ~7x of static chrome —
-    measured 2.68 mean luma over the strip for a caption whose own band
-    moves by an order of magnitude more. The arithmetic is
-    `chrome_geometry`'s, duplicated at native size (the loop-vs-suite rule:
-    policy is not imported), then scaled, because the geometry's even-pixel
-    rounding does not commute with scaling.
+    Every medium's caption paints in the wrapper chrome's reserved band
+    below the app rect — web and segments since #358/#361, terminal since
+    #362 — and reading the legacy full-width bottom strip dilutes its
+    change with ~7x of static chrome: measured 2.68 mean luma over the
+    strip for a caption whose own band moves by an order of magnitude
+    more. The arithmetic is `chrome_geometry`'s, duplicated at native size
+    (the loop-vs-suite rule: policy is not imported), then scaled, because
+    the geometry's even-pixel rounding does not commute with scaling.
+    `label` no longer dispatches; it stays so a failure message's caller
+    reads the same as the checks it feeds.
     """
-    if label == "terminal":
-        width, height = frame_size
-        return caption_band((round(width * factor), round(height * factor)))
+    del label
     width, height = frame_size
     appw = int(width * 0.80) & ~1
     apph = int(height * 2 / 3) & ~1
@@ -8007,29 +8048,35 @@ def check_spotlight_transitions(
 
 
 def check_opening_card(out_dir: Path, info: dict) -> list[str]:
-    """A terminal segment opens on its card, not on a bare terminal (#110).
+    """A terminal segment opens on its cover, not on a bare slot (#110).
 
-    Three statements about one sweep of one corner of the frame, and each is
+    Three statements about one sweep of one strip of the app rect (#362
+    moved it inside the window — see OPENING_STRIP_FRACTIONS), and each is
     broken by a different mistake:
 
-      * the *first* frame is the card — a card raised at the storyboard's first
-        statement, or faded in rather than painted, fails here;
-      * every frame up to the first bare-terminal one is card, and there is at
-        least MIN_OPENING_CARD_S of them — a card that arrives after the
-        terminal does fails here;
-      * the corner does end up bare — a card that is never taken down (#91's
-        half of this seam) fails here, and without it the first two are equally
-        true of a recorder that painted a black rectangle and stopped.
+      * the *first* frame is the cover — a hold that never painted leaves
+        frame 0 reading the slot's white canvas;
+      * no frame of the strip is ever bare — a cover cleared before xterm.js
+        painted is a white flash in the window;
+      * the strip stops being a flat field, and not before
+        MIN_OPENING_CARD_S — a cover never taken down stays flat forever
+        (#91's half of this seam, and without it the first two statements
+        are equally true of a recorder that painted a rectangle and
+        stopped), and one taken down early shows the terminal before the
+        card could be read (#110). Structure rather than luma, because the
+        revealed terminal is as dark as the cover it replaces — see
+        TERMINAL_REVEAL_MIN_STDDEV for the measurement, and for why change
+        against frame 0 was measured and rejected.
     """
     failures: list[str] = []
     mp4 = out_dir / "demo.mp4"
-    corner = info["corner"]
-    frames = gray_frames(mp4, rect=corner, sample_fps=OPENING_SAMPLE_FPS)
+    strip = info["strip"]
+    frames = gray_frames(mp4, rect=strip, sample_fps=OPENING_SAMPLE_FPS)
     luma = [sum(f) / len(f) for f in frames]
     if len(luma) < MIN_OPENING_FRAMES:
         return [
-            f"terminal-opening: the corner sweep decoded {len(luma)} frames at "
-            f"{OPENING_SAMPLE_FPS} fps over {corner}, under the "
+            f"terminal-opening: the strip sweep decoded {len(luma)} frames at "
+            f"{OPENING_SAMPLE_FPS} fps over {strip}, under the "
             f"{MIN_OPENING_FRAMES} floor — every statement below would be "
             f"satisfied by a video too short to hold the card at all"
         ]
@@ -8044,47 +8091,49 @@ def check_opening_card(out_dir: Path, info: dict) -> list[str]:
     if kind(luma[0]) != "card":
         failures.append(
             f"terminal-opening: the recording's first frame reads "
-            f"{luma[0]:.1f} mean luma in the corner at {corner}, which is "
-            f"{kind(luma[0])!r} and not the card (card <= "
-            f"{OPENING_CARD_MAX_LUMA}, bare terminal >= "
-            f"{OPENING_BARE_MIN_LUMA}). The segment opens on the terminal and "
-            f"the card arrives afterwards — issue #110."
-        )
-    # The prefix ends at the first frame that is not card — including a frame
-    # that is neither, which is the card mid-fade and is not "before the card"
-    # by any reading.
-    prefix = 0
-    while prefix < len(luma) and kind(luma[prefix]) == "card":
-        prefix += 1
-    prefix_s = prefix / OPENING_SAMPLE_FPS
-    if prefix_s < MIN_OPENING_CARD_S:
-        failures.append(
-            f"terminal-opening: the card covers only the first {prefix_s:.2f}s "
-            f"of the recording ({prefix} frames at {OPENING_SAMPLE_FPS} fps), "
-            f"under the {MIN_OPENING_CARD_S}s bar for a card held "
-            f"{OPENING_HOLD_S}s. Frame {prefix} reads {luma[min(prefix, len(luma) - 1)]:.1f} "
-            f"— the viewer sees the terminal before the card that is supposed "
-            f"to be covering it."
+            f"{luma[0]:.1f} mean luma over the strip at {strip}, which is "
+            f"{kind(luma[0])!r} and not the cover (cover <= "
+            f"{OPENING_CARD_MAX_LUMA}, bare slot >= "
+            f"{OPENING_BARE_MIN_LUMA}). The segment opens on the slot's "
+            f"canvas and the cover arrives afterwards — issue #110."
         )
     bare = [i for i, value in enumerate(luma) if kind(value) == "bare"]
-    if not bare:
+    if bare:
         failures.append(
-            f"terminal-opening: the corner never reaches "
-            f"{OPENING_BARE_MIN_LUMA} mean luma in "
-            f"{len(luma) / OPENING_SAMPLE_FPS:.1f}s — the card the recorder "
-            f"raised is never taken down (issue #91), and the whole take is "
-            f"behind it. Corner range {min(luma):.1f}..{max(luma):.1f}."
+            f"terminal-opening: frame {bare[0]} "
+            f"({bare[0] / OPENING_SAMPLE_FPS:.2f}s) reads "
+            f"{luma[bare[0]]:.1f} mean luma over {strip} (bare >= "
+            f"{OPENING_BARE_MIN_LUMA}) — the slot's canvas showed through, "
+            f"so the cover came down before the terminal painted."
         )
-    elif kind(luma[-1]) != "bare":
+    spread = [statistics.pstdev(f) for f in frames]
+    revealed = next(
+        (i for i, s in enumerate(spread) if s >= TERMINAL_REVEAL_MIN_STDDEV), None
+    )
+    revealed_s = None if revealed is None else revealed / OPENING_SAMPLE_FPS
+    if revealed is None:
         failures.append(
-            f"terminal-opening: the recording's last frame reads {luma[-1]:.1f} "
-            f"in the corner ({kind(luma[-1])!r}) — the card came back, or never "
-            f"finished fading"
+            f"terminal-opening: no frame of {len(frames)} at "
+            f"{OPENING_SAMPLE_FPS} fps ever reaches "
+            f"{TERMINAL_REVEAL_MIN_STDDEV} luma stddev over {strip} (worst "
+            f"{max(spread):.2f}) — the strip is a flat field for the whole "
+            f"take, so the cover the recorder raised is never taken down "
+            f"(issue #91) and the whole take is behind it."
+        )
+    elif revealed_s < MIN_OPENING_CARD_S:
+        failures.append(
+            f"terminal-opening: the strip stops being a flat field at "
+            f"{revealed_s:.2f}s ({spread[revealed]:.2f} luma stddev, floor "
+            f"{TERMINAL_REVEAL_MIN_STDDEV}), under the {MIN_OPENING_CARD_S}s "
+            f"bar for a card held {OPENING_HOLD_S}s — the viewer sees the "
+            f"terminal before the card that is supposed to be covering it."
         )
     if not failures:
         print(
-            f"smoke: terminal-opening card covers the first {prefix_s:.2f}s "
-            f"(corner {luma[0]:.0f} -> {luma[-1]:.0f}), then clears"
+            f"smoke: terminal-opening cover up from frame 0 "
+            f"(luma {luma[0]:.0f}, no bare frame, max {max(luma):.0f}, "
+            f"covered stddev worst {max(spread[:revealed]):.2f}), "
+            f"terminal revealed from {revealed_s:.2f}s"
         )
     return failures
 
@@ -8115,11 +8164,12 @@ def check_reported_opening_card(out_dir: Path, info: dict) -> list[str]:
 
     The second is what keeps the rest from being a document agreeing with
     itself, and its independence is deliberately narrow: the strip comes from
-    `record_terminal_opening`'s own reading of the live `#__term_win` box, and
-    the frame is decoded here rather than taken from the take's word for it.
-    What it cannot see is a recorder and a harness making the same mistake
-    about which corner to read; the sweep above, which reads the whole take
-    rather than one frame, is what makes that mistake visible.
+    `record_terminal_opening`'s own copy of the OPENING_STRIP fractions over
+    the shared geometry, and the frame is decoded here rather than taken
+    from the take's word for it. What it cannot see is a recorder and a
+    harness making the same mistake about which strip to read; the sweep
+    above, which reads the whole take rather than one frame, is what makes
+    that mistake visible.
 
     **What is deliberately not asserted here**: that `state` follows the `luma`
     beside it. Every take this arm records opens on the card, so a `state`
@@ -8175,14 +8225,14 @@ def check_reported_opening_card(out_dir: Path, info: dict) -> list[str]:
     # the reason OPENING_FIRST_FRAME_S spells out.
     try:
         first = gray_frames(
-            out_dir / "demo.mp4", info["corner"], duration=OPENING_FIRST_FRAME_S
+            out_dir / "demo.mp4", info["strip"], duration=OPENING_FIRST_FRAME_S
         )
     except RuntimeError as exc:
         return failures + [f"{label}: {exc}"]
     if not first:
         return failures + [
             f"{label}: nothing decoded from the first {OPENING_FIRST_FRAME_S}s "
-            f"of demo.mp4 over {info['corner']}, so the reported reading has "
+            f"of demo.mp4 over {info['strip']}, so the reported reading has "
             f"nothing to be checked against"
         ]
     measured = sum(first[0]) / len(first[0])
@@ -8190,7 +8240,7 @@ def check_reported_opening_card(out_dir: Path, info: dict) -> list[str]:
         failures.append(
             f"{label}: the take reports its first frame at {luma} mean luma "
             f"over {card.get('rect')}, and frame zero of demo.mp4 reads "
-            f"{measured:.1f} over {info['corner']} — {abs(measured - luma):.1f} "
+            f"{measured:.1f} over {info['strip']} — {abs(measured - luma):.1f} "
             f"apart, over the {OPENING_CARD_AGREEMENT} these two readings of "
             f"one frame are allowed. The number in the timeline is not a "
             f"measurement of this video"
@@ -8202,7 +8252,7 @@ def check_reported_opening_card(out_dir: Path, info: dict) -> list[str]:
         failures.append(
             f"{label}: this take opened with TerminalRecorder(interlude=…) and "
             f"reports its first frame as {state!r} at {luma} mean luma — the "
-            f"segment opens on the terminal and the card arrives afterwards "
+            f"segment opens on the bare slot and the cover arrives afterwards "
             f"(issue #110), and this time the take's own report says so"
         )
     if card.get("raised") is not True:

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -672,18 +672,32 @@ INJECTIONS = [
         must_contain=("The number in the timeline is not a ",),
     ),
     Injection(
-        # The defect itself, exactly as #110 measured it: the card raised from
-        # a timer instead of at document start, so capture begins on the bare
-        # terminal and the card arrives afterwards. `check_opening_card` fires
-        # too — it is the same frame — and the entry is aimed at the *report*,
-        # which is the only account of that frame anybody ships.
-        name="the opening card is raised 400 ms into the document",
+        # The cover paints the wrong colour, so frame 0 is not the cover —
+        # the report says `bare` on a take that asked for a clause, which is
+        # what #110 reads like in the artifact. `check_opening_card` fires
+        # too, it is the same frame, and the entry is aimed at the *report*:
+        # the only account of that frame anybody ships.
+        #
+        # **This is not #110's own defect, and #110's own defect can no
+        # longer be planted here.** It was "the card is raised late", and it
+        # was plantable while one init script owned frame 0 on the terminal
+        # path (`terminal._OPENING_CARD_JS`, retired by #362). The terminal
+        # now records the shared chrome, which covers frame 0 **twice** and
+        # independently: `chrome.OPENING_HOLD_JS` on the initial document,
+        # and the `#__chrome_hold` element `chrome_html` ships opaque in its
+        # own markup. Measured — delaying the init script's build by 400 ms,
+        # the old injection exactly, leaves frame 0 reading 24.0 over the
+        # strip, because the chrome document is up by the first encoded
+        # frame. Breaking either cover alone changes nothing a frame can see,
+        # which is the fix working rather than the assertion failing.
+        #
+        # So the entry plants at the one place both covers read: the window
+        # body they are both painted with. A palette mistake there is the
+        # #291 class, which this repository has actually shipped.
+        name="the cover paints a colour that is not the window body",
         module="terminal.py",
-        old=(
-            "  if (document.body) build();\n"
-            "  else addEventListener('DOMContentLoaded', build);\n"
-        ),
-        new="  setTimeout(build, 400);\n",
+        old='TERM_WINDOW_BODY = _TERM_THEME["background"]',
+        new='TERM_WINDOW_BODY = "#f4f2ee"',
         arm="--polish-only",
         sites=("check_reported_opening_card",),
         must_contain=("and this time the take's own report says so",),

--- a/tests/unit
+++ b/tests/unit
@@ -171,7 +171,6 @@ from demo_recording.chrome import (  # noqa: E402
 from demo_recording.core import (  # noqa: E402
     CRITERION_HOLD_MAX_S,
     CRITERION_HOLD_MIN_S,
-    INTERLUDE_ID,
     _beat_verb,
     _CaptureClock,
     _DemoBase,
@@ -3578,15 +3577,6 @@ class PixelChecks(unittest.TestCase):
         self.assertEqual(px.opening_kind(px.OPENING_BARE_MIN_LUMA - 0.1), "between")
         self.assertEqual(px.opening_kind(px.OPENING_BARE_MIN_LUMA), "bare")
 
-    def test_card_prefix_ends_at_the_first_frame_that_is_not_card(self):
-        px = self.px
-        self.assertEqual(px.card_prefix([10.0, 20.0, 30.0]), 3)
-        # A mid-fade frame (`between`) ends the prefix — it is not "before the
-        # card" by any reading, which is #128's flake made a rule.
-        self.assertEqual(px.card_prefix([10.0, 80.0, 10.0]), 1)
-        self.assertEqual(px.card_prefix([226.0, 10.0]), 0)
-        self.assertEqual(px.card_prefix([]), 0)
-
     def test_beat_spans_returns_wellformed_beats_of_that_verb_only(self):
         doc = {
             "beats": [
@@ -4969,10 +4959,9 @@ class OpeningCardOnATake(unittest.TestCase):
     class Boxes(FakePage):
         """A page whose element boxes are the ones a test wrote down.
 
-        Keyed by selector, so a recorder reaching for `#__term_host` where it
-        means `#__term_win` reads `None` here rather than the other element's
-        box, and says it could not measure instead of measuring the wrong
-        thing.
+        Keyed by selector, so a recorder reaching for a selector it does not
+        mean reads `None` here rather than another element's box, and says it
+        could not measure instead of measuring the wrong thing.
         """
 
         def __init__(self, boxes: dict) -> None:
@@ -4983,32 +4972,36 @@ class OpeningCardOnATake(unittest.TestCase):
             box = self.boxes.get(selector)
             return types.SimpleNamespace(bounding_box=lambda: box)
 
-    def test_the_strip_starts_from_the_windows_unrounded_right_edge(self):
-        # `int(x) + int(w)` and `int(x + w)` are a column apart on a
-        # fractional box: 100.6 + 57.6 is 158.2, so the edge is 158 and the
-        # strip starts at 166 — two truncations give 157 and start it at 165.
-        # One column out of 58 is a fraction of a luma level and would never
-        # change the verdict; what it can do is drift the recorder's number
-        # away from tests/smoke's independent reading of the same strip, which
-        # is graded with a 1.0 bar. The two derive the edge the same way.
-        rec = recorder(
-            self,
-            cls=TermRec,
-            page=self.Boxes(
-                {"#__term_win": {"x": 100.6, "y": 70.0, "width": 57.6, "height": 400.0}}
+    def test_the_strip_is_the_shared_geometrys_arithmetic_exactly(self):
+        # The recorder's strip and the harnesses' (tests/smoke's, and
+        # tests/pixel's) are the same OPENING_STRIP fractions of the same
+        # `chrome_geometry` app rect, each side computing it for itself —
+        # and the agreement check between the recorder's reading and the
+        # harness's has a 1.0-luma bar, so the two derivations must land on
+        # the same integers. This pins the recorder's half to the
+        # arithmetic, digit for digit, at the stock viewport.
+        from demo_recording.terminal import OPENING_STRIP
+
+        rec = recorder(self, cls=TermRec, page=self.Boxes({}))
+        rec._geom = chrome_geometry(1280, 720)
+        geom = rec._geom
+        fx, fy, fw, fh = OPENING_STRIP
+        self.assertEqual(
+            rec._opening_card_rect(),
+            (
+                geom["appx"] + int(geom["appw"] * fx),
+                geom["appy"] + int(geom["apph"] * fy),
+                int(geom["appw"] * fw),
+                int(geom["apph"] * fh),
             ),
         )
-        rec._read_win_edge()
-        rect = rec._opening_card_rect()
-        self.assertIsNotNone(rect, "the window's box was read and gave no strip")
-        self.assertEqual(rect[0], 166)
 
     def test_a_take_that_lost_its_app_rect_still_reports_its_opening_frame(self):
         """The catalogue's clean-path-only assertion, on this field's guard.
 
         `_content_rect` raising nulls the whole `content.opening` block — so a
-        terminal take that could read `#__term_win` and not `#__term_host`
-        used to say nothing whatsoever about the frame it opened on, with
+        terminal take that had its chrome geometry and not its `#__term_host`
+        box used to say nothing whatsoever about the frame it opened on, with
         nothing anywhere saying why. The opening card is not measured over the
         app rect, so it has no reason to be lost with it.
         """
@@ -5242,8 +5235,9 @@ class WrapperChrome(unittest.TestCase):
         )
 
     def test_a_web_take_registers_the_opening_hold_script(self):
-        # The hold is an init script for _OPENING_CARD_JS's reasons — it has
-        # to exist on the wrapper page's initial document, before set_content
+        # The hold is an init script for the reasons the terminal's retired
+        # `_OPENING_CARD_JS` was one (#362 left this its only successor): it
+        # has to exist on the page's initial document, before set_content
         # replaces it. Exactly one: two registrations would be two elements
         # racing for one id.
         rec = recorder(self)
@@ -5349,6 +5343,40 @@ class WrapperChrome(unittest.TestCase):
         self.assertNotIn("domcontentloaded", page.subscribed)
         # #142's kept listener stays.
         self.assertIn("framenavigated", page.subscribed)
+
+    def test_the_motion_rule_is_reattached_to_the_written_chrome_document(self):
+        # `set_content` writes a new document and the context init script does
+        # not run again, so the motion rule's <style> goes with the old one.
+        # Measured red before #362 fixed it: every animation probe in
+        # tests/smoke --terminal-only read its authored duration, 2 s against
+        # the 1 ms the rule declares. Opt-in either way — a take that did not
+        # ask for determinism must not get the rule by this door.
+        for deterministic, expected in ((True, 1), (False, 0)):
+            for cls in (WebRec, TermRec):
+                with self.subTest(cls=cls.__name__, deterministic=deterministic):
+                    page = self.HoldPage()
+                    rec = recorder(
+                        self, cls=cls, page=page, deterministic=deterministic
+                    )
+                    rec._freeze_motion_here()
+                    rules = [s for s in page.evaluated if "__demo_motion" in s]
+                    self.assertEqual(len(rules), expected, page.evaluated)
+
+    def test_both_media_reattach_the_motion_rule_where_they_write_the_chrome(self):
+        # The call has to be in `_start`, after the `set_content` that wiped
+        # the rule — a re-attach that ran before the write would be undone by
+        # it, and the test above cannot see ordering.
+        for cls in (WebRec, TermRec):
+            with self.subTest(cls=cls.__name__):
+                source = inspect.getsource(cls._start)
+                self.assertIn("set_content", source)
+                self.assertIn("_freeze_motion_here()", source)
+                self.assertLess(
+                    source.index("set_content"),
+                    source.index("_freeze_motion_here()"),
+                    f"{cls.__name__}._start re-attaches the motion rule before "
+                    f"set_content writes the document that drops it",
+                )
 
 
 class VerbTarget(unittest.TestCase):
@@ -5834,35 +5862,26 @@ class CriterionHold(unittest.TestCase):
 
 
 # --------------------------------------------------------------------------
-# core.py — the interlude card each medium shows (issue #291, then #361)
+# terminal.py — the terminal mounts the shared chrome (#291, #361, then #362)
 # --------------------------------------------------------------------------
 #
-# One stylesheet used to serve both media and it was the terminal's, so on a
-# **web** take the full-screen card was a near-black field inside the
-# recorder's own dark window frame and read as a terminal window rather than
-# as a card over the app (#291) — the fix's history, including the rejected
-# candidates and the #301 encoder compensation the composite needed, is
-# `core.WEB_WINDOW_BODY`'s note. Since #361 there is no per-medium CSS
-# dispatch left to grade: the web card is an element the wrapper document
-# ships in its own card layer, painted from the same `window_body`
-# substitution as the window (`WrapperChrome` pins that wiring; `tests/smoke
-# --wrapper-only`'s check_wrapper_card reads the sameness out of demo.mp4).
-# Core's `_INTERLUDE_JS` only ever *finds* that element and toggles it —
-# the create-if-missing guard below is what keeps the terminal stylesheet it
-# still carries from ever painting on a web take.
+# One stylesheet used to serve both media's interlude card and it was the
+# terminal's, so on a **web** take the card read as a terminal window (#291)
+# — the fix's history is `core.WEB_WINDOW_BODY`'s note. #361 moved the web
+# card into the wrapper document's card layer, and #362 retired the last of
+# the per-medium chrome: the terminal records the same wrapper document,
+# xterm.js mounted in the chrome's content slot, so the card, the caption
+# band and the opening hold are one implementation (`WrapperChrome` pins the
+# document's wiring; `tests/smoke` and `tests/pixel` read the pixels). The
+# in-page overlay path — `_CAPTION_JS`, `_INTERLUDE_JS`'s builder and its
+# `INTERLUDE_CSS_TERMINAL` stylesheet — went with its last consumer; see
+# core's history note over `INTERLUDE_ID`.
 #
-# What is graded here is what remains browser-free: the terminal palette the
-# #110 blend was tuned to, the init-script/verb agreement a terminal segment
-# opens on, and the guard that makes the base stylesheet inert on a page
-# whose card already exists. **Whether a card reads as a card is not graded
-# anywhere and cannot be**: the same element, text and snapshot are produced
-# either way, and the only difference is a colour a person recognises.
-
-# The terminal palette, hand-written. A bound read off the code being graded
-# agrees with that code whatever it says, and this is the number other
-# things were chosen against: `tests/smoke`'s opening-card sweep calls
-# anything under 60 luma "the card", and the terminal one measures 26.
-TERMINAL_CARD_PALETTE = "background: #1c1a17; color: #f7f4ee;"
+# What is graded here is what remains browser-free: the terminal's half of
+# the chrome mount — the opening hold registered with the terminal's own
+# window body, the xterm mount targeting the chrome slot, the opening strip
+# deriving from the shared geometry, and the recorder clearing the covers it
+# raised.
 
 
 class _RecordingContext:
@@ -5880,80 +5899,105 @@ class _RecordingContext:
         self.scripts.append(script)
 
 
-def card_css(script: str) -> str:
-    """The stylesheet the card element is given, out of the script that builds
-    it — read the way the browser would, from the assignment it executes."""
-    match = re.search(r"style\.cssText = '([^']*)'", script)
-    return match.group(1) if match else ""
+class TerminalChrome(unittest.TestCase):
+    """The terminal's half of the shared chrome mount (#362), browser-free."""
 
-
-def card_declaration(css: str, want: str) -> str:
-    """One declaration out of a card's inline stylesheet, or `""`.
-
-    Hand-parsed rather than imported from the recorder: a helper shared with
-    the code under test agrees with that code's bugs by construction.
-    """
-    for declaration in css.split(";"):
-        name, _, value = declaration.partition(":")
-        if name.strip() == want:
-            return value.strip()
-    return ""
-
-
-def card_background(css: str) -> str:
-    """The `background:` declaration out of a card's inline stylesheet."""
-    return card_declaration(css, "background")
-
-
-class InterludePalette(unittest.TestCase):
-    def css_for(self, cls, **settings) -> str:
-        """The stylesheet a take of this medium gives its card.
-
-        Off `_interlude_script()`, which is the string `__enter__` registers on
-        the context, so every assertion below reads what the page would run.
-        """
-        return card_css(recorder(self, cls=cls, **settings)._interlude_script())
-
-    def test_a_terminal_take_still_raises_the_card_110_was_tuned_to(self):
-        # The blend `eca42c5` added is load-bearing on this medium: the card is
-        # what a terminal segment *opens* on, covering the recorder's own setup,
-        # and it has to be dark for the same reason the terminal is.
-        self.assertIn(TERMINAL_CARD_PALETTE, self.css_for(TermRec))
-
-    def test_the_base_stylesheet_cannot_paint_where_the_card_already_exists(self):
-        # The wiring that makes `_INTERLUDE_JS`'s terminal stylesheet inert on
-        # a web take: the script builds (and styles) the element only when the
-        # id is missing, and the wrapper document ships it in the card layer
-        # (`WrapperChrome`), so on a web page the script only ever toggles
-        # text and opacity. Drop the guard and every interlude would repaint
-        # the wrapper card as a full-viewport terminal-black field — the #291
-        # regression wearing #361's clothes.
-        script = recorder(self, cls=WebRec)._interlude_script()
-        create = script.index("createElement")
-        guard = script.index("if (!el)")
-        self.assertLess(
-            guard,
-            create,
-            "the interlude script creates its element unguarded, so the "
-            "stylesheet it carries would repaint a card the chrome document "
-            "already ships",
-        )
-        self.assertIn("getElementById", script[:guard])
-
-    def test_the_card_a_terminal_segment_opens_on_is_that_same_card(self):
-        # Two things build this element, and only one of them is the verb.
-        # `TerminalRecorder(interlude=…)` paints it from an init script before
-        # the page has painted at all (#110) — so a palette that arrived in
-        # `interlude()` alone would leave a segment opening on the other one,
-        # which is a card that changes colour mid-fade.
-        rec = recorder(self, cls=TermRec, interlude="…a few minutes later.")
+    def hold_scripts(self, **settings) -> list[str]:
+        rec = recorder(self, cls=TermRec, **settings)
         context = _RecordingContext()
         rec._init_context(context)
-        opening = [s for s in context.scripts if INTERLUDE_ID in s]
-        self.assertEqual(
-            len(opening), 1, "the opening card is not registered on the context"
+        return [s for s in context.scripts if "__chrome_hold" in s]
+
+    def test_a_terminal_take_registers_the_opening_hold_and_only_one(self):
+        # Frame 0 of a terminal take is the hold, whatever the storyboard
+        # does — an init script, because that runs on Chromium's initial
+        # empty document, earlier than any Python statement (#110's fix on
+        # #360's machinery). Exactly one: two registrations would be two
+        # elements racing for one id.
+        holds = self.hold_scripts()
+        self.assertEqual(len(holds), 1, "the terminal take registers no opening hold")
+
+    def test_the_hold_carries_the_terminal_window_body_and_the_app_rect(self):
+        # The hold, the window and the card are one declared colour on a
+        # terminal take — TERM_WINDOW_BODY, the theme's own background — and
+        # the hold sits on the shared geometry's app rect. A hold painted
+        # another colour is a visible flash at the card's fade; a hold
+        # placed off the app rect covers chrome and leaves the slot bare.
+        from demo_recording.terminal import _TERM_THEME, TERM_WINDOW_BODY
+
+        self.assertEqual(TERM_WINDOW_BODY, _TERM_THEME["background"])
+        geom = chrome_geometry(1280, 720)
+        hold = self.hold_scripts()[0]
+        self.assertIn(TERM_WINDOW_BODY, hold)
+        self.assertIn(f"left: {geom['appx']}px", hold)
+        self.assertIn(f"top: {geom['appy']}px", hold)
+
+    def test_the_xterm_mount_targets_the_chrome_slot(self):
+        # The one-chrome claim's wiring half: xterm.js goes into
+        # `#__chrome_slot`, where the web recorder mounts its app iframe,
+        # and keeps the `__term_host` id every geometry consumer reads
+        # (issue #97). The pixel half — the slot really shows a terminal —
+        # is tests/smoke --terminal-only's.
+        from demo_recording.terminal import _TERM_MOUNT_JS
+
+        self.assertIn("getElementById('__chrome_slot')", _TERM_MOUNT_JS)
+        self.assertIn("__term_host", _TERM_MOUNT_JS)
+
+    def test_the_opening_strip_reads_the_app_rect_and_never_the_band(self):
+        # #235's reading, re-based by #362: the strip is inside the app rect
+        # (the shared card layer covers the app rect only, so the old strip
+        # of background beside the window can no longer say what the take
+        # opened on) and clear of the caption band below it.
+        rec = recorder(self, cls=TermRec)
+        self.assertIsNone(
+            rec._opening_card_rect(),
+            "a take that never built its chrome claims a strip anyway",
         )
-        self.assertEqual(card_css(opening[0]), card_css(rec._interlude_script()))
+        rec._geom = chrome_geometry(1280, 720)
+        rect = rec._opening_card_rect()
+        self.assertIsNotNone(rect)
+        x, y, w, h = rect
+        geom = rec._geom
+        self.assertGreaterEqual(x, geom["appx"])
+        self.assertGreaterEqual(y, geom["appy"])
+        self.assertLessEqual(x + w, geom["appx"] + geom["appw"])
+        self.assertLessEqual(y + h, geom["appy"] + geom["apph"])
+        self.assertLess(y + h, geom["bandy"])
+
+    class ChromePage(FakePage):
+        """A page that remembers every script `evaluate` was handed."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.evaluated: list[str] = []
+
+        def evaluate(self, script, *args):
+            self.evaluated.append(str(script))
+            return None
+
+    def test_open_on_card_takes_down_the_card_and_the_hold_it_covered(self):
+        # #91's half of the seam, plus #362's: a card the recorder raises is
+        # a card the recorder clears, and the hold beneath goes down in the
+        # same breath — under the opaque card, so the card's fade reveals
+        # the terminal rather than a second flat field.
+        page = self.ChromePage()
+        rec = recorder(self, cls=TermRec, interlude="…a few minutes later.")
+        rec.page = page
+        rec._open_on_card()
+        downs = [
+            s
+            for s in page.evaluated
+            if "__demoChromeHoldClear" in s and "__demoInterlude('')" in s
+        ]
+        self.assertEqual(
+            len(downs),
+            1,
+            f"the opening card's clear does not take the card and the hold "
+            f"down together (scripts: {page.evaluated!r})",
+        )
+        beat = rec._beats[-1]
+        self.assertEqual(beat["verb"], "interlude")
+        self.assertEqual(beat["caption"], "…a few minutes later.")
 
     def test_the_web_card_is_not_painted_like_the_skills_terminal_widgets(self):
         # #291's own sentence, held on the card the wrapper document ships:
@@ -5971,27 +6015,6 @@ class InterludePalette(unittest.TestCase):
             f"the web card is painted {WEB_WINDOW_BODY}, which is a colour "
             f"the web recorder's own terminal prop draws with",
         )
-
-    def test_the_terminal_card_is_opaque_and_covers_the_frame(self):
-        # Not decoration, and not a restatement of the CSS:
-        # reference/limits.md reasons from all three of these — a card that
-        # is translucent, inset, or under the caption bar changes what the
-        # picture check can see and what a caption swap does to it. The web
-        # card's geometry is the chrome document's card layer, pinned by
-        # `WrapperChrome`; this is the terminal's, the one still built from
-        # this stylesheet.
-        css = self.css_for(TermRec)
-        self.assertIn("inset: 0", css)
-        self.assertIn("z-index: 2147483647", css)
-        # A flat `#rrggbb` and nothing else: `rgba(...)`, a gradient with a
-        # transparent stop, or a `background` left to the page are all ways
-        # for the app to show through.
-        self.assertRegex(card_background(css), r"^#[0-9a-f]{6}$")
-        # No border and no rounded corners: a radius clips the *background*
-        # too, so it would put the app back on screen at the four corners
-        # while the card is up (#297's rejected bordered card).
-        self.assertEqual(card_declaration(css, "border"), "")
-        self.assertEqual(card_declaration(css, "border-radius"), "")
 
 
 # --------------------------------------------------------------------------
@@ -10997,15 +11020,6 @@ INJECTIONS = [
         ["PixelChecks.test_opening_kind_grades_both_bars_at_the_boundary"],
     ),
     (
-        # The prefix counter calls a mid-fade frame 'still the card' — #128's
-        # flake reinstated: a card that fades in reads as up from frame 0.
-        "the opening-card prefix counts a mid-fade frame as card",
-        "tests/pixel",
-        '    while prefix < len(luma) and opening_kind(luma[prefix]) == "card":',
-        '    while prefix < len(luma) and opening_kind(luma[prefix]) != "bare":',
-        ["PixelChecks.test_card_prefix_ends_at_the_first_frame_that_is_not_card"],
-    ),
-    (
         # The card locator returns the first dark stretch instead of the
         # longest, so a dark flash before the card would be graded as it.
         "the card-stretch locator stops preferring the longest run",
@@ -12672,8 +12686,8 @@ INJECTIONS = [
         # The exception path as it shipped in the first draft of #235: the app
         # rect could not be worked out, so the whole `opening` block went null
         # and the frame the segment opened on went with it — a measurement
-        # that needs only `#__term_win`, lost because `#__term_host` was
-        # unreadable, with nothing saying so.
+        # that needs only the chrome geometry, lost because `#__term_host`
+        # was unreadable, with nothing saying so.
         "a take that lost its app rect reports nothing about its opening",
         "core.py",
         '            self._content["opening"] = opening_report(\n'
@@ -12691,16 +12705,18 @@ INJECTIONS = [
         ],
     ),
     (
-        # Two truncations instead of one. Invisible on an integral box, a
-        # column adrift on a fractional one — and the column is on the side
-        # tests/smoke's agreement check reads.
-        "the strip is measured from a twice-rounded window edge",
+        # The strip loses the app-rect offset, so the recorder reads its
+        # opening frame off the chrome to the window's upper-left — a
+        # confident number about the wrong pixels, and a drift tests/smoke's
+        # 1.0-luma agreement check would blame on the harness.
+        "the opening strip is measured without the app rect's offset",
         "terminal.py",
-        '            self._win_right = int(box["x"] + box["width"])',
-        '            self._win_right = int(box["x"]) + int(box["width"])',
+        '            geom["appx"] + int(geom["appw"] * fx),\n'
+        '            geom["appy"] + int(geom["apph"] * fy),',
+        '            int(geom["appw"] * fx),\n            int(geom["apph"] * fy),',
         [
             "OpeningCardOnATake."
-            "test_the_strip_starts_from_the_windows_unrounded_right_edge"
+            "test_the_strip_is_the_shared_geometrys_arithmetic_exactly"
         ],
     ),
     (
@@ -14418,89 +14434,71 @@ INJECTIONS = [
         ["CriterionHold.test_the_criterion_beat_covers_the_whole_spoken_line"],
     ),
     (
-        # **#291 wearing #361's clothes.** The wrapper document ships the
-        # card element, so core's `_INTERLUDE_JS` — which still carries the
-        # terminal stylesheet — must only ever find and toggle it. Drop the
-        # ask-the-page half and the script styles a fresh full-viewport
-        # element on every interlude: the web card repaints as a
-        # terminal-black field over the whole chrome.
-        "the interlude script stops asking the page before it builds a card",
-        "core.py",
-        "window.__demoInterlude = (text) => {\n"
-        "  let el = document.getElementById('__ID__');",
-        "window.__demoInterlude = (text) => {\n  let el = null;",
-        [
-            "InterludePalette."
-            "test_the_base_stylesheet_cannot_paint_where_the_card_already_exists",
-        ],
-    ),
-    (
-        # The web palette moved onto the terminal, which is #110's fix undone:
-        # a terminal segment then opens on a light field and fades it into a
-        # dark terminal, which is the flash that card exists to cover, brighter.
-        "the terminal's card is repainted in the web palette",
-        "core.py",
-        'INTERLUDE_CSS_TERMINAL = (\n    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"\n)',
-        'INTERLUDE_CSS_TERMINAL = (\n    _INTERLUDE_LAYOUT + " background: #efe7d8; color: #1c1a17;"\n)',
-        # Not `test_the_card_a_terminal_segment_opens_on_is_that_same_card`:
-        # that one grades the two builders of this element against **each
-        # other**, and both move together under a palette change. It is graded
-        # by the injection below, which is the fault it exists for.
-        [
-            "InterludePalette.test_a_terminal_take_still_raises_the_card_110_was_tuned_to",
-        ],
-    ),
-    (
-        # The palette fixed in `interlude()` and not in the init script that
-        # raises the opening card — the half of this element a storyboard never
-        # touches. The segment would open on one colour and fade out another.
-        "the card a terminal segment opens on keeps its own palette",
+        # The terminal take loses its opening hold: frame 0 is then the
+        # slot's white canvas until xterm.js paints — #110's flash, brighter,
+        # on the shared chrome. The pixel half is tests/pixel's terminal
+        # opening check; this is the wiring half, and it has to fail without
+        # a browser.
+        "the terminal stops registering the shared opening hold",
         "terminal.py",
-        '                .replace("__CSS__", self._interlude_css)',
-        '                .replace("__CSS__", "background: #efe7d8; color: #1c1a17;")',
+        "        context.add_init_script(\n"
+        "            opening_hold_script(\n"
+        '                chrome_geometry(self._size["width"], self._size["height"]),\n'
+        "                window_body=TERM_WINDOW_BODY,\n"
+        "            )\n"
+        "        )",
+        "        pass",
         [
-            "InterludePalette.test_the_card_a_terminal_segment_opens_on_is_that_same_card",
+            "TerminalChrome."
+            "test_a_terminal_take_registers_the_opening_hold_and_only_one",
         ],
     ),
     (
-        # A border put back on the card. This is #297's second rejected
-        # candidate: the field matches the window, and the card draws an edge
-        # of its own between itself and the recorder's pad — the "additional
-        # edge of a third colour" the reviewer refused.
-        "the terminal card draws an edge of its own around the field",
-        "core.py",
-        '    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"',
-        '    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"\n'
-        '    + " border: 18px solid #b45309;"',
+        # The hold painted in a colour that is not the terminal window's own
+        # body — the retired `#1c1a17` card palette, say. The card's fade
+        # then reveals a second flat field in a different dark, which reads
+        # as a stuck screen, and the one-declaration rule (#360) is broken
+        # on the medium it just reached.
+        "the terminal's hold is painted away from its window body",
+        "terminal.py",
+        # The `chrome_geometry(...)` line above it, because `_start`'s
+        # `chrome_html(...)` call passes the same keyword and a bare
+        # `window_body=` line matches twice (#362 gave the terminal two
+        # consumers of one colour, which is the point of the constant).
+        '                chrome_geometry(self._size["width"], self._size["height"]),\n'
+        "                window_body=TERM_WINDOW_BODY,",
+        '                chrome_geometry(self._size["width"], self._size["height"]),\n'
+        '                window_body="#1c1a17",',
         [
-            "InterludePalette.test_the_terminal_card_is_opaque_and_covers_the_frame",
+            "TerminalChrome."
+            "test_the_hold_carries_the_terminal_window_body_and_the_app_rect",
         ],
     ),
     (
-        # A card that lets the app show through. The colour is right, and
-        # reference/limits.md's account of what the picture check can see —
-        # which rests on this card being opaque — stops being true of a
-        # terminal take.
-        "the terminal card is a scrim over the app rather than a card",
-        "core.py",
-        '    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"',
-        '    _INTERLUDE_LAYOUT + " background: rgba(28,26,23,.72); color: #f7f4ee;"',
+        # xterm.js mounted beside the chrome instead of in its content slot:
+        # the window shows its white slot canvas forever while a live
+        # terminal renders behind the chrome document's window — the
+        # one-chrome claim broken at the mount point.
+        "xterm mounts on the body instead of in the chrome slot",
+        "terminal.py",
+        "  const slot = document.getElementById('__chrome_slot');",
+        "  const slot = document.body;",
         [
-            "InterludePalette.test_the_terminal_card_is_opaque_and_covers_the_frame",
+            "TerminalChrome.test_the_xterm_mount_targets_the_chrome_slot",
         ],
     ),
     (
-        # The card's corners rounded off the frame. `border-radius` clips the
-        # background of an `inset: 0` element, so the four corners stop being
-        # painted and the app shows through them while the card is up —
-        # full-bleed lost to a styling flourish, with the colour correct.
-        "the terminal card's outer corners are rounded off the frame",
-        "core.py",
-        '    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"',
-        '    _INTERLUDE_LAYOUT + " background: #1c1a17; color: #f7f4ee;"\n'
-        '    + " border-radius: 14px;"',
+        # The opening card's clear takes the card down and leaves the hold
+        # up beneath it — the take then shows the window's flat body to its
+        # last frame, #91's shape with the recorder's own furniture.
+        "the opening card's clear leaves the hold standing",
+        "terminal.py",
+        '                "() => { window.__demoChromeHoldClear();"\n'
+        "                \" window.__demoInterlude(''); }\"",
+        "                \"() => { window.__demoInterlude(''); }\"",
         [
-            "InterludePalette.test_the_terminal_card_is_opaque_and_covers_the_frame",
+            "TerminalChrome."
+            "test_open_on_card_takes_down_the_card_and_the_hold_it_covered",
         ],
     ),
     (


### PR DESCRIPTION
Terminal takes now record the same window web takes do. `chrome.py` is the only
window chrome in the package: xterm.js mounts in its content slot, the caption
paints in its band, and the opening card is the shared card layer over the
shared opening hold.

Last slice of #355. Fixes #362, and closes #355 as delivered.

## What went

| deleted | what replaced it |
|---|---|
| `terminal._TERM_HOST_JS` — a second hand-maintained window (bar 40 px against the shared 36, radius 12 against 14, its own gradient, fixed 70/74 insets) | `chrome_html`: one window, two mounts |
| `terminal._TERM_BG` | `chrome.CHROME_BG` |
| `terminal._OPENING_CARD_JS` — a frame-0 init-script card | `chrome.OPENING_HOLD_JS`, already the web path's since #360 |
| `core._CAPTION_JS`, `_INTERLUDE_JS`, `_BRIDGE_JS`, `_INTERLUDE_LAYOUT`, `INTERLUDE_CSS_TERMINAL`, `_interlude_script` | the chrome document's own inline renderers |
| `_DemoBase._caption_bottom_px`, `_DemoBase._interlude_css` | nothing — no medium places a caption any more |
| `terminal._read_win_edge`, `OPENING_CARD_MARGIN_PX`, `OPENING_CARD_STRIP_PX` | `OPENING_STRIP`, off `chrome_geometry`'s app rect |
| `_pixels.caption_band` | `caption_probe_band` — one band for both media |

`caption_lost` is now unreachable on either medium. The kind stays published so
a timeline committed before the cutovers still reads.

## The visual change, stated

A terminal take's opening card was a full-bleed `#1c1a17` rectangle over the
whole frame. It is now the window's own body colour over the **app rect** — the
shared card layer. Cards are chrome; only slot content keeps the Catppuccin
palette. `TERM_WINDOW_BODY` is the theme's own background, numerically equal to
`core.WEB_WINDOW_BODY` today, kept as its own name because it is a content
parameter.

## Two defects the cutover surfaced, both fixed here

### 1. The motion rule never reached a written document

`page.set_content` writes a new document and the context init script does not
run again, so the `<style>` the determinism rule installs goes with the old one.
Measured directly: a probe init script's counter stays at 1 across
`set_content` while its style element is gone. Globals survive, which is why
the frozen clock needed nothing and this did.

It did not matter until now, because the only document either medium wrote was
the web wrapper, whose app is an iframe with a document of its own. The
terminal's content is *in* the written document.

Seen red — `tests/smoke --terminal-only`, before the fix:

```
- terminal: in the terminal page, a probe element's animation-duration is '2s',
  expected '0.001s' — the recorder's motion rule is not reaching this page
- terminal: in the terminal page, a probe element's transition-duration is '5s',
  expected '0.001s'
- terminal: an animated ::after's animation-duration is '3s', expected '0.001s'
- terminal: an animated ::before's animation-duration is '4s', expected '0.001s'
- terminal: a control element with the ticker's animation … reports '0.18s'
```

Fixed with `_DemoBase._freeze_motion_here()`, called by both media right after
they write their chrome. `#__chrome…` joins `#__demo…` and `#__term…` in the
rule's spared list: the hold's 450 ms reveal is recorder motion by the same
reading as a caption's fade.

Two `tests/unit` tests, both seen red:

- delete the call from `TerminalRecorder._start` →
  `test_both_media_reattach_the_motion_rule_where_they_write_the_chrome (cls='TermRec')`
- drop the `deterministic` guard →
  `test_the_motion_rule_is_reattached_to_the_written_chrome_document (deterministic=False)`,
  both media

### 2. `act` was in neither verb-classification set

#346 added `rec.act` and nothing classified it, so a held picture spanning an
`act` block never warned. It went unseen because `check_verb_classification`
only runs when the content arm's earlier problems list is empty, and it was
not. `act` is acting — the storyboard drives the app with raw Playwright inside
it. `reference/timeline.md`'s shipped table gains it; `tests/unit` compares the
two name by name.

## The opening check's discriminator was rebuilt

`terminal-opening` used to read a corner of background *beside* the bespoke
window. The shared card layer covers the app rect and nothing else, so that
corner never changes any more. The strip moved inside the window.

Inside, luma cannot separate cover from terminal — both are the same dark body.
The first attempt graded **change against frame 0**, and it does not grade:

| mean abs. luma vs frame 0 | pixel loop's take | this suite's take |
|---|---:|---:|
| covered stretch | 0.00 | **1.68** |
| first revealed command | 1.86 | 1.86 |

The 1.68 is the chrome document arriving *after* frame 0 on a slower host and
shifting the whole flat field when it does. A bar between 1.68 and 1.86 picks a
host, not a defect. Caught by `--terminal-only` failing at 0.05 s.

The strip's own **standard deviation** separates them on structure instead. The
cover is a flat field by construction; terminal text is not:

| luma stddev | pixel loop | this suite |
|---|---:|---:|
| covered | 0.105 | 0.147 |
| chrome-arrival transient | — | 0.686 |
| first revealed command | 2.10 | 2.12 |
| settled terminal | 13.9 | 13.7 |

`TERMINAL_REVEAL_MIN_STDDEV = 1.2` is the geometric middle of 0.686 and 2.10:
1.75× clear of the worst covered reading, 1.75× under the weakest revealed one.
Same constant, same measurement, in `tests/smoke` and `tests/pixel`.

## #110's own defect can no longer be planted, and the injection says so

`tests/smoke-inject`'s fourth `--polish-only` entry was "the card is raised
400 ms into the document" — #110 itself. It no longer fires. The terminal path
now covers frame 0 **twice, independently**: `chrome.OPENING_HOLD_JS` on the
initial document, and the `#__chrome_hold` element `chrome_html` ships opaque
in its own markup. Measured — with the init script's build delayed 400 ms, the
old injection exactly, frame 0 still reads **24.0** over the strip.

That is the fix working, not the assertion failing, so the entry is re-aimed at
the one place both covers read: the window body they are both painted with. A
palette mistake there is the #291 class, which this repository has shipped.

```
PASS  break: the cover paints a colour that is not the window body  [30s]
      --polish-only, in terminal.py: TERM_WINDOW_BODY = _TERM_THEME["background"]…
      caught: terminal-opening: this take opened with TerminalRecorder(interlude=…)
      and reports its first frame as 'bare' at 242.0 mean luma
```

One `tests/unit` injection also needed disambiguating: `window_body=TERM_WINDOW_BODY,`
now matches twice in `terminal.py` (one colour, two consumers — the point of
the constant), and the driver refused the whole run with exit 3 rather than
plant it ambiguously. Repointed with the line above it.

## Gates

| gate | result |
|---|---|
| `tests/unit` | 536 tests, OK |
| `tests/unit --fault-inject` | **all 338 injections caught** |
| `tests/ci-unit` | 147 tests, OK |
| `tests/ci-unit --fault-inject` | all 107 injections caught |
| `tests/lint` | all checks passed, 27 files formatted |
| `mypy` (CI's pin, 1.18.2) | no issues, 14 files |
| SKILL.md budget | 630 / 630 lines |
| `tests/smoke-inject --self-test` | every guard refused what it exists to refuse |
| `tests/smoke --wrapper-only` | **PASSED** |
| `tests/smoke --cheap` | **PASSED** |
| `tests/smoke --terminal-only` | **not green locally — see below** |

```
tests/pixel
terminal/opening-card: ok - frame 0 luma 24.0 over (138, 109, 921, 76) (cover <= 60),
                       no bare frame (max 28.3), terminal revealed from 3.00s
                       (bar 1.0s, stddev floor 1.2)
web/card-vs-window:    ok - card 3 off (24, 24, 37) (bar 6) and 1 off the window body
                       (bar 5) over 2 instants; card-down control 213 off
web/cursor-parked:     ok - disc centre (591.1, 401.2) vs park (590.5, 401.0),
                       off (+0.6, +0.2)px (bar 3.0), 252 accent px
web/cursor-absence:    ok - 9 frames before beat 11 probed, worst frame 0 accent px
pixel: 6 checks, 0 failing
```

## `--terminal-only` is red on this host, and the host is why

This machine's wall clock **steps backward ~1.29 s roughly every 25 s**.
Reproduced in 30 seconds with no browser:

```
steps (t_s, delta_ms): [(24.06, -1283)]   # one discrete jump per 30 s window
```

WSL2, uptime 14.5 days, `hyperv_clocksource_tsc_page`. Chromium stamps every
screencast frame with that clock, so `demo.mp4` loses the step and every beat
after it sits that far ahead of the frame it names.

Across four `--terminal-only` runs today the arm reported, in different
combinations: a caption skew drift of −520 ms against a 250 ms bar; a closing
caption whose band moves +640 ms and +720 ms outside a 1.5 s search window; and
a held stretch reported as spanning `run` because the beat log and the video
disagree by 1.3 s. The last run was down to **one** failure, that residual
slide. The check names the cause itself: *"the window is already centred on
where the host's measured wall-clock steps put this beat in the video, so this
slide is something else."* The correction removes the whole step where the
video lost roughly half of it — #255, unchanged by this PR.

`--wrapper-only` and `--cheap` are green on the same host in the same session,
so this is the timing arms specifically. **Please run the `smoke-full` label on
this PR** to grade `--terminal-only` on a clean runner.

## Stated limits

- **The opening strip cannot see a cover that fades in** rather than being
  painted opaque — unchanged from before. The recorder spends longer injecting
  xterm.js than the fade lasts, so the frames are byte-identical either way. The
  construction (appended already opaque) is what rules it out, not this.
- **`#__chrome…` being spared by the motion rule is a taste choice, not a graded
  one.** Nothing fails if the hold's fade is flattened; it would just pop.
  Written on the constant rather than given an assertion.
- **`tests/pixel` failed once mid-session on the same host clock** — a card
  stretch measured 1.4 s against a 1.4 s floor, with the step landing at 2.5 s
  inside the card. Passed on re-record with the step at 8.5 s. Same #255.
