### PR TITLE
Stills without a video: the same storyboard, run for its pictures in ~2 s

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -147,6 +147,7 @@ read them all up front, and do not skip one the text tells you to open.
 | [reference/failures.md](reference/failures.md) | When a take raises, when `strict=True` refuses one, or when `failure/` appears beside the demo |
 | [reference/terminal.md](reference/terminal.md) | When writing a `TerminalRecorder` storyboard — the full verb table, the four patterns, the gotchas |
 | [reference/narration.md](reference/narration.md) | When `ELEVENLABS_API_KEY` is set and captions will be spoken |
+| [reference/stills.md](reference/stills.md) | When you want the pictures now and the video later — `stills_only=True` runs the same storyboard in seconds |
 | [reference/ci.md](reference/ci.md) | When wiring the recording into GitHub Actions so branches record themselves |
 
 ## Setup (once per project)
@@ -237,6 +238,7 @@ three it is not the variable lowercased, so do not infer it:
 | `DEMO_VIDEO_TIMEZONE` | `timezone_id` — browser timezone, always applied | `UTC` |
 | `DEMO_VIDEO_LOCALE` | `locale` — browser locale, always applied | `en-US` |
 | `DEMO_VIDEO_SPEECH` | `speech` — force narration on/off (`1`/`0`). **`speech=False` records silently even with a key set**; with no key it is off already, and forcing it *on* without one refuses the take | auto by API key |
+| `DEMO_VIDEO_STILLS_ONLY` | `stills_only` — run the storyboard for its `shot()` pictures and record no video (`1`/`0`). Pacing zeroed, narration off; writes no mp4 and no `frames/`, and `timeline.json` says `mode: "stills"` so nothing reads it as a take — [reference/stills.md](reference/stills.md) | off |
 | `DEMO_VIDEO_STRICT` | `strict` — fail the take on console errors / non-zero exits (`1`/`0`) | off |
 | `DEMO_VIDEO_EVIDENCE` | `evidence` — write `evidence/beat-NN.json` per beat (`1`/`0`) — see [reference/review.md](reference/review.md) | **on** |
 | `DEMO_VIDEO_VOICE_ID` | `voice_id` — ElevenLabs voice | Sarah (premade) |
@@ -305,9 +307,6 @@ below are encoded in the recorder; the point is to *not fight them*.
   rec.spotlight()     # then clear
   ```
 
-  `hold()` waits for the current narration line to finish (or `min_s` when
-  silent). Without it, a short `pause()` can clear the highlight while the
-  narrator is still talking about it — exactly the flicker above.
 - **One salient change at a time.** The eye can track one moving/appearing
   thing. Don't navigate, spotlight, and type in the same instant; sequence
   them, caption first (it tells the eye where to look), then the visual.
@@ -421,7 +420,10 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
    - End with a closing line that sums up the story, then `caption("")`.
 4. **Record:** `uv run <demo folder>/record.py` (with the project's env
    loaded if it configures DEMO_VIDEO_* or the ElevenLabs key:
-   `set -a; source .env; set +a`). Aim for 30–60 s.
+   `set -a; source .env; set +a`). Aim for 30–60 s. **While the storyboard
+   is still wrong, run it with `DEMO_VIDEO_STILLS_ONLY=1`** — same verbs and
+   the same stills in seconds, no video ([reference/stills.md](reference/stills.md));
+   record the take once the pictures are right.
 5. **Verify by looking, not by exit code:** read the `images/*.png` stills
    to confirm the story is actually visible; check `ffprobe` duration. Read
    `timeline.md` too — it is the take's own account of what ran and when, so

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -747,6 +747,18 @@ def _beat_verb(
     return decorate
 
 
+#: Finish every animation that has an end (see `_settle_animations`). Returns
+#: the count, which nothing reads today — the value is that a future caller
+#: can tell "settled nothing" from "could not run".
+_SETTLE_JS = """() => {
+  let done = 0;
+  for (const a of document.getAnimations()) {
+    try { a.finish(); done += 1; } catch (e) { /* infinite, or detached */ }
+  }
+  return done;
+}"""
+
+
 class _DemoBase:
     """Recording + narration substrate shared by every demo medium.
 
@@ -810,7 +822,7 @@ class _DemoBase:
             # extension points, each beside the sealed member it extends
             "_watch_extra",
             "_before_shot",
-            "_idle",
+            "_hold_frame",
         }
     )
 
@@ -869,6 +881,12 @@ class _DemoBase:
         evidence: bool | None = None,
         criteria: dict[str, str] | None = None,
         ticket: str | None = None,
+        stills_only: bool | None = None,
+        # Last, and kept last. `tests/unit`'s "a way to permit a public host
+        # appears as a constructor argument" injection anchors on this line
+        # followed by the closing paren, and a parameter added after it makes
+        # that injection stop landing — which the fault-injection driver
+        # refuses on (exit 3) rather than quietly passing.
         allow_private: bool | None = None,
     ) -> None:
         # Every setting resolves explicit parameter > DEMO_VIDEO_* env var
@@ -913,6 +931,23 @@ class _DemoBase:
         self._ticket = _checked_ticket(ticket)
         self.images_dir = self.out_dir / "images"
         self._video_dir = self.out_dir / ".video"
+        # Run the storyboard for its pictures and skip the video (issue #372).
+        # Every verb still runs; what goes is the pacing, which exists for a
+        # viewer's eyes and for nothing else — the field take this was measured
+        # on spent 68% of 124 s holding frames, and `shot()` is a plain
+        # `page.screenshot()` that has never had anything to do with the
+        # recording.
+        #
+        # A *mode*, not a faster take, and the difference is written down
+        # everywhere it could be mistaken: no screencast is attached, so there
+        # is no webm, no encode, and no picture to measure; `timeline.json`
+        # carries `mode: "stills"` with `media: null` and no `content`; and the
+        # consumers that cut frames out of an mp4 refuse the directory by name.
+        # This supersedes #354, which asked for the same run with the pictures
+        # thrown away — one flag, because two would be two ways to be wrong.
+        if stills_only is None:
+            stills_only = _env_flag("STILLS_ONLY")
+        self.stills_only = False if stills_only is None else bool(stills_only)
         if accent_rgb is None:
             raw = _env("ACCENT_RGB", "235,110,20")
             parts = [p.strip() for p in raw.split(",")]
@@ -953,7 +988,15 @@ class _DemoBase:
             raise RuntimeError(
                 "speech is forced on but ELEVENLABS_API_KEY is not set"
             )
+        if speech is True and self.stills_only:
+            raise RuntimeError(
+                "speech is forced on for a stills-only run, which encodes no "
+                "mp4 and so has no audio track to mix a voice onto. Drop "
+                "speech=True, or record a take."
+            )
         self._speech = bool(api_key) if speech is None else speech
+        if self.stills_only:
+            self._speech = False
         self._api_key = api_key
         # Default voice "Sarah" is premade — works on free-tier keys.
         self._voice_id = voice_id or _env("VOICE_ID", "EXAVITQu4vr4xnSDxMaL")
@@ -1047,6 +1090,12 @@ class _DemoBase:
         if self._speech:
             print(f"demo-video: narration ON (voice {self._voice_id})",
                   file=sys.stderr)
+        elif self.stills_only:
+            print(
+                "demo-video: narration OFF — a stills-only run encodes no "
+                "mp4, so there is no track for a voice to go on.",
+                file=sys.stderr,
+            )
         else:
             print(
                 "demo-video: narration OFF — no ELEVENLABS_API_KEY in this "
@@ -1083,6 +1132,21 @@ class _DemoBase:
                 f"of this storyboard will not match. Recorder("
                 f"deterministic=True) freezes it; read the skill's "
                 f"reference/determinism.md first, it changes what some apps do.",
+                file=sys.stderr,
+            )
+        # ...and, loudest of the three, that this run is not a recording. The
+        # other two describe a take; this one says there is no take. Somebody
+        # who set the env var in a shell three commands ago and then wondered
+        # where demo.mp4 went is the reader.
+        if self.stills_only:
+            print(
+                "demo-video: STILLS-ONLY run — the storyboard runs in full, "
+                "every shot() is written to images/, and no video is "
+                "recorded. Pacing is zeroed, narration is off, and "
+                "timeline.json says mode: stills with media: null, so nothing "
+                "downstream can read this as a take. Unset "
+                "DEMO_VIDEO_STILLS_ONLY (or pass stills_only=False) to "
+                "record one.",
                 file=sys.stderr,
             )
 
@@ -1163,10 +1227,19 @@ class _DemoBase:
             # out the same on a machine in Tórshavn as on a CI runner in
             # us-east-1. None of the three changes what an app computes, so
             # none of them is gated on `deterministic`.
