### PR TITLE
Evidence names the on-screen text its snapshot cannot carry

### DIFF
--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -463,6 +463,11 @@ EVIDENCE_LIMITS = {
     # silently stopped saying which line was on screen would fail #9's
     # criterion while every remaining field stayed plausible.
     "chrome": EVIDENCE_MAX_HTML,
+    # On-screen text `aria_snapshot()` structurally cannot carry — a
+    # rich-text editor's contents, an `aria-hidden` subtree that is still
+    # painted (#353). Absent when the page held none, so it is capped only
+    # when it is there, and `limits` names it only then.
+    "aria_omits": EVIDENCE_MAX_ARIA,
 }
 EVIDENCE_TRUNCATED = "\n…[demo-video: truncated here, {n} more characters]"
 

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -267,6 +267,88 @@ _CHROME_TEXT_JS = """() => {
   ].filter(Boolean).join('\\n');
 }"""
 
+# On-screen text the ARIA snapshot structurally cannot carry (issue #353).
+#
+# **Evidence claims to describe what the beat showed.** Two shapes of visible
+# text never reach `aria_snapshot()`, and until this field they left no trace
+# at all — the file read as a complete account of a screen it had only
+# partly seen. Measured against Playwright 1.62.0, one page, seven input
+# shapes filled and read back out of one `body` snapshot:
+#
+#   | shape                                   | in the snapshot |
+#   |-----------------------------------------|-----------------|
+#   | `contenteditable` with `role="textbox"` | **absent**      |
+#   | subtree under `aria-hidden="true"`      | **absent**      |
+#   | `contenteditable`, no role              | present         |
+#   | `<input type="number">`                 | present         |
+#   | `<input type="password">`               | present         |
+#   | `readonly` input                        | present         |
+#   | input under `role="presentation"`       | present         |
+#   | input inside a shadow root              | present         |
+#   | textbox inside `<dialog aria-modal>`    | present         |
+#
+# The last row is why this field exists in the shape it does. #353 was filed
+# saying dialogs drop typed values; they do not, and an assertion written to
+# that could never have failed. The real classes are the first two, and both
+# are **structural**: a `textbox`'s accessible value is read off a `value`
+# property a `div` does not have, and `aria-hidden` removes a subtree from the
+# accessibility tree by definition while the pixels stay on screen.
+#
+# **Absent when there is nothing to say** (#24's rule), so every take that has
+# no such element on screen writes exactly the evidence it wrote before.
+#
+# Written in the snapshot's own `- role "name": value` idiom rather than as
+# JSON: the reader already knows how to read that, and a lint tokenising
+# `aria` can tokenise this with the same code (#356).
+_ARIA_OMITS_JS = r"""() => {
+  const MAX_ENTRIES = 40, MAX_TEXT = 500;
+  const out = [];
+  const clip = (s) => {
+    const t = (s || '').replace(/\s+/g, ' ').trim();
+    return t.length > MAX_TEXT ? t.slice(0, MAX_TEXT) + '…' : t;
+  };
+  // The recorder's own furniture, if any of it ever lands in this document.
+  // It is chrome rather than app, and `chrome` is the field that carries it.
+  const ours = (el) => (el.id || '').startsWith('__demo')
+    || (el.id || '').startsWith('__chrome');
+
+  // 1. A rich-text editor. `role="textbox"` promises the tree an accessible
+  //    *value*, which for a div is read off a property it does not have, so
+  //    the node renders as `- textbox "Name"` with nothing after the colon.
+  for (const el of document.querySelectorAll('[contenteditable]')) {
+    if (out.length >= MAX_ENTRIES) break;
+    const editable = el.getAttribute('contenteditable');
+    if (editable === 'false') continue;
+    const role = (el.getAttribute('role') || '').toLowerCase();
+    if (!['textbox', 'searchbox', 'combobox'].includes(role)) continue;
+    if (ours(el)) continue;
+    const text = clip(el.innerText);
+    if (!text) continue;
+    const name = el.getAttribute('aria-label') || el.getAttribute('title') || '';
+    out.push('- ' + role + ' ' + JSON.stringify(name) + ': ' + text);
+  }
+
+  // 2. An `aria-hidden` subtree that is nonetheless painted. Outermost only —
+  //    a nested one is already inside the text reported for its ancestor —
+  //    and painted only, because the overwhelmingly common use of the
+  //    attribute is on something already invisible, which is not an omission.
+  for (const el of document.querySelectorAll('[aria-hidden="true"]')) {
+    if (out.length >= MAX_ENTRIES) break;
+    const parent = el.parentElement;
+    if (parent && parent.closest('[aria-hidden="true"]')) continue;
+    if (ours(el)) continue;
+    const box = el.getBoundingClientRect();
+    if (box.width === 0 || box.height === 0) continue;
+    const style = getComputedStyle(el);
+    if (style.visibility === 'hidden' || style.display === 'none') continue;
+    if (parseFloat(style.opacity || '1') <= 0) continue;
+    const text = clip(el.innerText || el.textContent);
+    if (!text) continue;
+    out.push('- aria-hidden: ' + text);
+  }
+  return out.join('\n');
+}"""
+
 # The spotlight target's markup, cleaned, from a *clone* — nothing here may
 # touch the live page, which is being recorded.
 #
