### PR TITLE
Fast local checks: prek hooks over the commands CI already runs, wired up by mise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,10 +199,19 @@ jobs:
         with:
           enable-cache: true
 
+      # Through `tests/typecheck`, not by hand, for the reason the ruff step
+      # above gives: the script reads MYPY_VERSION out of this file as text,
+      # so a contributor's local run is this step at this version. A `run:`
+      # line invoking mypy directly would carry its own — `tests/typecheck
+      # --self-test` refuses one.
+      #
       # Settings live in mypy.ini and are deliberately permissive — see the
       # comments there for what to ratchet up and when.
+      - name: tests/typecheck --self-test
+        run: tests/typecheck --self-test
+
       - name: mypy
-        run: uv run --with "mypy==$MYPY_VERSION" --with playwright mypy skills/demo-video/helpers/
+        run: tests/typecheck
 
   secrets:
     name: secrets (gitleaks)

--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ tests/.pixel-cache/
 # them: tests/lint read 657 files here against CI's 13, and a red run pointed
 # at files on other branches (#219).
 .claude/
+
+# prek/pre-commit caches
+.prek-cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,107 @@
+# Git hooks, run by prek. `mise run setup` installs them; `mise install` first
+# if this is a fresh clone.
+#
+# **Every hook shells out to the command CI runs.** None of them re-implements
+# a check and none of them names a tool version. That is load-bearing rather
+# than tidy: `tests/lint` reads ruff's version out of the `RUFF_VERSION:` line
+# of `.github/workflows/ci.yml` as text so the repo has exactly one pin, and a
+# hook that called `ruff` itself would be the second one — issue #189, where a
+# local `uvx ruff` and CI's pinned ruff disagreed on 33 files, in the direction
+# that demands reformatting CI was happy with. shellcheck and actionlint come
+# from PyPI through `uv run --with` for the reason ci.yml states beside each:
+# the same binary locally as on the runner.
+#
+# **The budget is the whole point.** The always-on pre-commit hooks measure
+# ~6 s together warm — lint 0.9 s, its self-test 0.4 s, ci-unit 1.3 s, unit
+# 3.7 s. Anything that needs the network (`tests/lint --issues`) or a browser
+# (`tests/smoke`, `tests/pixel`) is pre-push or manual, never pre-commit: a
+# hook people disable is worse than no hook.
+
+default_install_hook_types: [pre-commit, pre-push]
+fail_fast: false
+
+repos:
+  - repo: local
+    hooks:
+      # -- pre-commit: the fast gate ------------------------------------------
+
+      - id: lint-self-test
+        name: the ruff pin, the file set and the fence checker are live
+        entry: tests/lint --self-test
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: lint
+        name: ruff check + format + doc fences + shipped pointers (CI's pin)
+        entry: tests/lint
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: unit
+        name: tests/unit — the recorder, browser-free
+        entry: tests/unit
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: ci-unit
+        name: tests/ci-unit — the CI helpers
+        entry: tests/ci-unit
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      # Scoped by `files:`, so they cost nothing on a commit that does not
+      # touch what they read.
+
+      - id: shellcheck
+        name: shellcheck the skills' shell scripts
+        entry: uv run --with shellcheck-py shellcheck --severity=style
+        language: system
+        files: ^skills/.*\.sh$
+        stages: [pre-commit]
+
+      - id: actionlint
+        name: actionlint over the workflows
+        entry: >-
+          uv run --no-project --with actionlint-py --with shellcheck-py
+          actionlint
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: mypy
+        name: mypy over the recorder (CI's pin, read out of ci.yml)
+        entry: tests/typecheck
+        language: system
+        files: ^skills/demo-video/helpers/.*\.py$
+        pass_filenames: false
+        stages: [pre-commit]
+
+      # A credential reaching the repository is the one thing worth catching
+      # before the commit exists rather than after it is pushed. CI's job pins
+      # its own binary through `gitleaks/gitleaks-action@v2`; this is a
+      # pre-filter on staged content, not a replica. Both read .gitleaks.toml.
+      #
+      # Through `mise exec` because gitleaks is the one tool here that a git
+      # hook's shell cannot find on its own: `uv` and `mise` are on PATH from
+      # ~/.local/bin, gitleaks is mise-managed and only on a shim path. Run
+      # `mise install` if this hook says the binary is missing.
+      - id: gitleaks
+        name: gitleaks over the staged diff
+        entry: mise exec -- gitleaks git --staged --redact --no-banner
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      # -- pre-push: the checks that need the network -------------------------
+
+      - id: lint-issues
+        name: every issue a document presents as pending is still open
+        entry: tests/lint --issues
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,32 @@ with no expected misses is not a measurement, and the requirement is not met by
 editing an `expected.json` until it agrees with a result — a corpus that can
 only agree with itself measures nothing.
 
+## Setting up, and the checks that run before a commit
+
+```sh
+mise install        # uv, prek, gitleaks
+mise run setup      # installs the git hooks
+```
+
+`prek` runs the hooks. **Every one of them shells out to the command CI runs**
+— `tests/lint`, `tests/typecheck`, `tests/unit`, `tests/ci-unit`, and the
+shellcheck / actionlint invocations `ci.yml` spells out. None re-implements a
+check and none names a tool version, because the repo has exactly one pin per
+tool and the scripts read it out of `ci.yml` as text (#189). A hook that called
+`ruff` or `mypy` itself would be the second pin; `tests/lint --self-test` and
+`tests/typecheck --self-test` refuse one.
+
+The pre-commit set measures **~6 s** over the whole tree. What needs the
+network runs on pre-push instead (`tests/lint --issues`), and what needs a
+browser (`tests/smoke`, `tests/pixel`) is not a hook at all — a hook people
+disable is worse than no hook.
+
+`mise run check` is the same set by hand. `mise tasks` lists the rest
+(`pixel`, `smoke`, `budget`).
+
+Bypassing a hook is `git commit --no-verify`; if you do, say so in the pull
+request, because CI will ask the same question a few minutes later.
+
 ## Housekeeping
 
 - Never commit `node_modules/`, `dist/`, `build/`, `__pycache__/`, `.tts/`, or

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,58 @@
+# Tooling and task front door for this repo.
+#
+#     mise install && mise run setup      # once per clone
+#     mise run check                      # the fast gate, ~6 s
+#
+# **Deliberately not pinned here: ruff and mypy.** CI pins both on the
+# `RUFF_VERSION:` / `MYPY_VERSION:` lines of `.github/workflows/ci.yml`, and
+# `tests/lint` reads that file as text so there is one pin and one command. A
+# version in this file would be a second pin, which is the defect issue #189
+# already cost a cycle: a local `uvx ruff` and CI's pinned ruff disagreed on 33
+# files, in the direction where the local run demands reformatting CI is happy
+# with. Same reasoning for shellcheck and actionlint — the tasks below reach
+# them through `uv run --with …`, exactly as ci.yml does, so a contributor runs
+# the same binary the runner does.
+#
+# What IS here is only what has no version opinion: the runner (uv), the hook
+# runner (prek) and the secret scanner.
+
+[tools]
+uv = "latest"
+prek = "latest"
+# CI scans with `gitleaks/gitleaks-action@v2`, which pins its own binary. This
+# one is a pre-filter on staged content, not a replica of that job — it exists
+# so a credential is caught before it is committed rather than after it is
+# pushed. Both read `.gitleaks.toml`.
+gitleaks = "latest"
+
+[tasks.setup]
+description = "Install the git hooks (pre-commit and pre-push)"
+run = "prek install"
+
+[tasks.lint]
+description = "ruff, doc fences and shipped pointers, at CI's pinned version"
+run = "tests/lint"
+
+[tasks.typecheck]
+description = "mypy over the recorder, at CI's pinned version"
+run = "tests/typecheck"
+
+[tasks.test]
+description = "The browser-free suites: the recorder's and the CI helpers'"
+run = ["tests/unit", "tests/ci-unit"]
+
+[tasks.check]
+description = "Everything a commit is gated on — the same set the pre-commit hook runs"
+depends = ["lint", "typecheck", "test"]
+
+[tasks.pixel]
+description = "The chrome reference loop — cached takes, no lock (#324)"
+run = "tests/pixel"
+
+[tasks.smoke]
+description = "The cheap smoke arms; the expensive ones are --web-only/--terminal-only/--content-only"
+run = "tests/smoke --cheap"
+
+[tasks.budget]
+description = "What SKILL.md costs a caller on every invocation"
+run = "tests/unit --budget"

--- a/ruff.toml
+++ b/ruff.toml
@@ -21,6 +21,7 @@ extend-include = [
     "tests/unit",
     "tests/lint",
     "tests/pixel",
+    "tests/typecheck",
     "tests/eval-grader",
     ".github/scripts/*",   # the CI workflow's PEP 723 executables
     "skills/*/scripts/*",  # every skill's PEP 723 executables

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1096,10 +1096,10 @@ class _DemoBase:
         its style element is gone. Globals survive (same realm), which is
         why the frozen clock needs nothing here and this does.
 
-        It went unnoticed until #362, because until then the only document
-        either medium wrote its chrome into was the web wrapper, whose app
-        is an iframe with a document of its own where the init script does
-        run. The terminal's content is *in* the written document, so every
+        It went unnoticed while the only document either medium wrote its
+        chrome into was the web wrapper, whose app is an iframe with a
+        document of its own where the init script does run. #362 put the
+        terminal's content *in* the written document, so every
         animation probe in this repository's `tests/smoke --terminal-only`
         read its authored duration — 2 s where the rule says 1 ms.
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -1374,10 +1374,10 @@ MIN_SPOTLIGHT_CLEAR_S = 0.45
 # transparent, and it says nothing about a card painted late, because a beat's
 # timestamp is when the recorder logged the card, not when a viewer saw it.
 #
-# The discriminator is a strip of the app rect, re-based when #362 mounted
-# the terminal in the shared chrome (until then it was a corner of
+# The discriminator is a strip of the app rect. #362 re-based it there when
+# it mounted the terminal in the shared chrome: it had been a corner of
 # background beside the bespoke window, which the shared card layer — app
-# rect only — made blind):
+# rect only — made blind. Two states:
 #
 #   the cover     the opening hold / clause card, window body    luma ~24
 #   the defect    the slot's unheld white canvas                 luma ~255

--- a/tests/typecheck
+++ b/tests/typecheck
@@ -1,0 +1,167 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""mypy at exactly the version CI pins, over exactly what CI checks.
+
+    tests/typecheck            # what ci.yml's `typecheck` job runs
+    tests/typecheck --self-test  # prove the pin is live rather than decorative
+
+`tests/lint` exists because a local `uvx ruff` and CI's pinned ruff answered
+different questions (#189). mypy had the same shape and no such script: the
+version lives on the `MYPY_VERSION:` line of `.github/workflows/ci.yml` and
+the only way to run CI's mypy locally was to retype that job's command, pin
+included. This reads the pin out of that file as text, so there is one pin and
+one command, exactly as for ruff.
+
+Settings are `mypy.ini`'s and are deliberately permissive — that file's
+comments say what to ratchet and when. Nothing here adds a flag CI does not
+pass; a local run that is stricter than the gate is a local run people learn
+to ignore.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CI = REPO / ".github" / "workflows" / "ci.yml"
+WORKFLOWS = REPO / ".github" / "workflows"
+
+# Anchored to the key, for `tests/lint`'s reason: a `mypy==` written anywhere
+# else in the file must not be able to stand in for the pin.
+PIN = re.compile(r'^\s*MYPY_VERSION:\s*"([^"]+)"\s*$', re.MULTILINE)
+
+# A workflow step running mypy by hand instead of through this script: such a
+# step carries its own version, which is the drift the pin exists to prevent.
+# `tests/lint` holds the same line for ruff (INLINE_RUFF) and this is its
+# counterpart — without it, CI could stop using this script and nothing would
+# say so.
+INLINE_MYPY = re.compile(r"^\s*run:.*\bmypy\b.*$", re.MULTILINE)
+
+# What a `run:` line is allowed to say while still naming mypy: this script.
+ALLOWED_RUN = re.compile(r"^\s*run:\s*tests/typecheck(\s+--self-test)?\s*$")
+
+# What CI type-checks. One path today; a list so adding one is a one-line
+# change here and in ci.yml rather than a rewrite.
+TARGETS = ("skills/demo-video/helpers/",)
+
+
+class Refused(Exception):
+    """The pin cannot be read, or has stopped being the only one."""
+
+
+def pinned_version(text: str) -> str:
+    """The mypy version the workflow pins. Exactly one line may say so."""
+    found = PIN.findall(text)
+    if len(found) != 1:
+        raise Refused(
+            f"{len(found)} `MYPY_VERSION:` lines in the workflow, expected "
+            f"exactly 1 — with none there is no pin, and with two the local "
+            f"command and CI can run different mypys."
+        )
+    version = found[0]
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        raise Refused(f"MYPY_VERSION is {version!r}, which is not a pinned version")
+    return version
+
+
+def mypy(version: str, *args: str) -> subprocess.CompletedProcess[str]:
+    """mypy, resolved by uv at `version`, run from the repository root.
+
+    `--with playwright` because the recorder imports it and mypy reads the
+    installed package for its types; without it every `page.` attribute is
+    `Any` and the check quietly stops asking most of its questions.
+    """
+    return subprocess.run(
+        [
+            "uv",
+            "run",
+            "--with",
+            f"mypy=={version}",
+            "--with",
+            "playwright",
+            "mypy",
+            *args,
+        ],
+        cwd=REPO,
+        text=True,
+    )
+
+
+def self_test() -> int:
+    """The pin is read, and changing it changes what this script runs."""
+    text = CI.read_text(encoding="utf-8")
+    version = pinned_version(text)
+    print(f"OK       the pin is {version}, read out of .github/workflows/ci.yml")
+
+    # Behavioural, not a string comparison: a ci.yml pinning a version that
+    # does not exist must make this script fail to resolve one. Otherwise the
+    # version in ci.yml is decorative and the two can drift apart again.
+    bogus = text.replace(f'MYPY_VERSION: "{version}"', 'MYPY_VERSION: "9.9.9"')
+    got = pinned_version(bogus)
+    if got != "9.9.9":
+        print(f"DEAD PIN a ci.yml pinning 9.9.9 still resolved to {got!r}")
+        return 1
+    print("OK       changing MYPY_VERSION changes the version this script runs")
+
+    stray = []
+    for workflow in sorted(WORKFLOWS.glob("*.yml")):
+        for line in INLINE_MYPY.findall(workflow.read_text(encoding="utf-8")):
+            if not ALLOWED_RUN.match(line):
+                stray.append(f"{workflow.name}: {line.strip()}")
+    if stray:
+        print("INLINE   a workflow runs mypy without this script, so it can")
+        print("         carry its own version:")
+        for line in stray:
+            print(f"           {line}")
+        return 1
+    print(
+        f"OK       no workflow reaches mypy any other way "
+        f"({len(list(WORKFLOWS.glob('*.yml')))} checked)"
+    )
+
+    for name, replacement in (
+        ("no MYPY_VERSION line at all", 'env:\n  RUFF_VERSION: "0.16.1"\n'),
+        (
+            "two MYPY_VERSION lines",
+            '  MYPY_VERSION: "1.0.0"\n  MYPY_VERSION: "2.0.0"\n',
+        ),
+        ("a version that is not pinned", '  MYPY_VERSION: "latest"\n'),
+    ):
+        broken = PIN.sub(replacement.rstrip("\n"), text, count=1)
+        try:
+            pinned_version(broken)
+        except Refused:
+            print(f"OK       refuses {name}")
+        else:
+            print(f"ACCEPTED {name} — the pin guard is decorative")
+            return 1
+    print("\nOne pin, one command: tests/typecheck runs exactly what CI runs.")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog="typecheck")
+    parser.add_argument(
+        "--self-test", action="store_true", help="prove the pin is live"
+    )
+    args = parser.parse_args()
+    try:
+        version = pinned_version(CI.read_text(encoding="utf-8"))
+    except Refused as exc:
+        print(f"typecheck: refusing — {exc}", file=sys.stderr)
+        return 2
+    if args.self_test:
+        return self_test()
+    print(f"typecheck: mypy {version}, pinned by .github/workflows/ci.yml")
+    return mypy(version, *TARGETS).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
CI lint failures kept arriving minutes after a push for things a second-long
check answers. This wires the same commands into git hooks.

```sh
mise install        # uv, prek, gitleaks
mise run setup      # installs pre-commit and pre-push
```

## What runs, and when

| stage | hooks | cost |
|---|---|---|
| pre-commit | `tests/lint --self-test`, `tests/lint`, `tests/unit`, `tests/ci-unit`, `tests/typecheck`, shellcheck, actionlint, gitleaks over the staged diff | **~6 s** over the whole tree |
| pre-push | `tests/lint --issues` | ~2 s, needs the network |
| not a hook | `tests/smoke`, `tests/pixel` | needs a browser |

`shellcheck`, `actionlint` and `mypy` are gated by `files:`, so they cost
nothing on a commit that does not touch what they read. The commit that
produced this branch measured **5.9 s** with shellcheck correctly skipped.

A hook people disable is worse than no hook, which is the whole reason the
browser suites are not in here.

## No hook re-implements a check, and none names a version

Every entry shells out to the command `ci.yml` runs. That is the constraint the
repo already had: `tests/lint` reads ruff's version out of the `RUFF_VERSION:`
line as text so there is exactly one pin, and #189 is what a second one cost —
a local `uvx ruff` and CI's pinned ruff disagreed on 33 files, in the direction
that demands reformatting CI was happy with. A hook calling `ruff` would be
that second pin.

`mise.toml` pins only what has no version opinion: `uv`, `prek`, `gitleaks`.
Ruff and mypy are deliberately absent and the file says why.

## `tests/typecheck` is new, and closes the same gap for mypy

mypy had ruff's shape and no script: the pin lived on `MYPY_VERSION:` and the
only way to run CI's mypy locally was to retype the job's command. `tests/typecheck`
reads that line the way `tests/lint` reads `RUFF_VERSION`, and `ci.yml`'s
typecheck job now calls it instead of spelling out the command.

Its `--self-test`, all five statements seen pass and the inline guard seen red:

```
OK       the pin is 1.18.2, read out of .github/workflows/ci.yml
OK       changing MYPY_VERSION changes the version this script runs
OK       no workflow reaches mypy any other way (5 checked)
OK       refuses no MYPY_VERSION line at all
OK       refuses two MYPY_VERSION lines
OK       refuses a version that is not pinned
```

Against a planted `run: uv run --with "mypy==1.18.2" mypy skills/` in ci.yml:

```
INLINE   a workflow runs mypy without this script, so it can
         carry its own version:
           ci.yml: run: uv run --with "mypy==1.18.2" mypy skills/
exit=1
```

`tests/typecheck` is added to `ruff.toml`'s `extend-include` — `tests/lint
--self-test` requires every PEP 723 executable to be inside the set ruff reads
(#212), so leaving it out would have failed that check rather than gone quiet.

## The hooks were seen red before they were trusted

- **lint** — a two-line unformatted file staged: `1 file would be reformatted`,
  `lint: ruff format --check failed`.
- **gitleaks** — a staged file with a generated AWS key and a `ghp_` token:
  `leaks found: 2`, hook `Failed`. (The first attempt used
  `AKIAIOSFODNN7EXAMPLE` and passed — that string is gitleaks' own documented
  example and its default ruleset allowlists it. Worth knowing before anyone
  tests this hook the obvious way and concludes it does nothing.)
- **lint-issues** — fired on its first real run, below.

## What the pre-push hook caught immediately

Two sentences merged this morning in #369 read as pending work while naming
#362, which that PR closed:

```
issues: skills/demo-video/helpers/demo_recording/core.py:1099: presented as
  pending work, but #362 is closed: 'It went unnoticed until #362, because
  until then the only document either medium wrote its chrome into was …'
issues: tests/smoke:1378: presented as pending work, but #362 is closed:
  '# The discriminator is a strip of the app rect, re-based when #362 mounted
  # the terminal in the shared chrome (until then it was a corner of …'
```

Both reworded to read as history. The trigger phrase is `until then`; the
vocabulary is deliberately small and literal, and widening it to tell intent
apart would fire on every issue this repo cites as a measurement.

## Stated limits

- **The gitleaks hook is a pre-filter, not a replica of CI's job.** CI runs
  `gitleaks/gitleaks-action@v2`, which pins its own binary; this runs the
  mise-managed one over the staged diff. Both read `.gitleaks.toml`. Versions
  can differ, which for a scanner means "may catch more or fewer", not "demands
  a change CI does not".
- **The gitleaks hook goes through `mise exec`.** It is the one tool a git
  hook's shell cannot find on its own — `uv` and `mise` are on `PATH` from
  `~/.local/bin`, gitleaks is only on a shim path.
- **Nothing enforces that the hook set stays equal to CI's job set.** A new CI
  job will not appear here on its own. A guard is possible and is not in this
  change.
- **The eval corpus is stale against the wrapper cutover.** Re-recording it
  moved every committed still by ~9 dB PSNR — the takes predate #358–#362, so
  the stills are pre-wrapper chrome. Not touched here; it needs a re-score, and
  a re-score needs readers.
