### PR TITLE
Five ways the still link was plausible and wrong (#300)

### DIFF
--- a/.github/scripts/demo-comment
+++ b/.github/scripts/demo-comment
@@ -49,6 +49,7 @@ import argparse
 import json
 import os
 import re
+import sys
 from pathlib import Path
 from typing import NamedTuple
 from urllib.parse import quote
@@ -100,6 +101,22 @@ def _cell(text: str) -> str:
     out = (text or "").replace("\\", "\\\\").replace("|", "\\|")
     out = " ".join(out.split())  # a newline in a cell ends the row
     return out or "&nbsp;"
+
+
+def _label(text: str) -> str:
+    """`_cell`, plus the two brackets that would end a link's visible text.
+
+    Only for text that goes **inside `[...]`**, which is a narrower place than
+    a table cell and needs one more escape. A committed file named
+    `x](/o/other).png` renders as `[x](/o/other).png](href)` — a link whose
+    visible text and target disagree, and this is the one cell in the comment
+    a reviewer is invited to click (issue #300).
+
+    Not folded into `_cell`: captions are authored prose and already admit
+    markdown by design, so escaping brackets everywhere would turn a
+    storyboard's own link into literal text.
+    """
+    return _cell(text).replace("[", "\\[").replace("]", "\\]")
 
 
 def story_beats(beats: list[dict]) -> list[tuple[float, str]]:
@@ -208,6 +225,13 @@ class _Picture(NamedTuple):
 
     cell: str
     found: bool  # a still this take published, which the cell points at
+    # Why there is no picture, when there is none: one of "raised",
+    # "outside", "missing", "none" — or "" when `found`. The gap headline
+    # above the table is written per reason, because "no still was published"
+    # was **false** for the `outside` branch: that still exists and was
+    # published, it just is not inside the demo (issue #300, item 4). Absent
+    # on the old shape, so a caller reading only `cell`/`found` is unchanged.
+    reason: str = ""
 
 
 def _inside_demo(still: str) -> str | None:
@@ -260,12 +284,38 @@ def _picture(
     missing rather than linked as this take's. A still the manifest names and
     nothing published is the artifact-lies case: it is reported, never skipped
     and never linked.
+
+    **Which still, when a clause has several — the rule, written down because
+    the table is one picture per clause and the choice is invisible in it.**
+
+    1. **A beat marked `shows="unmet"` wins**, earliest first. The storyboard
+       is pointing at that frame as evidence the clause does *not* hold, and
+       that is the frame a reviewer must not be steered away from (#374).
+    2. **Otherwise the last published still** among the clause's claims.
+
+    Last, not first, and this is the item this rule exists for (issue #300).
+    A storyboard demonstrates a clause by building to it, so the first shot
+    that claims a clause is usually the **pre-state**: in this repository's own
+    `2026-08-11-criterion-card` take, `AC-1` linked `01-queue.png` — beat 4,
+    the queue before anything was typed — while `02-invoice.png` at beat 12 is
+    the frame that shows the clause satisfied. The link worked, resolved, and
+    showed the wrong moment, which is the failure a reviewer actually acts on.
+
+    **The limit, stated because "last" is a heuristic and not a proof.** A
+    clause shown mid-take and then navigated away from links its final frame,
+    which may no longer show it. Nothing here reads the pixels, so no rule
+    available at this layer can do better; `scripts/demo-shots` renders *every*
+    still a take published and is the answer when one picture is not enough.
     """
     if not rows:
-        return _Picture("—", False)
+        return _Picture("—", False, "none")
     named: list[str] = []
     outside: list[str] = []
     raised: list[str] = []
+    # (is this claim against the clause, path inside the demo) for each row
+    # whose still this take actually published. Collected rather than returned
+    # on, because the choice between them is a rule — see the docstring.
+    usable: list[tuple[bool, str]] = []
     for row in rows:
         # Before the existence check, and that order is the point: on a take
         # that died, a still of this name left behind by a *previous* recording
@@ -286,10 +336,16 @@ def _picture(
             continue
         if not (directory / rel).exists():
             continue
+        usable.append((row.get("shows") == "unmet", rel))
+    if usable:
+        # Rule 1 then rule 2, and `next` keeps the earliest unmet rather than
+        # the last: a storyboard that says a clause fails says it once, and if
+        # it says it twice the first is where the reviewer's attention goes.
+        rel = next((r for against, r in usable if against), usable[-1][1])
         href = _still_href(repo_url, sha, f"{demo}/{rel}")
         # The file name alone in the cell: the row already says which clause
         # and which demo, and the full path crowds a three-column table.
-        label = _cell(rel.rsplit("/", 1)[-1])
+        label = _label(rel.rsplit("/", 1)[-1])
         return _Picture(f"[{label}]({href})" if href else f"`{_cell(rel)}`", True)
     if raised:
         # First among the reasons there is nothing here, because it is a fact
@@ -298,20 +354,23 @@ def _picture(
         return _Picture(
             f"*the beat claiming this raised {_cell(raised[0])}, so it wrote no still*",
             False,
+            "raised",
         )
     if outside:
         return _Picture(
             f"*`{_cell(outside[0])}` is not a path inside this demo, "
             f"so it is not linked*",
             False,
+            "outside",
         )
     if named:
         return _Picture(
             f"*`{_cell(named[0])}` is named here, but this take published "
             f"no such file*",
             False,
+            "missing",
         )
-    return _Picture("*no still*", False)
+    return _Picture("*no still*", False, "none")
 
 
 def _ticket_check(directory: Path) -> dict | None:
@@ -498,7 +557,20 @@ def render_coverage(
         for key in criteria
     }
     unillustrated = [
-        key for key in criteria if key not in unclaimed and not pictures[key].found
+        key
+        for key in criteria
+        if key not in unclaimed
+        and not pictures[key].found
+        and pictures[key].reason != "outside"
+    ]
+    # Split out, because the sentence below is **false** for this branch: the
+    # still exists and this take published it, it is simply not inside the
+    # demo directory, so it has no URL here (issue #300, item 4). The cell
+    # said so two lines down and the headline contradicted it.
+    outside_demo = [
+        key
+        for key in criteria
+        if key not in unclaimed and pictures[key].reason == "outside"
     ]
 
     gap: list[str] = []
@@ -538,6 +610,16 @@ def render_coverage(
             f"no still was published for "
             f"{_plural(len(unillustrated), 'it', 'them')}. There is nothing "
             f"here to open.**",
+            "",
+        ]
+    if outside_demo:
+        ids = _and_list([f"`{_cell(key)}`" for key in outside_demo])
+        gap += [
+            f"**{ids} {_plural(len(outside_demo), 'is', 'are')} claimed by a "
+            f"beat whose still is outside this demo's directory.** The file "
+            f"exists; it has no URL here, because a path that leaves the demo "
+            f"can name any picture in the repository. The cell says which "
+            f"path it was.",
             "",
         ]
     if covered:
@@ -618,7 +700,7 @@ def demo_dir(demo_root: str, name: str) -> Path:
     return Path(demo_root) / name if demo_root else Path(name)
 
 
-def repo_path(prefix: str, name: str) -> str:
+def repo_path(prefix: str, name: str) -> str | None:
     """`name` as the *repository* sees it, not as the workflow ran it.
 
     A `--demo` path is relative to the caller's `working-directory`, which the
@@ -627,8 +709,25 @@ def repo_path(prefix: str, name: str) -> str:
     `demos/2026-07-28-queue-search` is four directories down in git. A still
     linked without that prefix is a 404 that looks exactly like a working link,
     which is why the prefix is passed in rather than inferred.
+
+    **Returns None for a prefix that is not a plain relative path** — the same
+    discipline `_inside_demo` applies to the still, and it was missing here
+    (issue #300). Measured: `repo_path("../up", "demos/x")` gave
+    `../up/demos/x` and `repo_path("/abs", "demos/x")` silently gave
+    `abs/demos/x`, dropping the leading slash and linking a path that is not
+    the one anybody asked for. Both produce a URL that is plausible and wrong,
+    which is worse for a reviewer than no link.
+
+    The caller refuses rather than falling back: unlike a still, the prefix is
+    **configuration**, not data. A workflow with a bad `--path-prefix` gets
+    every link in the comment wrong at once, and that is a thing to fix rather
+    than to work around quietly.
     """
+    if prefix.startswith("/") or "\\" in prefix:
+        return None
     parts = [p for p in f"{prefix}/{name}".split("/") if p not in ("", ".")]
+    if ".." in parts:
+        return None
     return "/".join(parts)
 
 
@@ -699,7 +798,10 @@ def render_demo(
     # report exists to test (issue #273, the same ordering `timeline.md` uses).
     lines += render_coverage(
         timeline.get("coverage"),
-        demo=repo_path(path_prefix, name),
+        # `main()` refused a prefix that is not a plain relative path, so
+        # this cannot be None. Named rather than assumed: a caller that
+        # skipped that check would otherwise get `None/x` into a URL.
+        demo=repo_path(path_prefix, name) or "",
         directory=demo_dir(demo_root, name),
         repo_url=repo_url,
         sha=sha,
@@ -847,10 +949,18 @@ def _default_repo_url() -> str:
     Both are set in every Actions step, so the workflow needs no new argument
     for the still links to work; the server URL is read rather than hardcoded
     so a GitHub Enterprise host links its own blobs and not github.com's.
+
+    **Neither is defaulted (issue #300).** Falling back to `github.com` when
+    `GITHUB_SERVER_URL` is missing put an Enterprise runner's stills at a host
+    that has never held them — a link that resolves, for somebody else's
+    repository or for nothing. Everything around this already prefers
+    refusing: `_still_href` returns None without a repo url or a sha, and the
+    still is *named* in the table instead of linked. Returning "" here joins
+    that behaviour rather than guessing at the one place a guess is invisible.
     """
-    server = (os.environ.get("GITHUB_SERVER_URL") or "https://github.com").rstrip("/")
+    server = (os.environ.get("GITHUB_SERVER_URL") or "").rstrip("/")
     repo = (os.environ.get("GITHUB_REPOSITORY") or "").strip("/")
-    return f"{server}/{repo}" if repo else ""
+    return f"{server}/{repo}" if server and repo else ""
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -931,6 +1041,20 @@ def main(argv: list[str] | None = None) -> int:
             )
             continue
         demos.append((name, json.loads(timeline_path.read_text(encoding="utf-8"))))
+
+    # Before anything renders (issue #300). The prefix is configuration, not
+    # data: a bad one gets every still link in the comment wrong at once, and
+    # each is a URL that resolves to nothing while looking exactly like a
+    # working link. Refusing here is the only place it can be said once.
+    if repo_path(args.path_prefix, "probe") is None:
+        print(
+            f"demo-comment: --path-prefix {args.path_prefix!r} is not a plain "
+            f"relative path. It is joined to every demo name to build the "
+            f"still links, so a `..`, a leading `/` or a backslash makes every "
+            f"picture in this comment point somewhere nobody asked for.",
+            file=sys.stderr,
+        )
+        return 2
 
     body = render(
         demos,

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -423,6 +423,30 @@ in `unmet` was claimed — somebody pointed a frame at it and said it does not
 hold. A clause in `unclaimed` had no beat at all. Reporting the first as the
 second would file the more useful evidence under "nobody showed this".
 
+### Which still the CI comment links, when a clause has several
+
+The comment's acceptance table is **one picture per clause**, so when a clause
+is claimed by several beats it has to choose. The rule:
+
+1. **A beat marked `shows="unmet"` wins**, earliest first. The storyboard is
+   pointing at that frame as evidence the clause does *not* hold, and that is
+   the frame a reviewer must not be steered away from.
+2. **Otherwise the last published still** among the clause's claims.
+
+Last, not first, and the reason is worth knowing when you write a storyboard: a
+demo builds *to* a clause, so the first shot that claims one is usually the
+**pre-state**. This repo's own `2026-08-11-criterion-card` take linked
+`01-queue.png` for `AC-1` — the queue before anything was typed — while
+`02-invoice.png`, eight beats later, is the frame that shows the clause
+satisfied. The link worked, resolved, and showed the wrong moment.
+
+**The limit.** "Last" is a heuristic. A clause shown mid-take and then
+navigated away from links its final frame, which may no longer show it. Nothing
+in CI reads the pixels, so no rule at that layer can do better — take the shot
+that demonstrates a clause **last** among that clause's shots, and the comment
+picks it. When one picture is not enough, `scripts/demo-shots` renders every
+still the take published.
+
 **A clause claimed both ways is in `unmet`.** One beat says it holds and
 another says it does not; the second is the one a reviewer has to look at, and
 a rule that needed every beat to agree would hide it.

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -40,6 +40,7 @@ import unittest
 import urllib.error
 from pathlib import Path
 from types import ModuleType
+from unittest import mock
 
 REPO = Path(__file__).resolve().parents[1]
 SCRIPTS = REPO / ".github" / "scripts"
@@ -801,6 +802,7 @@ def claim(
     still: str | None = None,
     segment: str | None = None,
     raised: str | None = None,
+    shows: str | None = None,
 ) -> dict:
     """One row of `coverage.claimed[id]`, shaped as `coverage_report` writes it.
 
@@ -818,6 +820,11 @@ def claim(
     }
     if raised is not None:
         row["error"] = {"type": raised, "message": "no such locator"}
+    # Absent unless asked for, the same way the recorder writes it (#374): a
+    # fixture that always carried `shows` would let a renderer that reads it
+    # pass on the take where nothing points against a clause.
+    if shows is not None:
+        row["shows"] = shows
     return row
 
 
@@ -1789,6 +1796,251 @@ class Coverage(unittest.TestCase):
             },
         )
         self.assertEqual(self.cell(self.body(stitched), "AC-1"), "beat 6 (`part2`)")
+
+
+class StillLinks(unittest.TestCase):
+    """Five ways the one linked still was plausible and wrong (#300).
+
+    All five were found by an independent review that fetched the emitted URLs
+    against real GitHub rather than reasoning about their shape, and none was
+    reachable in this repository's configuration on the day. That is what makes
+    them worth assertions: a link that resolves to the wrong thing is worse for
+    a reviewer than no link, because nothing about it looks wrong.
+
+    **The fifth is the one a reviewer was actually misled by**, and it needed a
+    decision rather than a guard — see `test_the_frame_linked_is_the_one_that
+    _shows_the_clause`.
+    """
+
+    SHA = "abcdef1234567890abcdef1234567890abcdef12"
+    REPO_URL = "https://github.com/o/r"
+    #: A committed file whose *name* closes the link's visible text and opens
+    #: a target of its own. No slash in it — a real filename cannot hold one —
+    #: which does not weaken the forgery: `[x](evil)` is a link either way,
+    #: and a relative target resolves against the repository just as well.
+    FORGED = "x](evil).png"
+
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.images = self.root / "demos/x/images"
+        self.images.mkdir(parents=True)
+        for name in ("01-pre.png", "02-shows-it.png", "03-third.png", self.FORGED):
+            (self.images / name).write_bytes(b"\x89PNG")
+        (self.root / "leaked.png").write_bytes(b"\x89PNG")
+
+    def picture(self, rows, **kw):
+        opts = dict(
+            demo="demos/x",
+            directory=self.root / "demos/x",
+            repo_url=self.REPO_URL,
+            sha=self.SHA,
+        )
+        opts.update(kw)
+        return comment._picture(rows, **opts)
+
+    def body(self, coverage, **kw):
+        opts = dict(
+            artifact_url=None,
+            artifact_bytes=None,
+            retention_days=30,
+            evidence_retention_days=None,
+            failure_artifact_url=None,
+            run_url=None,
+            sha=self.SHA,
+            repo_url=self.REPO_URL,
+            demo_root=str(self.root),
+            path_prefix="",
+        )
+        opts.update(kw)
+        return comment.render([("demos/x", dict(TIMELINE, coverage=coverage))], **opts)
+
+    # -- 1. the prefix escapes without complaint -----------------------------
+
+    def test_a_path_prefix_that_is_not_a_plain_relative_path_is_refused(self):
+        # Measured in the issue: `../up` came back joined, and `/abs` came back
+        # with the leading slash silently dropped — a different path, linked
+        # with no complaint.
+        for bad in ("../up", "/abs", "a\\b", "up/../../out"):
+            self.assertIsNone(
+                comment.repo_path(bad, "demos/x"),
+                f"{bad!r} is not a plain relative path and must not build a URL",
+            )
+
+    def test_an_ordinary_prefix_is_still_joined(self):
+        # The control. A guard that refused everything would pass every case
+        # above and break the workflow this repository actually runs.
+        self.assertEqual(
+            comment.repo_path("examples/ticket-queue", "demos/x"),
+            "examples/ticket-queue/demos/x",
+        )
+        self.assertEqual(comment.repo_path("", "demos/x"), "demos/x")
+        self.assertEqual(comment.repo_path("./a", "demos/x"), "a/demos/x")
+
+    def test_the_command_refuses_a_bad_prefix_instead_of_rendering_it(self):
+        # The prefix is configuration, not data: one bad value makes *every*
+        # still link in the comment wrong, so it is said once and loudly rather
+        # than fallen back on per still.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "stage"
+            (root / "demos/x").mkdir(parents=True)
+            (root / "demos/x/timeline.json").write_text(json.dumps(TIMELINE))
+            out = Path(tmp) / "body.md"
+            done = subprocess.run(
+                [
+                    sys.executable,
+                    str(_DIR / "demo-comment"),
+                    "--demo",
+                    "demos/x",
+                    "--demo-root",
+                    str(root),
+                    "--retention-days",
+                    "30",
+                    "--out",
+                    str(out),
+                    "--path-prefix",
+                    "../up",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(done.returncode, 2, done.stdout + done.stderr)
+            self.assertIn("--path-prefix", done.stderr)
+            self.assertFalse(out.exists(), "a refused run must write no comment")
+
+    # -- 2. a missing server URL invents a host ------------------------------
+
+    def test_a_missing_server_url_names_the_still_rather_than_guessing_a_host(self):
+        # Both variables are always set together in Actions, so this is the
+        # Enterprise-runner path rather than a live one — and the failure mode
+        # is a link to github.com for blobs that only ever lived elsewhere.
+        # Everything around it already prefers refusing.
+        with mock.patch.dict(os.environ, {"GITHUB_REPOSITORY": "o/r"}, clear=True):
+            self.assertEqual(comment._default_repo_url(), "")
+
+    def test_both_variables_present_still_build_the_host(self):
+        # The control: refusing unconditionally would take the links out of
+        # every real Actions run, which is the whole feature.
+        with mock.patch.dict(
+            os.environ,
+            {"GITHUB_SERVER_URL": "https://ghe.acme.com", "GITHUB_REPOSITORY": "o/r"},
+            clear=True,
+        ):
+            self.assertEqual(comment._default_repo_url(), "https://ghe.acme.com/o/r")
+
+    # -- 3. markdown label injection through a basename ----------------------
+
+    def test_a_committed_basename_cannot_forge_the_link_it_is_labelling(self):
+        cell = self.picture([claim(3, f"images/{self.FORGED}")]).cell
+        # Counted rather than searched for, because the forged text is
+        # *supposed* to still be in the label — the file really is called that.
+        # What must not survive is a second thing markdown reads as a link, so
+        # the escaped brackets come out and what is left is counted: exactly
+        # one `](`, the real one. Unfixed this cell holds two.
+        unescaped = re.sub(r"\\[\[\]]", "", cell)
+        self.assertEqual(
+            unescaped.count("]("),
+            1,
+            f"a basename opened a second link target: {cell!r}",
+        )
+        self.assertIn("\\]", cell)
+        # And the real target is still there, which is what makes the cell
+        # useful rather than merely safe.
+        self.assertIn(f"{self.SHA}/demos/x/images/", cell)
+
+    def test_an_ordinary_basename_is_not_mangled(self):
+        cell = self.picture([claim(3, "images/01-pre.png")]).cell
+        self.assertIn("[01-pre.png]", cell)
+        self.assertNotIn("\\", cell)
+
+    # -- 4. the gap headline is false for one branch -------------------------
+
+    def outside_coverage(self):
+        return {
+            "criteria": {"AC-1": "A clause whose still sits outside the demo."},
+            "claimed": {"AC-1": [claim(3, "../../leaked.png")]},
+            "unclaimed": [],
+            "tagged_beats": 1,
+            "untagged_beats": 0,
+        }
+
+    def test_a_still_published_outside_the_demo_is_not_called_unpublished(self):
+        # It *was* published — the file is on disk, and the cell two lines
+        # below says which path it is. The headline said the opposite.
+        body = self.body(self.outside_coverage())
+        self.assertNotIn("no still was published", body)
+        self.assertIn("outside this demo's directory", body)
+
+    def test_a_still_that_really_was_never_written_still_says_so(self):
+        # The control, and the branch the headline was written for. Without
+        # this, item 4's fix is satisfied by deleting the sentence.
+        body = self.body(
+            {
+                "criteria": {"AC-1": "A clause whose still was never written."},
+                "claimed": {"AC-1": [claim(3, "images/99-never.png")]},
+                "unclaimed": [],
+                "tagged_beats": 1,
+                "untagged_beats": 0,
+            }
+        )
+        self.assertIn("no still was published", body)
+
+    # -- 5. the linked frame is the pre-state --------------------------------
+
+    def test_the_frame_linked_is_the_one_that_shows_the_clause(self):
+        # The failure this repository shipped, in its own take: `AC-1` linked
+        # `01-queue.png` (beat 4, the queue before anything was typed) while
+        # `02-invoice.png` (beat 12) is the frame that shows the clause
+        # satisfied. The link worked, resolved, and showed the wrong moment.
+        #
+        # A storyboard builds to a clause, so the *last* still that claims it
+        # is the demonstration and the first is usually the setup.
+        cell = self.picture(
+            [
+                claim(3, "images/01-pre.png"),
+                claim(7),  # a caption beat, no still — must not win by being last
+                claim(9, "images/02-shows-it.png"),
+            ]
+        ).cell
+        self.assertIn("[02-shows-it.png]", cell)
+        self.assertNotIn("01-pre.png", cell)
+
+    def test_a_beat_pointed_against_the_clause_wins_over_the_last_one(self):
+        # #374's polarity outranks recency: a storyboard saying a clause does
+        # *not* hold is pointing at the frame a reviewer must not be steered
+        # away from, and "last" would steer them to whatever came after it.
+        cell = self.picture(
+            [
+                claim(3, "images/01-pre.png"),
+                claim(5, "images/02-shows-it.png", shows="unmet"),
+                claim(9, "images/03-third.png"),
+            ]
+        ).cell
+        self.assertIn("[02-shows-it.png]", cell)
+
+    def test_the_earliest_unmet_frame_wins_when_there_are_two(self):
+        cell = self.picture(
+            [
+                claim(3, "images/01-pre.png", shows="unmet"),
+                claim(9, "images/03-third.png", shows="unmet"),
+            ]
+        ).cell
+        self.assertIn("[01-pre.png]", cell)
+
+    def test_a_still_that_was_never_published_cannot_win_by_being_last(self):
+        # The rule picks among stills this take *published*, not among the
+        # names the manifest holds. A "last" that counted a missing file would
+        # report no picture for a clause that has one.
+        cell = self.picture(
+            [claim(3, "images/01-pre.png"), claim(9, "images/99-never.png")]
+        ).cell
+        self.assertIn("[01-pre.png]", cell)
+
+    def test_a_clause_with_one_still_is_unchanged(self):
+        # The control on the whole rule: the common case must not move.
+        cell = self.picture([claim(3, "images/01-pre.png")]).cell
+        self.assertIn("[01-pre.png]", cell)
 
 
 class Ticket(unittest.TestCase):
@@ -3253,6 +3505,103 @@ class UnmetInTheComment(unittest.TestCase):
 
 
 INJECTIONS = [
+    # -- five ways the still link was plausible and wrong (issue #300) -------
+    (
+        # The prefix goes back to being joined without discipline. Measured:
+        # `repo_path("../up", "demos/x")` gave `../up/demos/x`, and `/abs` came
+        # back as `abs/...` with the leading slash silently dropped. Every
+        # still link in the comment then points somewhere nobody asked for,
+        # and each one looks exactly like a working link.
+        "the path prefix is joined without checking it stays inside the tree",
+        "demo-comment",
+        '    if prefix.startswith("/") or "\\\\" in prefix:\n        return None',
+        "    if False:\n        return None",
+        [
+            "StillLinks.test_a_path_prefix_that_is_not_a_plain_relative_path_is_refused",
+            "StillLinks.test_the_command_refuses_a_bad_prefix_instead_of_rendering_it",
+        ],
+    ),
+    (
+        # The other half of the same rule: a `..` in the middle. `up/../../out`
+        # normalises out of the tree without ever starting with one.
+        "a prefix may climb out of the tree with a .. in the middle",
+        "demo-comment",
+        '    if ".." in parts:\n        return None',
+        "    if False:\n        return None",
+        ["StillLinks.test_a_path_prefix_that_is_not_a_plain_relative_path_is_refused"],
+    ),
+    (
+        # The command renders a comment full of broken links instead of saying
+        # once that its configuration is wrong.
+        "a bad prefix is rendered rather than refused",
+        "demo-comment",
+        '    if repo_path(args.path_prefix, "probe") is None:',
+        "    if False:",
+        ["StillLinks.test_the_command_refuses_a_bad_prefix_instead_of_rendering_it"],
+    ),
+    (
+        # github.com invented for an Enterprise runner. Both variables are
+        # always set together in Actions, so this never fires on a live path —
+        # and when it does it is a link to a host that has never held these
+        # blobs, for somebody else's repository or for nothing.
+        "a missing server URL is filled in with github.com",
+        "demo-comment",
+        '    server = (os.environ.get("GITHUB_SERVER_URL") or "").rstrip("/")\n'
+        '    repo = (os.environ.get("GITHUB_REPOSITORY") or "").strip("/")\n'
+        '    return f"{server}/{repo}" if server and repo else ""',
+        '    server = (os.environ.get("GITHUB_SERVER_URL") or "https://github.com").rstrip(\n'
+        '        "/"\n'
+        "    )\n"
+        '    repo = (os.environ.get("GITHUB_REPOSITORY") or "").strip("/")\n'
+        '    return f"{server}/{repo}" if repo else ""',
+        [
+            "StillLinks.test_a_missing_server_url_names_the_still_rather_than_guessing_a_host"
+        ],
+    ),
+    (
+        # The label goes back through `_cell`, which escapes `|` and `\` and
+        # not the two brackets that end a link's visible text. A committed file
+        # named `x](evil).png` then renders a link whose text and target
+        # disagree — in the one cell the comment invites a reviewer to click.
+        "a committed basename can forge the link that labels it",
+        "demo-comment",
+        '        label = _label(rel.rsplit("/", 1)[-1])',
+        '        label = _cell(rel.rsplit("/", 1)[-1])',
+        ["StillLinks.test_a_committed_basename_cannot_forge_the_link_it_is_labelling"],
+    ),
+    (
+        # The headline goes back to covering the outside-the-demo branch, where
+        # it is false: that still exists and this take published it. The cell
+        # says so two lines below, so the comment contradicts itself.
+        "a still published outside the demo is called unpublished",
+        "demo-comment",
+        '        and pictures[key].reason != "outside"',
+        "        and True",
+        [
+            "StillLinks.test_a_still_published_outside_the_demo_is_not_called_unpublished"
+        ],
+    ),
+    (
+        # The pre-state is linked again — the failure a reviewer actually acts
+        # on. In this repository's own take `AC-1` linked the queue *before*
+        # anything was typed, while the frame that shows the clause satisfied
+        # was eight beats later. The link works, resolves, and shows the wrong
+        # moment.
+        "the first still is linked instead of the one that shows the clause",
+        "demo-comment",
+        "        rel = next((r for against, r in usable if against), usable[-1][1])",
+        "        rel = next((r for against, r in usable if against), usable[0][1])",
+        ["StillLinks.test_the_frame_linked_is_the_one_that_shows_the_clause"],
+    ),
+    (
+        # Polarity stops outranking recency, so a storyboard saying a clause
+        # does *not* hold has the reviewer steered to whatever came after it.
+        "a beat pointed against a clause loses to a later one",
+        "demo-comment",
+        "        rel = next((r for against, r in usable if against), usable[-1][1])",
+        "        rel = usable[-1][1]",
+        ["StillLinks.test_a_beat_pointed_against_the_clause_wins_over_the_last_one"],
+    ),
     # -- a clause the storyboard marks unmet (issue #374) --------------------
     (
         # The disagreement rendered in take order, wherever it happened to
@@ -3610,16 +3959,7 @@ INJECTIONS = [
         # be perfect and never be called.
         "render_demo stops rendering the coverage section",
         "demo-comment",
-        '    lines += render_coverage(\n        timeline.get("coverage"),\n'
-        "        demo=repo_path(path_prefix, name),\n"
-        "        directory=demo_dir(demo_root, name),\n"
-        "        repo_url=repo_url,\n        sha=sha,\n"
-        "        # Without this the section renders a crashed take's claims "
-        "exactly like\n"
-        "        # a clean take's, five lines above a block that says the take "
-        "failed\n"
-        "        # (issue #278).\n"
-        "        failure=failure,",
+        '    lines += render_coverage(\n        timeline.get("coverage"),',
         "    lines += [] and render_coverage(\n        None,",
         [
             "Coverage.test_the_gap_is_stated_before_anything_that_was_claimed",
@@ -3972,7 +4312,7 @@ INJECTIONS = [
         # not, and every other assertion about the href passes.
         "the still link forgets the directory the storyboards are rooted at",
         "demo-comment",
-        "        demo=repo_path(path_prefix, name),",
+        '        demo=repo_path(path_prefix, name) or "",',
         "        demo=name,",
         ["Coverage.test_a_demo_below_the_repository_root_is_linked_where_git_holds_it"],
     ),
@@ -4075,9 +4415,8 @@ INJECTIONS = [
         # a picture right there in the row.
         "the no-picture finding names every claimed clause",
         "demo-comment",
-        "        key for key in criteria if key not in unclaimed "
-        + "and not pictures[key].found",
-        "        key for key in criteria if key not in unclaimed",
+        "        and not pictures[key].found\n",
+        "        and True\n",
         [
             "Coverage.test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture",
             "Coverage.test_a_take_whose_clauses_all_have_a_picture_prints_neither_gap",
@@ -4089,8 +4428,8 @@ INJECTIONS = [
         # said the true one.
         "a clause nothing claims is reported as a claim with no still",
         "demo-comment",
-        '        return _Picture("—", False)',
-        '        return _Picture("*no still*", False)',
+        '        return _Picture("—", False, "none")',
+        '        return _Picture("*no still*", False, "none")',
         [
             "Coverage.test_a_clause_claimed_only_by_a_caption_is_named_as_having_no_picture"
         ],


### PR DESCRIPTION
Closes #300.

Five edges around a happy path that was verified working. Each produces a link
that is **plausible and wrong**, which is worse for a reviewer than no link,
because nothing about it looks wrong. None was reachable in this repository's
configuration on the day the issue was filed.

I reproduced items 1–3 by running the code rather than reading it, before
changing anything:

```
repo_path('../up','demos/x') -> '../up/demos/x'
repo_path('/abs','demos/x')  -> 'abs/demos/x'
_default_repo_url() with GITHUB_SERVER_URL unset -> 'https://github.com/o/r'
_cell('x](/o/other).png')    -> 'x](/o/other).png'
```

## 5 is the one a reviewer was actually misled by, and it needed a decision

The table links the **first** published still among a clause's claims. A
storyboard builds *to* a clause, so the first shot that claims one is usually
the **pre-state**. In this repository's own take:

| clause | before | after |
|---|---|---|
| `AC-1` "narrows the list as you type" | `01-queue.png` — beat 4, the queue before anything was typed | **`02-invoice.png`** — beat 12, *"Typing invoice in lower case narrows the list"* |
| `AC-3` "typing part of a name or address finds that person's tickets" | `03-requester.png` — beat 25, the name half | **`04-address.png`** — beat 31, *"Part of an address finds that person's tickets too"* |

Run against the real take, not a fixture. The link worked, resolved, and showed
the wrong moment.

**The rule, now written down in `reference/review.md` where a storyboard author
reads it:**

1. A beat marked `shows="unmet"` wins, earliest first — the storyboard is
   pointing at that frame as evidence the clause does *not* hold (#374), and
   that is the frame a reviewer must not be steered away from.
2. Otherwise the **last** published still among the clause's claims.

**The limit is stated in the same paragraph**, because "last" is a heuristic
and not a proof: a clause shown mid-take and then navigated away from links its
final frame, which may no longer show it. Nothing in CI reads the pixels, so no
rule available at that layer can do better. `scripts/demo-shots` (#373) renders
every still and is the answer when one picture is not enough.

## The other four

**1 — the prefix escapes.** `_inside_demo` refuses `..` in a still; `repo_path`
applied no such discipline to `--path-prefix`. It does now, and **`main()`
refuses the run**: unlike a still, the prefix is *configuration*. One bad value
makes every link in the comment wrong at once, so it is said once and loudly
rather than fallen back on per still.

**2 — an invented host.** With `GITHUB_SERVER_URL` unset it fell back to
`github.com`, which on a GitHub Enterprise runner is a link to a host that has
never held these blobs. It now returns `""`, so the still is *named* rather than
linked — exactly what the surrounding code already does without a sha or a repo
url. Consistency, as the issue asked.

**3 — label injection.** A committed file named `x](evil).png` rendered a link
whose visible text and target disagree, in the one cell the comment invites a
reviewer to click. Labels now go through `_label`, which escapes `[` and `]` on
top of `_cell`. **Not folded into `_cell`:** captions are authored prose and
already admit markdown by design, so escaping brackets everywhere would turn a
storyboard's own link into literal text.

The assertion counts rather than searches, because the forged text is *supposed*
to survive in the label — the file really is called that. What must not survive
is a second thing markdown reads as a link, so the escaped brackets come out and
what is left is counted: exactly one `](`. Unfixed, that cell holds two.

**4 — a false headline.** "no still was published for it" was printed for a
clause whose still **was** published, just outside the demo directory — while
the cell two lines below said so correctly. `_Picture` now carries a `reason`
and that branch has its own sentence. The key is absent on the old shape, so
nothing reading `cell`/`found` changes.

## Assertions, each seen red

Eight injections, all caught, and 14 new tests:

```
PASS  break: the path prefix is joined without checking it stays inside the tree
PASS  break: a prefix may climb out of the tree with a .. in the middle
PASS  break: a bad prefix is rendered rather than refused
PASS  break: a missing server URL is filled in with github.com
PASS  break: a committed basename can forge the link that labels it
PASS  break: a still published outside the demo is called unpublished
PASS  break: the first still is linked instead of the one that shows the clause
PASS  break: a beat pointed against a clause loses to a later one
```

Every one names the test that reddens, and each fix has a control beside it —
an ordinary prefix still joins, both env vars still build the host, an ordinary
basename is not mangled, a still that really was never written still says so,
and a clause with one still is unchanged.

**Worth noting about the 14:** `tests/ci-unit` was green against the old
behaviour on every one of these. Item 5 in particular was ungraded — nothing
asserted which still got linked, which is why "first" survived.

## Four stale injection anchors, repaired

Four existing entries stopped matching because this change edited the lines they
anchored on, and the driver aborted rather than reporting a pass — correctly.
Three are re-anchored on the shorter, stabler part of what they were watching;
the `render_coverage` one had been anchored on eleven lines including two
comments, which turns any edit to that call into an abort, and is now anchored
on the call and its first argument.

## Gates

- `tests/ci-unit` — 185 tests; **133 injections**, 0 missed, 0 aborted
- `tests/unit` — 591 tests
- `mise run check` — 7.0 s, green
- `tests/pixel` — not run: no rendered frame changes here

## Rebased onto #381

The `tests/lint` fixture fix this branch needed was cherry-picked from #381
while both were open; #381 has since merged and the rebase dropped the
duplicate. Only the #300 commit is here now.