@@ -664,6 +746,12 @@ class Recorder(_DemoBase):
             # furniture (see _CHROME_TEXT_JS).
             "chrome": self.page.evaluate(_CHROME_TEXT_JS),
         }
+        # What the snapshot above structurally could not carry (#353). The key
+        # is written only when there is something to say, so a page with no
+        # such element on screen produces exactly the document it always did.
+        omits = doc.evaluate(_ARIA_OMITS_JS)
+        if omits:
+            payload["aria_omits"] = omits
         if self._spotlit:
             target = doc.locator(self._spotlit).first
             payload["scope_aria"] = self._aria(target)[0]

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -283,6 +283,7 @@ off.
 |---|---|
 | `aria` | **`Recorder`**: the app document's ARIA snapshot — a compact YAML tree of roles and accessible names, the same thing `expect(...).toMatchAriaSnapshot` compares. Semantic, ~10× smaller than the markup, and stable across restyling, which is why it is preferred over raw HTML |
 | `scope` / `scope_aria` / `html` | the current `spotlight()` target: its selector, its own ARIA tree, and its `outerHTML` with every value-bearing attribute stripped. All three are null when no spotlight is up |
+| `aria_omits` | **`Recorder`**, and **absent unless there is something to say**: on-screen text the ARIA snapshot structurally cannot carry, in the snapshot's own idiom. Two shapes reach it — a rich-text editor (`contenteditable` with `role="textbox"`, whose accessible *value* is read off a `value` property a `div` does not have) and a painted `aria-hidden` subtree, which the attribute removes from the accessibility tree by definition while the pixels stay. Nothing that was never painted is listed |
 | `chrome` | **`Recorder`**: what the recorder's own chrome shows on screen — the visible caption line, and any card or bridge label that is up. Read out of the wrapper document's DOM at capture time, never copied from the beat log: the caption lives in the chrome's reserved band, not in the app document the `aria` describes, so without this field no evidence file could say which narration line the frame showed |
 | `screen` | **`TerminalRecorder`**: the rendered screen, ANSI resolved by xterm.js, scrollback included — the same text `wait_for_text()` matches against |
 | `truncated` / `limits` | which fields were cut, and at what budget. A cut field also says so inline where it stops |
@@ -314,6 +315,16 @@ Two things are dropped, and neither is a security control:
 Both are statements about what belongs in a text dump of an element, and this
 repo's `tests/smoke` grades them directly: its evidence take injects an element
 holding a `<script>` and a `srcdoc` and requires neither in the markup.
