### PR TITLE
Refuse the timing arms on a stepping host before recording, not after

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -339,6 +339,43 @@ and tightening the bars was not worth a ticket nobody would pick up. The
 measurement survives in its issue body. `--allow-concurrent` overrides the
 refusal; a run that needed it cannot be read as a verdict.
 
+### The clock probe, before anything is recorded
+
+A host whose wall clock steps backwards takes that time out of `demo.mp4` and
+leaves the beat log where it was, so every timing bar in `tests/smoke` reads a
+skew that is the host's rather than the recorder's. Until
+[#370](https://github.com/rogvid/skills/issues/370) that was discovered by
+recording for three minutes and failing a bar: four `--terminal-only` runs in
+one session, ~32 minutes, none green, every failure the step.
+
+So `--web-only`, `--terminal-only` and a whole run now watch the clock for
+**40 s** first, and refuse before recording if it steps. The refusal prints the
+step, states a cadence only if it saw two of them, and names the arms that are
+still safe on that host. Measured on a stepping box: **38.7 s to a refusal**
+against 123 s to a confusing bar failure.
+
+Three things about the window, because each of them is a trade rather than a
+default:
+
+- **40 s is set by the cadence**, not by taste. A probe shorter than the
+  interval between steps cannot promise to see one, and the widest interval
+  this repo has measured is 32.3 s. `ClockProbe` in `tests/unit` holds those
+  measurements and fails if the window drops below the widest.
+- **`--segments-only` and `--cheap` are not probed.** `--segments-only` reaches
+  a timing phase but costs 29 s, so a 40 s probe in front of it spends more
+  than it can save; `tests/smoke-inject` re-records that arm on a step instead
+  ([#258](https://github.com/rogvid/skills/issues/258)). `--cheap` is what CI
+  runs on every push, and it pays nothing.
+- **`tests/smoke-inject` passes `--allow-stepping-clock` on every arm**, for
+  that same reason: it already handles a stepping host after the fact, and
+  paying 40 s per entry to be told what the re-record fixes would be the cost
+  the per-arm flags exist to avoid. The arm costs in the table below are
+  therefore unchanged.
+
+`--allow-stepping-clock` overrides the refusal by hand too, with the same
+caveat `--allow-concurrent` carries: a run that needed it cannot be read as a
+verdict.
+
 Prerequisites: `uv`, `ffmpeg`/`ffprobe` on PATH, and Chromium for Playwright
 (`uv run --with playwright playwright install chromium`; add `--with-deps` on a
 fresh Linux box). The script's PEP 723 header pins **Playwright ≥ 1.49**:

--- a/tests/README.md
+++ b/tests/README.md
@@ -116,7 +116,7 @@ as PNGs named by check and instant, for a pull request's before/after.
 What stays ungraded here, deliberately: spotlight transition shape and
 caption timing are time-measuring and belong to smoke's lock; whether a
 viewer *recognises* the card as a card is graded nowhere (Known gaps); and
-`frames.md` ordering is manifest arithmetic, owned by
+`frames.md` ordering is manifest arithmetic, and is tracked in
 [#300](https://github.com/rogvid/skills/issues/300).
 The contract: a change to anything that draws a frame - the chrome in
 `skills/demo-video/helpers/demo_recording/` - runs this loop before its PR
@@ -3015,15 +3015,23 @@ knows is missing is worse than one that is openly absent.
   after Chromium's clock goes backwards, which is not something this repo can
   measure from outside. [#224](https://github.com/rogvid/skills/issues/224) is
   closed as not reproducing — its −900 ms was an artifact of the sampler #250
-  fixed — and the live defect at that magnitude is tracked in
-  [#255](https://github.com/rogvid/skills/issues/255), with the opposite sign.
+  fixed. The defect at that magnitude with the opposite sign was #255, and
+  **#255 is closed**: all four of its slices shipped (#256 the hole, #257 the
+  message, #258 the baseline, #259 folded into #256), and its second mechanism
+  — **a partial loss**, a capture keeping only a fraction of the step — was
+  **retracted**.
+  There is no such fraction; the muxer loses the whole step or none of it, at
+  97.0–100.2 % over 10 steps in 9 takes. The three figures that looked like
+  partial losses were in-hole instants read as though they were shifts.
 
   **The bars were not widened for it.** `MAX_SKEW_DRIFT_S` at 250 ms is the
   sharp claim this whole correction exists to make usable, and a bar wide
   enough for -800 ms of it grades nothing at all. So a `--terminal-only` run on
   a box whose wall clock steps inside the take is still red about half the
   time, and it is red about something true and now says which part of it is
-  the host and which is not.
+  the host and which is not. Since
+  [#370](https://github.com/rogvid/skills/issues/370) it does not get that far:
+  the arm is refused before it records, in 40 s rather than 186 s.
 
 - **~~`stitch()` does not merge `capture_clock`.~~ Fixed**
   ([#225](https://github.com/rogvid/skills/issues/225)). The merged envelope

--- a/tests/README.md
+++ b/tests/README.md
@@ -2323,7 +2323,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **16 of `tests/smoke`'s 50 check functions have no entry**, and the harness
+- **17 of `tests/smoke`'s 51 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -2342,6 +2342,7 @@ paragraph whose job is to say what this manifest does not cover.
 
   | ungraded check function | what carries its browser-free claims |
   |---|---|
+  | `check_clock_before_recording` | `ClockProbe` in `tests/unit` — the whole of it, on a scripted step list: the refusal's wording, the cadence it will and will not state, and the two sweeps that derive the safe-arms list from `run_phases` (#370). Genuinely ungraded *as a check that runs*: it refuses before a take exists, so no arm of this manifest can reach it, and a host that does not step its clock never produces the refusal at all |
   | `check_take` | `ContentRect` — the rect the picture half is scored over, exactly, on all four numbers (#135/#195). The artifact half — the files exist, are this run's, and are not repeats of one another — is genuinely ungraded |
   | `check_content_healthy` | `ContentRect`, same six tests: the trim reaches the caption bar on both media, does not eat the app, and never comes back zero-sized |
   | `check_caption` | genuinely ungraded as a *picture*. `CaptionTruth` grades which caption a beat is stamped with across a navigation (#134), never that the bar was drawn |

--- a/tests/lint
+++ b/tests/lint
@@ -1202,17 +1202,25 @@ def issue_guard() -> int:
     number).
     """
     bad = 0
-    states = {26: "CLOSED", 255: "OPEN"}
+    # **Numbers this repository will never carry, and that is the fix rather
+    # than a shortcut.** These strings are examples of prose, not prose — but
+    # `check_issue_refs` sweeps every tracked `.py`, this file included, so a
+    # real number here is read as a live pointer. The table used #26 and #255,
+    # and it passed only while #255 stayed open: closing it made the sweep
+    # report this fixture as two stale pointers, on a push that had nothing to
+    # do with either. `states` is injected, so what the cases grade is
+    # unchanged; what changes is that the tracker can no longer redden them.
+    states = {9000: "CLOSED", 9002: "OPEN"}
     cases = (
-        ("a closed issue presented as pending", "Tracked in [#26](x).", 1),
-        ("an open issue presented as pending", "Tracked in [#255](x).", 0),
-        ("a closed issue cited as a measurement", "Measured in #26.", 0),
-        ("a closed issue beside an open one", "Tracked in #26 and #255.", 0),
+        ("a closed issue presented as pending", "Tracked in [#9000](x).", 1),
+        ("an open issue presented as pending", "Tracked in [#9002](x).", 0),
+        ("a closed issue cited as a measurement", "Measured in #9000.", 0),
+        ("a closed issue beside an open one", "Tracked in #9000 and #9002.", 0),
         ("a number the tracker does not carry", "Tracked in PR #9001.", 0),
-        ("a closed issue named only by URL", "Until then, see /issues/26.", 1),
+        ("a closed issue named only by URL", "Until then, see /issues/9000.", 1),
         (
             "pending prose two sentences from the number",
-            "It is tracked in the usual place. Nobody reads #26.",
+            "It is tracked in the usual place. Nobody reads #9000.",
             0,
         ),
     )

--- a/tests/smoke
+++ b/tests/smoke
@@ -918,6 +918,75 @@ HOST_CLOCK_MIN_STEP_S = 0.005
 # nothing about it, which is precisely what the catalogue says to expect.
 HOST_CLOCK_MAX_GAP_S = 0.25
 
+# -- the clock probe (issue #370) ------------------------------------------
+#
+# **How long a run watches the wall clock before it records anything.** A host
+# that steps its clock backwards takes that time out of demo.mp4 and leaves the
+# beat log where it was, so every timing bar in this file reads a skew that is
+# the host's rather than the recorder's. Today that is discovered by recording
+# for three minutes and failing a bar; issue #370 measured four `--terminal-only`
+# runs in one session, ~32 minutes, none green, every failure the step.
+#
+# **The window is set by the cadence, not by taste.** A probe shorter than the
+# interval between steps cannot promise to see one, and the interval is the
+# thing being detected — so the window is the longest cadence measured on a
+# stepping box plus a margin:
+#
+#   | measured                    | step            | cadence  |
+#   |-----------------------------|-----------------|----------|
+#   | issue #370, 2026-08-23      | -1.29 s         | ~25 s    |
+#   | issue #255, 44 steps, 1407 s| -1.460…-1.509 s | ~32.2 s  |
+#   | this box, 2026-08-23, 60 s  | -1.498, -1.479 s| 32.3 s   |
+#
+# 40 s covers all three. It does **not** buy a cadence figure: at 32 s the
+# window usually holds exactly one step, and one step has no interval. That is
+# why `clock_probe_report` states the cadence only when it saw two — a mean of
+# one gap is a number a reader would act on and this probe cannot earn it.
+#
+# There is no early exit on the first step. It would save ~20 s on a host that
+# is about to be refused anyway, and it would cost the second step, which is
+# the only thing that turns "it stepped" into "it steps".
+CLOCK_PROBE_S = 40.0
+
+# How often the probe checks whether its window is up. Nothing to do with the
+# sampling rate — `HostClock` runs its own thread at `INTERVAL_S` — this is
+# only how long a finished probe may sit there before it returns.
+CLOCK_PROBE_POLL_S = 0.1
+
+# Which arms this probe stands in front of, and the whole of the argument for
+# the list being this short.
+#
+# `run_web`, `run_terminal` and `run_segments` are the three phases that hand a
+# beat log and a video to `check_timeline`, so they are the three that a step
+# can redden. `--segments-only` reaches only the third and costs 29 s: a 40 s
+# probe in front of a 29 s arm spends more than it can save, and
+# `tests/smoke-inject` already re-records that arm when `capture_clock.steps`
+# is non-empty (issue #258), which is the same protection bought after the fact
+# instead of before it. So the probe guards the two expensive timing arms and a
+# full run, and `--cheap` — which CI runs on every push, and which reaches
+# `run_segments` — pays nothing.
+CLOCK_PROBE_ARMS = ("--web-only", "--terminal-only")
+
+# The arms a stepping host may still be certified on: every arm that never
+# reaches `check_timeline`. `--segments-only` is **not** here — it reaches
+# `run_segments`, and the reason it is out of `CLOCK_PROBE_ARMS` is cost, not
+# safety.
+CLOCK_SAFE_ARMS = (
+    "--determinism-only",
+    "--evidence-only",
+    "--narration-only",
+    "--failure-only",
+    "--polish-only",
+    "--content-only",
+    "--overlay-only",
+    "--coverage-only",
+    "--strict-only",
+    "--wrapper-only",
+    "--stills-only",
+    "--issues-only",
+    "--lock-only",
+)
+
 # The rate the window is sampled at (the recorders encode at 25 fps, so this is
 # every frame and the measurement quantises to 40 ms), and how far past the
 # beat it runs.
@@ -2393,6 +2462,124 @@ def watch_wall_clock() -> Iterator[HostClock]:
     finally:
         clock._stop.set()
         clock._thread.join(timeout=1.0)
+
+
+def probe_wall_clock(window_s: float = CLOCK_PROBE_S) -> HostClock:
+    """Watch the host's wall clock for `window_s`, recording nothing else.
+
+    **Deliberately the same `HostClock` the takes are graded with**, and that
+    is not the catalogue's "check that shares the bug's blind spot". This
+    probe's question is not *does the host step* in the abstract — it is *will
+    the sampler that grades the next take see a step*, and the only instrument
+    that can answer that is the sampler itself. A second implementation here
+    could disagree with the one that matters, and the disagreement would be
+    the probe's, not the host's.
+
+    The window is wall-clock time spent doing nothing, which is the cost of
+    the whole feature. See `CLOCK_PROBE_S`.
+    """
+    with watch_wall_clock() as clock:
+        deadline = time.monotonic() + window_s
+        while time.monotonic() < deadline:
+            time.sleep(CLOCK_PROBE_POLL_S)
+    return clock
+
+
+def clock_probe_report(
+    steps: list[tuple[float, float]],
+    window_s: float,
+    refused: tuple[str, ...],
+    safe: tuple[str, ...],
+) -> list[str]:
+    """What the probe saw, as lines. Empty when the clock held still.
+
+    Pure, and separate from `probe_wall_clock` for the usual reason: the
+    interesting behaviour is what a reader is told, and a test that had to
+    wait forty seconds for a real host to misbehave would grade the wait.
+
+    `steps` is `HostClock.steps` — (seconds from the probe's start, delta).
+    """
+    if not steps:
+        return []
+    sizes = ", ".join(f"{delta * 1000:+.0f} ms" for _, delta in steps)
+    at = ", ".join(f"{t:.1f} s" for t, _ in steps)
+    lines = [
+        f"the host's wall clock stepped {len(steps)} "
+        f"{'time' if len(steps) == 1 else 'times'} in {window_s:.0f} s of "
+        f"watching: {sizes}, at {at} into the probe.",
+    ]
+    if len(steps) >= 2:
+        gaps = [b - a for (a, _), (b, _) in zip(steps, steps[1:], strict=False)]
+        mean = sum(gaps) / len(gaps)
+        lines.append(
+            f"Cadence: one step every {mean:.1f} s "
+            f"({', '.join(f'{g:.1f} s' for g in gaps)} between them)."
+        )
+    else:
+        # One step is not a cadence, and saying so is the point: a reader
+        # handed "every 40 s" from a single observation would size a timeout
+        # against a number this probe never measured.
+        lines.append(
+            f"One step is not a cadence — this {window_s:.0f} s window saw "
+            f"one, so how often it happens is not measured here."
+        )
+    lines += [
+        "",
+        "A backward step takes that much wall time out of demo.mp4 and leaves "
+        "the beat log where it was, so every timing bar in "
+        f"{' and '.join(refused)} reads a skew that is this host's and not the "
+        "recorder's. Refusing before recording rather than after (issue #370).",
+        "",
+        f"Safe to run on this host anyway: {' '.join(safe)}. None of them "
+        "grades a beat log against a video.",
+        "",
+        "To record regardless — a run that needs this cannot be read as a "
+        "verdict — pass --allow-stepping-clock.",
+    ]
+    return lines
+
+
+def check_clock_before_recording(
+    only: str | None, allow: bool, window_s: float = CLOCK_PROBE_S
+) -> list[str]:
+    """Refuse the timing arms on a host whose wall clock steps (issue #370).
+
+    Returns the refusal as failure lines, or `[]` to carry on. A full run
+    (`only is None`) is probed too: it reaches all three timing phases.
+    """
+    if allow or not (only is None or only in CLOCK_PROBE_ARMS):
+        return []
+    if window_s <= 0:
+        return []
+    refused = CLOCK_PROBE_ARMS if only is None else (only,)
+    print(
+        f"smoke: watching the wall clock for {window_s:.0f}s before recording "
+        f"(issue #370)...",
+        flush=True,
+    )
+    clock = probe_wall_clock(window_s)
+    if not clock.covered:
+        # The probe's own sampler stalled. Saying "steady" here would be the
+        # catalogue's environment-agreeing assertion: a watcher that was away
+        # cannot report what it did not watch.
+        print(
+            f"smoke: the clock probe's sampler left a {clock.max_gap * 1000:.0f} ms "
+            f"gap, over its own {HOST_CLOCK_MAX_GAP_S * 1000:.0f} ms limit — it "
+            f"cannot say whether the clock held still, so it says nothing and "
+            f"the run goes ahead.",
+            flush=True,
+        )
+        return []
+    lines = clock_probe_report(clock.steps, window_s, refused, CLOCK_SAFE_ARMS)
+    if not lines:
+        print(
+            f"smoke: wall clock steady over {window_s:.0f}s "
+            f"({clock.samples} samples, widest gap "
+            f"{clock.max_gap * 1000:.0f} ms) — timing arms may run.",
+            flush=True,
+        )
+        return []
+    return ["\n    ".join(lines)]
 
 
 def _check_clock_coverage(
@@ -12981,6 +13168,15 @@ def main() -> int:
         "needs this flag cannot be read as a verdict.",
     )
     parser.add_argument(
+        "--allow-stepping-clock",
+        action="store_true",
+        help="record the timing arms even when the pre-run probe finds the "
+        "host's wall clock stepping (issue #370). Same shape as "
+        "--allow-concurrent and the same caveat: a step comes out of "
+        "demo.mp4 and not out of the beat log, so a run that needs this "
+        "flag cannot be read as a verdict.",
+    )
+    parser.add_argument(
         "--out-dir",
         type=Path,
         help="where recordings land (default: a fresh temp dir). The web/ and "
@@ -13035,6 +13231,24 @@ def main() -> int:
         return 1
 
     scrub_env()
+
+    # Before the machine lock, and that ordering is deliberate: the probe
+    # records nothing and touches no shared state, so holding the lock for
+    # forty seconds of watching a clock would block a suite that could have
+    # run. A refusal here also never reaches `open_output`, so it leaves no
+    # directory to send anybody to — the same shape as the lock's own refusal
+    # (issue #105), and `main()` already words that case.
+    refusal = check_clock_before_recording(only, args.allow_stepping_clock)
+    if refusal:
+        print("\nsmoke: REFUSED", file=sys.stderr)
+        for line in refusal:
+            print(f"  - {line}", file=sys.stderr)
+        print(
+            "\nsmoke: nothing was recorded — this run never started, so "
+            "there is no output directory to look in.",
+            file=sys.stderr,
+        )
+        return 1
 
     failures: list[str] = []
     out_root: Path | None = None

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -1631,7 +1631,19 @@ def run_arm(root: Path, arm: str, out_dir: Path) -> tuple[int, str, str]:
     """One arm of the staged `tests/smoke`, through its own shebang."""
     try:
         done = subprocess.run(
-            [str(root / "tests" / "smoke"), arm, "--out-dir", str(out_dir)],
+            [
+                str(root / "tests" / "smoke"),
+                arm,
+                "--out-dir",
+                str(out_dir),
+                # The pre-run clock probe (issue #370) refuses the timing arms
+                # on a stepping host. This driver must not be refused: it
+                # already handles that host, differently and after the fact —
+                # `rerecord_reason` throws away a take whose clock stepped and
+                # records again (issue #258). Both together would mean paying
+                # 40 s per entry to be told what the re-record already fixes.
+                "--allow-stepping-clock",
+            ],
             capture_output=True,
             text=True,
             timeout=ARM_TIMEOUT_S,

--- a/tests/unit
+++ b/tests/unit
@@ -10259,6 +10259,223 @@ class BaselineRerecord(unittest.TestCase):
         self.assertIn("genuinely flaky", block)
 
 
+class ClockProbe(unittest.TestCase):
+    """The probe that refuses the timing arms before recording (issue #370).
+
+    The loop this replaces cost eight minutes to say what forty seconds says:
+    four `--terminal-only` runs in one session, ~32 minutes, none green, every
+    failure the host's wall clock stepping. `GOAL.md` is explicit that a slow
+    loop gets fixed rather than routed around.
+
+    **Two claims are graded here and they are different in kind.** That the
+    message is honest about what one observation can support is a claim about
+    words, and substrings are enough for it. That the arms the probe calls
+    *safe* are actually safe is a claim about the suite's own structure, and a
+    hand-written list would go stale the first time somebody adds a phase —
+    so `test_no_safe_arm_grades_a_beat_log_against_a_video` reads
+    `run_phases` and answers it from the code.
+    """
+
+    # Every cadence between wall-clock steps this repo has measured on a
+    # stepping box. The probe's window has to cover the widest of them or it
+    # cannot promise to see a step at all — which is the one thing it is for.
+    MEASURED_CADENCES_S = (
+        25.0,  # issue #370, 2026-08-23
+        32.2,  # issue #255, 44 steps over 1407 s
+        32.3,  # this box, 2026-08-23, two steps in 60 s
+    )
+
+    def setUp(self):
+        self.smoke = _smoke_module()
+        self.report = self.smoke.clock_probe_report
+
+    def said(self, *steps, window_s=40.0, refused=("--web-only",)):
+        return "\n".join(
+            self.report(list(steps), window_s, refused, self.smoke.CLOCK_SAFE_ARMS)
+        )
+
+    def test_a_steady_clock_says_nothing_at_all(self):
+        # The empty list is the interface: `check_clock_before_recording`
+        # reads "no lines" as "carry on", so a report that returned a cheerful
+        # sentence here would refuse every run on every host.
+        self.assertEqual(
+            self.report([], 40.0, ("--web-only",), self.smoke.CLOCK_SAFE_ARMS),
+            [],
+            "a probe that saw no step must produce no refusal lines",
+        )
+
+    def test_a_step_names_the_arm_it_refuses_and_what_the_step_was(self):
+        said = self.said((21.7, -1.485))
+        self.assertIn("-1485 ms", said)
+        self.assertIn("21.7 s", said)
+        self.assertIn("--web-only", said)
+
+    def test_two_steps_state_the_cadence_they_measured(self):
+        said = self.said((22.5, -1.498), (54.8, -1.479), window_s=60.0)
+        self.assertIn("one step every 32.3 s", said)
+
+    def test_one_step_refuses_to_state_a_cadence(self):
+        # The whole of the honesty here. A reader handed "every 40 s" from a
+        # single observation would size a timeout against a number nobody
+        # measured — this repo's *ungraded constant*, arrived at from the
+        # other end.
+        said = self.said((21.7, -1.485))
+        self.assertIn("not a cadence", said)
+        self.assertNotIn("every", said.split("not a cadence")[0])
+        self.assertNotIn("Cadence:", said)
+
+    def test_the_window_covers_every_cadence_this_repo_has_measured(self):
+        widest = max(self.MEASURED_CADENCES_S)
+        self.assertGreaterEqual(
+            self.smoke.CLOCK_PROBE_S,
+            widest,
+            f"the probe watches for {self.smoke.CLOCK_PROBE_S} s against a "
+            f"measured cadence of {widest} s — a window shorter than the "
+            f"interval between steps cannot promise to see one, and seeing "
+            f"one is the whole of what this probe does",
+        )
+
+    def test_the_refusal_says_how_to_override_it(self):
+        self.assertIn("--allow-stepping-clock", self.said((21.7, -1.485)))
+
+    # -- the structural claim ------------------------------------------------
+
+    def phases_by_arm(self) -> dict:
+        """arm -> the `run_*` phases it reaches, read out of `run_phases`."""
+        tree = ast.parse(SMOKE.read_text())
+        body = next(
+            n
+            for n in ast.walk(tree)
+            if isinstance(n, ast.FunctionDef) and n.name == "run_phases"
+        )
+        out: dict[str, set[str]] = {}
+        for node in body.body:
+            if not isinstance(node, ast.If):
+                continue
+            call = node.test
+            if not (
+                isinstance(call, ast.Call) and getattr(call.func, "id", "") == "selects"
+            ):
+                continue
+            arms = [a.value for a in call.args[1].elts]
+            phases = {
+                n.func.id
+                for n in ast.walk(node)
+                if isinstance(n, ast.Call)
+                and isinstance(n.func, ast.Name)
+                and n.func.id.startswith(("run_", "check_"))
+            }
+            for arm in arms:
+                out.setdefault(arm, set()).update(phases)
+            # `--cheap` names itself in no tuple — `selects()` derives it from
+            # the arms that do (`EXPENSIVE_ARMS`), and CI runs it on every
+            # push, so leaving it out would hide the one arm whose exposure
+            # matters most.
+            if self.smoke.selects("--cheap", tuple(arms)):
+                out.setdefault("--cheap", set()).update(phases)
+        return out
+
+    def timing_phases(self) -> set:
+        """The `run_*` phases whose grading reads a beat log against a video."""
+        tree = ast.parse(SMOKE.read_text())
+        out = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef) or not node.name.startswith(
+                "run_"
+            ):
+                continue
+            calls = {
+                n.func.id
+                for n in ast.walk(node)
+                if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            }
+            if "check_timeline" in calls:
+                out.add(node.name)
+        return out
+
+    def test_run_phases_is_still_readable_by_this_class(self):
+        # The control on the two sweeps below. Both answer "no problem found"
+        # when the parse comes back empty, so a `run_phases` this parser
+        # cannot read would make them pass while grading nothing — the
+        # catalogue's vacuous sweep, exactly.
+        by_arm = self.phases_by_arm()
+        self.assertGreaterEqual(len(by_arm), 10, by_arm)
+        timing = self.timing_phases()
+        self.assertEqual(
+            timing,
+            {"run_web", "run_terminal", "run_segments"},
+            "the phases that hand a beat log and a video to check_timeline "
+            "have changed; CLOCK_PROBE_ARMS and CLOCK_SAFE_ARMS are derived "
+            "from this set and both need re-deciding",
+        )
+
+    def test_no_safe_arm_grades_a_beat_log_against_a_video(self):
+        # The claim the refusal makes to a reader who has just been stopped:
+        # "safe to run on this host anyway". If any arm on that list reaches a
+        # timing phase, the message sends somebody at the failure it just
+        # saved them from.
+        by_arm, timing = self.phases_by_arm(), self.timing_phases()
+        for arm in self.smoke.CLOCK_SAFE_ARMS:
+            self.assertFalse(
+                by_arm.get(arm, set()) & timing,
+                f"{arm} is offered as safe on a stepping host but reaches "
+                f"{sorted(by_arm.get(arm, set()) & timing)}, which grades a "
+                f"beat log against a video",
+            )
+
+    def test_every_timing_arm_is_probed_or_excused_by_name(self):
+        # The other direction, and the one that catches a *new* timing arm.
+        # `--segments-only` is excused on cost, not on safety — 29 s of arm
+        # behind a 40 s probe — and tests/smoke-inject re-records it on a step
+        # instead (issue #258). Anything else appearing here is a timing arm
+        # nobody decided about.
+        by_arm, timing = self.phases_by_arm(), self.timing_phases()
+        exposed = {arm for arm, phases in by_arm.items() if phases & timing}
+        self.assertEqual(
+            exposed - set(self.smoke.CLOCK_PROBE_ARMS),
+            {"--segments-only", "--cheap"},
+            "an arm reaches a timing phase without the probe in front of it "
+            "and without being one of the two excused by name",
+        )
+
+    # -- what the probe stands in front of, and what it does not -------------
+
+    def gate(self, only, allow=False, window_s=40.0):
+        return self.smoke.check_clock_before_recording(only, allow, window_s)
+
+    def test_a_cheap_arm_is_not_made_to_wait(self):
+        # The cost claim, measured rather than asserted: a 40 s window would
+        # take 40 s. `--stills-only` records in 2.3 s and grades no timing, so
+        # a probe in front of it would be the largest cost in the arm.
+        started = time.monotonic()
+        self.assertEqual(self.gate("--stills-only"), [])
+        self.assertLess(time.monotonic() - started, 1.0)
+
+    def test_allow_stepping_clock_skips_the_wait_entirely(self):
+        started = time.monotonic()
+        self.assertEqual(self.gate("--web-only", allow=True), [])
+        self.assertLess(time.monotonic() - started, 1.0)
+
+    def test_a_full_run_is_probed_and_refuses_for_both_arms(self):
+        # `only is None` reaches every timing phase, so a full run has to be
+        # probed even though it names no arm.
+        said = "\n".join(
+            self.report(
+                [(21.7, -1.485)],
+                40.0,
+                self.smoke.CLOCK_PROBE_ARMS,
+                self.smoke.CLOCK_SAFE_ARMS,
+            )
+        )
+        self.assertIn("--web-only", said)
+        self.assertIn("--terminal-only", said)
+        # And the gate must actually watch on a full run rather than fall
+        # through the arm check.
+        started = time.monotonic()
+        self.gate(None, window_s=0.3)
+        self.assertGreater(time.monotonic() - started, 0.2)
+
+
 class LogEarlyCause(unittest.TestCase):
     """Which end `tests/smoke` blames for a beat ahead of its frame (#257).
 
@@ -12265,6 +12482,82 @@ INJECTIONS = [
             "FrameClockCorrection.test_two_holes_that_overlap_clamp_to_the_first_of_them",
             "FrameClockCorrection.test_a_hole_the_next_beat_outlives_leaves_that_beat_alone",
         ],
+    ),
+    # -- the clock probe (issue #370) ----------------------------------------
+    (
+        # A window shorter than the interval between steps cannot promise to
+        # see one, and seeing one is the whole of what the probe does. 20 s
+        # against a 32.3 s cadence catches roughly six runs in ten, and the
+        # four it misses record for three minutes and fail a timing bar —
+        # exactly the loop this replaces, now with 20 s added to it.
+        "the clock probe watches for less time than the cadence it looks for",
+        "tests/smoke",
+        "CLOCK_PROBE_S = 40.0",
+        "CLOCK_PROBE_S = 20.0",
+        ["ClockProbe.test_the_window_covers_every_cadence_this_repo_has_measured"],
+    ),
+    (
+        # One observation, stated as a rate. This is the *ungraded constant*
+        # arrived at from the reader's end: nothing downstream checks the
+        # figure, and somebody sizing a timeout against "every 40 s" is
+        # sizing it against a number this probe never measured.
+        "one step is reported as a cadence",
+        "tests/smoke",
+        '            f"One step is not a cadence — this {window_s:.0f} s window saw "\n'
+        '            f"one, so how often it happens is not measured here."',
+        '            f"Cadence: one step every {window_s:.1f} s."',
+        ["ClockProbe.test_one_step_refuses_to_state_a_cadence"],
+    ),
+    (
+        # The refusal's own advice, turned into the failure it just saved
+        # somebody from. `--segments-only` reaches `run_segments`, which hands
+        # a beat log and a video to `check_timeline`; offering it as safe on a
+        # stepping host sends the reader straight back into the bar.
+        "the refusal offers a timing arm as safe to run anyway",
+        "tests/smoke",
+        '    "--issues-only",\n    "--lock-only",\n)',
+        '    "--issues-only",\n    "--lock-only",\n    "--segments-only",\n)',
+        ["ClockProbe.test_no_safe_arm_grades_a_beat_log_against_a_video"],
+    ),
+    (
+        # A new timing arm, or an existing one quietly dropped off the probe's
+        # list. Either way an arm that grades a beat log against a video runs
+        # unprotected, and nothing else in this suite would notice.
+        "a timing arm loses the probe standing in front of it",
+        "tests/smoke",
+        'CLOCK_PROBE_ARMS = ("--web-only", "--terminal-only")',
+        'CLOCK_PROBE_ARMS = ("--web-only",)',
+        ["ClockProbe.test_every_timing_arm_is_probed_or_excused_by_name"],
+    ),
+    (
+        # `--allow-stepping-clock` stops being honoured. The flag is the
+        # documented way to record anyway, and a run that passes it and is
+        # refused regardless has no way through at all.
+        "the override flag stops letting a run through",
+        "tests/smoke",
+        "    if allow or not (only is None or only in CLOCK_PROBE_ARMS):",
+        "    if not (only is None or only in CLOCK_PROBE_ARMS):",
+        ["ClockProbe.test_allow_stepping_clock_skips_the_wait_entirely"],
+    ),
+    (
+        # A full run stops being probed. It names no arm, so an arm-membership
+        # test alone passes it through — and it reaches all three timing
+        # phases, which makes it the most expensive thing the probe protects.
+        "a whole run is no longer probed because it names no arm",
+        "tests/smoke",
+        "    if allow or not (only is None or only in CLOCK_PROBE_ARMS):",
+        "    if allow or only not in CLOCK_PROBE_ARMS:",
+        ["ClockProbe.test_a_full_run_is_probed_and_refuses_for_both_arms"],
+    ),
+    (
+        # The steady path made to speak. `check_clock_before_recording` reads
+        # "no lines" as "carry on", so a report that says something cheerful
+        # about a clock that held still refuses every run on every host.
+        "a steady clock produces refusal lines",
+        "tests/smoke",
+        "    if not steps:\n        return []",
+        "    if False:\n        return []",
+        ["ClockProbe.test_a_steady_clock_says_nothing_at_all"],
     ),
     (
         # ...and the other side of the same key, which `narration.py` has

--- a/tests/unit
+++ b/tests/unit
@@ -10341,55 +10341,38 @@ class ClockProbe(unittest.TestCase):
     # -- the structural claim ------------------------------------------------
 
     def phases_by_arm(self) -> dict:
-        """arm -> the `run_*` phases it reaches, read out of `run_phases`."""
-        tree = ast.parse(SMOKE.read_text())
-        body = next(
-            n
-            for n in ast.walk(tree)
-            if isinstance(n, ast.FunctionDef) and n.name == "run_phases"
-        )
+        """arm -> the `run_*` phases it reaches, read out of `run_phases`.
+
+        Through `_smoke_guards`, which `CheapArm` already uses. A second
+        walker here would be a second answer to the same question, and the
+        first thing it did was collide with `CheapArm`'s own injection.
+        """
         out: dict[str, set[str]] = {}
-        for node in body.body:
-            if not isinstance(node, ast.If):
-                continue
-            call = node.test
-            if not (
-                isinstance(call, ast.Call) and getattr(call.func, "id", "") == "selects"
-            ):
-                continue
-            arms = [a.value for a in call.args[1].elts]
-            phases = {
-                n.func.id
-                for n in ast.walk(node)
-                if isinstance(n, ast.Call)
-                and isinstance(n.func, ast.Name)
-                and n.func.id.startswith(("run_", "check_"))
-            }
+        for arms, phase in _smoke_guards()[0]:
             for arm in arms:
-                out.setdefault(arm, set()).update(phases)
-            # `--cheap` names itself in no tuple — `selects()` derives it from
-            # the arms that do (`EXPENSIVE_ARMS`), and CI runs it on every
-            # push, so leaving it out would hide the one arm whose exposure
-            # matters most.
-            if self.smoke.selects("--cheap", tuple(arms)):
-                out.setdefault("--cheap", set()).update(phases)
+                out.setdefault(arm, set()).add(phase)
+            # `--cheap` names itself in no guard — `selects()` derives it from
+            # the arms that do — and CI runs it on every push, so leaving it
+            # out would hide the one arm whose exposure matters most.
+            if self.smoke.selects("--cheap", arms):
+                out.setdefault("--cheap", set()).add(phase)
         return out
 
     def timing_phases(self) -> set:
         """The `run_*` phases whose grading reads a beat log against a video."""
-        tree = ast.parse(SMOKE.read_text())
+        tree = ast.parse(SMOKE.read_text(encoding="utf-8"))
         out = set()
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.FunctionDef) or not node.name.startswith(
-                "run_"
-            ):
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef):
                 continue
-            calls = {
-                n.func.id
-                for n in ast.walk(node)
-                if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)
+            if not node.name.startswith("run_"):
+                continue
+            named = {
+                inner.func.id
+                for inner in ast.walk(node)
+                if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name)
             }
-            if "check_timeline" in calls:
+            if "check_timeline" in named:
                 out.add(node.name)
         return out
 


### PR DESCRIPTION
Closes #370.

`tests/smoke` used to find out that the host's wall clock steps the same way a
reviewer does: by recording for three minutes and failing a timing bar. The
issue measured four `--terminal-only` runs in one session, ~32 minutes, none
green, every failure the step.

Now `--web-only`, `--terminal-only` and a whole run watch the clock for 40 s
first and refuse before recording. **Measured on this box: 38.7 s to a
refusal, against 123 s to a confusing bar failure.**

```
$ tests/smoke --web-only
smoke: watching the wall clock for 40s before recording (issue #370)...

smoke: REFUSED
  - the host's wall clock stepped 1 time in 40 s of watching: -1485 ms, at 21.7 s into the probe.
    One step is not a cadence — this 40 s window saw one, so how often it happens is not measured here.

    A backward step takes that much wall time out of demo.mp4 and leaves the beat log where it was,
    so every timing bar in --web-only reads a skew that is this host's and not the recorder's.
    Refusing before recording rather than after (issue #370).

    Safe to run on this host anyway: --determinism-only --evidence-only --narration-only
    --failure-only --polish-only --content-only --overlay-only --coverage-only --strict-only
    --wrapper-only --stills-only --issues-only --lock-only. None of them grades a beat log
    against a video.

    To record regardless — a run that needs this cannot be read as a verdict —
    pass --allow-stepping-clock.

smoke: nothing was recorded — this run never started, so there is no output directory to look in.

tests/smoke --web-only  38.750 total
```

## Where this misses the acceptance criterion, deliberately

The criterion asks for a probe that "on a stable host costs a few seconds".
**This one costs 40 s, and it has to.** A probe shorter than the interval
between steps cannot promise to see one, and seeing one is the whole of what it
does:

| measured | step | cadence |
|---|---|---|
| #370, 2026-08-23 | −1.29 s | ~25 s |
| #255, 44 steps over 1407 s | −1.460…−1.509 s | ~32.2 s |
| this box, 2026-08-23, 60 s | −1.498, −1.479 s | 32.3 s |

The criterion was written before the cadence was known to be 32 s — I flagged
that on the issue during triage rather than quietly shipping a 30 s window that
catches nine runs in ten. 40 s in front of a 123 s or 186 s arm is the trade;
it is stated in `tests/README.md` and `ClockProbe` fails if the window ever
drops below the widest measured cadence.

Two consequences of the same arithmetic:

- **`--segments-only` is not probed.** It reaches a timing phase but costs
  29 s, so a 40 s probe spends more than it can save. `tests/smoke-inject`
  already re-records that arm on a step (#258) — the same protection, bought
  after the fact.
- **`--cheap` pays nothing**, so CI on every push is unchanged.

`tests/smoke-inject` passes `--allow-stepping-clock` on every arm for the same
reason, so the arm-cost table in `tests/README.md` is still accurate.

## What the probe will not claim

It states a cadence **only when it saw two steps**. At a 32 s cadence a 40 s
window usually holds exactly one, and one observation is not a rate — a reader
handed "every 40 s" would size a timeout against a number nobody measured.
There is a test and an injection for that specific sentence.

It also says nothing at all when its own sampler stalled past
`HOST_CLOCK_MAX_GAP_S`: a watcher that was away cannot report the clock held
still. That is #247's lesson, and reporting "steady" there would be the
catalogue's environment-agreeing assertion.

**The probe reuses `HostClock`, the sampler the takes are graded with.** That
looks like the catalogue's "check that shares the bug's blind spot" and is not:
the question is not *does this host step* in the abstract, it is *will the
sampler that grades the next take see a step*, and only that sampler can answer
it. A second implementation could disagree, and the disagreement would be the
probe's.

## The safe-arms list is derived, not written down

The refusal tells you which arms to run instead. If that list were maintained by
hand it would be wrong the first time somebody adds a phase — and being wrong
sends the reader straight back into the failure the probe just saved them from.

`test_no_safe_arm_grades_a_beat_log_against_a_video` parses `run_phases`, maps
each arm (including `--cheap`, which names itself in no tuple) to the phases it
reaches, finds the phases that call `check_timeline`, and asserts the
intersection is empty. `test_every_timing_arm_is_probed_or_excused_by_name`
runs it the other way, so a **new** timing arm reddens unless somebody decides
about it. Both have a control —
`test_run_phases_is_still_readable_by_this_class` — because both answer "no
problem" on an empty parse, which is the catalogue's vacuous sweep exactly.

The claim was also spot-checked by running two of the arms the refusal
recommends, on this stepping box, in the same session as the refusal above —
both green, and neither paid the probe:

```
tests/smoke --wrapper-only   smoke: PASSED   44.4 s
tests/smoke --stills-only    smoke: PASSED    1.7 s
```

## Assertions, each seen red

Seven injections, all caught, each by the test that names it:

```
PASS  break: the clock probe watches for less time than the cadence it looks for
      FAIL: ClockProbe.test_the_window_covers_every_cadence_this_repo_has_measured
PASS  break: one step is reported as a cadence
      FAIL: ClockProbe.test_one_step_refuses_to_state_a_cadence
PASS  break: the refusal offers a timing arm as safe to run anyway
      FAIL: ClockProbe.test_no_safe_arm_grades_a_beat_log_against_a_video
PASS  break: a timing arm loses the probe standing in front of it
      FAIL: ClockProbe.test_every_timing_arm_is_probed_or_excused_by_name
PASS  break: the override flag stops letting a run through
      FAIL: ClockProbe.test_allow_stepping_clock_skips_the_wait_entirely
PASS  break: a whole run is no longer probed because it names no arm
      FAIL: ClockProbe.test_a_full_run_is_probed_and_refuses_for_both_arms
PASS  break: a steady clock produces refusal lines
      FAIL: ClockProbe.test_a_steady_clock_says_nothing_at_all
```

## Gates

- `tests/unit` — **591 tests**, 4.9 s; **363 injections**, 0 missed, 0 aborted
- `tests/ci-unit` — 171 tests
- `mise run check` — 7.4 s, green
- `tests/pixel` — not run: this change touches no rendered frame, only `tests/`

## Out of scope, per the issue

Correcting for the step (#255, now closed — all four slices shipped) and
changing any bar. No bar in this diff moved.

## One thing this change broke, and why it is in the same PR

Closing #255 (all four slices shipped) made `tests/lint --issues` fail on
**`tests/lint` itself**. Its self-test table used `#26` and `#255` as its
closed/open examples, and `check_issue_refs` sweeps every tracked `.py` — so
the fixture's example sentences were read as live pointers, and passed only
while #255 stayed open.

The fixture now uses numbers this repository will never carry. `states` is
injected, so the cases grade exactly what they did; what changes is that the
tracker can no longer redden them on a push that has nothing to do with either
issue.

It also flagged one **real** stale pointer: `tests/README.md` said a defect was
tracked in #255. That paragraph now records that the slices shipped and that
the partial-loss mechanism was retracted — written in the summary terms
`LogEarlyCause` deliberately permits, not the shipped wording it bans, which is
a thing I got wrong once on the way here and the assertion caught.
