### PR TITLE
demo-shots: the take's own stills as one pasteable block

### DIFF
--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -154,6 +154,8 @@ demo-video/
 ├── scripts/
 │   ├── demo-grade                 # the blind reader's brief, and the verdict
 │   │                              #   comparing it with the ac= tags (step 6b)
+│   ├── demo-shots                 # the take's stills as one pasteable block,
+│   │                              #   captions and ac= tags, grading nothing
 │   └── demo-target-guard          # the target classifier, on the command line
 └── helpers/
     ├── demo_recording/            # package: the recorders, and what reads their output
@@ -174,6 +176,7 @@ demo-video/
     │   ├── failure.py             #   the dump a take that did not finish leaves
     │   ├── narration.py           #   ElevenLabs synthesis and its content cache
     │   ├── markdown.py            #   escaping a value into a markdown table
+    │   ├── links.py               #   a committed still's path, caption, and URL
     │   └── stitching.py           #   joining segments into one demo, losslessly
     └── assets/xterm/              # vendored xterm.js (terminal rendering)
 ```

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -143,7 +143,7 @@ read them all up front, and do not skip one the text tells you to open.
 | [reference/limits.md](reference/limits.md) | Before planning a demo, when two of a take's artifacts seem to contradict each other, or before reading a green run as coverage — every limit above, with its measurement |
 | [reference/determinism.md](reference/determinism.md) | Before `deterministic=True`. A frozen clock changes what an app does, and usually does it silently |
 | [reference/timeline.md](reference/timeline.md) | When reading `timeline.json`/`timeline.md`, when a take warns about its `content`, or when consuming the beat log as a contract |
-| [reference/review.md](reference/review.md) | At Process step 6 — handing a take to a reviewing agent, reading `evidence/`, or recording against a ticket with `criteria=` |
+| [reference/review.md](reference/review.md) | At Process step 6 — handing a take to a reviewing agent or a person, reading `evidence/`, or recording against a ticket with `criteria=` |
 | [reference/failures.md](reference/failures.md) | When a take raises, when `strict=True` refuses one, or when `failure/` appears beside the demo |
 | [reference/terminal.md](reference/terminal.md) | When writing a `TerminalRecorder` storyboard — the full verb table, the four patterns, the gotchas |
 | [reference/narration.md](reference/narration.md) | When `ELEVENLABS_API_KEY` is set and captions will be spoken |
@@ -527,11 +527,13 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
    the merged pair `stitch()` wrote next to `demo.mp4`; the per-segment
    `*.seg.timeline.*` are working files that go with `*.seg.mp4`, and
    `stitch()` removes them for you unless you asked to keep the parts.
-   **When 6b graded the take**: commit, push, then run
-   `scripts/demo-grade pr-block <demo folder>` and put its output in the
-   pull-request description. The block embeds each judged beat's committed
-   still, raw off GitHub at the head commit. Nothing under `review/` is
-   committed — it is a working file like the rest.
+   **To hand a person the pictures**, `scripts/demo-shots <demo folder>`
+   prints one markdown block: every `shot()` in order, under the caption that
+   was up, tagged with its `ac=`. It grades nothing. **When 6b graded the
+   take**, commit and push, then `scripts/demo-grade pr-block <demo folder>`
+   prints a second block carrying the reader's findings. Both embed committed
+   stills raw off GitHub at the head commit, and both name a file they cannot
+   link rather than dropping it. Nothing under `review/` is committed.
    **`demo.mp4` does not.** A video is
    stale by the next change to the feature and bloats history permanently,
    and anyone with the skill installed can regenerate it with
@@ -616,8 +618,8 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
 
 The skill is self-contained: this file, the `reference/` directory it links
 into, the `helpers/demo_recording/` package, `ensure.sh` at the skill root,
-`scripts/demo-grade` (step 6b) and `scripts/demo-target-guard` (the target
-classifier), the vendored `helpers/assets/xterm/` terminal assets, and
+`scripts/demo-grade` (step 6b), `scripts/demo-shots` (the stills block) and
+`scripts/demo-target-guard` (the target classifier), the vendored `helpers/assets/xterm/` terminal assets, and
 `README.md`. Install it with the `skills` CLI — into the current project:
 
 ```sh