+
+**Two shapes of on-screen text the ARIA tree cannot hold are named rather than
+dropped.** A rich-text editor's contents and a painted `aria-hidden` subtree
+are both invisible to `aria_snapshot()` — structurally, not by accident — so
+they go in `aria_omits` (see the table above). Before that they left no trace
+and the file read as a complete account of a screen it had only partly seen.
+
+Measured on one page with seven input shapes filled: the other five come
+through the snapshot normally, **dialogs included**. If you are reading this
+because a value is missing from evidence, the dialog is not the reason.
 
 **Fields are capped** — 12 000 characters of ARIA or screen text, 8 000 of
 markup — and truncation is **marked, never silent**. A TUI's scrollback is

--- a/tests/README.md
+++ b/tests/README.md
@@ -136,7 +136,7 @@ seen red under a planted recorder defect in #351's pull request.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~54 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~55 min, nightly)
 ├── unit               # the browser-free half (~4 s, 568 tests, no dependencies)
 ├── ci-unit            # the .github/scripts helpers, and the two skill
 │                      #   CLIs whose output a person pastes (~2.5 s)
@@ -318,7 +318,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~195 s)
-tests/smoke-inject                # all 73 entries, ~54 min
+tests/smoke-inject                # all 76 entries, ~55 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -1257,15 +1257,26 @@ So the assertions were **written rather than trimmed**, and there are three:
   and named in `truncated`. A cap applied to `aria` and not to `scope_aria` is
   a cap on a third of what a spotlight beat writes.
 
