### PR TITLE
goto() classifies its own argument, before Playwright navigates

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -38,14 +38,14 @@ checked **even when a storyboard passes a loopback `base_url`** — a shell
 exporting production and a storyboard saying otherwise is refused rather than
 quietly resolved. Loopback passes, a private host needs `allow_private=True`, a
 public one is refused and no option permits it. CI runs the same classifier
-over `extra-env` and each storyboard's source
-([reference/ci.md](reference/ci.md)).
+over `extra-env` and each storyboard's source ([reference/ci.md](reference/ci.md)).
 
-**Nothing else is classified, and `goto()` is where that shows.** It passes an
-absolute URL straight through, so `rec.goto("https://app.acme.com/")` records
-production and nothing refuses it; `rec.page` is further out still. The guard
-catches a target you *misconfigured*, not one you *named* — it is not a
-control, and the paragraphs above are still the whole of the guidance.
+**`goto()` classifies its own argument too**, before Playwright navigates:
+`goto("https://app.acme.com/")` is refused, and so is a relative path that
+reaches another host through userinfo, `goto("@app.acme.com/")`. **`rec.page`
+is not, and never will be** — it is the escape hatch, so `rec.page.goto(...)`,
+the app's own `fetch`, and any URL you compute reach the network unexamined.
+This is a classifier over configuration and source, not an egress control.
 
 ## Overview
 

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -696,6 +696,39 @@ class Recorder(_DemoBase):
     @_beat_verb("goto")
     def goto(self, path: str = "") -> None:
         url = path if path.startswith("http") else self.base_url + path
+        # **The storyboard's own argument, classified (issue #268).** The
+        # construction-time guard runs over `DEMO_VIDEO_BASE_URL` and the
+        # resolved `base_url` and over nothing else, so until now
+        # `rec.goto("https://app.acme.com/")` recorded production on a take
+        # whose `base_url` was loopback — and the guard is the reason a
+        # storyboard author believes that cannot happen. A storyboard is the
+        # thing an agent writes, so the argument it passes is exactly the
+        # input that needs classifying.
+        #
+        # **The built URL, not the absolute branch of it**, and that is not
+        # belt-and-braces. A *relative* path can change the host too: `path`
+        # is concatenated, not joined, so `goto("@evil.com/")` builds
+        # `http://127.0.0.1:8901@evil.com/`, in which the declared base is
+        # **userinfo** and the host is `evil.com`. Measured against two local
+        # servers: Chromium lands on the second one and the declared app is
+        # never asked for anything. Issue #268 reasoned that only the absolute
+        # branch could escape; it is the branch that escapes *visibly*.
+        #
+        # Nothing legitimate is refused by classifying the join, because the
+        # join keeps `base_url`'s host in every case that is not this one, and
+        # that host was accepted at construction — `goto("/orders")` and
+        # `goto("about:blank")` both come back loopback on a loopback take.
+        #
+        # **`self._allow_private`, never the environment.** Re-reading
+        # `DEMO_VIDEO_ALLOW_PRIVATE` here would let a take permitted at
+        # construction be refused at beat 12 because something changed the
+        # environment mid-run — a refusal at the worst possible moment, with
+        # the browser open and the artifacts half-written. The flag this take
+        # was built with is the flag that decides.
+        #
+        # Before the retry loop and before Playwright: a refused URL must not
+        # reach the network even once.
+        guard_target(url, self._allow_private, source="this goto()'s argument")
         # The *iframe* navigates; the wrapper document — which holds the
         # caption, the cursor and the chrome — never does, so a mid-take
         # goto cannot take the caption off the screen (see `_watch_extra`).

--- a/tests/README.md
+++ b/tests/README.md
@@ -116,8 +116,8 @@ as PNGs named by check and instant, for a pull request's before/after.
 What stays ungraded here, deliberately: spotlight transition shape and
 caption timing are time-measuring and belong to smoke's lock; whether a
 viewer *recognises* the card as a card is graded nowhere (Known gaps); and