--- a/skills/demo-video/helpers/demo_recording/links.py
+++ b/skills/demo-video/helpers/demo_recording/links.py
@@ -1,0 +1,124 @@
+"""Turning a take's committed stills into links, for whatever renders them.
+
+`images/*.png` are the only part of a take that has a URL at all: `demo.mp4` is
+not committed and `frames/` is gitignored. So every renderer that wants to put
+a picture in front of a person — `scripts/demo-grade pr-block`, and
+`scripts/demo-shots` (#373) — needs the same five facts: which beat wrote which
+still, what caption was on screen, whether the path is one this take may link,
+which commit holds it, and what the remote calls the repository.
+
+**Nothing here raises, and that is the point of the split.** The two callers
+want opposite things from a link that cannot be built. `pr-block` refuses: it
+renders a graded verdict, and a verdict whose evidence is a broken image is
+worse than no block. `demo-shots` falls back to a relative path: it is meant to
+be run in a session against a working tree, where an uncommitted take is the
+normal case and refusing would make the command useless exactly when it is most
+wanted. One implementation of the facts, two policies over them.
+
+Every function returns the fact or `None`. A caller that wants a refusal writes
+one, naming the thing it could not find.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from urllib.parse import quote
+
+#: The one host these functions can build an image URL for. A remote elsewhere
+#: yields None rather than a guessed URL that resolves nowhere.
+GITHUB_REMOTE = re.compile(
+    r"github\.com[:/](?P<owner>[^/\s]+)/(?P<repo>[^/\s]+?)(?:\.git)?/?$"
+)
+
+
+def git(demo: Path, *args: str) -> subprocess.CompletedProcess:
+    """Run git inside the demo directory. Never raises; check `returncode`."""
+    return subprocess.run(
+        ["git", "-C", str(demo), *args], capture_output=True, text=True
+    )
+
+
+def git_fact(demo: Path, *args: str) -> str | None:
+    """One stripped line of git output, or None if the command failed.
+
+    None covers "not a git repository", "no origin remote" and "this ref does
+    not exist" alike, because to every caller here they are the same answer:
+    there is no link to build.
+    """
+    done = git(demo, *args)
+    if done.returncode != 0:
+        return None
+    return done.stdout.strip()
+
+
+def github_repo(remote: str | None) -> str | None:
+    """`owner/repo` out of an origin remote URL, or None if it is not GitHub."""
+    if not remote:
+        return None
+    found = GITHUB_REMOTE.search(remote.strip())
+    if not found:
+        return None
+    return f"{found.group('owner')}/{found.group('repo')}"
+
+
+def take_relative(still: str) -> str | None:
+    """`still` as a plain path inside the take, or None.
+
+    **This is a guard, not a tidy-up.** `timeline.json` is a committed file, so
+    its `still` value is editable in a pull request, and both callers paste it
+    into a URL and into a `git cat-file` argument. `../../elsewhere.png` is the
+    shape to refuse: it can exist on disk and would publish a picture that has
+    nothing to do with this take, under this take's caption.
+
+    A normalised relative path is the whole allowance. An absolute path, a
+    backslash (a Windows path, or an attempt to smuggle a separator past the
+    split) and any `..` component are refused; `./` and empty components are
+    dropped, because they mean nothing and a caller comparing strings should
+    not have to care.
+    """
+    if still.startswith("/") or "\\" in still:
+        return None
+    parts = [p for p in still.split("/") if p not in ("", ".")]
+    if not parts or ".." in parts:
+        return None
+    return "/".join(parts)
+
+
+def raw_url(repo: str, sha: str, path: str) -> str:
+    """The raw.githubusercontent.com URL for a blob at one commit.
+
+    The commit, never a branch name: a branch moves, and a picture embedded in
+    a pull-request description has to keep showing what it showed when it was
+    pasted.
+    """
+    return f"https://raw.githubusercontent.com/{repo}/{quote(sha)}/{quote(path)}"
+
+
+def beat_stills(timeline: dict) -> dict[int, str]:
+    """Which committed still each beat wrote, by beat index, from the beat log."""
+    out: dict[int, str] = {}
+    for beat in timeline.get("beats") or []:
+        index = beat.get("index")
+        still = beat.get("still")
+        if isinstance(index, int) and isinstance(still, str) and still.strip():
+            out[index] = still.strip()
+    return out
+
+
+def beat_captions(timeline: dict) -> dict[int, str]:
+    """Each beat's storyboard caption, by beat index, from the beat log.
+
+    The caption is the one sentence about a beat written for a viewer rather
+    than for the recorder, so it is what a still is labelled with. A beat index
+    is recorder bookkeeping: the third live read of #337 asked what "beat 20"
+    was even for, and there was no answer a reviewer could use.
+    """
+    out: dict[int, str] = {}
+    for beat in timeline.get("beats") or []:
+        index = beat.get("index")
+        caption = beat.get("caption")
+        if isinstance(index, int) and isinstance(caption, str) and caption.strip():
+            out[index] = caption.strip()
+    return out

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -144,6 +144,56 @@ from demo_recording import beat_frames
 beat_frames(Path("demos/2026-07-26-x"))
 ```
 
+## Handing a person the pictures (`scripts/demo-shots`)
+
+Everything above is about a *reader* — an agent given the frames, or the beat
+log read by a tool. This section is the other audience. `images/*.png` is the
+storyboard author's own selection of key moments, it is committed, and it is
+already in the pull request; what it needs is a shape a person reads in
+seconds.
+
+```sh
+scripts/demo-shots <demo folder>
+```
+
+prints one markdown block — every `shot()` in the order it was taken, under
+the caption that was on screen at the time, tagged with the criterion the beat
+claimed. Paste it into a session, a pull-request description, or a comment.
+
+**It is not a verdict and it is built so it cannot become one.** No sentence
+it writes says a clause was shown; this repository's own `tests/ci-unit`
+sweeps its output for the vocabulary that would say so — the same alphabet
+the CI comment is held to — and the only text exempt is what it quotes: a caption is the author's words
+and a clause is the ticket's. Whether a still shows its clause is the
+reader's question, and this command's whole job is to put the picture in
+front of them with enough context to ask it.
+
+Two things it will not do quietly:
+
+- **A still the beat log names and this take did not write is reported**, not
+  skipped. Four beats rendering as three pictures reads as a demo that showed
+  three things.
+- **A path that leaves the take is named, never linked.** `timeline.json` is
+  committed and editable in a pull request, and the value goes into a URL.
+
+### When the pictures embed, and when they do not
+
+Off a commit that is on a remote branch, the stills are embedded raw at that
+commit and render inline in a GitHub comment. Four things send the block back
+to relative paths instead, and it prints which one on stderr, because the fix
+differs:
+
+| what it found | what to do |
+|---|---|
+| no git repository | nothing — relative paths are the answer here |
+| a repository with no commits | commit the take |
+| uncommitted changes in the demo folder | commit them; the commit does not hold what is on disk |
+| a commit on no remote branch | push it |
+| an origin remote that is not github.com | nothing — there is no raw URL to build |
+
+Relative paths render in a pull-request *description* and not in a comment, so
+the note is worth reading before pasting.
+
 ## Why the comprehension review reports contradictions separately
 
 Step 6's reviewer answers four questions, not three, and the fourth — the

--- a/skills/demo-video/scripts/demo-grade
+++ b/skills/demo-video/scripts/demo-grade
@@ -116,14 +116,20 @@ import hashlib
 import json
 import re
 import shutil
-import subprocess
 import sys
 from pathlib import Path
-from urllib.parse import quote
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "helpers"))
 
 from demo_recording.frames import frames_paths  # noqa: E402
+from demo_recording.links import (  # noqa: E402
+    beat_captions,
+    beat_stills,
+    git,
+    raw_url,
+    take_relative,
+)
+from demo_recording.links import github_repo as _github_repo  # noqa: E402
 from demo_recording.timeline import timeline_paths  # noqa: E402
 
 REVIEW_DIRNAME = "review"
@@ -1150,22 +1156,24 @@ def cmd_verdict(demo: Path, reading_path: Path) -> int:
 # repository to carry it.
 
 
-#: The one host this block can build an image URL for. A remote elsewhere gets
-#: a refusal rather than a guessed URL that resolves nowhere.
-_GITHUB_REMOTE = re.compile(
-    r"github\.com[:/](?P<owner>[^/\s]+)/(?P<repo>[^/\s]+?)(?:\.git)?/?$"
-)
-
-
-def _git(demo: Path, *args: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        ["git", "-C", str(demo), *args], capture_output=True, text=True
-    )
+# The facts these two need are `demo_recording.links`' (#373): which beat wrote
+# which still, what caption was up, whether a path may be linked, and what the
+# remote calls the repository. `scripts/demo-shots` renders the same pictures
+# without a verdict and needs every one of them, and one copy of "is this path
+# inside the take" is the only acceptable number — it is the guard that stops
+# a pull-request-edited `timeline.json` pasting `../../elsewhere.png` into a
+# URL under this take's caption.
+#
+# What stays here is the **policy**: this command refuses where the module
+# returns None. A graded verdict whose evidence is a broken image is worse than
+# no block, so every missing fact is a refusal naming what was missing.
+# `demo-shots` spends the same facts the other way and falls back to relative
+# paths. See the module docstring.
 
 
 def _git_fact(demo: Path, *args: str) -> str:
     """One fact from git, or a refusal that names the command that failed."""
-    done = _git(demo, *args)
+    done = git(demo, *args)
     if done.returncode != 0:
         raise Refused(
             f"`git {' '.join(args)}` failed in {demo}: "
@@ -1176,58 +1184,14 @@ def _git_fact(demo: Path, *args: str) -> str:
 
 def github_repo(remote: str) -> str:
     """`owner/repo` out of the origin remote URL, or a refusal."""
-    found = _GITHUB_REMOTE.search(remote.strip())
-    if not found:
+    found = _github_repo(remote)
+    if found is None:
         raise Refused(
             f"the origin remote is {remote.strip()!r}, which is not a "
             f"github.com URL, so there is no raw.githubusercontent.com URL to "
             f"build the pictures from."
         )
-    return f"{found.group('owner')}/{found.group('repo')}"
-
-
-def beat_stills(timeline: dict) -> dict[int, str]:
-    """Which committed still each beat wrote, by beat index, from the beat log."""
-    out: dict[int, str] = {}
-    for beat in timeline.get("beats") or []:
-        index = beat.get("index")
-        still = beat.get("still")
-        if isinstance(index, int) and isinstance(still, str) and still.strip():
-            out[index] = still.strip()
-    return out
-
-
-def beat_captions(timeline: dict) -> dict[int, str]:
-    """Each beat's storyboard caption, by beat index, from the beat log.
-
-    The caption is the one sentence about a beat written for a viewer rather
-    than for the recorder, so it is what a still is labelled with in the
-    block. A beat index is recorder bookkeeping: the third live read of #337
-    asked what "beat 20" was even for, and there was no answer a reviewer
-    could use.
-    """
-    out: dict[int, str] = {}
-    for beat in timeline.get("beats") or []:
-        index = beat.get("index")
-        caption = beat.get("caption")
-        if isinstance(index, int) and isinstance(caption, str) and caption.strip():
-            out[index] = caption.strip()
-    return out
-
-
-def _take_relative(still: str) -> str | None:
-    """`still` as a plain path inside the take, or None.
-
-    `timeline.json` is committed and editable, and this value is pasted into a
-    URL and a `git cat-file` argument. `../../elsewhere.png` is the shape to
-    refuse; a normalised relative path is the whole allowance.
-    """
-    if still.startswith("/") or "\\" in still:
-        return None
-    parts = [p for p in still.split("/") if p not in ("", ".")]
-    if not parts or ".." in parts:
-        return None
-    return "/".join(parts)
+    return found
 
 
 def cited_beats(row: dict) -> list[int]:
@@ -1431,7 +1395,7 @@ def cmd_pr_block(demo: Path) -> int:
     prefix = _git_fact(demo, "rev-parse", "--show-prefix")
     stills: dict[int, str] = {}
     for index, still in beat_stills(timeline).items():
-        rel = _take_relative(still)
+        rel = take_relative(still)
         if rel is None:
             # Not a path inside the take, so it is never linked. The beat then
             # reads as one that wrote no still, which is the honest rendering.
@@ -1440,14 +1404,14 @@ def cmd_pr_block(demo: Path) -> int:
 
     def url_for(rel: str) -> str:
         path = f"{prefix}{rel}"
-        if _git(demo, "cat-file", "-e", f"{sha}:{path}").returncode != 0:
+        if git(demo, "cat-file", "-e", f"{sha}:{path}").returncode != 0:
             raise Refused(
                 f"commit {sha[:12]} does not hold {path}, which this block "
                 f"would embed. Commit the still, then re-run — and push the "
                 f"commit, because the raw.githubusercontent.com URLs resolve "
                 f"only once it is on GitHub."
             )
-        return f"https://raw.githubusercontent.com/{repo}/{sha}/{quote(path)}"
+        return raw_url(repo, sha, path)
 
     block = render_pr_block(doc, stills, beat_captions(timeline), url_for)
     print(block, end="")

--- a/skills/demo-video/scripts/demo-shots
+++ b/skills/demo-video/scripts/demo-shots
@@ -1,0 +1,359 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""One markdown block of a take's stills, ready to paste.
+
+    <skill-dir>/scripts/demo-shots <demo-dir>
+
+`images/*.png` is already the storyboard author's own selection of key
+moments, already committed, already in the pull request. What did not exist
+until #373 is a command that turns it into something a person reads in
+seconds. This prints every `shot()` still in the order it was taken, under the
+caption that was on screen at the time, tagged with the acceptance criterion
+the beat claimed. Paste it into a session, a pull-request description, or a
+comment.
+
+## What it is not
+
+It is not `demo-grade`. That command hands a blind reader the clauses and the
+frames and compares what they found with what the storyboard claimed; it needs
+a reading, dispatched by hand, and it produces a verdict. This produces no
+verdict and makes no comparison. **Every sentence it writes is about what the
+storyboard claimed**, and `tests/ci-unit` sweeps its output for the vocabulary
+that would turn a claim into one (`demonstrated`, `verified`, `shown`,
+`passed`, `met`, a ticked box, a checkmark). Captions and clauses are quoted
+through untouched — they are the author's words and the ticket's, and only the
+sentences this file writes are swept.
+
+Whether a still shows its clause is the reader's question. This command's
+whole job is to put the picture in front of them with enough context to ask it.
+
+## Links
+
+Off a commit that is on a remote branch, the stills are embedded raw at that
+commit — the picture renders in a GitHub comment with nothing to click. When
+the commit is not pushed, when the demo directory has uncommitted changes,
+when the remote is not GitHub, or when there is no repository at all, the
+block uses relative paths instead and says on stderr which of those it was.
+Relative paths render in a pull-request *description* on GitHub and not in a
+comment, so the note matters.
+
+**A missing still is reported, never skipped and never linked.** A beat whose
+`still` names a file this take did not publish is the artifact-lie case: the
+block says the file is absent rather than quietly rendering four stills as
+three.
+
+## Exit status
+
+`0` when a block was written. `2` when the command refuses — a directory with
+no timeline, a timeline this code cannot read, or a take that took no stills
+at all, which has no block to paste.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+_DEFAULT_SKILL_DIR = Path(__file__).resolve().parent.parent
+SKILL_DIR = Path(os.environ.get("DEMO_VIDEO_SKILL_DIR") or _DEFAULT_SKILL_DIR)
+sys.path.insert(0, str(SKILL_DIR / "helpers"))
+
+from demo_recording.links import (  # noqa: E402
+    beat_captions,
+    beat_stills,
+    git,
+    git_fact,
+    github_repo,
+    raw_url,
+    take_relative,
+)
+from demo_recording.timeline import timeline_paths  # noqa: E402
+
+#: The comment that lets a tool find this block again, and lets a person
+#: reading the raw markdown see what produced it.
+MARKER = "<!-- demo-video: the storyboard's own stills; nothing here is graded -->"
+
+
+class Refused(Exception):
+    """The command cannot do its job on this input, and says why."""
+
+
+def _load_timeline(demo: Path) -> tuple[dict, Path]:
+    path = timeline_paths(demo)[0]
+    try:
+        text = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise Refused(
+            f"there is no timeline.json at {path}. This reads a take's own "
+            f"beat log — point it at a demo folder the recorder wrote."
+        ) from None
+    except OSError as exc:
+        raise Refused(f"cannot read {path}: {exc}") from None
+    try:
+        doc = json.loads(text)
+    except ValueError as exc:
+        raise Refused(f"{path} is not readable JSON: {exc}") from None
+    if not isinstance(doc, dict):
+        raise Refused(f"{path} is not a JSON object")
+    return doc, path
+
+
+class Shot:
+    """One `shot()` beat, as this block renders it."""
+
+    def __init__(self, index: int, name: str, caption: str, criteria: list[str]):
+        self.index = index
+        self.name = name
+        self.caption = caption
+        self.criteria = criteria
+        #: The still's path inside the take, or None when the beat named a
+        #: path this take may not link (see `take_relative`).
+        self.rel: str | None = None
+        #: Why there is no picture, when there is none. Rendered in place of
+        #: the image, never silently dropped.
+        self.missing: str | None = None
+
+
+def shots(timeline: dict) -> list[Shot]:
+    """The take's `shot()` beats in order, each with its caption and tags.
+
+    Read off `beats` rather than off `coverage.claimed`, and the difference
+    matters: `claimed` is indexed by criterion, so a still tagged with two
+    criteria appears twice there and an untagged still does not appear at all.
+    This block is a walk through the pictures, so the pictures are what it
+    iterates.
+    """
+    stills = beat_stills(timeline)
+    captions = beat_captions(timeline)
+    out: list[Shot] = []
+    for beat in timeline.get("beats") or []:
+        index = beat.get("index")
+        if not isinstance(index, int) or index not in stills:
+            continue
+        name = beat.get("selector")
+        tags = [t for t in (beat.get("ac") or []) if isinstance(t, str)]
+        shot = Shot(
+            index,
+            str(name) if isinstance(name, str) and name.strip() else stills[index],
+            captions.get(index, ""),
+            tags,
+        )
+        error = beat.get("error")
+        if isinstance(error, dict):
+            # Before the path check, and that order is deliberate: a beat that
+            # raised wrote no still, and a file of that name sitting in the
+            # folder is a *previous* recording's. Linking it would put last
+            # week's picture under this take's caption.
+            shot.missing = (
+                f"the beat raised {error.get('type') or 'an exception'}, "
+                f"so it took no still"
+            )
+        else:
+            shot.rel = take_relative(stills[index])
+            if shot.rel is None:
+                shot.missing = (
+                    f"`{stills[index]}` is not a path inside this take, "
+                    f"so it is not linked"
+                )
+        out.append(shot)
+    return out
+
+
+def tagged_clauses(timeline: dict, found: list[Shot]) -> list[tuple[str, str]]:
+    """`(id, text)` for each declared clause at least one still tags.
+
+    Only the tagged ones. A reader meeting a bare `AC-1` under a picture needs
+    the sentence, and that is the whole reason the clauses are here; the
+    clauses *nothing* claimed are the coverage report's subject, not this
+    block's, and printing them would make this look like one.
+    """
+    coverage = timeline.get("coverage")
+    criteria = (coverage or {}).get("criteria")
+    if not isinstance(criteria, dict):
+        return []
+    claimed = [c for shot in found for c in shot.criteria]
+    return [
+        (key, str(text))
+        for key, text in criteria.items()
+        if key in claimed and isinstance(text, str)
+    ]
+
+
+class Links:
+    """How this run turns a still into something a reader can look at."""
+
+    def __init__(self, repo: str | None, sha: str | None, prefix: str, why: str):
+        self.repo = repo
+        self.sha = sha
+        self.prefix = prefix
+        #: Why the block is using relative paths, when it is. Printed on
+        #: stderr, never into the block: a note about the tooling is not part
+        #: of what somebody pastes.
+        self.why = why
+
+    @property
+    def absolute(self) -> bool:
+        return bool(self.repo and self.sha)
+
+
+def resolve_links(demo: Path) -> Links:
+    """Whether this take's stills can be embedded at a commit, and if not why.
+
+    Four ways to end up with relative paths, and each is reported by name
+    because the fix is different for each one. The order is the order a person
+    hits them: no repository at all, then a remote that is not GitHub, then an
+    uncommitted take, then a commit nobody else can see.
+
+    The last check is `branch -r --contains`, which asks whether the commit is
+    on any remote-tracking branch. It is a local read of what the last fetch
+    saw, so it costs nothing and needs no network — and it is the difference
+    between a link and a broken image, because raw.githubusercontent.com
+    resolves a commit only once GitHub has it.
+    """
+    nowhere = Links(None, None, "", "")
+    if git_fact(demo, "rev-parse", "--is-inside-work-tree") != "true":
+        return Links(None, None, "", f"{demo} is not inside a git repository")
+    sha = git_fact(demo, "rev-parse", "HEAD")
+    if sha is None:
+        # A repository with no commits. Distinct from having no repository at
+        # all, and the fix is different — `git commit`, not `git init` — which
+        # is the whole reason these are separate sentences. Reported by a test
+        # that expected the other message and got this one.
+        return Links(None, None, "", "this repository has no commits yet")
+    repo = github_repo(git_fact(demo, "remote", "get-url", "origin"))
+    if repo is None:
+        return Links(None, None, "", "the origin remote is not a github.com URL")
+    prefix = git_fact(demo, "rev-parse", "--show-prefix")
+    if prefix is None:
+        return nowhere
+    dirty = git(demo, "status", "--porcelain", "--", ".")
+    if dirty.returncode == 0 and dirty.stdout.strip():
+        return Links(
+            None,
+            None,
+            prefix,
+            f"the demo directory has uncommitted changes, so {sha[:12]} does "
+            f"not hold what is on disk",
+        )
+    if not (git_fact(demo, "branch", "-r", "--contains", sha) or ""):
+        return Links(
+            None,
+            None,
+            prefix,
+            f"commit {sha[:12]} is not on any remote branch yet, so a "
+            f"raw.githubusercontent.com URL would resolve to nothing — push "
+            f"it and re-run for embedded pictures",
+        )
+    return Links(repo, sha, prefix, "")
+
+
+def picture(shot: Shot, demo: Path, links: Links) -> str:
+    """The markdown for one still: an image, a path, or why there is neither."""
+    if shot.missing is not None:
+        return f"*{shot.missing}*"
+    rel = shot.rel
+    assert rel is not None  # `missing` is set whenever `rel` is None
+    if not (demo / rel).exists():
+        return (
+            f"*`{rel}` is named in the beat log, and this take published no such file*"
+        )
+    if not links.absolute:
+        return f"![{shot.name}]({rel})"
+    path = f"{links.prefix}{rel}"
+    assert links.repo is not None and links.sha is not None
+    if git(demo, "cat-file", "-e", f"{links.sha}:{path}").returncode != 0:
+        # On disk but not in the commit the URL would name. Naming the file
+        # beats embedding a URL that 404s under a caption that says it shows
+        # something.
+        return f"*`{rel}` is on disk but not in commit {links.sha[:12]}*"
+    return f"![{shot.name}]({raw_url(links.repo, links.sha, path)})"
+
+
+def render(
+    timeline: dict, found: list[Shot], demo: Path, where: str, links: Links
+) -> str:
+    """The block. A pure function of the take's own documents and the links."""
+    n = len(found)
+    out = [
+        MARKER,
+        "",
+        f"## {n} still{'s' if n != 1 else ''} the storyboard took",
+        "",
+        f"From `{where}`, in the order they were taken. Each caption is the "
+        f"line that was on screen at that moment.",
+        "",
+    ]
+    ticket = timeline.get("ticket")
+    if isinstance(ticket, str) and ticket.strip():
+        out += [
+            f"The take names **{ticket.strip()}** as the ticket it was "
+            f"recorded against. Nothing here read that ticket.",
+            "",
+        ]
+    clauses = tagged_clauses(timeline, found)
+    if clauses:
+        out += [
+            "An `AC-n` under a picture is a tag the storyboard's author typed "
+            "against that beat. It says which criterion the beat was there "
+            "for, and nothing compared the picture with the words:",
+            "",
+        ]
+        out += [f"- **{key}** — {text}" for key, text in clauses]
+        out += [""]
+    if timeline.get("mode") == "stills":
+        out += [
+            "This was a stills-only run: the storyboard ran for its pictures "
+            "and recorded no video.",
+            "",
+        ]
+    for position, shot in enumerate(found, 1):
+        tags = " ".join(f"`{c}`" for c in shot.criteria)
+        head = f"**{position}.**" + (f" {tags}" if tags else "")
+        caption = shot.caption or f"*no caption was up — the still is `{shot.name}`*"
+        out += [f"{head} {caption}", "", picture(shot, demo, links), ""]
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="One markdown block of a take's stills.")
+    ap.add_argument("demo_dir", help="a take's output folder")
+    args = ap.parse_args(argv)
+    demo = Path(args.demo_dir)
+    try:
+        timeline, path = _load_timeline(demo)
+        found = shots(timeline)
+        if not found:
+            raise Refused(
+                f"{path} records no shot() beats, so there are no stills to "
+                f'put in a block. Add rec.shot("name") at the moments a '
+                f"written guide would show a picture, and re-record."
+            )
+        links = resolve_links(demo)
+        prefix = links.prefix or demo.as_posix()
+        where = prefix.rstrip("/") or demo.as_posix()
+        print(render(timeline, found, demo, where, links), end="")
+    except Refused as refusal:
+        print(f"demo-shots: refusing — {refusal}", file=sys.stderr)
+        return 2
+    if links.why:
+        print(
+            f"  note: the block uses relative paths because {links.why}. "
+            f"They render in a pull-request description and not in a comment.",
+            file=sys.stderr,
+        )
+    else:
+        print(
+            f"  note: the pictures are embedded at commit {links.sha[:12]}.",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/README.md
+++ b/tests/README.md
@@ -137,8 +137,9 @@ seen red under a planted recorder defect in #351's pull request.
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
 ├── smoke-inject       # proves smoke's assertions can still fail (~54 min, nightly)
-├── unit               # the browser-free half (~6 s, 536 tests, no dependencies)
-├── ci-unit            # the three .github/scripts helpers (~0.2 s)
+├── unit               # the browser-free half (~4 s, 568 tests, no dependencies)
+├── ci-unit            # the .github/scripts helpers, and the two skill
+│                      #   CLIs whose output a person pastes (~2.5 s)
 ├── lint               # ruff at the version ci.yml pins, over the files CI
 │                      #   sees, plus the docs' python fences (~0.3 s)
 ├── pixel              # the iteration loop: two cached chrome reference takes,
@@ -181,7 +182,7 @@ have read this sentence:
 ```sh
 tests/unit                        # the browser-free half of the recorder
 tests/unit --fault-inject         # break each thing an assertion watches
-tests/ci-unit                     # the CI workflow's three helper scripts
+tests/ci-unit                     # the CI helpers, demo-grade and demo-shots
 tests/ci-unit --fault-inject
 tests/lint                        # ruff check + ruff format --check + doc fences
 tests/lint --self-test            # prove all three grade something

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -85,6 +85,12 @@ GUARD_CLI = _SKILL / "scripts" / "demo-target-guard"
 # `guard` is.
 grade = load("demo-grade", _SKILL / "scripts")
 
+# The stills block (#373) — the other command whose output a person pastes,
+# and the reason `VERDICT_WORDS` below is not `demo-comment`'s private
+# business. Loaded off `_SKILL` for the same reason `grade` is.
+shots = load("demo-shots", _SKILL / "scripts")
+SHOTS_CLI = _SKILL / "scripts" / "demo-shots"
+
 
 # --------------------------------------------------------------------------
 # demo-storyboards — which storyboards a diff makes stale
@@ -2753,7 +2759,414 @@ class PrBlock(unittest.TestCase):
 # --------------------------------------------------------------------------
 
 # (name, script, exact text to replace, replacement, tests that must then fail)
+
+# Four `shot()` beats and one that is not. Beat 6 carries two tags, so the
+# "each still once" claim has a beat that would be printed twice by a renderer
+# walking `coverage.claimed`; beat 8 carries none, so it would be dropped by
+# one. Beat 4's caption is empty on purpose.
+SHOTS_BEATS = [
+    {"index": 0, "verb": "caption", "caption": "A support queue."},
+    {
+        "index": 2,
+        "verb": "shot",
+        "selector": "01-a",
+        "still": "images/01-a.png",
+        "caption": "A support queue.",
+        "ac": ["AC-1"],
+    },
+    {
+        "index": 4,
+        "verb": "shot",
+        "selector": "02-b",
+        "still": "images/02-b.png",
+        "caption": "",
+    },
+    {
+        "index": 6,
+        "verb": "shot",
+        "selector": "03-c",
+        "still": "images/03-c.png",
+        "caption": "One click empties the box.",
+        "ac": ["AC-1", "AC-2"],
+    },
+    {
+        "index": 8,
+        "verb": "shot",
+        "selector": "04-d",
+        "still": "images/04-d.png",
+        "caption": "The heading agrees.",
+    },
+]
+
+SHOTS_ESCAPING = [
+    dict(beat, still="../../../etc/passwd.png")
+    if beat.get("selector") == "02-b"
+    else beat
+    for beat in SHOTS_BEATS
+]
+
+SHOTS_RAISED = [
+    dict(beat, error={"type": "TimeoutError", "message": "no such element"})
+    if beat.get("selector") == "02-b"
+    else beat
+    for beat in SHOTS_BEATS
+]
+
+
+# The clauses `demo-shots` renders. Four declared and two tagged, so "only the
+# tagged ones" is a statement with something to be wrong about — a renderer
+# that printed all four would pass a fixture where every clause is claimed.
+SHOTS_CRITERIA = {
+    "AC-1": "The search box narrows the list as you type.",
+    "AC-2": "A clear control empties the box in one click.",
+    "AC-3": "Search matches the requester as well as the title.",
+    "AC-4": "The heading counts what the filter lists.",
+}
+
+
+class ShotsBlock(unittest.TestCase):
+    """`demo-shots` — the take's own pictures, as one pasteable block (#373).
+
+    Everything here is graded against a real git repository rather than a
+    mock, because what the command does with git's answers *is* the feature:
+    the difference between an embedded picture and a relative path is four
+    separate facts about a working tree, and each is a different reason.
+    """
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.demo = self.root / "demos" / "x"
+
+    def git(self, *args: str) -> str:
+        done = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(self.root),
+                "-c",
+                "user.email=t@example.invalid",
+                "-c",
+                "user.name=t",
+                "-c",
+                "commit.gpgsign=false",
+                *args,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(done.returncode, 0, done.stderr)
+        return done.stdout.strip()
+
+    def take(
+        self,
+        beats=None,
+        *,
+        ticket="o/r#7",
+        mode=None,
+        unwritten=(),
+        commit=True,
+        push=True,
+        remote="git@github.com:o/r.git",
+    ):
+        """A take on disk, optionally committed and optionally pushed.
+
+        `push` is a real second repository the branch is pushed to, not a
+        flag: the command asks `git branch -r --contains`, and the only way to
+        grade that honestly is for there to be a remote branch or not.
+        """
+        beats = SHOTS_BEATS if beats is None else beats
+        timeline = {
+            "schema": 1,
+            "beats": beats,
+            "coverage": {"criteria": SHOTS_CRITERIA, "claimed": {}},
+        }
+        if ticket is not None:
+            timeline["ticket"] = ticket
+        if mode is not None:
+            timeline["mode"] = mode
+        (self.demo / "images").mkdir(parents=True)
+        for beat in beats:
+            still = beat.get("still")
+            if not still or still in unwritten or still.startswith(".."):
+                continue
+            (self.demo / still).write_bytes(b"\x89PNG")
+        (self.demo / "timeline.json").write_text(json.dumps(timeline), encoding="utf-8")
+        self.git("init", "-q")
+        if remote is not None:
+            self.git("remote", "add", "origin", remote)
+        if not commit:
+            return
+        self.git("add", "-A")
+        self.git("commit", "-qm", "the take")
+        self.sha = self.git("rev-parse", "HEAD")
+        if push:
+            bare = self.root.parent / f"{self.root.name}.git"
+            subprocess.run(["git", "init", "-q", "--bare", str(bare)], check=True)
+            self.addCleanup(shutil.rmtree, bare, True)
+            self.git("remote", "set-url", "origin", str(bare))
+            self.git("push", "-q", "origin", "HEAD")
+            self.git("fetch", "-q", "origin")
+            if remote is not None:
+                # Push over a path remote, then put the GitHub URL back: the
+                # command reads the remote-tracking ref (local) and the remote
+                # *name* (for the URL), and only a real push creates the ref.
+                self.git("remote", "set-url", "origin", remote)
+
+    def run_shots(self, demo=None):
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = shots.main([str(self.demo if demo is None else demo)])
+        return code, out.getvalue(), err.getvalue()
+
+    def block(self) -> str:
+        code, out, err = self.run_shots()
+        self.assertEqual(code, 0, err)
+        return out
+
+    # -- the walk through the pictures --------------------------------------
+
+    def test_every_still_appears_once_in_the_order_it_was_taken(self):
+        # Off `beats`, not off `coverage.claimed`: beat 6 below is tagged with
+        # two criteria, and a renderer iterating `claimed` would print it
+        # twice and drop the untagged one entirely.
+        self.take()
+        body = self.block()
+        order = [
+            body.index(name)
+            for name in ("images/01-a.png", "images/02-b.png", "images/03-c.png")
+        ]
+        self.assertEqual(order, sorted(order), body)
+        self.assertEqual(body.count("images/03-c.png"), 1, body)
+        self.assertIn("**4.**", body)
+        self.assertNotIn("**5.**", body)
+
+    def test_only_the_clauses_a_still_tags_are_printed(self):
+        # A reader meeting a bare `AC-1` needs the sentence; a reader meeting
+        # every declared clause is reading a coverage report, which this is
+        # not and must not resemble.
+        self.take()
+        body = self.block()
+        for key in ("AC-1", "AC-2"):
+            self.assertIn(f"**{key}** — {SHOTS_CRITERIA[key]}", body)
+        for key in ("AC-3", "AC-4"):
+            self.assertNotIn(SHOTS_CRITERIA[key], body)
+
+    def test_a_beat_with_no_caption_says_so_rather_than_going_blank(self):
+        self.take()
+        body = self.block()
+        self.assertIn("no caption was up", body)
+
+    def test_a_stills_only_run_is_named_as_one(self):
+        # Both ways. The sentence is a statement about this take, so a take
+        # that carries it always would be saying nothing.
+        self.take(mode="stills")
+        self.assertIn("stills-only run", self.block())
+        self.setUp()
+        self.take()
+        self.assertNotIn("stills-only run", self.block())
+
+    # -- what a picture resolves to, and the four ways it does not ----------
+
+    def test_a_pushed_commit_embeds_the_still_at_that_commit(self):
+        self.take()
+        body = self.block()
+        self.assertIn(
+            f"https://raw.githubusercontent.com/o/r/{self.sha}/demos/x/images/01-a.png",
+            body,
+        )
+
+    def test_an_unpushed_commit_falls_back_and_says_which_of_the_four(self):
+        # Not a refusal: this command is run in a session against a working
+        # tree, and refusing there would make it useless exactly when it is
+        # wanted. But a reader has to be told, or the note is the difference
+        # between a picture and a broken image nobody notices.
+        self.take(push=False)
+        code, body, err = self.run_shots()
+        self.assertEqual(code, 0, err)
+        self.assertIn("![01-a](images/01-a.png)", body)
+        self.assertNotIn("raw.githubusercontent.com", body)
+        self.assertIn("not on any remote branch", err)
+
+    def test_an_uncommitted_change_falls_back_and_says_so(self):
+        # Committed and pushed, then edited: the commit exists and does not
+        # hold what is on disk, so a URL at it would show the previous bytes
+        # under a caption describing the current ones.
+        self.take()
+        (self.demo / "images" / "01-a.png").write_bytes(b"\x89PNGdifferent")
+        code, body, err = self.run_shots()
+        self.assertEqual(code, 0, err)
+        self.assertNotIn("raw.githubusercontent.com", body)
+        self.assertIn("uncommitted changes", err)
+
+    def test_a_repository_with_no_commits_says_that_and_not_no_repository(self):
+        # Two different sentences because the fix is different: `git commit`
+        # against `git init`. The first version of this command reported one
+        # as the other, and this test is why.
+        self.take(commit=False)
+        code, body, err = self.run_shots()
+        self.assertEqual(code, 0, err)
+        self.assertIn("no commits yet", err)
+        self.assertNotIn("not inside a git repository", err)
+
+    def test_no_repository_at_all_says_that(self):
+        outside = self.root.parent / f"{self.root.name}-loose"
+        (outside / "images").mkdir(parents=True)
+        self.addCleanup(shutil.rmtree, outside, True)
+        (outside / "images" / "01-a.png").write_bytes(b"\x89PNG")
+        (outside / "timeline.json").write_text(
+            json.dumps({"schema": 1, "beats": SHOTS_BEATS[:2]}), encoding="utf-8"
+        )
+        code, body, err = self.run_shots(demo=outside)
+        self.assertEqual(code, 0, err)
+        self.assertIn("not inside a git repository", err)
+
+    def test_a_remote_that_is_not_github_falls_back_and_says_so(self):
+        self.take(remote="git@gitlab.example.invalid:o/r.git", push=False)
+        code, body, err = self.run_shots()
+        self.assertEqual(code, 0, err)
+        self.assertNotIn("raw.githubusercontent.com", body)
+        self.assertIn("not a github.com URL", err)
+
+    def test_a_still_the_beat_log_names_and_nothing_wrote_is_reported(self):
+        # Never skipped and never linked. A block that quietly rendered three
+        # pictures for four beats is the artifact-lie this whole repository
+        # is about, one command down.
+        self.take(unwritten=("images/02-b.png",))
+        body = self.block()
+        self.assertIn("published no such file", body)
+        self.assertIn("`images/02-b.png`", body)
+        self.assertIn("**2.**", body)
+
+    def test_a_still_outside_the_take_is_named_and_never_linked(self):
+        # `timeline.json` is committed and editable in a pull request, and
+        # this value goes into a URL. `../` is the shape to refuse.
+        self.take(beats=SHOTS_ESCAPING)
+        body = self.block()
+        self.assertIn("not a path inside this take", body)
+        self.assertNotIn("etc/passwd", body.split("not a path")[1])
+
+    def test_a_beat_that_raised_is_reported_as_taking_no_still(self):
+        # Before the file check, and that order is the point: on a take that
+        # died, a file of that name is a *previous* recording's, and linking
+        # it would put last week's picture under this take's caption.
+        self.take(beats=SHOTS_RAISED)
+        body = self.block()
+        self.assertIn("the beat raised TimeoutError", body)
+        self.assertNotIn("![02-b]", body)
+
+    # -- it never promotes a claim to a verdict ------------------------------
+
+    def test_the_block_carries_no_verdict_word(self):
+        # The #373 requirement, and the same alphabet the CI comment is held
+        # to. Captions and clauses are quoted through untouched, so the
+        # fixture above deliberately contains none of these words: what is
+        # being graded is the sentences this renderer writes.
+        self.take()
+        self.assertEqual(_verdict_hits(self.block()), [])
+
+    def test_the_sweep_over_this_block_is_not_vacuous(self):
+        # The control. Every assertion above is satisfied by a `_verdict_hits`
+        # that stopped matching, and by a block that came back empty. One
+        # verdict sentence planted in a caption — a caption is quoted through,
+        # so this reaches the swept text by the shortest possible route.
+        planted = [dict(b) for b in SHOTS_BEATS]
+        # Into a beat the block *renders*. The first version of this test
+        # planted the sentence in beat 0, which takes no still and is never
+        # printed — the control was itself vacuous, and this is what it caught.
+        planted[1]["caption"] = "Each clause is demonstrated below."
+        self.take(beats=planted)
+        self.assertEqual(_verdict_hits(self.block()), ["demonstrat*"])
+
+    # -- refusals ------------------------------------------------------------
+
+    def test_a_folder_with_no_timeline_is_refused_by_name(self):
+        code, out, err = self.run_shots(demo=self.root / "nothing-here")
+        self.assertEqual(code, 2)
+        self.assertIn("there is no timeline.json", err)
+        self.assertEqual(out, "")
+
+    def test_a_take_that_took_no_stills_is_refused_and_told_what_to_add(self):
+        # There is no block to paste, and printing an empty one would read as
+        # a take that showed nothing rather than a storyboard that called no
+        # shot().
+        self.take(beats=[{"index": 0, "caption": "A queue.", "verb": "caption"}])
+        code, out, err = self.run_shots()
+        self.assertEqual(code, 2)
+        self.assertIn("records no shot() beats", err)
+        self.assertIn('rec.shot("name")', err)
+        self.assertEqual(out, "")
+
+
 INJECTIONS = [
+    # -- demo-shots: the take's own pictures, as a block (issue #373) --------
+    (
+        # The block walks `coverage.claimed` instead of the beat log: a still
+        # tagged with two criteria is printed twice, and an untagged one
+        # vanishes. The pictures are what the block is *for*, so a renderer
+        # indexed by criterion is describing a different document.
+        "the stills block iterates the claims instead of the pictures",
+        "scripts/demo-shots",
+        '    for beat in timeline.get("beats") or []:\n'
+        '        index = beat.get("index")\n'
+        "        if not isinstance(index, int) or index not in stills:",
+        '    for beat in timeline.get("beats") or []:\n'
+        '        index = beat.get("index")\n'
+        '        if not isinstance(index, int) or index not in stills or beat.get("ac"):',
+        ["ShotsBlock.test_every_still_appears_once_in_the_order_it_was_taken"],
+    ),
+    (
+        # A still the beat log names and nothing wrote, quietly dropped. Four
+        # beats render as three pictures and the block reads as a complete
+        # walk — the artifact-lie class, one command down.
+        "a still nothing wrote is skipped instead of reported",
+        "scripts/demo-shots",
+        '            f"*`{rel}` is named in the beat log, and this take '
+        'published no such file*"',
+        '            ""',
+        ["ShotsBlock.test_a_still_the_beat_log_names_and_nothing_wrote_is_reported"],
+    ),
+    (
+        # The guard on a pull-request-editable path, removed: `../../x.png`
+        # goes into a raw.githubusercontent.com URL, and the block publishes a
+        # picture that has nothing to do with this take under its caption.
+        "the stills block links a path that escapes the take",
+        "scripts/demo-shots",
+        "            shot.rel = take_relative(stills[index])",
+        "            shot.rel = stills[index]",
+        ["ShotsBlock.test_a_still_outside_the_take_is_named_and_never_linked"],
+    ),
+    (
+        # The order that keeps last week's picture out: check the file before
+        # the exception, and a beat that raised gets the still a *previous*
+        # recording left in the folder, under this take's caption.
+        "a beat that raised is given whatever file is lying there",
+        "scripts/demo-shots",
+        '        error = beat.get("error")\n        if isinstance(error, dict):',
+        "        error = None\n        if isinstance(error, dict):",
+        ["ShotsBlock.test_a_beat_that_raised_is_reported_as_taking_no_still"],
+    ),
+    (
+        # An unpushed commit embedded anyway. Every picture in the block is a
+        # 404 that renders as a broken image, and the note that would have
+        # said why is gone with it.
+        "the block embeds pictures at a commit nobody else has",
+        "scripts/demo-shots",
+        '    if not (git_fact(demo, "branch", "-r", "--contains", sha) or ""):',
+        "    if False:",
+        ["ShotsBlock.test_an_unpushed_commit_falls_back_and_says_which_of_the_four"],
+    ),
+    (
+        # The renderer promotes the claim. One sentence, of the sort an author
+        # would reasonably write, and the block stops being a statement about
+        # what the storyboard claimed.
+        "the stills block says the pictures show their clauses",
+        "scripts/demo-shots",
+        '            "for, and nothing compared the picture with the words:",',
+        '            "for, and each picture below is shown to meet it:",',
+        ["ShotsBlock.test_the_block_carries_no_verdict_word"],
+    ),
     (
         "app_root always returns the repository root",
         "demo-storyboards",
@@ -3655,7 +4068,10 @@ INJECTIONS = [
         # block embeds its URL regardless.
         "a still the commit does not hold is embedded anyway",
         "scripts/demo-grade",
-        '        if _git(demo, "cat-file", "-e", f"{sha}:{path}").returncode != 0:',
+        # `git`, not `_git`: the helper moved to `demo_recording.links` when
+        # `demo-shots` needed the same one (#373), and this anchor is how the
+        # driver said so — exit 3 rather than a quietly unproven claim.
+        '        if git(demo, "cat-file", "-e", f"{sha}:{path}").returncode != 0:',
         "        if False:",
         ["PrBlock.test_a_still_the_commit_does_not_hold_is_refused_with_the_path"],
     ),
@@ -3707,10 +4123,13 @@ INJECTIONS = [
     (
         # Seven characters resolve today and are ambiguous later — the
         # artifact lying slowly, in the URL a reviewer's browser fetches.
+        # In `links.py` since #373, where `demo-shots` reads it too. A short
+        # sha resolves on github.com and not on raw.githubusercontent.com, so
+        # every picture in both blocks becomes a broken image.
         "the raw URL is built at the abbreviated sha",
-        "scripts/demo-grade",
-        '        return f"https://raw.githubusercontent.com/{repo}/{sha}/{quote(path)}"',
-        '        return f"https://raw.githubusercontent.com/{repo}/{sha[:7]}/{quote(path)}"',
+        "helpers/demo_recording/links.py",
+        '    return f"https://raw.githubusercontent.com/{repo}/{quote(sha)}/{quote(path)}"',
+        '    return f"https://raw.githubusercontent.com/{repo}/{sha[:7]}/{quote(path)}"',
         ["PrBlock.test_the_picture_is_the_committed_still_raw_at_head"],
     ),
     (
@@ -3951,12 +4370,16 @@ def fault_inject() -> int:
             shutil.copy(Path(__file__).resolve(), inner)
             if script == "target.py":
                 target = skill / "helpers" / "demo_recording" / script
-            elif script in ("scripts/demo-target-guard", "scripts/demo-grade"):
-                # Both CLIs ship with the skill rather than under
-                # `.github/scripts/`. `GuardExitCode` runs the first; `grade`
-                # at the top of this file imports the second, which is how an
-                # injection into the grader reddens the couplings the comment
-                # has with it and cannot import.
+            elif script.startswith(("scripts/", "helpers/")):
+                # Anything shipped with the skill rather than under
+                # `.github/scripts/`: the three CLIs, and the package modules
+                # they import. `GuardExitCode` runs `demo-target-guard`;
+                # `grade` and `shots` at the top of this file import the other
+                # two, which is how an injection into either reddens the
+                # couplings the comment has with them and cannot import. A
+                # prefix rather than a list because the list was a second
+                # place to remember, and `demo_recording/links.py` (#373) is
+                # the first module either CLI's behaviour lives in.
                 target = skill / script
             elif script == "demo-video.yml":
                 target = workflow

--- a/tests/unit
+++ b/tests/unit
@@ -102,6 +102,13 @@ from demo_recording.frames import (  # noqa: E402
     beat_frames,
     render_frames_md,
 )
+from demo_recording.links import (  # noqa: E402
+    beat_captions,
+    beat_stills,
+    github_repo,
+    raw_url,
+    take_relative,
+)
 from demo_recording.markdown import _fmt_t, _md_cell  # noqa: E402
 from demo_recording.narration import (  # noqa: E402
     TTS_KEY_CHARS,
@@ -1853,7 +1860,20 @@ _EXAMPLES = Path(os.environ.get("UNIT_EXAMPLES", REPO / "examples"))
 # names, and `hold(min_s=1.5)` is documented in full in the verb table. A
 # restatement earns its place less than the one sentence telling an author
 # the fast loop exists. What was left over is this raise.
-SKILL_LINE_BUDGET = 632
+# Raised 632 → 634 on 2026-08-23, for `scripts/demo-shots` (#373): a shipped
+# command the always-loaded file has to name, in the one place a reader is
+# deciding what to put in front of a person. Two lines net, and they are net:
+# the first draft of the paragraph cost five, and it was rewritten twice —
+# `pr-block`'s "the block embeds each judged beat's committed still, raw off
+# GitHub at the head commit" is now one sentence covering both commands
+# instead of one sentence per command, which is where three of the five went.
+#
+# What was *not* paid for by trimming, and the honest reason: nothing else in
+# step 8 earns its place less than naming the command. The alternative was to
+# leave `demo-shots` documented only in `scripts/` and in reference/, where an
+# agent deciding how to hand a reviewer the pictures would never meet it —
+# which is the failure the budget's own preamble says a budget must not cause.
+SKILL_LINE_BUDGET = 634
 
 # `reference/` holding fewer than this is `reference/` being emptied, which
 # would make both assertions below hold trivially. Not a count of the files
@@ -4117,6 +4137,120 @@ STORYBOARD_PAGE_ATTRS = frozenset({"keyboard", "mouse"})
 
 #: Under this, the sweep is reading an emptied `examples/`.
 STORYBOARD_SWEEP_FILE_FLOOR = 4
+
+
+class StillPaths(unittest.TestCase):
+    """`links.take_relative` — the guard on a path that goes into a URL (#373).
+
+    `timeline.json` is a committed file, so its `still` value is editable in a
+    pull request, and two commands paste it into a raw.githubusercontent.com
+    URL and a `git cat-file` argument. This is the only thing between that and
+    publishing a picture from somewhere else under this take's caption, so it
+    is graded at its edges rather than on one happy path.
+    """
+
+    def test_an_ordinary_path_inside_the_take_survives_unchanged(self):
+        self.assertEqual(take_relative("images/01-a.png"), "images/01-a.png")
+        self.assertEqual(take_relative("a/b/c.png"), "a/b/c.png")
+
+    def test_noise_that_means_nothing_is_dropped(self):
+        # `./` and doubled separators are not an escape, and a caller
+        # comparing the result with a path on disk should not have to care.
+        self.assertEqual(take_relative("./images/01-a.png"), "images/01-a.png")
+        self.assertEqual(take_relative("images//01-a.png"), "images/01-a.png")
+
+    def test_every_shape_that_leaves_the_take_is_refused(self):
+        for escaping in (
+            "../elsewhere.png",
+            "images/../../elsewhere.png",
+            "a/b/../../../c.png",
+            "/etc/passwd",
+            "/images/01-a.png",
+            "..",
+            "images\\..\\..\\x.png",
+            "..\\x.png",
+        ):
+            with self.subTest(escaping):
+                self.assertIsNone(take_relative(escaping))
+
+    def test_a_path_that_is_only_noise_is_refused(self):
+        # Not "" — an empty relative path would join to the take directory
+        # itself, and `(demo / "").exists()` is True.
+        for empty in ("", ".", "./", "//", "./././"):
+            with self.subTest(repr(empty)):
+                self.assertIsNone(take_relative(empty))
+
+    def test_a_backslash_anywhere_is_refused_outright(self):
+        # Not split on, refused. A backslash is a separator on the platform
+        # half of the world, and `a\\..\\b` survives a `/`-only split with
+        # its `..` invisible.
+        self.assertIsNone(take_relative("images\\01-a.png"))
+
+
+class RemoteUrls(unittest.TestCase):
+    """`links.github_repo` and `links.raw_url` — what a picture is linked at."""
+
+    def test_the_remote_spellings_git_actually_writes(self):
+        for remote in (
+            "git@github.com:rogvid/skills.git",
+            "git@github.com:rogvid/skills",
+            "https://github.com/rogvid/skills.git",
+            "https://github.com/rogvid/skills",
+            "https://github.com/rogvid/skills/",
+            "ssh://git@github.com/rogvid/skills.git",
+        ):
+            with self.subTest(remote):
+                self.assertEqual(github_repo(remote), "rogvid/skills")
+
+    def test_anything_that_is_not_github_gets_no_url_rather_than_a_guess(self):
+        for remote in (
+            "git@gitlab.com:rogvid/skills.git",
+            "https://example.invalid/rogvid/skills",
+            "/srv/git/skills.git",
+            "",
+            None,
+        ):
+            with self.subTest(remote):
+                self.assertIsNone(github_repo(remote))
+
+    def test_a_url_names_the_commit_and_never_a_branch(self):
+        # A branch moves. A picture pasted into a pull-request description has
+        # to keep showing what it showed when it was pasted.
+        url = raw_url("o/r", "a" * 40, "demos/x/images/01-a.png")
+        self.assertEqual(
+            url,
+            f"https://raw.githubusercontent.com/o/r/{'a' * 40}/demos/x/images/01-a.png",
+        )
+
+    def test_a_path_with_a_space_is_escaped_rather_than_broken(self):
+        self.assertIn("a%20b.png", raw_url("o/r", "sha", "images/a b.png"))
+
+
+class BeatColumns(unittest.TestCase):
+    """`links.beat_stills` / `beat_captions` — the two columns a block reads."""
+
+    BEATS = {
+        "beats": [
+            {"index": 0, "caption": "A queue.", "still": "images/01.png"},
+            {"index": 1, "caption": "   ", "still": "  "},
+            {"index": 2, "caption": "Filtered.", "still": None},
+            {"caption": "no index", "still": "images/orphan.png"},
+            {"index": "3", "caption": "index is a string", "still": "images/s.png"},
+        ]
+    }
+
+    def test_only_beats_with_a_usable_index_and_value_are_returned(self):
+        # Whitespace, null, a missing index and an index of the wrong type all
+        # drop out. A block that took `"  "` as a still would render an image
+        # tag pointing at the take directory.
+        self.assertEqual(beat_stills(self.BEATS), {0: "images/01.png"})
+        self.assertEqual(beat_captions(self.BEATS), {0: "A queue.", 2: "Filtered."})
+
+    def test_a_timeline_with_no_beats_is_empty_rather_than_an_error(self):
+        for doc in ({}, {"beats": None}, {"beats": []}):
+            with self.subTest(doc):
+                self.assertEqual(beat_stills(doc), {})
+                self.assertEqual(beat_captions(doc), {})
 
 
 class StoryboardsReachTheApp(unittest.TestCase):


### PR DESCRIPTION
Closes #373.

`scripts/demo-shots <demo folder>` prints every `shot()` in the order it was taken, under the caption that was on screen at the time, tagged with the criterion the beat claimed. One markdown block, ready to paste into a session, a pull-request description, or a comment.

**Everything below the line is that command's actual output**, run on `examples/ticket-queue/demos/2026-08-18-clear-search` at this branch's head. It is the deliverable, so the PR carries it rather than describing it.

---

<!-- demo-video: the storyboard's own stills; nothing here is graded -->

## 4 stills the storyboard took

From `examples/ticket-queue/demos/2026-08-18-clear-search`, in the order they were taken. Each caption is the line that was on screen at that moment.

The take names **rogvid/skills#336** as the ticket it was recorded against. Nothing here read that ticket.

An `AC-n` under a picture is a tag the storyboard's author typed against that beat. It says which criterion the beat was there for, and nothing compared the picture with the words:

- **AC-1** — While the search box holds text, a clear control ("×") is visible beside it. While the box is empty, the control is absent.
- **AC-2** — Activating the clear control empties the box and restores the list to what the active status filter alone would show, with the heading count agreeing.

**1.** `AC-1` The search box is empty, and no clear control sits beside it.

![01-empty-box](https://raw.githubusercontent.com/rogvid/skills/a18d462974bd20e35d294b0db6e95c4928c5aa67/examples/ticket-queue/demos/2026-08-18-clear-search/images/01-empty-box.png)

**2.** `AC-1` Typing a term narrows the list, and a × appears beside the box.

![02-control-appears](https://raw.githubusercontent.com/rogvid/skills/a18d462974bd20e35d294b0db6e95c4928c5aa67/examples/ticket-queue/demos/2026-08-18-clear-search/images/02-control-appears.png)

**3.** `AC-2` One click on the × empties the box.

![03-restored](https://raw.githubusercontent.com/rogvid/skills/a18d462974bd20e35d294b0db6e95c4928c5aa67/examples/ticket-queue/demos/2026-08-18-clear-search/images/03-restored.png)

**4.** `AC-2` The heading counts what the Open filter lists.

![04-heading](https://raw.githubusercontent.com/rogvid/skills/a18d462974bd20e35d294b0db6e95c4928c5aa67/examples/ticket-queue/demos/2026-08-18-clear-search/images/04-heading.png)

---

## What it is, and what it is built not to become

It grades nothing. No sentence it writes says a clause was shown, and `tests/ci-unit` sweeps its rendered block with the same `VERDICT_WORDS` alphabet the CI comment is held to — `demonstrat*`, `verified`, `shown`, `passed`, `met`, `[x]`, `✓`. Captions and clauses are quoted through untouched: they are the author's words and the ticket's, and only the sentences the renderer writes are swept.

That sweep has a control, and the control earned its place immediately. The first version planted a verdict sentence in beat 0 of the fixture — a `caption` beat, which takes no still and is never rendered — so the "not vacuous" test passed while measuring nothing. It now plants into a beat the block actually prints.

## Two things it will not do quietly

- **A still the beat log names and this take did not write is reported.** Four beats rendering as three pictures reads as a demo that showed three things.
- **A path that leaves the take is named, never linked.** `timeline.json` is committed and editable in a pull request, and the value goes into a `raw.githubusercontent.com` URL.
- A beat that **raised** is reported as taking no still, checked *before* the file exists — on a take that died, a file of that name is a previous recording's, and linking it puts last week's picture under this take's caption.

## Links, and the four ways there are none

| what it found | what the block does | what to do |
|---|---|---|
| commit on a remote branch | embeds raw at that commit | — |
| no git repository | relative paths | nothing; that is the answer here |
| repository with no commits | relative paths | commit the take |
| uncommitted changes in the demo folder | relative paths | commit them |
| commit on no remote branch | relative paths | push it |
| origin remote is not github.com | relative paths | nothing; there is no raw URL |

It **falls back rather than refusing**, which is the one place its policy differs from `demo-grade pr-block`. This command is run in a session against a working tree, where an uncommitted take is the normal case; refusing there would make it useless exactly when it is wanted. `pr-block` refuses, because a graded verdict whose evidence is a broken image is worse than no block.

The reason is printed on stderr, never into the block — a note about the tooling is not part of what somebody pastes. Relative paths render in a pull-request *description* and not in a comment, so the note matters.

## The shared module

The git and beat-log machinery is now `demo_recording/links.py`, imported by both commands. `demo-grade` loses its private copies and keeps its policy — it refuses where the module returns `None`.

One copy of `take_relative` is the only acceptable number: it is the guard between a pull-request-edited `timeline.json` and a URL. **It had no tests before this.** It does now, at its edges — eight escaping shapes, the noise that is not an escape, `""` (which would join to the take directory itself, and `(demo / "").exists()` is `True`), and a backslash anywhere, refused outright rather than split on.

## Evidence

**`tests/ci-unit`** — 164 tests (22 new in `ShotsBlock`), 2.5 s. Graded against a real git repository with a real second repo pushed to, because `git branch -r --contains` is the fact that decides whether a picture embeds, and the only honest way to grade it is for the remote branch to exist or not.

**`tests/ci-unit --fault-inject`** — 113 injections, 0 missed, 0 aborted. Seven are new:

| break | what it would ship |
|---|---|
| walk `coverage.claimed` instead of the beats | a still tagged twice printed twice, an untagged one dropped |
| skip a still nothing wrote | four beats rendering as three pictures |
| drop `take_relative` | `../../x.png` in a raw URL under this take's caption |
| check the file before the exception | last week's picture under a beat that raised |
| embed at an unpushed commit | every picture a 404, and the note that says why is gone |
| one verdict sentence in the renderer | the block stops being a statement about a claim |
| `raw_url` truncates the sha | *(re-aimed at `links.py`)* both blocks' pictures break |

That last one is the shared module proving it is shared: one injection now reddens a `PrBlock` test and a `ShotsBlock` test together.

**`tests/unit`** — 568 tests (11 new in `StillPaths`, `RemoteUrls`, `BeatColumns`); full `--fault-inject` 350 injections, 0 missed.

`mise run check` 6.3 s. `tests/lint`, `tests/typecheck` green.

## Two injections the driver refused before this landed

Both were mine, both caused by the extraction, and both would have been silently unproven claims:

- `a still the commit does not hold is embedded anyway` anchored on `_git(`, which the move renamed to `git(`.
- `the raw URL is built at the abbreviated sha` anchored on a line that had moved into `links.py` entirely.

The second needed the ci-unit driver taught where a package module lives. It now resolves any `scripts/` or `helpers/` path against the skill, as a prefix rather than a list — the list was a second place to remember.

## SKILL.md budget

Raised 632 → 634, and the two lines are net: the first draft cost five, and `pr-block`'s "the block embeds each judged beat's committed still" is now one sentence covering both commands instead of one per command. Nothing else in step 8 earns its place less than naming the command — the alternative was leaving `demo-shots` documented only in `reference/`, where an agent deciding how to hand a reviewer the pictures would never meet it.

## Stated limits

- The block prints only the clauses at least one still tags. A clause nothing claimed is the coverage report's subject; printing it here would make this look like one. `demo-comment` and `timeline.md` both carry the unclaimed list.
- Nothing wraps a long caption or caps the number of stills. A 40-shot take produces a 40-picture block. No take in this repository is near that, so the cap would be a guess.
- `demo-shots` has no `--out` — it writes to stdout and the caller redirects. Same shape as `demo-grade pr-block`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtAHHPE1efhQpMykGpYgPG