+            # Declining the screencast is the whole saving of a stills-only
+            # run, and this is the only place it can be declined: Chromium
+            # starts capturing with the page. `page.video` is then None, so
+            # every downstream "did this take encode anything" answer —
+            # `_converted`, `duration`, `content`, the beat-frame sheet —
+            # follows from the recording that does not exist rather than from
+            # a second flag somebody has to remember to check.
             self._context = self._browser.new_context(
                 viewport=self._size,
-                record_video_dir=str(self._video_dir),
-                record_video_size=self._size,
+                record_video_dir=(
+                    None if self.stills_only else str(self._video_dir)
+                ),
+                record_video_size=None if self.stills_only else self._size,
                 locale=self._locale,
                 timezone_id=self._timezone_id,
                 reduced_motion="reduce",
@@ -1816,7 +1889,7 @@ class _DemoBase:
             "generated_by": "demo-video",
             "recorder": type(self).__name__,
             "segment": self.segment,
-            "media": self._media_path().name,
+            "media": self._media_name(),
             "beat": {
                 key: beat.get(key)
                 for key in ("index", "t_start", "t_end", "verb", "selector",
@@ -1983,7 +2056,7 @@ take with fewer beats than the last one would otherwise leave the
             # story surprisingly often.
             "issues": [dict(issue) for issue in self._issues],
             "issue_count": self._issue_count,
-            "media": self._media_path().name,
+            "media": self._media_name(),
             "screen_captured": self._failure_screen_text is not None,
         }
         return doc
@@ -2142,6 +2215,20 @@ take with fewer beats than the last one would otherwise leave the
         name = f"{self.segment}.seg.mp4" if self.segment else "demo.mp4"
         return self.out_dir / name
 
+    def _media_name(self) -> str | None:
+        """What an artifact should call this take's video — None on a stills
+        run, where there is not one (issue #372).
+
+        Null rather than the name it *would* have had. A name is a pointer,
+        and in a directory that has been recorded into before — which is the
+        ordinary case, because `record.py` is committed so it can be re-run —
+        `demo.mp4` is sitting right there from a previous take. Writing the
+        name anyway would point this run's timeline, its evidence documents
+        and its failure dump at that file: the stale-`duration` lie of #20,
+        one field over and in three more places.
+        """
+        return None if self.stills_only else self._media_path().name
+
     def _note_overlays_up(self) -> None:
         """Ask the page whether this recorder's own overlays are still showing.
 
@@ -2290,6 +2377,22 @@ take with fewer beats than the last one would otherwise leave the
                     f"that needs the length has to probe the file itself.",
                     file=sys.stderr,
                 )
+        elif self.stills_only:
+            # Not a warning. A stills-only run encoding nothing is the mode
+            # working, and printing the take's "no mp4" alarm over it would
+            # train a reader to ignore the line that matters.
+            print(
+                "demo-video: stills-only run — no video was recorded, so "
+                "timeline.json says mode: stills, media: null and "
+                "duration: null."
+                + (
+                    f" The {mp4.name} in {self.out_dir} is a previous run's, "
+                    f"and this timeline does not describe it."
+                    if mp4.exists()
+                    else ""
+                ),
+                file=sys.stderr,
+            )
         else:
             print(
                 "demo-video: this take encoded no mp4, so timeline.json says "
@@ -2314,7 +2417,7 @@ take with fewer beats than the last one would otherwise leave the
             # outside one, so a timeline written before this key existed reads
             # as it always did. Nothing here fetched or resolved it.
             **_ticket_field(self._ticket),
-            "media": mp4.name,
+            "media": self._media_name(),
             "duration": duration,
             # Which clock produced this take. Without it a still committed to a
             # repo carries no record of the conditions it was recorded under,
@@ -2363,6 +2466,21 @@ take with fewer beats than the last one would otherwise leave the
             "issues": issues,
             "issue_count": self._issue_count,
         }
+        # Both of these are the `failure` construction below, for the same
+        # reason: **presence is the signal** (issue #372).
+        #
+        # `mode` is absent on a take, so a take's timeline.json is byte-for-byte
+        # what it was before stills-only runs existed, and a reader that has
+        # never heard of one is never handed `mode: "take"` to interpret.
+        #
+        # `content` is *removed* rather than left null, and the difference is
+        # a real one. On a take, `content: null` means an mp4 was expected and
+        # the picture could not be measured — the answer #97 exists to give.
+        # A stills run has no frames at all, so it makes no claim about them:
+        # the key is not there, and `mode` says why.
+        if self.stills_only:
+            doc.pop("content")
+            doc["mode"] = "stills"
         # Absent on a clean take, so a successful take's timeline.json is
         # byte-for-byte what it was before this key existed — and so that its
         # presence is the whole signal, with no `failure: null` to skim past.
@@ -2373,7 +2491,70 @@ take with fewer beats than the last one would otherwise leave the
     # -- shared storyboard verbs -------------------------------------------
 
     def _idle(self, seconds: float) -> None:
-        """Hold for `seconds`. Overridden by media that must keep working
+        """Hold the frame for `seconds` — the one place this package waits.
+
+        Every paced verb arrives here: `pause`, `hold`, the tail of a caption,
+        an interlude, a criterion card, the terminal's per-keystroke delay.
+        That is why the stills-only short-circuit is *here* and why `_idle`
+        itself is sealed (issue #372). A medium extends the waiting by
+        implementing `_hold_frame`; it cannot reach past the mode check, so
+        there is no medium in which a stills-only run quietly still paces.
+
+        The pump survives the short-circuit. Playwright's sync API delivers
+        `console`/`pageerror` only while it is inside a call, so skipping it
+        would hand every event a stills run provokes to whichever beat made
+        the next call — the storyboard would run fast and misattribute what it
+        found.
+
+        What is deliberately *not* here is landing the animations the pacing
+        used to land. That belongs to `shot()` and only there: a stills run's
+        one visual output is the stills, so settling anywhere else would be a
+        cost paid per beat for a picture nobody takes.
+        """
+        if self.stills_only:
+            self._pump_events()
+            return
+        self._hold_frame(seconds)
+
+    def _settle_animations(self) -> None:
+        """Land every running animation on its end state (stills-only).
+
+        **Zeroing the pacing is not enough on its own, and this is the half
+        that was measured.** The determinism rule spares the recorder's own
+        overlays — `#__demo*`, `#__chrome*`, anything marked
+        `data-demo-video-animate` — precisely so a spotlight, a caption and an
+        interlude card *do* fade on camera. In a take the hold after the verb
+        is what lets them finish. Take the hold away and nothing does: the
+        first stills run of the reference storyboard caught its criterion card
+        mid-fade and its spotlight's scrim half-faded — dimming the whole app
+        instead of picking out the tile the caption names — at 12.0 dB and
+        21.7 dB PSNR from the take's own stills. A difference anyone would
+        see, in the direction of showing less.
+
+        So the mode restores by construction what the pacing used to restore
+        by waiting. Every frame, not just the wrapper's: the app's own
+        transitions were settled by the same hold, and a still of a panel
+        halfway open is the same lie one field over.
+
+        Called from `shot()` and nowhere else. Everything a stills run leaves
+        behind is a document except the stills, and a document does not care
+        what a transition was halfway through — so one evaluate per picture
+        is the whole cost, rather than one per beat.
+
+        Skipped rather than forced where there is no end to jump to — an
+        infinite animation (a spinner) throws on `finish()`, and a spinner
+        still spinning is what a take would have shown too. Never fatal: like
+        the pump, this is here to make the picture right and is not a reason
+        to lose a run.
+        """
+        for frame in self.page.frames:
+            try:
+                frame.evaluate(_SETTLE_JS)
+            except Exception:  # noqa: BLE001 - a detached frame, mid-navigation
+                continue
+
+    def _hold_frame(self, seconds: float) -> None:
+        """Wait out `seconds`. Overridden by media that must keep working
         (pumping output) while the frame is held.
 
         Sliced against a deadline rather than one flat sleep, so page events
@@ -2639,13 +2820,24 @@ take with fewer beats than the last one would otherwise leave the
         the beat and its `ac` claim with it, and the coverage report reads
         nothing else. Medium-specific work goes in `_before_shot`.
         """
+        # A stills run has no hold for the recorder's own overlays to finish
+        # inside, so this is where they are finished (#372). Here and not in
+        # `_idle`: the still is the only thing such a run renders. Read
+        # `_settle_animations` — the picture it exists for was measured
+        # 12.0 dB wrong without it.
+        if self.stills_only:
+            self._settle_animations()
         self._before_shot()
         claims = self._checked_ac(ac, "shot()")
         path = self.images_dir / f"{name}.png"
         rel = path.relative_to(self.out_dir).as_posix()
         with self._beat("shot", selector=name, still=rel, **_ac_field(claims)):
-            # Full-bleed on the web recorder — the whole page, no window
-            # frame — so a still is not a crop of the video.
+            # The recorded page, chrome and all. On the wrapper path (#358)
+            # that page *is* the framed picture, so a still and the frame the
+            # video shows at the same instant are the same image — which is
+            # what lets a stills-only run stand in for one (#372). The
+            # comment this replaces described the composite, where the still
+            # was full-bleed and the video was not; #368 deleted that path.
             self.page.screenshot(path=str(path))
         return path
 

--- a/skills/demo-video/helpers/demo_recording/frames.py
+++ b/skills/demo-video/helpers/demo_recording/frames.py
@@ -297,13 +297,14 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
     out_dir = Path(out_dir)
     if doc is None:
         doc = json.loads(timeline_paths(out_dir)[0].read_text())
+    stills_only = doc.get("mode") == "stills"
     mp4 = out_dir / str(doc.get("media") or "demo.mp4")
     frames_dir, json_path, md_path = frames_paths(out_dir)
     beats = doc.get("beats") or []
     manifest: dict = {
         "schema": FRAMES_SCHEMA,
         "generated_by": "demo-video",
-        "media": mp4.name,
+        "media": None if stills_only else mp4.name,
         "duration": doc.get("duration"),
         "recorder": doc.get("recorder"),
         "frames": [],
@@ -318,6 +319,20 @@ def beat_frames(out_dir: Path | str, doc: dict | None = None) -> dict:
         "clock_correction": None,
         "skipped": None,
     }
+    # First, because it is the more fundamental refusal: a segment has a video
+    # that belongs to a different sheet, and this has no video at all. Without
+    # it the `or "demo.mp4"` above walks into a previous run's file and cuts a
+    # sheet of frames from a recording this timeline does not describe — under
+    # this run's beat names (issue #372, the shape of #20).
+    if stills_only:
+        manifest["skipped"] = (
+            "this is a stills-only run, not a take: it attached no screencast "
+            "and encoded no video, so there is no recording to cut frames out "
+            "of. The pictures it did take are in images/, named by the "
+            "storyboard, and every beat that took one points at it. Re-run "
+            "the storyboard without stills_only for a sheet"
+        )
+        return manifest
     if doc.get("segment"):
         manifest["skipped"] = (
             f"{doc['segment']} is one segment of a demo, not a demo; its beats "

--- a/skills/demo-video/helpers/demo_recording/stitching.py
+++ b/skills/demo-video/helpers/demo_recording/stitching.py
@@ -255,6 +255,12 @@ def _segment_timeline(out_dir: Path, segment: str, media: Path, probed: float) -
             f"segment rather than merging a document this code does not know "
             f"the shape of"
         )
+    if doc.get("mode") == "stills":
+        raise ValueError(
+            f"{json_path} is a stills-only run, not a segment (issue #372): "
+            f"it recorded no video, so there is nothing of it to join onto "
+            f"this demo. Re-record segment {segment!r} without stills_only."
+        )
     if doc.get("media") != media.name:
         raise ValueError(
             f"{json_path} describes {doc.get('media')!r}, not {media.name!r} — "

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -264,6 +264,7 @@ class TerminalRecorder(_DemoBase):
         evidence: bool | None = None,
         criteria: dict[str, str] | None = None,
         ticket: str | None = None,
+        stills_only: bool | None = None,
         allow_private: bool | None = None,
         type_delay_ms: int = 45,
         interlude: str | None = None,
@@ -280,6 +281,7 @@ class TerminalRecorder(_DemoBase):
             deterministic=deterministic, clock=clock,
             timezone_id=timezone_id, locale=locale, evidence=evidence,
             criteria=criteria, ticket=ticket, allow_private=allow_private,
+            stills_only=stills_only,
         )
         self._shell = shell or _env("TERMINAL_SHELL") or "/bin/bash"
         fs = font_size
@@ -695,9 +697,15 @@ class TerminalRecorder(_DemoBase):
                 beat=beat, exit_code=code, command=command,
             )
 
-    def _idle(self, seconds: float) -> None:
+    def _hold_frame(self, seconds: float) -> None:
         """Hold the frame while pumping program output, so long-running
-        commands keep scrolling on screen instead of freezing."""
+        commands keep scrolling on screen instead of freezing.
+
+        `_hold_frame` and not `_idle`: the base seals `_idle` so a stills-only
+        run cannot be paced by a medium that forgot about it (#372). Nothing
+        is lost by not running here in that mode — the PTY is drained by
+        `_screen()`, which is what `wait_for_text` and `wait_for_prompt` call
+        on every pass of their own loops."""
         end = time.monotonic() + seconds
         while True:
             self._pump()

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -62,7 +62,20 @@ from .markdown import _fmt_t, _md_cell
 #                          answer and picking one would be this document
 #                          stating something no segment said. Each part's own
 #                          is in `segments` either way.
-#   media         str    — the mp4 this timeline describes, e.g. "demo.mp4"
+#   mode          str?   — **absent on a take**, and "stills" on a stills-only
+#                          run (issue #372): a run that drove the storyboard
+#                          for its `shot()` pictures with no video attached.
+#                          Absent rather than "take" for #24's reason — a
+#                          reader that never heard of the mode meets the
+#                          document it always met. When it is present, `media`
+#                          and `duration` are null and `content` is *absent*,
+#                          and `beat_frames`, `demo-grade` and `stitch` all
+#                          refuse the folder by name. See reference/stills.md.
+#   media         str?   — the mp4 this timeline describes, e.g. "demo.mp4".
+#                          Null when `mode` is "stills": nothing was recorded,
+#                          and a name here would point at a *previous* run's
+#                          file in any folder recorded into before (#20's lie,
+#                          one field over).
 #   duration      float? — that mp4's real duration (ffprobe), null if absent
 #   determinism   dict   — the conditions the take was recorded under:
 #                          `deterministic` (was the clock frozen and motion
@@ -164,10 +177,15 @@ from .markdown import _fmt_t, _md_cell
 #                          longest stretch in seconds where nothing in the rect
 #                          changed), `static_from`, `static_limit`, `opening`
 #                          (see below) and `warnings` (empty on a healthy take).
-#                          **Null** on a take that encoded no mp4. This is the
-#                          only field in this document that describes the frames
-#                          rather than the storyboard — see "did the recording
-#                          show anything?" for why it had to exist.
+#                          **Null** on a take that encoded no mp4, and
+#                          **absent** on a stills-only run — two different
+#                          statements. Null says an mp4 was expected and the
+#                          picture could not be measured; absent says the run
+#                          never had frames to make a claim about (#372).
+#                          This is the only field in this document that
+#                          describes the frames rather than the storyboard —
+#                          see "did the recording show anything?" for why it
+#                          had to exist.
 #   content.opening
 #                 dict?  — what the take opened on, and what the encode did
 #                          about it: `gap` (seconds of featureless, unchanging
@@ -1280,7 +1298,14 @@ def render_timeline_md(doc: dict) -> str:
     a take on exit, or a stitch that merges several — renders the same way.
     """
     beats = doc.get("beats") or []
-    head = [f"`{doc.get('media') or 'demo.mp4'}`"]
+    # A stills-only run has no video, and the header is the one line every
+    # reader sees. `doc.get('media') or 'demo.mp4'` would put a filename there
+    # that names nothing — or, in a folder recorded into before, a previous
+    # take's file (issue #372).
+    stills = doc.get("mode") == "stills"
+    head = ["**no video** — stills-only run"] if stills else [
+        f"`{doc.get('media') or 'demo.mp4'}`"
+    ]
     if doc.get("segment"):
         head.append(f"segment `{doc['segment']}`")
     if doc.get("recorder"):
@@ -1310,6 +1335,17 @@ def render_timeline_md(doc: dict) -> str:
         "edit it by hand, re-record instead.",
         "",
     ]
+    if stills:
+        out += [
+            "This storyboard was run for its pictures only. **Nothing here "
+            "describes a recording**: no video was captured, so `media` and "
+            "`duration` are null and there is no picture check. The stills "
+            "the beats point at are real and were taken by this run. The "
+            "start and end times below are seconds from the start of the "
+            "run, not offsets into a video, because there is no video for "
+            "them to be offsets into.",
+            "",
+        ]
     # Before the beat table, not after it. A reader who opens this file after a
     # crash is reading it *because* something went wrong, and a timeline that
     # only mentions the failure in a footnote is the artifact-lies problem in

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -360,6 +360,7 @@ class Recorder(_DemoBase):
         evidence: bool | None = None,
         criteria: dict[str, str] | None = None,
         ticket: str | None = None,
+        stills_only: bool | None = None,
         allow_private: bool | None = None,
     ) -> None:
         super().__init__(
@@ -370,6 +371,7 @@ class Recorder(_DemoBase):
             deterministic=deterministic, clock=clock,
             timezone_id=timezone_id, locale=locale, evidence=evidence,
             criteria=criteria, ticket=ticket, allow_private=allow_private,
+            stills_only=stills_only,
         )
         self.base_url = (
             base_url or _env("BASE_URL", "http://localhost:8000")
@@ -949,7 +951,12 @@ class Recorder(_DemoBase):
         records, and what it does not defend against" in SKILL.md.
         """
         self.click(selector)
-        self.page.keyboard.type(text, delay=delay_ms)
+        # The per-character delay is pacing — it exists so a viewer sees the
+        # text appear rather than snap into place — and it is the one piece of
+        # pacing that does not go through `_idle`, because Playwright owns the
+        # loop. A stills-only run zeroes it here for the same reason the base
+        # zeroes the rest (#372): a 40-character field costs 1.6 s of nothing.
+        self.page.keyboard.type(text, delay=0 if self.stills_only else delay_ms)
 
     @_beat_verb("clear")
     def clear(self, selector: str) -> None:

--- a/skills/demo-video/reference/stills.md
+++ b/skills/demo-video/reference/stills.md
@@ -1,0 +1,102 @@
+# Stills without a video
+
+A stills-only run drives the storyboard from end to end and writes its
+pictures, and records no video. Same verbs, same app, same `shot()` calls,
+same `images/*.png`. What it skips is the pacing — the holds, the reading
+time, the per-keystroke delay — because pacing exists for a viewer's eyes and
+a still does not have any.
+
+    rec = Recorder(out_dir, base_url=..., stills_only=True)
+    DEMO_VIDEO_STILLS_ONLY=1 uv run demos/my-demo/record.py
+
+Measured on a 13-beat storyboard against the reference fixture: **19.0 s as a
+take, 2.1 s as a stills run**, both writing the same two stills. The field
+notes this came from measured 68% of a 124 s take as pure pacing — 48 s of
+caption, 19 s of hold, 17 s of pause — and none of it is anything a picture
+records.
+
+## Use it while you are still working
+
+The loop it is for is: change the app, run the storyboard, look at the
+pictures. A wrong selector, a dialog that never opened, a page that renders
+empty — all of it surfaces in seconds instead of after a full paced take plus
+an encode. Record the take once the story is right.
+
+It is also the cheap way to answer "does this branch do what the ticket
+said": the `criteria=` map, the `ac=` tags and the coverage table all work
+exactly as they do in a take, and `timeline.md` comes out with the same
+acceptance section.
+
+## What it writes, and what it does not
+
+| Written | Not written |
+|---|---|
+| `images/<name>.png` — every `shot()` | `demo.mp4` — no screencast is attached |
+| `timeline.json` / `timeline.md` | `frames/` — there is no video to cut frames from |
+| `evidence/beat-NN.json` | narration — there is no audio track to mix onto |
+| `failure/` and the failure marker, if it raises | `content` — nothing measured a picture |
+
+`timeline.json` says which of the two it was, and says it in three places
+that agree:
+
+    "mode": "stills",   "media": null,   "duration": null
+
+`mode` is **absent on a take**, so a take's timeline is byte-for-byte what it
+was before this mode existed and nothing has to interpret `mode: "take"`.
+`content` is absent rather than null, because null on a take means an mp4 was
+expected and the picture could not be measured — a different statement.
+
+## Three things refuse a stills folder, by name
+
+None of them can do their job without a recording, and each says so rather
+than failing for an adjacent reason:
+
+- **`beat_frames()`** returns a manifest whose `skipped` names the mode and
+  writes no `frames/`. Without the refusal it would fall back to `demo.mp4`
+  and cut a sheet out of whatever video the folder already held — a previous
+  take's — under this run's beat names.
+- **`scripts/demo-grade`** refuses both `brief` and `verdict` at exit 2. It
+  would have refused anyway, on the missing frame sheet, but "there is no
+  frames/frames.json" reads as a sheet somebody forgot to generate.
+- **`stitch()`** refuses a stills run offered as a segment.
+
+## What it changes about the picture, and what it does not
+
+**Every animation is landed on its end state before each still is taken.**
+This is not cosmetic and it is not optional. The determinism rule deliberately
+*spares* the recorder's own overlays — the spotlight, the caption, the
+interlude card — so they animate on camera; in a take the hold after the verb
+is what lets them finish. Take the hold away and nothing does. The first
+stills run of the reference storyboard photographed its criterion card mid-fade
+and its spotlight's scrim half-faded — dimming the whole app instead of picking
+out the tile its caption named — at **12.0 dB and 21.7 dB PSNR** from the
+take's own stills, with nothing wrong in the beat log, the filenames or the
+timeline. This repository's own `tests/pixel` grades it: it records the
+reference storyboard both ways and holds the stills against each other. Today
+they come back byte-identical.
+
+An animation with no end — a spinner, a blinking caret — is left running,
+which is what a take would have shown too. Nothing settles on a beat that
+takes no picture: everything else a stills run leaves behind is a document,
+and a document does not care what a transition was halfway through.
+
+**Wait timeouts are unchanged.** `wait_for`, `wait_for_text` and
+`wait_for_prompt` keep their full deadlines. Shortening them would make a
+stills run fail where the take passes, and a fast wrong answer is worse than
+a slow right one.
+
+## Two things that are exactly as they are in a take
+
+- **It drives the real app and mutates real state.** A stills run submits the
+  forms, writes the rows and sends the requests a take does. Re-run the seed
+  between runs, same as between takes.
+- **The target guard applies unchanged.** The URL is classified before the
+  browser opens, and a public host is refused. There is no fast path around
+  it, because there is nothing about a picture that makes a target safer.
+
+## Not a substitute for the take
+
+The video is what a person watches to follow the story and catch the nuance
+a still cannot hold — the order things happened in, how long something took,
+what moved. A stills run answers "is this right yet". Record the take when
+the answer is yes.

--- a/skills/demo-video/reference/timeline.md
+++ b/skills/demo-video/reference/timeline.md
@@ -89,6 +89,14 @@ key is fine, renaming one is not:
 - `duration` is the length of the mp4 **this take encoded**, and is `null`
   when it encoded none — even if a `demo.mp4` from an earlier run is sitting
   right there. A null is the honest answer; the previous take's number is not.
+- `mode` is **absent on a take** and `"stills"` on a stills-only run — a run
+  that drove the storyboard for its `shot()` pictures with no video attached
+  ([stills.md](stills.md)). When it is present, `media` and `duration` are
+  `null` and `content` is **absent**, and `beat_frames()`, `demo-grade` and
+  `stitch()` each refuse the folder naming the mode. `content` absent and
+  `content: null` are different statements: null says an mp4 was expected and
+  its picture could not be measured, absent says the run never had frames to
+  make a claim about.
 - `issues` is what the recorder saw *behind* the pixels; `issue_count` is how
   many it saw, and is larger than `len(issues)` only when a take blew past the
   200-issue cap.

--- a/skills/demo-video/scripts/demo-grade
+++ b/skills/demo-video/scripts/demo-grade
@@ -257,6 +257,32 @@ def _load_json(path: Path, what: str) -> dict:
     return doc
 
 
+def refuse_stills_only(timeline: dict, where: Path) -> None:
+    """Refuse a stills-only run, by name and before anything is graded.
+
+    A stills-only run (issue #372) writes a `timeline.json` and an `images/`
+    folder and no video. This tool grades what a blind reader finds **in the
+    frames**, and the frames come out of the recording — so on such a
+    directory there is nothing to grade. Without this it would refuse anyway,
+    for the wrong reason: `frames/frames.json` is simply absent, and "there is
+    no frames/frames.json" reads as a sheet somebody forgot to generate rather
+    than as a run that could never have one.
+
+    Named here rather than left to `frame_records`: the difference between a
+    missing artifact and an artifact that cannot exist is the whole of what a
+    caller needs to know to do the right next thing.
+    """
+    if timeline.get("mode") != "stills":
+        return
+    raise Refused(
+        f"{where} is a stills-only run, not a take: it recorded no video, so "
+        f"there is no frame sheet for a reader to look at and nothing here to "
+        f"grade. A stills run is for putting pictures in front of a person "
+        f"quickly; grading is for a take. Re-run the storyboard without "
+        f"stills_only (unset DEMO_VIDEO_STILLS_ONLY) and grade that."
+    )
+
+
 def declared_criteria(timeline: dict, where: Path) -> dict[str, str]:
     """The clauses this take was recorded against, as the ticket words them.
 
@@ -1044,6 +1070,7 @@ def cmd_brief(demo: Path) -> int:
     timeline_json = timeline_paths(demo)[0]
     frames_json = frames_paths(demo)[1]
     timeline = _load_json(timeline_json, "timeline.json")
+    refuse_stills_only(timeline, timeline_json)
     criteria = declared_criteria(timeline, timeline_json)
     records = frame_records(_load_json(frames_json, "frames/frames.json"), frames_json)
     frames = [str(record["file"]) for record in records]
@@ -1085,6 +1112,7 @@ def cmd_verdict(demo: Path, reading_path: Path) -> int:
     frames_dir = frames_paths(demo)[0]
     timeline_json = timeline_paths(demo)[0]
     timeline = _load_json(timeline_json, "timeline.json")
+    refuse_stills_only(timeline, timeline_json)
     frames_json = frames_paths(demo)[1]
     criteria = declared_criteria(timeline, timeline_json)
     records = frame_records(_load_json(frames_json, "frames/frames.json"), frames_json)
@@ -1380,6 +1408,7 @@ def cmd_pr_block(demo: Path) -> int:
         )
     timeline_json = timeline_paths(demo)[0]
     timeline = _load_json(timeline_json, "timeline.json")
+    refuse_stills_only(timeline, timeline_json)
     basis = doc.get("basis") or {}
     criteria = declared_criteria(timeline, timeline_json)
     if basis.get("digest") != basis_digest(criteria, claimed_beats(timeline)):

--- a/tests/README.md
+++ b/tests/README.md
@@ -51,7 +51,9 @@ also owe an injection manifest; `tests/eval/grader/README.md` is the corpus.
 It records two short chrome reference takes into the gitignored
 `tests/.pixel-cache/` - a terminal opening on its title card, and the web
 chrome (criterion card, interlude, caption, spotlight, cursor park) against
-`tests/fixture` on an ephemeral port - keyed by a digest over every
+`tests/fixture` on an ephemeral port, the web one recorded **twice** - paced,
+then again as a stills-only run into `web/stills-only/`
+([#372](https://github.com/rogvid/skills/issues/372)) - keyed by a digest over every
 `helpers/demo_recording/*.py`, each take's own storyboard source, the vendored
 xterm assets and the fixture page.
 Cold (a stale or missing take) costs ~20-25 s per take, one Chromium launch
@@ -64,8 +66,8 @@ loop makes is colour or geometry off frames already on disk.
 What it grades ([#351](https://github.com/rogvid/skills/issues/351)):
 completeness (demo.mp4, timeline.json, at least one review frame - the floor;
 when it fails, the take's golden properties are skipped rather than failing
-for a reason they do not name), then the four golden chrome properties, one
-line of measured numbers each. Thresholds are duplicated from `smoke` by
+for a reason they do not name), then the five golden properties, one line of
+measured numbers each. Thresholds are duplicated from `smoke` by
 design - the loop must not import the 12k-line suite - and each names its
 counterpart at its definition:
 
@@ -74,6 +76,16 @@ counterpart at its definition:
   smoke's `MIN_OPENING_CARD_S`), and the corner later reads bare (≥ 150) as
   the control. Frame 0 is read by index out of one full decode, never by
   seeking a timestamp (#128).
+- **stills-match** (web take, #372): every `images/*.png` the stills-only
+  arm wrote, held against the paced arm's under the same name, at ≥ 40 dB
+  PSNR. The mode's acceptance criterion is that its stills are the frames
+  `shot()` would have written either way, and this is the only thing that
+  grades it: zeroing the pacing also takes away the wait the recorder's own
+  overlays were finishing inside, and the determinism rule spares those
+  overlays on purpose so they animate on camera. Both stills read `inf` dB
+  today; with the stills-only settle removed they read 12.0 and 21.7 dB,
+  which is where the bar sits between. A still one arm did not write fails
+  the same check - it means the two arms stopped running one storyboard.
 - **card-vs-window** (web take, #291/#360): the criterion card and the
   window's bottom pad read out of `demo.mp4` at two instants inside the
   card, ≤ 6 levels off the ONE declared colour (`core.WEB_WINDOW_BODY`,
@@ -116,7 +128,9 @@ Its cache arithmetic - digest, staleness, marker - is graded browser-free in
 `unit` (`PixelCache`), and the checks' pure arithmetic - the opening
 classifier, the card-stretch locator, the accent predicate and centroid, the
 beat-span lookup, the dump naming - in `PixelChecks`, with eight `tests/pixel`
-entries in the `INJECTIONS` table. The frame readings themselves were each
+entries in the `INJECTIONS` table. `stills-match` is graded the other way
+round: the recorder defect it exists for is planted in `helpers/`, and the
+`StillsOnly` entries in `INJECTIONS` cover the browser-free half. The frame readings themselves were each
 seen red under a planted recorder defect in #351's pull request.
 
 ```
@@ -283,6 +297,8 @@ tests/smoke --strict-only         # just the two takes strict=True must refuse
 tests/smoke --wrapper-only        # just the wrapper pair: verbs through the
                                   #   app iframe, caption band, and the take
                                   #   that must refuse X-Frame-Options (#358)
+tests/smoke --stills-only         # just the stills-only run: the pictures
+                                  #   with no video and no pacing (#372)
 tests/smoke --issues-only         # just the broken page and the failing
                                   #   commands, which is what check_issues
                                   #   grades (issue #197)
@@ -301,7 +317,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~195 s)
-tests/smoke-inject                # all 71 entries, ~54 min
+tests/smoke-inject                # all 73 entries, ~54 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -2146,6 +2162,7 @@ are what changed that, and they are now load-bearing rather than a convenience.
 | arm | clean, measured on one box |
 |---|---|
 | `--lock-only` | 1 s |
+| `--stills-only` | 3 s |
 | `--evidence-only` | 7 s |
 | `--coverage-only` | 15 s |
 | `--narration-only` | 8 s |
@@ -2223,7 +2240,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-71 entries, 14 arms, ~54.3 min of takes
+73 entries, 15 arms, ~54.5 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -2254,6 +2271,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--narration-only` | 6 | the narration fixture goes back to leaving its interlude card up for the whole take, so every frame after the third beat — both captions the arm measures included — is the card and not the app, and nothing fails ([#168](https://github.com/rogvid/skills/issues/168)); or the three claims this 8 s arm is the cheapest way to reach stop grading ([#238](https://github.com/rogvid/skills/issues/238)) — the recorder reporting a healthy 2xx as a problem, which is the *only* over-reporting assertion in the file; a beat opening while the voice is still on the previous line; and every clip mixed in at zero offset, which the silent window before the first line is the control for. Two more are about *where* the voice went ([#226](https://github.com/rogvid/skills/issues/226)), which no window bar can see: the mix landing 250 ms from the second the take's own record names, and the record naming a second the mix did not use — caught only because the arm now watches the host's wall clock itself and compares |
 | `--coverage-only` | 12 | the report flatters the storyboard: nothing reported unclaimed, a claim pointing at the wrong beat or forgetting its segment, an undeclared tag accepted, the finding dropped from `timeline.md`. Or the card that puts the ticket's own sentence on screen stops carrying it ([#280](https://github.com/rogvid/skills/issues/280)): the id shown in place of the clause, the clause claimed by nothing, the beat not saying which clause was up, and — the one no reading of `timeline.json` can catch — a card logged in full and never drawn, caught only by the assertion that reads the page snapshot. The fifth is the control: with no card raised at all, the other four have nothing to grade. Two more grade the *picture* of that card ([#291](https://github.com/rogvid/skills/issues/291), single-encoder since [#361](https://github.com/rogvid/skills/issues/361)) — pixels read off `demo.mp4`, not values read out of a document: the card's field repainted off the window body it must equal, and a card dispatched in the right colour and never made visible. The compensated-pair entries died with the composite: a window repaint carries the card with it now, by construction, and is no longer a defect anything should catch |
 | `--strict-only` | 2 | a take that should have been refused passes, or the refusal never says which beat caused it |
+| `--stills-only` | 2 | the mode that skips the video stops being either of the two things it claims ([#372](https://github.com/rogvid/skills/issues/372)): a run that declines the screencast and gets one anyway, leaving a real `demo.mp4` in a folder whose timeline says `media: null` — the artifact-lie outcome, and the only half a browser is needed for; or a run that records nothing and paces the storyboard anyway, which is correct and pointless. Either alone is satisfied by the wrong fix, which is why there are two. The pictures the mode produces are graded in `tests/pixel` (`stills-match`) and its artifact shape in `tests/unit` (`StillsOnly`) |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the cursor dot parked on-screen so it ships in every still with no pointer verb run, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
 | `--polish-only` | 4 | a terminal segment stops saying what it opened on ([#235](https://github.com/rogvid/skills/issues/235)), which is the one account of that frame a demo directory ships: the field gone entirely; the number a plausible constant instead of a reading, which every other statement about the field is happy with; the cover painted a colour that is not the window body, so frame 0 is not the cover at all — #110's own defect, the card raised late, can no longer be planted here: since [#362](https://github.com/rogvid/skills/issues/362) the shared chrome covers frame 0 twice, independently, and breaking either cover alone leaves frame 0 reading 24.0; or the report forgetting that a card was asked for, without which `"bare"` cannot be told from a segment that never wanted one |
@@ -2267,7 +2285,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **16 of `tests/smoke`'s 49 check functions have no entry**, and the harness
+- **16 of `tests/smoke`'s 50 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 

--- a/tests/pixel
+++ b/tests/pixel
@@ -74,6 +74,7 @@ import argparse
 import hashlib
 import inspect
 import json
+import math
 import os
 import re
 import shutil
@@ -103,6 +104,7 @@ from _pixels import (  # noqa: E402
     channels_apart,
     gray_frames,
     off_card,
+    psnr_db,
     strip_rgb,
     to_video_rect,
 )
@@ -127,6 +129,27 @@ MIN_RECORDER_MODULES = 8
 # the first pointer verb. Below it the pointer-free stretch is too thin for an
 # absence probe to mean anything, and the take is refused rather than cached.
 MIN_POINTERLESS_BEATS = 3
+
+# -- the stills-only arm (#372) ------------------------------------------------
+#
+# The web take records its storyboard twice: once paced, then again with the
+# video declined. The second run lands in this sub-directory of the first, so
+# it shares one cache marker and one digest — two takes could go stale apart,
+# and a comparison between a fresh picture and a stale one grades nothing.
+STILLS_ARM = "stills-only"
+# What "the same picture" means here. The two runs drive the same app through
+# the same beats with the page's clock frozen, so the pixels are expected to
+# be identical and mostly are: on the take this bar was set from, one still
+# came back byte-for-byte and the other at 96 dB — a text caret, which is an
+# infinite animation and is deliberately left running.
+#
+# The bar is 40 dB rather than "identical" because that caret is real, and it
+# is nowhere near the failure it has to catch: with the stills-only settle
+# removed the same two stills come back at 12.0 dB and 21.7 dB — a card
+# caught mid-fade and a spotlight scrim dimming the whole app instead of
+# picking out the tile its caption names. 40 dB sits in the empty middle of
+# that gap, which is the only place a threshold is worth putting.
+MIN_STILLS_PSNR = 40.0
 
 SERVER_START_TIMEOUT_S = 10.0
 
@@ -350,18 +373,31 @@ def record_web(out_dir: Path, base_url: str) -> dict:
     #351's absence probe needs. The marker records the beat index where that
     stretch ends, read back off the take's own timeline rather than counted
     by hand.
+
+    **Recorded twice** (#372): once paced, then again with the video declined.
+    The stills-only mode's whole claim is that its pictures are the frames
+    `shot()` would have written either way, and the only way to grade that is
+    to hold both against each other — `check_stills_match_the_take` does.
     """
     from demo_recording import Recorder
 
     criteria = {"AC-1": "The dashboard shows the current figures."}
-    with Recorder(
-        out_dir,
+    settings = dict(
         base_url=base_url,
         speech=False,
         strict=True,
         deterministic=True,
         criteria=criteria,
-    ) as rec:
+    )
+
+    def storyboard(rec) -> None:
+        """The beats both arms run, verbatim.
+
+        Nested rather than a module-level helper, and that is the cache key
+        talking: `digest_inputs` hashes `inspect.getsource(RECORD["web"])`, so
+        a storyboard living inside this function is hashed with it and one
+        living beside it silently would not be.
+        """
         rec.goto("/")
         rec.wait_for("#kpi-rev")
         # Settle the app before the card, the same distance tests/smoke's
@@ -373,11 +409,20 @@ def record_web(out_dir: Path, base_url: str) -> dict:
         # -- the pointer-free stretch: nothing above or below this comment
         # moves the cursor until the move_to further down -------------------
         rec.criterion("AC-1")
+        # Both stills are aimed at the recorder's own overlays on purpose:
+        # those are the elements the determinism rule spares so they animate
+        # on camera, which makes them the ones a run with no pacing can
+        # photograph half-finished (#372). This one is on the card as it
+        # fades in.
+        rec.shot("01-criterion", ac="AC-1")
         rec.interlude("")
         rec.caption("A small dashboard.", ac="AC-1")
         rec.hold()
         rec.spotlight("#kpi-rev")
         rec.hold()
+        # The still the mode's first run got wrong: the spotlight's scrim
+        # caught mid-fade, 15.7 dB from this one.
+        rec.shot("02-spotlight", ac="AC-1")
         rec.spotlight()
         rec.caption("The pointer has not moved yet.")
         # -- first pointer verb of the take: the park ------------------------
@@ -393,6 +438,8 @@ def record_web(out_dir: Path, base_url: str) -> dict:
         rec.hold()
         rec.caption("")
 
+    with Recorder(out_dir, **settings) as rec:
+        storyboard(rec)
         geom = dict(rec._geom)
         size = (rec._size["width"], rec._size["height"])
         # The park in the app document's OWN coordinates, read inside the
@@ -408,6 +455,13 @@ def record_web(out_dir: Path, base_url: str) -> dict:
         )
         if not park or len(park) != 4:
             raise PixelFailure("web: #search has no box - the page never rendered")
+
+    # Second, so the paced arm is what `check_complete` reads, and into a
+    # sub-directory of it so the two share one marker and one digest: two
+    # takes could go stale apart, and a comparison between a fresh picture
+    # and a stale one grades nothing.
+    with Recorder(out_dir / STILLS_ARM, stills_only=True, **settings) as rec:
+        storyboard(rec)
 
     doc = json.loads((out_dir / "timeline.json").read_text(encoding="utf-8"))
     beats = doc.get("beats") or []
@@ -1205,10 +1259,92 @@ def check_cursor_absence(
 # checks are skipped, so they never fail for a reason they do not name), then
 # the golden properties over the cached frames. A check reads the take and the
 # marker's `info`; it never records.
+def check_stills_match_the_take(
+    take: Path, info: dict | None, dump: Path | None = None
+) -> list[str]:
+    """The stills-only arm's pictures against the paced take's (#372).
+
+    The mode's acceptance criterion, and the only check here that grades it:
+    *the stills are the frames `shot()` would have written either way*. Both
+    arms drove the same app through the same beats with the page's clock
+    frozen, so every `images/*.png` should come back the same picture.
+
+    Why this needs a pixel check rather than an assertion. Zeroing the pacing
+    does not only make the run faster — it takes away the wait that the
+    recorder's own overlays were finishing inside. The determinism rule spares
+    those overlays on purpose so a spotlight, a caption and a card animate on
+    camera, so they are exactly the elements a run with no pacing photographs
+    half-finished. Nothing about that is visible in the beat log, the
+    filenames, the timeline, or any count: the run succeeds, writes the right
+    files, and hands over a picture showing less than it says.
+
+    Both directions are graded. A still the stills arm never wrote is as much
+    a failure as one that came out different, and a *paced* still missing is
+    the same check pointing the other way — either means the two arms stopped
+    running the same storyboard, which is the assumption everything above
+    rests on.
+    """
+    name = "stills-match"
+    problems = []
+    measured: list[str] = []
+    paced_dir = take / "images"
+    quick_dir = take / STILLS_ARM / "images"
+    paced = sorted(p.name for p in paced_dir.glob("*.png"))
+    quick = sorted(p.name for p in quick_dir.glob("*.png"))
+    if not paced:
+        problems = [
+            f"{take.name}/{name}: the paced arm wrote no stills - the "
+            f"storyboard must call shot(), it is what this check compares"
+        ]
+        _verdict(name, take, problems, "")
+        return problems
+    if paced != quick:
+        problems = [
+            f"{take.name}/{name}: the two arms wrote different stills - paced "
+            f"{paced}, stills-only {quick}. They ran the same storyboard, so "
+            f"this is a shot() that did not happen, not a picture that differs"
+        ]
+        _verdict(name, take, problems, "")
+        return problems
+    for shot in paced:
+        quality = psnr_db(paced_dir / shot, quick_dir / shot)
+        if quality is None:
+            problems.append(
+                f"{take.name}/{name}: {shot} could not be compared - ffmpeg returned no "
+                f"psnr, so nothing here is graded rather than passing"
+            )
+            continue
+        measured.append(
+            f"{shot} {'inf' if quality == math.inf else f'{quality:.0f}'} dB"
+        )
+        if quality < MIN_STILLS_PSNR:
+            problems.append(
+                f"{take.name}/{name}: {shot} is {quality:.1f} dB from the paced take's, "
+                f"under the {MIN_STILLS_PSNR:.0f} dB bar - the stills-only "
+                f"run photographed something the paced one had finished "
+                f"(an overlay mid-fade is the measured case)"
+            )
+        if dump is not None:
+            dump.mkdir(parents=True, exist_ok=True)
+            for arm, src in (("paced", paced_dir), ("stills", quick_dir)):
+                (dump / dump_name(name, f"{shot[:-4]}-{arm}")).write_bytes(
+                    (src / shot).read_bytes()
+                )
+    _verdict(
+        name,
+        take,
+        problems,
+        f"{len(paced)} still(s) held against the paced take: "
+        f"{', '.join(measured)} (bar {MIN_STILLS_PSNR:.0f} dB)",
+    )
+    return problems
+
+
 CHECKS: dict[str, list[Callable]] = {
     "terminal": [check_complete, check_opening_card],
     "web": [
         check_complete,
+        check_stills_match_the_take,
         check_card_vs_window,
         check_cursor_parked,
         check_cursor_absence,

--- a/tests/smoke
+++ b/tests/smoke
@@ -9939,6 +9939,119 @@ def check_wrapper_refusal(out_dir: Path, raised: BaseException | None) -> list[s
     return failures
 
 
+# -- the stills-only run (issue #372) ------------------------------------------
+#
+# A run that drives the storyboard for its `shot()` pictures and records no
+# video. The artifact shape is graded browser-free in `tests/unit`
+# (`StillsOnly`) and the pictures are graded in `tests/pixel`
+# (`stills-match`); what only a real browser can answer is here, and it is the
+# one that would make an artifact lie: **is there actually no mp4**. The mode
+# declines the screencast in `new_context`, and a mode that declined it and
+# got one anyway would write `mode: "stills"`, `media: null` and
+# `duration: null` over a real recording sitting in the folder.
+#
+# The pacing claim is graded with it, because this arm is the only place the
+# storyboard's declared holds and the wall clock can be compared. The floor is
+# generous on purpose — see STILLS_PACING_BUDGET_S.
+
+# What the stills-only storyboard below asks to be held for, in seconds. A run
+# that paced it cannot finish inside the budget under it.
+STILLS_DECLARED_HOLD_S = 4.0 + 4.0 + 3.0
+# The bar. Well above the ~2 s this arm measures and well under the pacing it
+# must not have spent: the gap is the whole reading, and putting the bar in
+# the empty middle of it is what keeps a slow CI box from failing an arm that
+# is behaving. Browser launch and page load are inside the number.
+STILLS_PACING_BUDGET_S = 8.0
+
+STILLS_CAPTION = "The same storyboard, without the waiting."
+
+
+def run_stills_only(out_root: Path) -> list[str]:
+    """A stills-only run against the fixture: no video, and no time spent."""
+    from demo_recording import Recorder
+
+    out_dir = fresh_take_dir(out_root, "stills-only")
+    started = time.monotonic()
+    with fixture_server() as base_url:
+        try:
+            with Recorder(
+                out_dir,
+                base_url=base_url,
+                speech=False,
+                strict=True,
+                stills_only=True,
+                criteria={"AC-1": STILLS_CLAUSE},
+            ) as rec:
+                rec.goto("/")
+                rec.wait_for("#kpi-rev")
+                rec.criterion("AC-1", hold=4.0)
+                rec.interlude("")
+                rec.caption(STILLS_CAPTION, ac="AC-1")
+                rec.shot("01-dashboard", ac="AC-1")
+                rec.pause(4.0)
+                rec.interlude("A card, held for three seconds.", hold=3.0)
+                rec.shot("02-card")
+                rec.interlude("")
+        except Exception as exc:  # noqa: BLE001 - a raising take is the failure
+            return [f"stills-only: recording raised {type(exc).__name__}: {exc}"]
+    return check_stills_only(out_dir, time.monotonic() - started)
+
+
+STILLS_CLAUSE = "The dashboard shows the current figures."
+
+
+def check_stills_only(out_dir: Path, elapsed: float) -> list[str]:
+    """Nothing here may be readable as a take, and none of it may be slow."""
+    failures = []
+    # The one a browser has to answer. Everything else about this folder is
+    # written by code `tests/unit` reaches with a fake page; whether Chromium
+    # was actually told not to capture is only visible here.
+    for stray in ("demo.mp4", "frames"):
+        if (out_dir / stray).exists():
+            failures.append(
+                f"stills-only: {stray} exists, and this run declined the "
+                f"screencast — so whatever wrote it is a recording the "
+                f"timeline beside it says does not exist ({stray})"
+            )
+    stills = sorted(p.name for p in (out_dir / "images").glob("*.png"))
+    if stills != ["01-dashboard.png", "02-card.png"]:
+        failures.append(
+            f"stills-only: images/ holds {stills}, not both shots — the "
+            f"pictures are the entire output of this mode"
+        )
+    doc = json.loads((out_dir / "timeline.json").read_text(encoding="utf-8"))
+    for key, want in (("mode", "stills"), ("media", None), ("duration", None)):
+        if doc.get(key, "absent") != want:
+            failures.append(
+                f"stills-only: timeline.json says {key}={doc.get(key, 'absent')!r}, "
+                f"not {want!r} — a reader cannot tell this from a take that "
+                f"failed to encode"
+            )
+    if "content" in doc:
+        failures.append(
+            "stills-only: timeline.json carries `content`, which is a claim "
+            "about frames this run never had"
+        )
+    if not (out_dir / "evidence").is_dir():
+        failures.append(
+            "stills-only: no evidence/ — the mode writes it, and a beat "
+            "pointing at a file that is not there is the ordering #11 forbids"
+        )
+    if elapsed > STILLS_PACING_BUDGET_S:
+        failures.append(
+            f"stills-only: the run took {elapsed:.1f}s against a "
+            f"{STILLS_PACING_BUDGET_S:.0f}s budget, over a storyboard "
+            f"declaring {STILLS_DECLARED_HOLD_S:.0f}s of holds — the pacing "
+            f"is being spent, which is the whole of what this mode saves"
+        )
+    print(
+        f"stills-only: {len(stills)} still(s), no video, {elapsed:.1f}s "
+        f"(budget {STILLS_PACING_BUDGET_S:.0f}s over "
+        f"{STILLS_DECLARED_HOLD_S:.0f}s of declared holds)"
+    )
+    return failures
+
+
 def run_wrapper(out_root: Path) -> list[str]:
     """The wrapper pair (#358): the healthy take, then the refused one."""
     from demo_recording import Recorder
@@ -12280,8 +12393,8 @@ def run_crash_interrupt(out_root: Path, base_url: str) -> list[str]:
     `KeyboardInterrupt` is a `BaseException`, so `except Exception` around the
     beat body would let it through unrecorded and every guard written for
     `Exception` misses it. A real SIGINT arrives inside the `time.sleep` in
-    `_idle`, which is where `pause()` spends its whole beat — so `_idle` is
-    where it is raised from here. The beat is a real `pause` beat, opened and
+    `_hold_frame`, which is where `pause()` spends its whole beat — so
+    `_hold_frame` is where it is raised from here. The beat is a real `pause` beat, opened and
     closed by the recorder's own decorator.
     """
     from demo_recording import Recorder
@@ -12297,7 +12410,7 @@ def run_crash_interrupt(out_root: Path, base_url: str) -> list[str]:
             def _sigint(_seconds: float) -> None:
                 raise KeyboardInterrupt("operator gave up on a hung demo")
 
-            rec._idle = _sigint  # type: ignore[method-assign]
+            rec._hold_frame = _sigint  # type: ignore[method-assign]
             rec.pause(1.0)
     except BaseException as exc:  # noqa: BLE001 - the raise is the assertion
         raised = exc
@@ -12835,6 +12948,12 @@ def main() -> int:
         "sending X-Frame-Options (issue #358)",
     )
     parser.add_argument(
+        "--stills-only",
+        action="store_true",
+        help="record only the stills-only run: the storyboard's pictures with "
+        "no video, no pacing and nothing readable as a take (issue #372)",
+    )
+    parser.add_argument(
         "--issues-only",
         action="store_true",
         help="record only the broken-page and failing-command takes, which is "
@@ -12891,6 +13010,7 @@ def main() -> int:
             ("--coverage-only", args.coverage_only),
             ("--strict-only", args.strict_only),
             ("--wrapper-only", args.wrapper_only),
+            ("--stills-only", args.stills_only),
             ("--issues-only", args.issues_only),
             ("--lock-only", args.lock_only),
             ("--cheap", args.cheap),
@@ -13124,6 +13244,11 @@ def run_phases(only: str | None, out_root: Path) -> list[str]:
     # — the arm records in well under a minute against --web-only's 123 s.
     if selects(only, ("--web-only", "--wrapper-only")):
         failures += run_wrapper(out_root)
+    # Stills without a video (#372). A web take, so --web-only reaches it; its
+    # own flag exists because the arm records in ~2 s and an assertion is only
+    # as gradeable as its cheapest arm (#197).
+    if selects(only, ("--web-only", "--stills-only")):
+        failures += run_stills_only(out_root)
     if selects(only, ("--web-only", "--evidence-only")):
         failures += run_evidence(out_root)
     # Speech end to end (issue #157). A web take, so it is reachable from

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -109,6 +109,9 @@ ARM_SECONDS = {
     # before a browser starts. Measured at 0.31 s, rounded to the 1 s this
     # table's other rows are in.
     "--lock-only": 1,
+    # The storyboard declares 11 s of holds and spends none of them: measured
+    # at 2.3 s wall clock, browser launch included, rounded up.
+    "--stills-only": 3,
     "--evidence-only": 7,
     "--coverage-only": 15,
     "--issues-only": 26,
@@ -141,6 +144,42 @@ class Injection(NamedTuple):
 # The order is the order they run in: cheapest arm first, so a manifest that is
 # going to abort on a stale search string does it in eight seconds.
 INJECTIONS = [
+    # -- stills without a video (issue #372), ~3 s an entry
+    #
+    # Two entries against one check, and they are the two halves it exists for:
+    # the mode's claim is "no recording" *and* "no waiting", and either alone
+    # is satisfied by the wrong fix. A mode that declines the screencast and
+    # then paces the storyboard is correct and pointless; one that runs fast
+    # and leaves a real mp4 in a folder whose timeline says `media: null` is
+    # fast and lying. The picture the mode produces is graded in
+    # `tests/pixel` (`stills-match`) and its artifact shape browser-free in
+    # `tests/unit` (`StillsOnly`) — this arm is only what needs a browser.
+    Injection(
+        name="a stills-only run records a video after all",
+        module="core.py",
+        old=(
+            "                record_video_dir=(\n"
+            "                    None if self.stills_only else str(self._video_dir)\n"
+            "                ),"
+        ),
+        new="                record_video_dir=str(self._video_dir),",
+        arm="--stills-only",
+        sites=("check_stills_only",),
+        must_contain=("this run declined the ",),
+    ),
+    Injection(
+        name="a stills-only run holds every frame it was told to",
+        module="core.py",
+        old=(
+            "        if self.stills_only:\n"
+            "            self._pump_events()\n"
+            "            return\n"
+        ),
+        new="        if False:\n            return\n",
+        arm="--stills-only",
+        sites=("check_stills_only",),
+        must_contain=("s budget, over a storyboard",),
+    ),
     # -- what a run that never started leaves behind (issue #105), 1 s an entry
     #
     # Three entries against one check function, because it is a *pair* of

--- a/tests/unit
+++ b/tests/unit
@@ -52,6 +52,7 @@ import tokenize
 import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO = Path(__file__).resolve().parents[1]
 HELPERS = REPO / "skills" / "demo-video" / "helpers"
@@ -111,6 +112,7 @@ from demo_recording.narration import (  # noqa: E402
 from demo_recording.stitching import (  # noqa: E402
     MERGE_OVERLAP_SLACK_S,
     _merged_timeline,
+    _segment_timeline,
 )
 from demo_recording.target import TargetRefused  # noqa: E402
 from demo_recording.timeline import (  # noqa: E402
@@ -1837,7 +1839,21 @@ _EXAMPLES = Path(os.environ.get("UNIT_EXAMPLES", REPO / "examples"))
 # 1.5 s floor exists earns its place less than a rule whose absence killed a
 # take. What was left over is this raise. The reviewer reading protocol went
 # to reference/review.md, not here, per the first paragraph's preference.
-SKILL_LINE_BUDGET = 630
+# Raised 630 → 632 on 2026-08-23, for stills-only runs (#372): the mode that
+# takes the storyboard's pictures without recording a video, which turns the
+# inner loop from ~19 s per look into ~2 s on the storyboard it was measured
+# on. Three lines: the Configuration row, the reference-table row, and the
+# sentence in step 4 that is the only place a storyboard author meets it —
+# the rest of it is reference/stills.md.
+#
+# The argument the paragraph above demands, made in kind first: three lines
+# were cut from **Pacing and perception** to pay for it. They restated the
+# code fence directly above them ("`hold()` waits for the current narration
+# line to finish") and the flicker the section's own first bullet already
+# names, and `hold(min_s=1.5)` is documented in full in the verb table. A
+# restatement earns its place less than the one sentence telling an author
+# the fast loop exists. What was left over is this raise.
+SKILL_LINE_BUDGET = 632
 
 # `reference/` holding fewer than this is `reference/` being emptied, which
 # would make both assertions below hold trivially. Not a count of the files
@@ -4203,9 +4219,15 @@ class _VerbBodyStopped(RuntimeError):
 
 
 class _NoWait:
-    """Hold no frames. These tests grade the beat log, not the wall clock."""
+    """Hold no frames. These tests grade the beat log, not the wall clock.
 
-    def _idle(self, seconds: float) -> None:
+    `_hold_frame`, not `_idle`: `_idle` is sealed on `_DemoBase` so that the
+    stills-only short-circuit cannot be reached past (#372), and this mixin
+    sits ahead of the recorder in the MRO — which `__init_subclass__` treats
+    as a shadow exactly as it treats a method on the class.
+    """
+
+    def _hold_frame(self, seconds: float) -> None:
         return None
 
 
@@ -4246,6 +4268,10 @@ class FakePage:
         # this process about, readable without a round trip. The issue a lost
         # caption records names it (#180).
         self.url = url
+        # A page with no iframes, which is what `page.frames` is on one: the
+        # main frame, and the main frame is the page. `FramedPage` below is
+        # the other shape.
+        self.frames = [self]
 
     def on(self, event: str, handler) -> None:
         self.subscribed.setdefault(event, []).append(handler)
@@ -5608,6 +5634,65 @@ class DrawingPage(FakePage):
         return None
 
 
+class _Keyboard:
+    """Playwright's `page.keyboard`, remembering what delay it was typed at."""
+
+    def __init__(self) -> None:
+        self.delays: list[int] = []
+
+    def type(self, text: str, delay: int = 0) -> None:
+        self.delays.append(delay)
+
+
+class TypingPage(DrawingPage):
+    """A page with a keyboard. The per-character delay is the only pacing in
+    the package Playwright owns rather than `_idle`, so it is the only one
+    that has to be read off the call (#372)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.keyboard = _Keyboard()
+
+
+class _SettledFrame:
+    """One frame of a page, which logs when it is asked to settle."""
+
+    def __init__(self, name: str, log: list[str], dead: bool) -> None:
+        self.name = name
+        self._log = log
+        self._dead = dead
+
+    def evaluate(self, script, arg=None, **kwargs):
+        if self._dead:
+            raise RuntimeError("Frame was detached")
+        self._log.append(self.name)
+        return 0
+
+
+class FramedPage(DrawingPage):
+    """A wrapper page with the app frame inside it, as a web take has.
+
+    `frames` is Playwright's: the main frame first, then every child. The
+    stills-only settle runs over all of them, so a page with one frame would
+    not tell "settles the page" from "settles everything on it" (#372).
+    """
+
+    def __init__(self, dead=frozenset()) -> None:
+        super().__init__()
+        self.settled: list[str] = []
+        self.frames = [
+            _SettledFrame(name, self.settled, name in dead)
+            for name in ("wrapper", "app")
+        ]
+
+    def screenshot(self, path: str, **kwargs) -> None:
+        # `recorder()` builds no directories — `__enter__` does, and these
+        # tests never enter one.
+        out = Path(path)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"")
+
+
 # A clause with the shape of a real one: a whole sentence out of a ticket, long
 # enough that showing its id instead would be an obvious difference and short
 # enough to be a card. Taken from ticket #129's AC-1, which the reference
@@ -5724,7 +5809,7 @@ class _HoldClock:
 
     Stood in for `core.time` so a 7.5 s spoken line costs this suite
     microseconds while the beat log still comes out with the timestamps a real
-    take would write. `_idle` is where a take spends a hold, and it is left
+    take would write. `_hold_frame` is where a take spends a hold, and it is left
     running exactly as it ships — its own `time.sleep` is what moves this
     clock, so a hold the recorder skipped moves nothing.
     """
@@ -5754,7 +5839,7 @@ class CriterionHold(unittest.TestCase):
             super().__init__(*args, **kwargs)
             self.held: list[float] = []
 
-        def _idle(self, seconds: float) -> None:
+        def _hold_frame(self, seconds: float) -> None:
             self.held.append(seconds)
 
     def held_for(self, text: str, spoken: float | None = None, **call) -> float:
@@ -5798,7 +5883,7 @@ class CriterionHold(unittest.TestCase):
         """The beat log of a take that raised a card while a line was still
         being spoken, and then took it down with the documented clear.
 
-        Run over `_HoldClock` and with the production `_idle` — the loop, the
+        Run over `_HoldClock` and with the production `_hold_frame` — the loop, the
         pump and the slicing against a deadline, all of it — because what is
         being read here is `t_start`/`t_end`, and a recorder that holds nothing
         writes a beat log where every beat is instantaneous.
@@ -10298,6 +10383,30 @@ class _GradeCase(unittest.TestCase):
         return done.stderr
 
 
+class GradeRefusesAStillsRun(_GradeCase):
+    """#372: the grader reads frames, and a stills run has none."""
+
+    def test_every_command_refuses_before_it_grades_anything(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        demo = _grade_demo(tmp.name)
+        doc = json.loads((demo / "timeline.json").read_text())
+        doc["mode"] = "stills"
+        doc["media"] = None
+        (demo / "timeline.json").write_text(json.dumps(doc), encoding="utf-8")
+        # Both commands, because each loads the timeline for itself. The
+        # frames manifest here is intact and full of beats, so a command that
+        # graded it would look like it worked.
+        reading = demo / "reading.json"
+        reading.write_text(json.dumps(_grade_reading([])), encoding="utf-8")
+        for args in (
+            ("brief", str(demo)),
+            ("verdict", str(demo), "--reading", str(reading)),
+        ):
+            with self.subTest(args[0]):
+                self.assertIn("stills-only run", self.refused(*args))
+
+
 class BriefIsBlind(_GradeCase):
     """The brief is a pure function of the clauses and the frame manifest."""
 
@@ -10971,10 +11080,408 @@ class ExitStatus(_GradeCase):
         self.assertEqual(set(re.findall(r"\b([0-9])\b", section)), {"0", "2"})
 
 
+class StillsOnly(unittest.TestCase):
+    """A run that takes the pictures and skips the video (issue #372).
+
+    The mode's whole risk is that it produces a folder that *looks* like a
+    take. Every test here is about a way that could happen: an artifact that
+    names a video, a consumer that reads one, or a picture that came out
+    different because nothing waited for it.
+    """
+
+    def built(self, **settings):
+        """A constructed recorder. Not `recorder()`, which pins speech off —
+        and whether it is off, and for which of two reasons, is half of what
+        is being graded here."""
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        with target_env(), contextlib.redirect_stderr(io.StringIO()):
+            return Recorder(tmp.name, evidence=False, **settings)
+
+    def doc(self, **settings) -> dict:
+        """The timeline document a run with these settings would write."""
+        rec = recorder(self, page=DrawingPage(), **settings)
+        rec.caption("A small dashboard.")
+        with contextlib.redirect_stderr(io.StringIO()):
+            return rec._timeline_doc()
+
+    def test_the_timeline_says_which_of_the_two_this_was(self):
+        stills = self.doc(stills_only=True)
+        self.assertEqual(stills["mode"], "stills")
+        self.assertIsNone(stills["media"])
+        self.assertIsNone(stills["duration"])
+        # The claim `content` would make is about frames, and there are none.
+        # Not `content: null`, which on a take means an mp4 was expected and
+        # could not be measured.
+        self.assertNotIn("content", stills)
+
+    def test_a_take_carries_none_of_it_and_is_unchanged(self):
+        # The control on the test above. Without it "stills runs say mode"
+        # holds just as well on a recorder that says it on every run, and a
+        # reader who has to interpret `mode: "take"` is a reader this mode
+        # created work for.
+        take = self.doc()
+        self.assertNotIn("mode", take)
+        self.assertEqual(take["media"], "demo.mp4")
+        self.assertIn("content", take)
+
+    def test_the_evidence_documents_name_no_video_either(self):
+        # The same pointer, three files over. `evidence/beat-NN.json` is read
+        # on its own — that is what its envelope is for — so a `media` naming
+        # a file this run did not write is the timeline's lie, distributed.
+        for stills_only, expected in ((True, None), (False, "demo.mp4")):
+            with self.subTest(stills_only=stills_only):
+                rec = recorder(self, page=DrawingPage(), stills_only=stills_only)
+                doc = rec._evidence_doc({"index": 0, "verb": "caption"}, {})
+                self.assertEqual(doc["media"], expected)
+
+    def test_the_failure_dump_names_no_video_either(self):
+        rec = recorder(self, page=DrawingPage(), stills_only=True)
+        dump = rec._failure_doc(
+            {"type": "RuntimeError", "message": "no", "beat": None, "verb": None}
+        )
+        self.assertIsNone(dump["media"])
+
+    # -- the pacing ---------------------------------------------------------
+
+    def held(self, stills_only: bool) -> list[float]:
+        """What the run asked `_hold_frame` to wait out, in order."""
+
+        class Held(Recorder):
+            def __init__(self, *args, **kwargs) -> None:
+                super().__init__(*args, **kwargs)
+                self.waits: list[float] = []
+
+            def _hold_frame(self, seconds: float) -> None:
+                self.waits.append(seconds)
+
+        rec = recorder(self, cls=Held, page=DrawingPage(), stills_only=stills_only)
+        rec.pause(5.0)
+        rec.hold(3.0)
+        rec.caption("Six words is over the floor.")
+        return rec.waits
+
+    def test_a_stills_run_waits_for_nothing_and_a_take_waits_for_all_of_it(self):
+        # Both halves, because "held nothing" is also what a broken harness
+        # reports. The take's numbers are the storyboard's own: 5.0 and 3.0 as
+        # written, and the caption's read-speed hold.
+        self.assertEqual(self.held(stills_only=True), [])
+        self.assertEqual(self.held(stills_only=False), [5.0, 3.0, 0.6 + 6 * 0.34])
+
+    def test_no_medium_can_pace_a_stills_run_past_the_mode(self):
+        # `_idle` is sealed and `_hold_frame` is the hook, so the check is
+        # unreachable-by-construction rather than a rule two media remembered.
+        self.assertIn("_hold_frame", _DemoBase.MEDIUM_HOOKS)
+        self.assertNotIn("_idle", _DemoBase.MEDIUM_HOOKS)
+        with self.assertRaises(TypeError) as refused:
+            type("Paced", (Recorder,), {"_idle": lambda self, s: None})
+        self.assertIn("_idle", str(refused.exception))
+
+    def test_the_terminal_types_through_the_hook_and_not_around_it(self):
+        # The per-keystroke delay is pacing, and it is the one piece of it a
+        # medium owns. Read off the source because running it needs a PTY:
+        # what matters is that it goes through `_idle`, which the mode
+        # short-circuits, and not through a `time.sleep` of its own.
+        typed = inspect.getsource(TerminalRecorder._type)
+        self.assertIn("self._idle(self._type_delay)", typed)
+        self.assertNotIn("time.sleep", typed)
+
+    def test_the_web_recorder_types_at_full_speed_in_a_stills_run(self):
+        # The other keystroke delay, and the only pacing in the package that
+        # does not pass through `_idle` — Playwright owns that loop.
+        for stills_only, expected in ((True, 0), (False, 40)):
+            with self.subTest(stills_only=stills_only):
+                rec = recorder(self, page=TypingPage(), stills_only=stills_only)
+                # `type_into` clicks the field first, and a click needs a live
+                # locator. The delay is what is under test, so the click is
+                # stood down rather than simulated.
+                rec.click = lambda selector: None  # type: ignore[method-assign]
+                rec.type_into("#search", "overdraft")
+                self.assertEqual(rec.page.keyboard.delays, [expected])
+
+    # -- the picture --------------------------------------------------------
+
+    def test_a_stills_run_lands_every_animation_before_it_takes_a_still(self):
+        # The defect this was measured on: the determinism rule spares the
+        # recorder's own overlays so they fade on camera, and with the hold
+        # gone the spotlight's scrim was caught halfway — a still 15.7 dB
+        # from the take's, dimming the app instead of picking out the tile.
+        page = FramedPage()
+        rec = recorder(self, page=page, stills_only=True)
+        rec.shot("01-dashboard")
+        # Every frame, not only the wrapper's: the app's own transitions were
+        # settled by the same hold.
+        self.assertEqual(page.settled, ["wrapper", "app"])
+
+    def test_a_take_settles_nothing_because_holding_the_frame_does(self):
+        page = FramedPage()
+        rec = recorder(self, cls=WebRec, page=page, stills_only=False)
+        rec.shot("01-dashboard")
+        self.assertEqual(page.settled, [])
+
+    def test_nothing_settles_on_a_beat_that_takes_no_picture(self):
+        # The cost half of the same decision: a document does not care what a
+        # transition was halfway through, so a stills run pays one evaluate
+        # per picture and not one per beat.
+        page = FramedPage()
+        rec = recorder(self, page=page, stills_only=True)
+        rec.pause(1.0)
+        rec.caption("A small dashboard.")
+        self.assertEqual(page.settled, [])
+
+    def test_a_frame_that_cannot_be_reached_does_not_lose_the_run(self):
+        # A frame navigating away mid-run detaches, and `evaluate` throws.
+        # Settling is here to make the picture right; it is not a reason to
+        # lose one.
+        page = FramedPage(dead={"app"})
+        rec = recorder(self, page=page, stills_only=True)
+        rec.shot("01-dashboard")
+        self.assertEqual(page.settled, ["wrapper"])
+
+    # -- narration ----------------------------------------------------------
+
+    def test_narration_is_off_even_with_a_key_in_the_environment(self):
+        with mock.patch.dict(os.environ, {"ELEVENLABS_API_KEY": "sk-real"}):
+            self.assertFalse(self.built(stills_only=True)._speech)
+            # The control: the same environment, the other mode, speech on.
+            self.assertTrue(self.built(stills_only=False)._speech)
+
+    def test_forcing_speech_on_a_stills_run_is_refused_at_the_constructor(self):
+        # Not silently ignored. There is no mp4 for a voice to go onto, and a
+        # storyboard that asked for one has misunderstood which mode it is in.
+        with mock.patch.dict(os.environ, {"ELEVENLABS_API_KEY": "sk-real"}):
+            with self.assertRaises(RuntimeError) as refused:
+                self.built(stills_only=True, speech=True)
+        self.assertIn("stills-only", str(refused.exception))
+
+    # -- how it is turned on ------------------------------------------------
+
+    def test_the_environment_turns_it_on_and_an_argument_overrides_that(self):
+        with mock.patch.dict(os.environ, {"DEMO_VIDEO_STILLS_ONLY": "1"}):
+            self.assertTrue(recorder(self).stills_only)
+            self.assertFalse(recorder(self, stills_only=False).stills_only)
+        self.assertFalse(recorder(self).stills_only)
+
+    def test_both_media_take_every_setting_the_base_offers(self):
+        # The gap this mode fell into while it was being written: the base
+        # grew a parameter, both media kept their own hand-copied signatures,
+        # and `Recorder(stills_only=True)` was a TypeError while
+        # `_DemoBase(stills_only=True)` worked. Nothing graded the seam, so
+        # every future setting has the same hole.
+        base = inspect.signature(_DemoBase.__init__).parameters
+        for cls in (Recorder, TerminalRecorder):
+            with self.subTest(cls.__name__):
+                mine = inspect.signature(cls.__init__).parameters
+                missing = [n for n in base if n not in mine]
+                self.assertEqual(
+                    missing,
+                    [],
+                    f"{cls.__name__} does not accept {missing} — the base "
+                    f"reads it, and no storyboard can reach it",
+                )
+                forwarded = inspect.getsource(cls.__init__).split("super().__init__")[1]
+                unforwarded = [
+                    n
+                    for n in base
+                    if n not in ("self", "out_dir") and f"{n}=" not in forwarded
+                ]
+                self.assertEqual(
+                    unforwarded,
+                    [],
+                    f"{cls.__name__} accepts {unforwarded} and drops them on "
+                    f"the floor, which is worse than not taking them",
+                )
+
+    # -- what refuses this folder -------------------------------------------
+
+    def test_the_frame_sheet_refuses_and_writes_nothing(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        out = Path(tmp.name)
+        (out / "timeline.json").write_text(
+            json.dumps(
+                {
+                    "schema": TIMELINE_SCHEMA,
+                    "mode": "stills",
+                    "media": None,
+                    "duration": None,
+                    "beats": [
+                        {"index": 0, "verb": "caption", "t_start": 0.0, "t_end": 0.1},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        manifest = beat_frames(out)
+        self.assertIn("stills-only run", manifest["skipped"])
+        self.assertIsNone(manifest["media"])
+        self.assertEqual(manifest["frames"], [])
+        # The half that matters. Without the refusal `media or "demo.mp4"`
+        # walks into whatever mp4 the folder holds — in a directory recorded
+        # into before, a previous take's — and cuts a sheet of frames from it
+        # under this run's beat names.
+        self.assertFalse((out / "frames").exists())
+
+    def test_stitching_refuses_a_stills_run_as_a_segment(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        out = Path(tmp.name)
+        (out / "part1.seg.mp4").write_bytes(b"not really a video")
+        (out / "part1.seg.timeline.json").write_text(
+            json.dumps(
+                {
+                    "schema": TIMELINE_SCHEMA,
+                    "mode": "stills",
+                    "media": None,
+                    "beats": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(ValueError) as refused:
+            _segment_timeline(out, "part1", out / "part1.seg.mp4", 1.0)
+        self.assertIn("stills-only run", str(refused.exception))
+
+
 # --------------------------------------------------------------------------
 
 # (name, module, exact text to replace, replacement, tests that must then fail)
 INJECTIONS = [
+    # -- stills-only runs (issue #372) ---------------------------------------
+    (
+        # The folder stops saying what it is. Everything else about it already
+        # looks like a take that failed to encode — beats, evidence, images —
+        # so this is the single field between "no video was recorded" and "the
+        # video is missing", and every refusal downstream reads it.
+        "a stills-only run stops declaring itself in the timeline",
+        "core.py",
+        '            doc.pop("content")\n            doc["mode"] = "stills"',
+        '            doc.pop("content")',
+        # Only the test that grades the *writer*. The three refusal tests
+        # below build their own stills timeline by hand — deliberately, since
+        # each grades a consumer's reading of the field and not the recorder's
+        # writing of it — so this injection leaves them green, which is what
+        # `--fault-inject` reported the first time this entry claimed them.
+        ["StillsOnly.test_the_timeline_says_which_of_the_two_this_was"],
+    ),
+    (
+        # The pointer comes back: three artifacts name a demo.mp4 this run did
+        # not write. In a directory recorded into before — the ordinary case,
+        # because record.py is committed so it can be re-run — that file is
+        # sitting there from a previous take. This is #20's stale duration,
+        # one field over and in three more places.
+        "a stills-only run names a video it did not record",
+        "core.py",
+        "        return None if self.stills_only else self._media_path().name",
+        "        return self._media_path().name",
+        [
+            "StillsOnly.test_the_timeline_says_which_of_the_two_this_was",
+            "StillsOnly.test_the_evidence_documents_name_no_video_either",
+            "StillsOnly.test_the_failure_dump_names_no_video_either",
+        ],
+    ),
+    (
+        # The short-circuit settles the frame and then holds it anyway. The
+        # mode still writes the right artifacts and the right pictures, so
+        # nothing is wrong with the output — it just costs the 68% of a take
+        # that is pure pacing, which is the entire reason the mode exists.
+        "a stills-only run settles the frame and then paces it anyway",
+        "core.py",
+        "        if self.stills_only:\n            self._pump_events()\n            return",
+        "        if self.stills_only:\n            self._pump_events()",
+        [
+            "StillsOnly."
+            "test_a_stills_run_waits_for_nothing_and_a_take_waits_for_all_of_it"
+        ],
+    ),
+    (
+        # **The defect this mode was measured making**, restored exactly. The
+        # determinism rule spares the recorder's own overlays so they fade on
+        # camera; with the hold gone nothing waits for them, and the reference
+        # storyboard's spotlight was caught mid-fade — a still 15.7 dB PSNR
+        # from the take's, dimming the whole app instead of picking out the
+        # tile its caption names. Nothing else in the run changes: same beats,
+        # same filenames, same timeline. Only the picture is wrong.
+        "a stills-only run photographs its overlays mid-animation",
+        "core.py",
+        "        if self.stills_only:\n            self._settle_animations()\n        self._before_shot()",
+        "        self._before_shot()",
+        [
+            "StillsOnly."
+            "test_a_stills_run_lands_every_animation_before_it_takes_a_still",
+        ],
+    ),
+    (
+        # Only the wrapper settles. The recorder's own chrome lands, so the
+        # spotlight and the caption look right and the still passes any check
+        # aimed at them — while the app inside the iframe, which is the half a
+        # reviewer is actually reading, is photographed mid-transition.
+        "the stills-only settle reaches the chrome but not the app",
+        "core.py",
+        "        for frame in self.page.frames:",
+        "        for frame in [self.page]:",
+        [
+            "StillsOnly."
+            "test_a_stills_run_lands_every_animation_before_it_takes_a_still",
+        ],
+    ),
+    (
+        # The frame sheet stops recognising the mode and falls through to
+        # `media or "demo.mp4"`: it cuts a sheet out of whatever mp4 the
+        # folder holds — a previous take's — and files it under this run's
+        # beat names, which is the exact lie the mode's `media: null` exists
+        # to prevent.
+        "the frame sheet reads a stills-only folder as a take",
+        "frames.py",
+        '    stills_only = doc.get("mode") == "stills"',
+        "    stills_only = False",
+        ["StillsOnly.test_the_frame_sheet_refuses_and_writes_nothing"],
+    ),
+    (
+        # The grader stops recognising it. It would still refuse — there is no
+        # frames/frames.json — but for the wrong reason, and "there is no
+        # frames/frames.json" reads as a sheet somebody forgot to generate
+        # rather than as a run that can never have one.
+        "the grader takes a stills-only run as a take with a missing sheet",
+        "scripts/demo-grade",
+        '    if timeline.get("mode") != "stills":\n        return',
+        "    return",
+        ["GradeRefusesAStillsRun.test_every_command_refuses_before_it_grades_anything"],
+    ),
+    (
+        # The one piece of pacing Playwright owns rather than `_idle`. A
+        # storyboard that fills a form pays its per-character delay in full —
+        # 1.6 s for a 40-character field — in a mode whose whole claim is that
+        # it pays none of it.
+        "a stills-only run still types one character at a time",
+        "web.py",
+        "        self.page.keyboard.type(text, delay=0 if self.stills_only else delay_ms)",
+        "        self.page.keyboard.type(text, delay=delay_ms)",
+        ["StillsOnly.test_the_web_recorder_types_at_full_speed_in_a_stills_run"],
+    ),
+    (
+        # Narration synthesizes and paces a run that will never encode an
+        # audio track: every line is sent to ElevenLabs, billed, cached, and
+        # then waited out by `_prepare_line` — the slowest thing in the
+        # recorder, in the mode built to be the fastest.
+        "a stills-only run still narrates",
+        "core.py",
+        "        if self.stills_only:\n            self._speech = False",
+        "        if self.stills_only:\n            pass",
+        ["StillsOnly.test_narration_is_off_even_with_a_key_in_the_environment"],
+    ),
+    (
+        # The seam this mode fell into while it was being written: the base
+        # grew a parameter, the medium kept its own hand-copied signature, and
+        # `Recorder(stills_only=True)` was a TypeError while the base accepted
+        # it fine. Silent for every setting that is only read from the
+        # environment, which is most of them.
+        "the web recorder accepts a base setting and drops it",
+        "web.py",
+        "criteria=criteria, ticket=ticket, allow_private=allow_private,\n            stills_only=stills_only,",
+        "criteria=criteria, ticket=ticket, allow_private=allow_private,",
+        ["StillsOnly.test_both_media_take_every_setting_the_base_offers"],
+    ),
     # -- the pixel loop's cache key (tests/pixel, #350) -----------------------
     (
         # The stale-input pass, exactly: the digest still names every recorder
@@ -14857,9 +15364,13 @@ INJECTIONS = [
         # swap mutation exists.
         "the brief orders the clauses by the beats that claim them",
         "scripts/demo-grade",
-        '    timeline = _load_json(timeline_json, "timeline.json")\n'
+        # Anchored on the refusal line above it (#372) rather than on the
+        # `_load_json` that used to be there: all three commands load a
+        # timeline, and this is the only one that reaches `declared_criteria`
+        # on the very next line.
+        "    refuse_stills_only(timeline, timeline_json)\n"
         "    criteria = declared_criteria(timeline, timeline_json)",
-        '    timeline = _load_json(timeline_json, "timeline.json")\n'
+        "    refuse_stills_only(timeline, timeline_json)\n"
         "    criteria = declared_criteria(timeline, timeline_json)\n"
         '    _claimed = (timeline.get("coverage") or {}).get("claimed") or {}\n'
         "    criteria = {\n"


### PR DESCRIPTION
Closes #372. Supersedes #354.

`Recorder(..., stills_only=True)` — or `DEMO_VIDEO_STILLS_ONLY=1` — runs the
storyboard from end to end, writes every `shot()`, and records no video.

**Measured on a 13-beat storyboard against `tests/fixture`: 19.0 s as a take,
2.1 s as a stills run.** Same 13 beats, same two stills, same `evidence/`.

## Why it is fast, and where the short-circuit is

Pacing is the whole saving. `_idle` is the one place this package waits —
`pause`, `hold`, a caption's read time, an interlude, a criterion card, the
terminal's per-keystroke delay all arrive there — so that is where the mode
returns early.

`_idle` is now **sealed**, and a medium overrides `_hold_frame` instead. A
medium cannot pace past the mode, which is a property of the seam rather than
a rule two files remembered. The one piece of pacing Playwright owns rather
than `_idle` — `type_into`'s per-character delay — is zeroed at its call.

## Zeroing the pacing was not enough, and this is the part worth reading

The determinism rule deliberately **spares** the recorder's own overlays so a
spotlight, a caption and an interlude card animate on camera. In a take, the
hold after the verb is what lets them finish. Take the hold away and nothing
does.

The first stills run of the reference storyboard photographed the spotlight's
scrim half-faded — the whole app dimmed instead of the tile its caption named
— and the criterion card mid-fade. **12.0 dB and 21.7 dB PSNR** from the
take's stills. The run succeeded. The beat log, the filenames, the timeline
and the coverage table were all correct. Only the picture was wrong.

So a stills run lands every finishable animation, in every frame, **before
each still**. In `shot()` and nowhere else: the stills are the only thing such
a run renders, and everything else it writes is a document that does not care
what a transition was halfway through — so the cost is one evaluate per
picture, not one per beat. An animation with no end (a caret, a spinner) is
left running, which is what a take shows too.

## Nothing downstream can read the folder as a take

`timeline.json` says `mode: "stills"`, `media: null`, `duration: null`, and
carries **no** `content` key. `mode` is absent on a take, so a take's timeline
is byte-for-byte what it was before this existed. `content` is absent rather
than null on purpose: null on a take means an mp4 was expected and its picture
could not be measured — a different statement from having no frames at all.
The evidence documents and the failure dump name no video either.

Three consumers refuse the folder **by name**, not for an adjacent reason:

| | what it would have done |
|---|---|
| `beat_frames()` | fallen through `media or "demo.mp4"` and cut a sheet out of a *previous* take's video, under this run's beat names |
| `demo-grade` | refused on the missing `frames/frames.json`, which reads as a sheet somebody forgot to generate |
| `stitch()` | reported a leftover from a different take |

Deliberately unchanged: **wait timeouts**. #354 asked for them to be
shortened; shortening them makes a stills run fail where the take passes, and
a fast wrong answer is worse than a slow right one. Stated here rather than
filed.

## Evidence

**`tests/pixel` — `stills-match`, the check that grades the acceptance
criterion.** The web reference take now records its storyboard twice, paced
and stills-only, into one cache entry, and holds the stills against each
other.

```
web/stills-match: ok - 2 still(s) held against the paced take: 01-criterion.png inf dB, 02-spotlight.png inf dB (bar 40 dB)
```

Seen red, with `self._settle_animations()` removed from `shot()`:

```
web/stills-match: FAIL - 2 still(s) held against the paced take: 01-criterion.png 12 dB, 02-spotlight.png 22 dB (bar 40 dB)
  - web/stills-match: 01-criterion.png is 12.0 dB from the paced take's, under the 40 dB bar - the stills-only run photographed something the paced one had finished (an overlay mid-fade is the measured case)
  - web/stills-match: 02-spotlight.png is 21.7 dB from the paced take's, under the 40 dB bar - ...
```

Nothing else moved: `opening-card`, `card-vs-window`, `cursor-parked` and
`cursor-absence` stayed green under the planted defect, which is why the bar
is at 40 — between `inf` and 12.0 with nothing near it. Warm run 2.4 s; cold
re-record 42 s for both takes.

Full green run:

```
terminal/opening-card: ok - frame 0 luma 24.0 over (138, 109, 921, 76) (cover <= 60), no bare frame (max 28.3), terminal revealed from 2.95s (bar 1.0s, stddev floor 1.2)
web/stills-match:      ok - 2 still(s) held against the paced take: 01-criterion.png inf dB, 02-spotlight.png inf dB (bar 40 dB)
web/card-vs-window:    ok - card 3 off (24, 24, 37) (bar 6) and 2 off the window body (bar 5) over 2 instants; card-down control 213 off
web/cursor-parked:     ok - disc centre (591.0, 401.1) vs park (590.5, 401.0), off (+0.5, +0.1)px (bar 3.0), 254 accent px
web/cursor-absence:    ok - 10 frames before beat 13 probed, worst frame 0 accent px in the 16x16px origin crop (bar 0)
pixel: 7 checks, 0 failing
```

**`tests/smoke --stills-only`** — a new 2.3 s arm, reachable from `--web-only`
and therefore from `--cheap`, so it gates per push. It answers the one thing
only a browser can: is there actually no mp4.

```
stills-only: 2 still(s), no video, 1.6s (budget 8s over 11s of declared holds)
```

**`tests/smoke-inject --arm=--stills-only`** — two entries, both caught, 19 s:

```
caught: stills-only: demo.mp4 exists, and this run declined the screencast — so whatever wrote it is a recording the timeline beside it says does not exist
caught: stills-only: the run took 16.2s against a 8s budget, over a storyboard declaring 11s of holds — the pacing is being spent
```

Two entries and not one because either half alone is satisfied by the wrong
fix: a mode that declines the screencast and paces anyway is correct and
pointless; one that runs fast and leaves a real mp4 beside a `media: null`
timeline is fast and lying. The 16.2 s reading is the paced measurement the
8 s bar sits under, against a 1.6–2.3 s clean run.

**`tests/unit`** — 555 tests (19 new in `StillsOnly` and
`GradeRefusesAStillsRun`), 3.4 s. Ten new `INJECTIONS` entries, every one
caught by the full sweep.

One of those tests exists because of a defect this change made on its way in:
the base grew a parameter, both media kept their hand-copied constructor
signatures, and `Recorder(stills_only=True)` was a `TypeError` while
`_DemoBase(stills_only=True)` worked. Nothing graded that seam, so every
future setting had the same hole; it now sweeps both media for parameters the
base accepts and they drop.

The `--fault-inject` run also refused an over-claiming entry of mine on its
first pass: the injection that stops the recorder writing `mode` listed the
three refusal tests as must-fail, and they build their stills timeline by hand
because each grades a *consumer* reading the field. Narrowed to the test that
grades the writer.

**Other gates:** `tests/lint`, `tests/typecheck`, `tests/ci-unit` green;
`mise run check` 5.9 s.

## SKILL.md budget

Raised 630 → 632, paid for first. Three lines came out of **Pacing and
perception** — they restated the code fence directly above them and the
flicker the section's own first bullet names, and `hold(min_s=1.5)` is
documented in full in the verb table. A restatement earns its place less than
the one sentence telling a storyboard author the fast loop exists. Everything
else about the mode is `reference/stills.md`, which is new.

## Stated limits

- `timeline.md`'s acceptance section still opens "This take was recorded
  against a ticket" on a stills run. The word is loose there; the header two
  lines above already reads **no video** — stills-only run, and the paragraph
  under it says nothing here describes a recording. One word in a rendered
  heading, not filed.
- No rendered frame a *take* produces changed. The web pixel take gained two
  `shot()` calls, which shifts its review-frame indices — a fixture, not
  shipped chrome — so there are no before/after `--dump` frames to attach.
- The eval corpus stills remain stale against the wrapper cutover
  (pre-existing, unrelated to this change).
- `tests/pixel`'s `card-vs-window` failed once during this work, at a 1.4 s
  card stretch against a 1.4 s floor, and passed on re-record. That is the
  stepping host clock of #255/#370, not this change: the step landed inside
  the card. Every reading quoted above is from a clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtAHHPE1efhQpMykGpYgPG