-`frames.md` ordering is manifest arithmetic, and is tracked in
-[#300](https://github.com/rogvid/skills/issues/300).
+`frames.md` ordering is manifest arithmetic, graded by `FrameClockCorrection`
+in `tests/unit` rather than by any pixel.
 The contract: a change to anything that draws a frame - the chrome in
 `skills/demo-video/helpers/demo_recording/` - runs this loop before its PR
 opens and pastes its lines and `--dump` frames there (`AGENTS.md`, "A change
@@ -1256,6 +1256,16 @@ So the assertions were **written rather than trimmed**, and there are three:
   `scope_aria` and `html` — cut *to* the budget with only the marker past it,
   and named in `truncated`. A cap applied to `aria` and not to `scope_aria` is
   a cap on a third of what a spotlight beat writes.
+
+  **Truncation is the only omission that is marked.** Two shapes of on-screen
+  text never reach the snapshot at all and nothing says so: the contents of a
+  rich-text editor (`contenteditable` with `role="textbox"`, whose accessible
+  value is read off a `value` property a `div` does not have) and anything
+  under `aria-hidden="true"`. Measured with Playwright 1.62.0 against a page
+  filling seven input shapes — the other five, dialog inputs included, come
+  through. That is tracked in
+  [#353](https://github.com/rogvid/skills/issues/353), and it bounds what any
+  evidence-reading tool can do.
 
 Plus the two that never touched masking: a previous take's evidence is cleared
 from the directory on a re-record while another *segment's* files survive, and
@@ -3383,16 +3393,30 @@ knows is missing is worse than one that is openly absent.
   And the standing one, which is a scope statement rather than a gap:
   **anything the take reaches other than its classified target.** A page that
   fetches another origin, a terminal storyboard that curls one, a URL computed
-  at run time — and, named because it is the one a storyboard author reaches
-  for by accident, **`goto()`'s own argument**: `web.py` passes an absolute URL
-  straight through, so `rec.goto("https://app.acme.com/")` records production
-  and no assertion here notices
-  ([#268](https://github.com/rogvid/skills/issues/268)). This is a static
-  classifier over configuration and source text, not an egress control, and
-  `target.py`'s docstring says so in the same words. `SKILL.md` now says it too
-  ([#267](https://github.com/rogvid/skills/issues/267)), which is what stops a
-  caller reading the guard as one. `scripts/demo-target-guard` is also outside
-  mypy's scope, which runs over `skills/demo-video/helpers/` only.
+  at run time from something the recorder was never given, and `rec.page` —
+  the documented escape hatch, a Playwright handle this cannot reach.
+
+  **`goto()`'s own argument used to be on that list and no longer is**
+  ([#268](https://github.com/rogvid/skills/issues/268)). It is classified
+  before Playwright navigates, against the opt-in the take was built with, and
+  `GotoTarget` in `tests/unit` grades it — five injections, including the two
+  that matter: the URL fetched *first* and classified afterwards, which every
+  other assertion in that class is blind to, and the guard narrowed to
+  arguments beginning with `http`.
+
+  That narrowing is the shape #268 itself reasoned in, and it is wrong: `path`
+  is concatenated onto `base_url` rather than joined, so `goto("@evil.com/")`
+  builds `http://127.0.0.1:8901@evil.com/`, in which the declared base is
+  **userinfo** and the host is `evil.com`. Measured against two local servers
+  with a real Chromium: it lands on the second and the declared app is never
+  asked for anything.
+
+  This is still a static classifier over configuration and source text, not an
+  egress control, and `target.py`'s docstring and `SKILL.md`
+  ([#267](https://github.com/rogvid/skills/issues/267)) both say so — which is
+  what stops a caller reading the guard as one.
+  `scripts/demo-target-guard` is also outside mypy's scope, which runs over
+  `skills/demo-video/helpers/` only.
 
 - **Whether prose about masking is *otherwise* true, and prose anywhere
   `MaskProse` does not read.** `tests/unit`'s sweep flags every mention of

--- a/tests/unit
+++ b/tests/unit
@@ -4599,6 +4599,153 @@ class TermRec(_NoWait, TerminalRecorder):
     pass
 
 
+class _NavPage:
+    """Enough page for `goto()` to finish, remembering where it was sent.
+
+    A recorder-shaped fake rather than a browser: the claim being graded is
+    that a URL is classified **before** Playwright is asked to navigate, and
+    the only way to see "before" is to be the thing that would have been
+    asked. `visited` empty after a refusal is the assertion.
+    """
+
+    def __init__(self):
+        self.visited: list[str] = []
+
+    def goto(self, url, timeout=None):
+        self.visited.append(url)
+
+    def wait_for_load_state(self, state, timeout=None):
+        return None
+
+    def evaluate(self, script, *args):
+        return None
+
+
+class GotoTarget(unittest.TestCase):
+    """`goto()`'s own argument is classified, not just `base_url` (#268).
+
+    `guard_target` ran over exactly two strings, both at construction:
+    `DEMO_VIDEO_BASE_URL` and the resolved `base_url`. `goto()` classified
+    nothing, so `rec.goto("https://app.acme.com/")` recorded production on a
+    take whose `base_url` was loopback, and the take came back green.
+
+    That matters more than an ordinary gap because **a storyboard is the thing
+    an agent writes**. The guard is configuration-shaped and the hole was in
+    the one input that is authored.
+
+    **This is still not an egress control**, and nothing here changes that:
+    `rec.page` is the documented escape hatch, a page's own `fetch` is
+    unreachable from Python, and a URL computed at run time from something
+    this module was never given is invisible. `target.py`'s docstring and
+    `SKILL.md` both say so and must keep saying so (#267).
+    """
+
+    def build(self, base_url=TARGET_LOOPBACK, **settings):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        with target_env(), contextlib.redirect_stderr(io.StringIO()):
+            rec = WebRec(
+                tmp.name, base_url=base_url, speech=False, evidence=False, **settings
+            )
+        page = _NavPage()
+        rec.page = page  # the chrome document goto() evaluates against
+        rec._target = lambda: page  # type: ignore[method-assign]
+        rec._t0 = time.monotonic()
+        return rec, page
+
+    def test_an_absolute_public_url_is_refused_naming_the_host_and_the_class(self):
+        rec, page = self.build()
+        with self.assertRaises(TargetRefused) as caught:
+            rec.goto(TARGET_PUBLIC)
+        message = str(caught.exception)
+        self.assertIn(TARGET_PUBLIC, message)
+        self.assertIn("public", message)
+        # Where the URL came from. Without it the refusal names a host that is
+        # nowhere in the recorder's configuration and reads as an invention.
+        self.assertIn("goto()", message)
+        # The claim the whole thing rests on: nothing was navigated to.
+        self.assertEqual(page.visited, [], "the refused URL reached Playwright")
+
+    def test_an_absolute_loopback_url_still_navigates(self):
+        # The control, and a real shape: a demo whose app is on one port and
+        # whose mail catcher is on another cannot express the second as a path
+        # relative to base_url, so it has to pass an absolute URL. A guard
+        # that refused every absolute URL would pass the test above and take
+        # this away.
+        rec, page = self.build()
+        rec.goto("http://127.0.0.1:1080/")
+        self.assertEqual(page.visited, ["http://127.0.0.1:1080/"])
+
+    def test_a_relative_path_is_unchanged(self):
+        rec, page = self.build()
+        rec.goto("/orders")
+        self.assertEqual(page.visited, [f"{TARGET_LOOPBACK}/orders"])
+
+    def test_the_flag_is_the_one_this_take_was_built_with(self):
+        # The trap the issue names. Re-deriving the opt-in here — from the
+        # environment, or by asking `target.py` again — refuses at beat 12 a
+        # take that was permitted at beat 0, which is the worst possible
+        # moment: the browser is open and the artifacts are half-written.
+        rec, page = self.build(base_url=TARGET_PRIVATE, allow_private=True)
+        with mock.patch.dict(os.environ, {}, clear=True):
+            rec.goto(TARGET_PRIVATE + "/admin")
+        self.assertEqual(page.visited, [TARGET_PRIVATE + "/admin"])
+
+    def test_a_private_url_is_still_refused_without_the_opt_in(self):
+        # The other side: the opt-in has to be *read*, not assumed.
+        rec, page = self.build()
+        with self.assertRaises(TargetRefused):
+            rec.goto(TARGET_PRIVATE + "/admin")
+        self.assertEqual(page.visited, [])
+
+    def test_a_relative_path_cannot_smuggle_a_host_through_userinfo(self):
+        # **The escape the issue reasoned could not exist.** #268 measured
+        # every `goto()` in the tree, found all of them relative, and
+        # concluded "zero callers would change behaviour" — reading *relative*
+        # as *cannot reach another host*. `path` is concatenated, not joined,
+        # so the declared base becomes **userinfo**:
+        #
+        #     base_url  http://127.0.0.1:8901
+        #     goto      "@tickets.acme.com/x"
+        #     built     http://127.0.0.1:8901@tickets.acme.com/x
+        #     host      tickets.acme.com
+        #
+        # Measured against two local servers with a real Chromium: it lands on
+        # the second one, and the declared app is never asked for anything.
+        rec, page = self.build()
+        with self.assertRaises(TargetRefused) as caught:
+            rec.goto("@tickets.acme.com/x")
+        self.assertIn("public", str(caught.exception))
+        self.assertEqual(page.visited, [])
+
+    def test_an_ordinary_relative_path_is_not_refused_by_that(self):
+        # The control on the line above, and it is load-bearing: the join
+        # keeps `base_url`'s host in every case that is not the userinfo one,
+        # and that host was classified at construction. `about:blank` is here
+        # because `SKILL.md`'s segment pattern sits next to it and it is the
+        # relative value least like a path.
+        rec, page = self.build()
+        rec.goto("about:blank")
+        rec.goto("/orders?q=1")
+        self.assertEqual(
+            page.visited,
+            [f"{TARGET_LOOPBACK}about:blank", f"{TARGET_LOOPBACK}/orders?q=1"],
+        )
+
+    def test_the_refusal_is_recorded_as_this_beat_failing(self):
+        # The exit path the issue asks about. `goto` is a `@_beat_verb`, so
+        # the refusal travels the same route as any raising verb — but "the
+        # artifacts say what they are" is a claim about *this* exception, and
+        # an assertion that took it on trust would be grading the decorator.
+        rec, page = self.build()
+        with self.assertRaises(TargetRefused):
+            rec.goto(TARGET_PUBLIC)
+        beat = rec._beats[-1]
+        self.assertEqual(beat["verb"], "goto")
+        self.assertEqual(beat["error"]["type"], "TargetRefused")
+        self.assertIn(TARGET_PUBLIC, beat["error"]["message"])
+
+
 class PressRec(WebRec):
     """#177's own example: a verb whose first parameter is named `key`.
 
@@ -11907,6 +12054,77 @@ class StillsOnly(unittest.TestCase):
 
 # (name, module, exact text to replace, replacement, tests that must then fail)
 INJECTIONS = [
+    # -- goto() classifies its own argument (issue #268) ----------------------
+    (
+        # The gap as it shipped: `guard_target` ran over `DEMO_VIDEO_BASE_URL`
+        # and the resolved `base_url` and over nothing else, so a storyboard
+        # that *named* production recorded it on a loopback take and came back
+        # green. A storyboard is the thing an agent writes, which is what makes
+        # this the input that most needed classifying.
+        "goto() stops classifying the URL a storyboard hands it",
+        "web.py",
+        '        guard_target(url, self._allow_private, source="this goto()\'s argument")',
+        "        pass",
+        [
+            "GotoTarget."
+            "test_an_absolute_public_url_is_refused_naming_the_host_and_the_class",
+            "GotoTarget.test_a_private_url_is_still_refused_without_the_opt_in",
+        ],
+    ),
+    (
+        # Refused, but **after** the request. The exception is identical, the
+        # message is identical, the beat records the same failure — and the
+        # page has already been fetched, which for a production host is the
+        # whole of the harm. Only the `visited` assertion can see this, which
+        # is why that assertion is there rather than a bare assertRaises.
+        "the URL is fetched first and classified afterwards",
+        "web.py",
+        '        guard_target(url, self._allow_private, source="this goto()\'s argument")',
+        "        self._target().goto(url, timeout=45_000)\n"
+        '        guard_target(url, self._allow_private, source="this goto()\'s argument")',
+        [
+            "GotoTarget."
+            "test_an_absolute_public_url_is_refused_naming_the_host_and_the_class"
+        ],
+    ),
+    (
+        # The opt-in re-derived from the environment instead of read off the
+        # take. A recorder built with `allow_private=True` is then refused at
+        # beat 12 — the browser open, the artifacts half-written — because the
+        # environment never carried the flag the constructor was handed.
+        "goto() re-reads the private opt-in instead of using this take's",
+        "web.py",
+        "        guard_target(url, self._allow_private, source=",
+        '        guard_target(url, _env_flag("ALLOW_PRIVATE") or False, source=',
+        ["GotoTarget.test_the_flag_is_the_one_this_take_was_built_with"],
+    ),
+    (
+        # The guard narrowed to the absolute branch — which is what I wrote
+        # first, on #268's own reasoning that a relative path cannot reach
+        # another host. It can: concatenation makes the declared base into
+        # userinfo, and `goto("@tickets.acme.com/x")` then walks straight
+        # past a guard that only reads arguments beginning with `http`.
+        "the guard only classifies an argument that starts with http",
+        "web.py",
+        '        guard_target(url, self._allow_private, source="this goto()\'s argument")',
+        '        if path.startswith("http"):\n'
+        '            guard_target(url, self._allow_private, source="this goto()\'s argument")',
+        ["GotoTarget.test_a_relative_path_cannot_smuggle_a_host_through_userinfo"],
+    ),
+    (
+        # The refusal stops saying where the URL came from. It then names a
+        # host that appears nowhere in the recorder's configuration, which is
+        # the exact failure `source=` was added for at construction (#267) —
+        # and it is worse here, because a storyboard has many gotos.
+        "the refusal stops saying which goto() named the host",
+        "web.py",
+        'source="this goto()\'s argument"',
+        'source=""',
+        [
+            "GotoTarget."
+            "test_an_absolute_public_url_is_refused_naming_the_host_and_the_class"
+        ],
+    ),
     # -- a beat pointed against a clause (issue #374) ------------------------
     (
         # The guard that makes an unmet claim checkable at all: without an


### PR DESCRIPTION
Closes #268.

`guard_target` ran over exactly two strings, both at construction:
`DEMO_VIDEO_BASE_URL` and the resolved `base_url`. `goto()` classified nothing,
so `rec.goto("https://app.acme.com/")` recorded production on a loopback take
and came back green.

That matters more than an ordinary gap because **a storyboard is the thing an
agent writes**. The guard is configuration-shaped, and the hole was in the one
input that is authored.

## The issue is wrong about relative paths, and I only found out by planting it

#268 measured every `goto()` in the tree, found all of them relative, and
concluded *"zero callers in this repo would change behaviour"* — reading
**relative** as **cannot reach another host**. I built the fix on that
reasoning: guard only the branch that starts with `http`.

Then the injection that was supposed to prove the narrowing safe **was not
caught**, because the test I wrote for it graded nothing. Chasing that:

```
base_url  http://127.0.0.1:8901
goto      "@tickets.acme.com/x"
built     http://127.0.0.1:8901@tickets.acme.com/x
host      tickets.acme.com
```

`path` is **concatenated** onto `base_url`, not joined, so the declared base
becomes **userinfo**. Measured with a real Chromium against two local servers:

```
base_url = http://127.0.0.1:39907
goto('@127.0.0.1:36653/secrets')

landed on: http://127.0.0.1:39907@127.0.0.1:36653/secrets
page says: THE OTHER HOST

requests to A (the declared app, port 39907): []
requests to B (the other host,   port 36653): ['/secrets']
```

Zero requests to the declared app. So the **built URL** is classified, not just
arguments beginning with `http`. Nothing legitimate is refused by that: the join
keeps `base_url`'s host in every other case, and that host was accepted at
construction — `goto("/orders")` and `goto("about:blank")` both come back
loopback on a loopback take, and there is a control asserting exactly that.

**The injection now plants my own first attempt**, so the narrowing cannot come
back:

```
PASS  break: the guard only classifies an argument that starts with http
      FAIL: GotoTarget.test_a_relative_path_cannot_smuggle_a_host_through_userinfo
```

## The other three things the issue asked for

**The opt-in is `self._allow_private`, never the environment.** The issue names
this trap precisely: re-deriving the flag refuses at beat 12 a take that was
permitted at beat 0 — the worst possible moment, browser open, artifacts
half-written. There is an injection that re-reads `DEMO_VIDEO_ALLOW_PRIVATE`,
and a test that runs `goto()` with the environment cleared.

**Before Playwright, not after.** An `assertRaises` cannot tell those apart —
same exception, same message, same beat record, and the page already fetched,
which for a production host *is* the harm. So the fake page records what it was
asked to navigate to and the assertion is `visited == []`, with an injection
that fetches first and classifies afterwards.

**The exit path.** The issue asks that a mid-take refusal leave artifacts that
say what they are. It does, and I verified it rather than trusting the
decorator:

```
RAISED TargetRefused: refusing to record against https://app.acme.com/ —
classified public: app.acme.com is a public DNS name. … (from this goto()'s argument)

failure: { "type": "TargetRefused", "beat": 2, "verb": "goto" }
demo-video-FAILED.md: failed at beat 2 (`goto`), with **TargetRefused**
```

The server log for that run shows one line, `GET /` — the refused host was
never contacted.

## What is still not classified, said in both documents that claimed otherwise

`SKILL.md` and `tests/README.md` both described this gap as open. Both now say
what is classified and what is not: **`rec.page`** — the documented escape
hatch, a Playwright handle this cannot reach — the app's own `fetch`, and any
URL a storyboard computes from something the recorder was never given. Still a
static classifier over configuration and source text, **not an egress control**.

`SKILL.md` is at 634 of its 634-line budget; the paragraph was compressed to fit
rather than the budget raised.

## Assertions, each seen red

Five injections, all caught; 8 new tests in `GotoTarget`.

```
PASS  break: goto() stops classifying the URL a storyboard hands it
PASS  break: the URL is fetched first and classified afterwards
PASS  break: goto() re-reads the private opt-in instead of using this take's
PASS  break: the guard only classifies an argument that starts with http
PASS  break: the refusal stops saying which goto() named the host
```

## Two documentation repairs this branch owes to merges, not to itself

- Closing #300 left `tests/README.md` saying `frames.md` ordering is *tracked
  in* #300. #300 never touched it, so that ownership claim is now false; it is
  a stated limit and reads as one.
- The pending-issue sweep needs at least one live pointer in the tree to prove
  its vocabulary still matches this repo's prose. The one that replaces it is
  true and in the right place: `#353`'s two shapes of on-screen text that
  evidence omits without a marker, beside the truncation bullet that describes
  the only omission that *is* marked.

## Gates

- `tests/unit` — 599 tests; **368 injections**, 0 missed, 0 aborted
- `tests/ci-unit` — 185 tests
- `tests/pixel` — 7 checks, 0 failing (no frame moved; run because the diff is
  inside `helpers/demo_recording/`)
- `mise run check` — 8.7 s, green