-  **Truncation is the only omission that is marked.** Two shapes of on-screen
-  text never reach the snapshot at all and nothing says so: the contents of a
-  rich-text editor (`contenteditable` with `role="textbox"`, whose accessible
-  value is read off a `value` property a `div` does not have) and anything
-  under `aria-hidden="true"`. Measured with Playwright 1.62.0 against a page
-  filling seven input shapes — the other five, dialog inputs included, come
-  through. That is tracked in
-  [#353](https://github.com/rogvid/skills/issues/353), and it bounds what any
-  evidence-reading tool can do.
+  **Truncation used to be the only omission that was marked.** Two shapes of
+  on-screen text never reach the snapshot at all — the contents of a rich-text
+  editor (`contenteditable` with `role="textbox"`, whose accessible value is
+  read off a `value` property a `div` does not have) and anything under
+  `aria-hidden="true"` — and until
+  [#353](https://github.com/rogvid/skills/issues/353) they left no trace, so
+  the file read as a complete account of a screen it had only partly seen.
+  They now go in `aria_omits`, a field absent when there is nothing to say.
+  Measured with Playwright 1.62.0 against a page filling seven input shapes:
+  the other five, **dialog inputs included**, come through — which is why the
+  shape #353 was filed against could never have been asserted.
+
+  Four injections cover it, and three of them are the *other* direction: a
+  probe that also reports what was never painted buries the two that matter
+  under every icon wrapper on a real page. There is one per visibility guard,
+  because `display:none` trips both and would otherwise leave either deletable
+  in silence — the fixture carries a clipped box for the zero-size test and a
+  `visibility:hidden` box for the computed-style one. The caption-claims lint
+  that will read this field is tracked in
+  [#356](https://github.com/rogvid/skills/issues/356).
 
 Plus the two that never touched masking: a previous take's evidence is cleared
 from the directory on a re-record while another *segment's* files survive, and
@@ -2288,7 +2299,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-73 entries, 15 arms, ~54.5 min of takes
+76 entries, 15 arms, ~54.8 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -2324,7 +2335,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
 | `--polish-only` | 4 | a terminal segment stops saying what it opened on ([#235](https://github.com/rogvid/skills/issues/235)), which is the one account of that frame a demo directory ships: the field gone entirely; the number a plausible constant instead of a reading, which every other statement about the field is happy with; the cover painted a colour that is not the window body, so frame 0 is not the cover at all — #110's own defect, the card raised late, can no longer be planted here: since [#362](https://github.com/rogvid/skills/issues/362) the shared chrome covers frame 0 twice, independently, and breaking either cover alone leaves frame 0 reading 24.0; or the report forgetting that a card was asked for, without which `"bare"` cannot be told from a segment that never wanted one |
 | `--segments-only` | 14 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the sheet stops saying **which clock** it cut them on, so a reviewer cannot tell a corrected sheet from one cut on the raw beat log ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
-| `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
+| `--evidence-only` | 4 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one. Or evidence goes back to omitting on-screen text in silence ([#353](https://github.com/rogvid/skills/issues/353)): a rich-text editor's contents and a painted `aria-hidden` subtree, neither of which `aria_snapshot()` can carry. The other two entries are the opposite direction — a probe that also reports what was never painted buries the two that matter under every icon wrapper on the page — and there is one per visibility guard, because `display:none` trips both and would leave either deletable in silence |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
 | `--wrapper-only` | 9 | the wrapper take (#358, #360) stops keeping its promises silently: a caption dispatched and never painted in its band; a caption too tall for the band shaved at both edges with no caption_clipped issue saying so (#366's review finding); the caption's appearance repainting pixels inside the app rect, which is the overlap the band exists to remove; evidence captured from the wrapper chrome instead of the app frame, with url, title and aria all plausible; a frame-refused app surfacing as a bare `ERR_BLOCKED_BY_RESPONSE` naming no header; or the block swallowed entirely, so a silently blank window records to the end as a demo — the artifact-lie outcome the issue names outright. Three more are #360's chrome parity, each invisible to every artifact but the encoded frames: the card layer shipping transparent, so the take opens on the slot's white canvas instead of the hold; the card's field nudged off the window body it must equal on the single-encoder path; and a mid-take goto emptying the caption band while the beat log keeps reporting the line |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
@@ -2333,7 +2344,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **17 of `tests/smoke`'s 51 check functions have no entry**, and the harness
+- **17 of `tests/smoke`'s 52 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 

--- a/tests/fixture/index.html
+++ b/tests/fixture/index.html
@@ -431,7 +431,36 @@ if (params.has("evidence")) {
     "font:12px/1.5 ui-monospace,monospace;color:#1c1a17;";
   ev.innerHTML =
     '<div id="ev-spot-attrs" data-token="zz-attr-00000000"\n' +
-    '  data-cfg=\'{"key":"zz-json-00000000"}\'>nothing rendered here</div>';
+    '  data-cfg=\'{"key":"zz-json-00000000"}\'>nothing rendered here</div>' +
+    // Two shapes of on-screen text `aria_snapshot()` structurally cannot
+    // carry (#353), and one control that is not on screen at all.
+    //
+    //   * a rich-text editor. `role="textbox"` promises the tree an
+    //     accessible *value*, read off a `value` property a div does not
+    //     have, so the node renders as `- textbox "…"` and stops there.
+    //   * an `aria-hidden` subtree that is still painted. The attribute
+    //     removes it from the accessibility tree by definition; the pixels
+    //     stay.
+    //   * the same attribute on something `display:none`. Nothing was on
+    //     screen, so nothing was omitted, and a probe that reported this
+    //     would be reporting every icon wrapper on every real page.
+    '<div id="ev-rich" contenteditable="true" role="textbox"\n' +
+    '  aria-label="Notes">zz-rich-00000000</div>' +
+    '<div id="ev-hidden" aria-hidden="true">zz-painted-00000000</div>' +
+    '<div id="ev-unpainted" aria-hidden="true" style="display:none">' +
+    'zz-unpainted-00000000</div>' +
+    // The second unpainted shape, and it is here so the probe's two
+    // visibility guards are gradeable apart. `display:none` is caught by the
+    // computed-style test *and* by the zero-size test; a box clipped to no
+    // height is caught only by the second, and its computed display is
+    // `block` with visibility `visible`.
+    '<div id="ev-clipped" aria-hidden="true"\n' +
+    '  style="height:0;overflow:hidden">zz-clipped-00000000</div>' +
+    // The third, and the one only the computed-style test can catch: a box
+    // with real width and height that is simply not painted. `display:none`
+    // trips both guards, so without this the style test grades nothing.
+    '<div id="ev-invisible" aria-hidden="true"\n' +
+    '  style="visibility:hidden">zz-invisible-00000000</div>';
   document.body.appendChild(ev);
 }
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -1545,6 +1545,21 @@ EVIDENCE_DIR_NAME = "evidence"
 # that code whatever it says. check_evidence_caps() asserts the package's own
 # constants equal these, so widening a cap has to be done on purpose.
 EVIDENCE_SCHEMA_EXPECTED = 1
+# The three shapes `?evidence=1` renders for #353: text the ARIA snapshot
+# structurally cannot carry, and one control that is not on screen at all.
+EVIDENCE_RICH_TEXT = "zz-rich-00000000"
+EVIDENCE_HIDDEN_TEXT = "zz-painted-00000000"
+EVIDENCE_UNPAINTED_TEXT = "zz-unpainted-00000000"
+# The second unpainted shape. `display:none` trips both of the probe's
+# visibility guards, so breaking either alone leaves the other holding and the
+# control cannot tell them apart; a box clipped to no height is caught by the
+# zero-size test only.
+EVIDENCE_CLIPPED_TEXT = "zz-clipped-00000000"
+# The third, and the only shape the computed-style test alone catches: a box
+# with real width and height that is not painted. `display:none` is 0x0 as
+# well, so without this the style test could be deleted and nothing would say.
+EVIDENCE_INVISIBLE_TEXT = "zz-invisible-00000000"
+
 EVIDENCE_LIMITS_EXPECTED = {
     "aria": 12_000,
     "scope_aria": 12_000,
@@ -1553,6 +1568,8 @@ EVIDENCE_LIMITS_EXPECTED = {
     # The chrome's own on-screen text (#361): the caption line and any card,
     # read out of the wrapper document — see reference/review.md.
     "chrome": 8_000,
+    # On-screen text the ARIA snapshot structurally cannot carry (#353).
+    "aria_omits": 12_000,
 }
 EVIDENCE_MARKER = "[demo-video: truncated here,"
 # The most a marker can add past a field's budget, so "cut to the cap" can be
@@ -11148,6 +11165,68 @@ def run_segments(out_root: Path) -> list[str]:
     )
 
 
+def check_evidence_omissions(
+    label: str, index: int, doc: dict, aria: str | None
+) -> list[str]:
+    """Does this beat's evidence say what its ARIA snapshot could not carry?
+
+    **Evidence claims to describe what the beat showed** (#9), and two shapes
+    of visible text never reach `aria_snapshot()` at all: the contents of a
+    rich-text editor (`contenteditable` with `role="textbox"`, whose
+    accessible value is read off a `value` property a `div` does not have) and
+    anything under `aria-hidden="true"`, which the attribute removes from the
+    accessibility tree by definition while the pixels stay on screen. Until
+    issue #353 they left no trace, so the file read as a complete account of a
+    screen it had only partly seen.
+
+    Read off the **unspotlit** beat: this is a property of the page, not of a
+    scope.
+
+    Both directions are graded, because the field can be wrong twice. Silence
+    is the defect #353 is about. A probe that reports *everything* is the same
+    artifact lie pointing the other way, and it is the one that gets the field
+    ignored — `aria-hidden` sits on an icon wrapper somewhere on nearly every
+    real page, and reporting those buries the two that matter.
+    """
+    failures: list[str] = []
+    omits = str(doc.get("aria_omits") or "")
+    aria_text = aria if isinstance(aria, str) else ""
+    for what, needle in (
+        ("a rich-text editor's contents", EVIDENCE_RICH_TEXT),
+        ("a painted aria-hidden subtree", EVIDENCE_HIDDEN_TEXT),
+    ):
+        # The control first, and it is the whole reason this can be graded: if
+        # the snapshot *did* carry it, `aria_omits` would be reporting an
+        # omission that did not happen, and the assertion below would be
+        # measuring the fixture rather than the recorder.
+        if needle in aria_text:
+            failures.append(
+                f"{label}: {needle!r} is in beat {index}'s ARIA tree, so "
+                f"{what} is not omitted after all — this fixture no longer "
+                f"reproduces issue #353 and `aria_omits` is being graded "
+                f"against a page that does not need it"
+            )
+        elif needle not in omits:
+            failures.append(
+                f"{label}: beat {index} shows {what} on screen and neither "
+                f"`aria` nor `aria_omits` contains {needle!r}. Evidence that "
+                f"omits on-screen text without saying so is an artifact "
+                f"describing a screen it only partly saw (issue #353)"
+            )
+    for needle, why in (
+        (EVIDENCE_UNPAINTED_TEXT, "`display:none`, so it was never painted"),
+        (EVIDENCE_CLIPPED_TEXT, "clipped to no height, so it was never painted"),
+        (EVIDENCE_INVISIBLE_TEXT, "`visibility:hidden`, so it was never painted"),
+    ):
+        if needle in omits:
+            failures.append(
+                f"{label}: beat {index}'s `aria_omits` names {needle!r}, "
+                f"which is {why} — nothing was on screen, so nothing was "
+                f"omitted"
+            )
+    return failures
+
+
 def run_evidence(out_root: Path) -> list[str]:
     """The evidence take: what a beat's page text carries, and what it caps.
 
@@ -11350,6 +11429,8 @@ def run_evidence(out_root: Path) -> list[str]:
                 f"{label}: beat {plain_i} carries `{field}` with no spotlight "
                 f"up, and it is the spotlight target's or nothing"
             )
+
+    failures += check_evidence_omissions(label, plain_i, plain, aria)
 
     # -- markup: what was never on screen is not in it ------------------------
     if attrs.get("scope") != EVIDENCE_ATTR_TARGET:

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -144,6 +144,53 @@ class Injection(NamedTuple):
 # The order is the order they run in: cheapest arm first, so a manifest that is
 # going to abort on a stale search string does it in eight seconds.
 INJECTIONS = [
+    # -- evidence says what it could not see (issue #353), ~7 s an entry
+    #
+    # Two entries, and they are the two directions the field can be wrong in.
+    # Silence is the defect the issue is about — evidence claims to describe
+    # what the beat showed, and two shapes of visible text never reach
+    # `aria_snapshot()` — but a probe that reports everything is the same
+    # artifact lie pointing the other way, and it is the one that gets the
+    # field ignored: `aria-hidden` is on an icon wrapper somewhere on nearly
+    # every real page, and reporting those buries the two that matter.
+    Injection(
+        name="evidence stops saying what the snapshot could not carry",
+        module="web.py",
+        old=(
+            "        omits = doc.evaluate(_ARIA_OMITS_JS)\n"
+            "        if omits:\n"
+            '            payload["aria_omits"] = omits'
+        ),
+        new="        pass",
+        arm="--evidence-only",
+        sites=("check_evidence_omissions",),
+        must_contain=("without saying so is an artifact",),
+    ),
+    Injection(
+        name="the omission probe reports text that was never on screen",
+        module="web.py",
+        old="    if (box.width === 0 || box.height === 0) continue;",
+        new="    if (false) continue;",
+        arm="--evidence-only",
+        sites=("check_evidence_omissions",),
+        must_contain=("clipped to no height, so it was never painted",),
+    ),
+    Injection(
+        # The other visibility guard. `display:none` trips this one *and* the
+        # zero-size test above, so the fixture carries a shape for each —
+        # otherwise breaking either leaves the other holding, and the control
+        # cannot say which of them was doing the work.
+        name="the omission probe stops checking whether a subtree is displayed",
+        module="web.py",
+        old=(
+            "    if (style.visibility === 'hidden' || style.display === 'none')"
+            " continue;"
+        ),
+        new="    if (false) continue;",
+        arm="--evidence-only",
+        sites=("check_evidence_omissions",),
+        must_contain=("`visibility:hidden`, so it was never painted",),
+    ),
     # -- stills without a video (issue #372), ~3 s an entry
     #
     # Two entries against one check, and they are the two halves it exists for:


### PR DESCRIPTION
Closes #353.

`evidence/beat-NN.json` claims to describe what a beat showed. Two shapes of
visible text never reach `aria_snapshot()` and left **no trace at all**, so the
file read as a complete account of a screen it had only partly seen.

They now go in a new `aria_omits` field, written in the snapshot's own idiom and
**absent when there is nothing to say** — every take with no such element on
screen writes exactly the evidence it wrote before.

```
=== aria (the snapshot) ===
- textbox "Amount": "95000"
- textbox "Notes"                       <- promises a value, carries none

=== aria_omits (new) ===
- textbox "Notes": Refund approved by Dana
- aria-hidden: Draft saved at 14:02 — unsent
```

## The issue names the wrong cause, and an assertion written to it could not have failed

#353 says typed values inside dialogs are dropped. **They are not.** Measured
against Playwright 1.62.0, one page, seven input shapes filled and read back out
of one `body` snapshot:

| shape | in the snapshot |
|---|---|
| `contenteditable` with `role="textbox"` | **absent** |
| subtree under `aria-hidden="true"` | **absent** |
| textbox inside `<dialog aria-modal>` | present |
| `contenteditable`, no role | present |
| `<input type="number">` / `password` / `readonly` | present |
| input under `role="presentation"` | present |
| input inside a shadow root | present |

So the issue's acceptance criterion — *a take that types into a dialog writes
that value into the beat's evidence* — was **already met**, and as an assertion
it is this repo's *ungraded constant*. The real classes are structural: a
`textbox`'s accessible value is read off a `value` property a `div` does not
have, and `aria-hidden` removes a subtree from the accessibility tree by
definition while the pixels stay on screen.

The honest criterion, and the one implemented: **evidence either carries the
text or says it could not.** Silence is the defect.

## Three of the four injections are the opposite direction

A probe that reports *everything* is the same artifact lie pointing the other
way, and it is the one that gets a field ignored — `aria-hidden` sits on an icon
wrapper somewhere on nearly every real page.

**Both visibility guards are independently gradeable**, which took two goes.
`display:none` is caught by the zero-size test *and* the computed-style test, so
breaking either left the other holding and the plant went unnoticed. The fixture
now carries a shape only each one catches:

```
PASS  break: evidence stops saying what the snapshot could not carry
      caught: beat 2 shows a rich-text editor's contents on screen and neither
              `aria` nor `aria_omits` contains 'zz-rich-00000000'
      caught: beat 2 shows a painted aria-hidden subtree on screen …
PASS  break: the omission probe reports text that was never on screen
      caught: `aria_omits` names 'zz-clipped-00000000', clipped to no height
PASS  break: the omission probe stops checking whether a subtree is displayed
      caught: `aria_omits` names 'zz-invisible-00000000', `visibility:hidden`
PASS  break: every beat's evidence describes the first beat's page   (pre-existing)
```

Each of the two "it is omitted" assertions has its control **first**: if the
snapshot did carry the text, `aria_omits` would be reporting an omission that
never happened, and the assertion below it would be grading the fixture rather
than the recorder.

## What #356 can now assume

The lint blocked on this issue can scope itself: evidence is blind to rich-text
editor contents and to `aria-hidden` subtrees **only when `aria_omits` is
absent**, and both are *not checkable* rather than *not found* — the distinction
that issue insists on three states for.

## Notes

- `run_evidence`'s assertions were extracted into `check_evidence_omissions`,
  because `smoke-inject`'s own guard refuses an entry whose site is not a
  top-level check function. It is a better home anyway.
- `reference/review.md` documents the field and says plainly that a dialog is
  not the reason a value is missing — that misreading cost this issue a year.

## Gates

- `tests/smoke --evidence-only` — passes; `tests/smoke-inject --arm evidence` —
  **4 injections, all caught**, 0.5 min
- `tests/smoke-inject --self-test` — every guard refused what it exists to
  refuse (README figures resynced: 76 entries, `--evidence-only` 4, 52 check
  functions)
- `mise run check` — 7.6 s, green