### PR TITLE
Rehearse before record: a broken feature costs seconds, not a take

### DIFF
--- a/.github/workflows/demo-video.yml
+++ b/.github/workflows/demo-video.yml
@@ -34,6 +34,12 @@ name: Demo video
 #      only when the branch changed something under the app that storyboard
 #      demonstrates. A pull request that touches the app but no storyboard
 #      still records; a pull request that touches neither exits in seconds.
+#   3. The rehearsal (#387) — the functional one. Each selected storyboard
+#      runs once before any take: same verbs, pacing zeroed, strict=True.
+#      A storyboard whose feature does not work reddens the job in seconds,
+#      names itself, and nothing is recorded, staged or published — because
+#      the alternative is spending encoder minutes producing artifacts that
+#      document a bug as if it were the demo.
 #
 # A label was the alternative and was rejected: it needs a human action on a
 # branch that already exists, and when somebody forgets, the failure mode is
@@ -194,7 +200,7 @@ jobs:
           skill="$root/skills/demo-video"
           # Packaging and some checkout paths drop the executable bit.
           chmod +x "$dir"/demo-storyboards "$dir"/demo-comment "$dir"/demo-ticket-check
-          chmod +x "$skill"/scripts/demo-target-guard
+          chmod +x "$skill"/scripts/demo-target-guard "$skill"/scripts/demo-rehearse
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
           echo "skill=$skill" >> "$GITHUB_OUTPUT"
 
@@ -350,10 +356,51 @@ jobs:
           echo "--- app log ---"; cat "$APP_LOG" || true
           exit 1
 
+      # The functional gate (#387), before a single encoder minute is spent.
+      # Every selected storyboard runs once as a rehearsal — the same
+      # storyboard, pacing zeroed, no video, strict=True — and one that fails
+      # is not recorded: the job reddens here in seconds naming the file,
+      # nothing is staged or published, and no take exists to document a bug
+      # as if it were the demo. It exports the same target facts the Record
+      # step does, for the same reason that step does: the recorder classifies
+      # its target again at construction, and WorkflowGates (tests/ci-unit)
+      # holds the two steps to the same facts. A storyboard whose app is fine
+      # costs its rehearsal seconds; that is the whole price of never encoding
+      # a broken feature.
+      - name: Rehearse
+        id: rehearse
+        if: steps.discover.outputs.count != '0'
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          SKILL: ${{ steps.helpers.outputs.skill }}
+          DEMO_VIDEO_BASE_URL: ${{ inputs.base-url }}
+          DEMO_VIDEO_ALLOW_PRIVATE: ${{ inputs.allow-private-network-target }}
+          DEMO_VIDEO_SPEECH: "0"
+        run: |
+          set -uo pipefail
+          status=ok
+          rehearsed=0
+          # fd 3, not stdin — `uv run` drains stdin, which ate every
+          # storyboard after the first until the Record step learned this.
+          while IFS= read -r sb <&3; do
+            [ -n "$sb" ] || continue
+            rehearsed=$((rehearsed + 1))
+            echo "::group::rehearse $sb"
+            if ! "$SKILL/scripts/demo-rehearse" "$sb" < /dev/null; then
+              echo "::error file=$sb::rehearsal failed — the feature does not work as the storyboard drives it; no take was recorded"
+              status=failed
+              echo "::endgroup::"
+              break
+            fi
+            echo "::endgroup::"
+          done 3< "$CHANGED.selected"
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          echo "rehearsal status: $status ($rehearsed storyboard(s) rehearsed)"
+
       # The take is allowed to fail here. What it left behind is the point of
       # every step after this one, so the job is failed at the very end instead.
       - name: Record
-        if: steps.discover.outputs.count != '0'
+        if: steps.discover.outputs.count != '0' && steps.rehearse.outputs.status == 'ok'
         id: record
         working-directory: ${{ inputs.working-directory }}
         env:

--- a/README.md
+++ b/README.md
@@ -67,8 +67,11 @@ jobs:
 ```
 
 It records only storyboards whose application changed, sets an explicit
-artifact retention and says it in the comment, and **refuses to record against
-a public host** — see
+artifact retention and says it in the comment, **refuses to record against
+a public host**, and **rehearses before it records**: each storyboard runs
+once, fast and strict (`scripts/demo-rehearse`), and one whose feature does
+not work fails the check in seconds — no take is made of something broken.
+See
 [`skills/demo-video/reference/ci.md`](skills/demo-video/reference/ci.md) for the
 trigger policy, what is published, and what the target guard does not cover.
 

--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -72,6 +72,12 @@ and a real terminal session (voice on):
   in this skill, deliberately, and `SKILL.md` opens with why. The same rules
   run as `scripts/demo-target-guard` in CI, over the workflow's configuration
   and each storyboard's source text.
+- **A gate on the thing being demoed** — before anything is polished or
+  recorded, the storyboard itself runs once as a *rehearsal*
+  (`scripts/demo-rehearse`): same verbs, pacing zeroed, seconds not minutes,
+  strict about console errors, failed requests and non-zero exits. A feature
+  that does not work fails there and no video of it is made. CI runs the same
+  command before spending encoder minutes on a take.
 - **Spoken narration (optional)** — with `ELEVENLABS_API_KEY` set, every
   caption line is synthesized via ElevenLabs and mixed onto the mp4 at the
   moment it appears. Clips are cached; pacing self-adjusts so speech is
@@ -152,6 +158,8 @@ demo-video/
 ├── README.md                      # this file — humans read this
 ├── ensure.sh                      # installs uv, restores exec bits — run once
 ├── scripts/
+│   ├── demo-rehearse              # the functional gate: storyboard, fast and
+│   │                              #   strict, before anything is recorded
 │   ├── demo-grade                 # the blind reader's brief, and the verdict
 │   │                              #   comparing it with the ac= tags (step 6b)
 │   ├── demo-shots                 # the take's stills as one pasteable block,

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -379,15 +379,21 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
    `TerminalRecorder(interlude="…")` instead — see
    [reference/terminal.md](reference/terminal.md).
 
-   **1.5. Smoke each state transition the storyboard will wait on** —
-   outside the browser (`curl` the API path), before writing any beat. In
-   the run that earned this step, the check would have surfaced a real app
-   bug in 20 seconds; instead it surfaced as a 25 s Playwright timeout four
-   minutes into a take.
+    **1.5. Smoke each state transition the storyboard will wait on** —
+    outside the browser (`curl` the API path), before writing any beat. In
+    the run that earned this step, the check would have surfaced a real app
+    bug in 20 seconds; instead it surfaced as a 25 s Playwright timeout four
+    minutes into a take.
 2. **Write `record.py`** in the demo folder as a short storyboard. Capture
    a still (`rec.shot("NN-name")`) at each moment a written guide would
    narrate. Make retakes idempotent — clean up state earlier takes created,
    and vary generated content if the app dedupes identical inputs.
+   - **Assert every transition you will narrate.** A caption promises what
+     the app *did*, so each state change a caption will narrate gets a
+     `wait_for` / `wait_for_text` / `wait_for_prompt` on its outcome — the
+     row exists, the flag appears, "done". A storyboard that only performs
+     actions rehearses green over a feature that does nothing: these
+     assertions are the gate's teeth, and they cost one line each.
    - **Show, don't assert.** An event the script triggers outside the
      browser (dropping a file, calling an API) is invisible — put it on
      screen with `rec.terminal(...)`, perform the real action right after,
@@ -395,6 +401,24 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
    - **Point at the evidence.** Set the caption first, then
      `rec.spotlight(selector)` on the element it talks about, so viewers
      never see a highlight belonging to the previous line.
+
+2.5. **Rehearse — the gate nothing downstream passes red.** Run
+
+    ```sh
+    bash <skill dir>/ensure.sh        # once per session
+    <skill dir>/scripts/demo-rehearse <demo folder>/record.py
+    ```
+
+    The same storyboard driven end to end in seconds — pacing zeroed, no
+    video encoded ([reference/stills.md](reference/stills.md)) — under
+    `strict=True`, so a console error, a failed request or a non-zero exit
+    fails the run and names itself. **A demo of something that does not work
+    is not made**: until this exits 0, do not polish captions, do not set
+    spotlights, and do not record a take. Polish invested before this line is
+    polish thrown away when the app turns out to be broken, and the broken
+    app is discovered here for seconds instead of in fresh-agent review after
+    minutes of encoding (a rehearsal may rewrite `images/`; that is fine —
+    commit only after the real take).
 3. **Caption every beat.** A fresh caption before each thing the viewer
    should understand, `caption("")` to end clean. The caption lives in the
    recorder's own band and survives every navigation — full loads and SPA
@@ -418,12 +442,15 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
      stale caption. Best: spend the wait touring what's already on screen;
      failing that, swap in a caption saying what is being waited for.
    - End with a closing line that sums up the story, then `caption("")`.
-4. **Record:** `uv run <demo folder>/record.py` (with the project's env
+4. **Record** (step 2.5 rehearsed green — if it did not, stop here):
+   `uv run <demo folder>/record.py` (with the project's env
    loaded if it configures DEMO_VIDEO_* or the ElevenLabs key:
    `set -a; source .env; set +a`). Aim for 30–60 s. **While the storyboard
    is still wrong, run it with `DEMO_VIDEO_STILLS_ONLY=1`** — same verbs and
    the same stills in seconds, no video ([reference/stills.md](reference/stills.md));
-   record the take once the pictures are right.
+   record the take once the pictures are right. Rehearse again whenever the
+   app changed under a committed storyboard — it is the cheap half of the
+   check CI runs before recording anything (#387).
 5. **Verify by looking, not by exit code:** read the `images/*.png` stills
    to confirm the story is actually visible; check `ffprobe` duration. Read
    `timeline.md` too — it is the take's own account of what ran and when, so
@@ -618,7 +645,8 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
 
 The skill is self-contained: this file, the `reference/` directory it links
 into, the `helpers/demo_recording/` package, `ensure.sh` at the skill root,
-`scripts/demo-grade` (step 6b), `scripts/demo-shots` (the stills block) and
+`scripts/demo-rehearse` (the step-2.5 gate), `scripts/demo-grade` (step 6b),
+`scripts/demo-shots` (the stills block) and
 `scripts/demo-target-guard` (the target classifier), the vendored `helpers/assets/xterm/` terminal assets, and
 `README.md`. Install it with the `skills` CLI — into the current project:
 

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -463,6 +463,11 @@ EVIDENCE_LIMITS = {
     # silently stopped saying which line was on screen would fail #9's
     # criterion while every remaining field stayed plausible.
     "chrome": EVIDENCE_MAX_HTML,
+    # On-screen text `aria_snapshot()` structurally cannot carry — a
+    # rich-text editor's contents, an `aria-hidden` subtree that is still
+    # painted (#353). Absent when the page held none, so it is capped only
+    # when it is there, and `limits` names it only then.
+    "aria_omits": EVIDENCE_MAX_ARIA,
 }
 EVIDENCE_TRUNCATED = "\n…[demo-video: truncated here, {n} more characters]"
 

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -267,6 +267,88 @@ _CHROME_TEXT_JS = """() => {
   ].filter(Boolean).join('\\n');
 }"""
 
+# On-screen text the ARIA snapshot structurally cannot carry (issue #353).
+#
+# **Evidence claims to describe what the beat showed.** Two shapes of visible
+# text never reach `aria_snapshot()`, and until this field they left no trace
+# at all — the file read as a complete account of a screen it had only
+# partly seen. Measured against Playwright 1.62.0, one page, seven input
+# shapes filled and read back out of one `body` snapshot:
+#
+#   | shape                                   | in the snapshot |
+#   |-----------------------------------------|-----------------|
+#   | `contenteditable` with `role="textbox"` | **absent**      |
+#   | subtree under `aria-hidden="true"`      | **absent**      |
+#   | `contenteditable`, no role              | present         |
+#   | `<input type="number">`                 | present         |
+#   | `<input type="password">`               | present         |
+#   | `readonly` input                        | present         |
+#   | input under `role="presentation"`       | present         |
+#   | input inside a shadow root              | present         |
+#   | textbox inside `<dialog aria-modal>`    | present         |
+#
+# The last row is why this field exists in the shape it does. #353 was filed
+# saying dialogs drop typed values; they do not, and an assertion written to
+# that could never have failed. The real classes are the first two, and both
+# are **structural**: a `textbox`'s accessible value is read off a `value`
+# property a `div` does not have, and `aria-hidden` removes a subtree from the
+# accessibility tree by definition while the pixels stay on screen.
+#
+# **Absent when there is nothing to say** (#24's rule), so every take that has
+# no such element on screen writes exactly the evidence it wrote before.
+#
+# Written in the snapshot's own `- role "name": value` idiom rather than as
+# JSON: the reader already knows how to read that, and a lint tokenising
+# `aria` can tokenise this with the same code (#356).
+_ARIA_OMITS_JS = r"""() => {
+  const MAX_ENTRIES = 40, MAX_TEXT = 500;
+  const out = [];
+  const clip = (s) => {
+    const t = (s || '').replace(/\s+/g, ' ').trim();
+    return t.length > MAX_TEXT ? t.slice(0, MAX_TEXT) + '…' : t;
+  };
+  // The recorder's own furniture, if any of it ever lands in this document.
+  // It is chrome rather than app, and `chrome` is the field that carries it.
+  const ours = (el) => (el.id || '').startsWith('__demo')
+    || (el.id || '').startsWith('__chrome');
+
+  // 1. A rich-text editor. `role="textbox"` promises the tree an accessible
+  //    *value*, which for a div is read off a property it does not have, so
+  //    the node renders as `- textbox "Name"` with nothing after the colon.
+  for (const el of document.querySelectorAll('[contenteditable]')) {
+    if (out.length >= MAX_ENTRIES) break;
+    const editable = el.getAttribute('contenteditable');
+    if (editable === 'false') continue;
+    const role = (el.getAttribute('role') || '').toLowerCase();
+    if (!['textbox', 'searchbox', 'combobox'].includes(role)) continue;
+    if (ours(el)) continue;
+    const text = clip(el.innerText);
+    if (!text) continue;
+    const name = el.getAttribute('aria-label') || el.getAttribute('title') || '';
+    out.push('- ' + role + ' ' + JSON.stringify(name) + ': ' + text);
+  }
+
+  // 2. An `aria-hidden` subtree that is nonetheless painted. Outermost only —
+  //    a nested one is already inside the text reported for its ancestor —
+  //    and painted only, because the overwhelmingly common use of the
+  //    attribute is on something already invisible, which is not an omission.
+  for (const el of document.querySelectorAll('[aria-hidden="true"]')) {
+    if (out.length >= MAX_ENTRIES) break;
+    const parent = el.parentElement;
+    if (parent && parent.closest('[aria-hidden="true"]')) continue;
+    if (ours(el)) continue;
+    const box = el.getBoundingClientRect();
+    if (box.width === 0 || box.height === 0) continue;
+    const style = getComputedStyle(el);
+    if (style.visibility === 'hidden' || style.display === 'none') continue;
+    if (parseFloat(style.opacity || '1') <= 0) continue;
+    const text = clip(el.innerText || el.textContent);
+    if (!text) continue;
+    out.push('- aria-hidden: ' + text);
+  }
+  return out.join('\n');
+}"""
+
 # The spotlight target's markup, cleaned, from a *clone* — nothing here may
 # touch the live page, which is being recorded.
 #
@@ -664,6 +746,12 @@ class Recorder(_DemoBase):
             # furniture (see _CHROME_TEXT_JS).
             "chrome": self.page.evaluate(_CHROME_TEXT_JS),
         }
+        # What the snapshot above structurally could not carry (#353). The key
+        # is written only when there is something to say, so a page with no
+        # such element on screen produces exactly the document it always did.
+        omits = doc.evaluate(_ARIA_OMITS_JS)
+        if omits:
+            payload["aria_omits"] = omits
         if self._spotlit:
             target = doc.locator(self._spotlit).first
             payload["scope_aria"] = self._aria(target)[0]

--- a/skills/demo-video/reference/review.md
+++ b/skills/demo-video/reference/review.md
@@ -283,6 +283,7 @@ off.
 |---|---|
 | `aria` | **`Recorder`**: the app document's ARIA snapshot — a compact YAML tree of roles and accessible names, the same thing `expect(...).toMatchAriaSnapshot` compares. Semantic, ~10× smaller than the markup, and stable across restyling, which is why it is preferred over raw HTML |
 | `scope` / `scope_aria` / `html` | the current `spotlight()` target: its selector, its own ARIA tree, and its `outerHTML` with every value-bearing attribute stripped. All three are null when no spotlight is up |
+| `aria_omits` | **`Recorder`**, and **absent unless there is something to say**: on-screen text the ARIA snapshot structurally cannot carry, in the snapshot's own idiom. Two shapes reach it — a rich-text editor (`contenteditable` with `role="textbox"`, whose accessible *value* is read off a `value` property a `div` does not have) and a painted `aria-hidden` subtree, which the attribute removes from the accessibility tree by definition while the pixels stay. Nothing that was never painted is listed |
 | `chrome` | **`Recorder`**: what the recorder's own chrome shows on screen — the visible caption line, and any card or bridge label that is up. Read out of the wrapper document's DOM at capture time, never copied from the beat log: the caption lives in the chrome's reserved band, not in the app document the `aria` describes, so without this field no evidence file could say which narration line the frame showed |
 | `screen` | **`TerminalRecorder`**: the rendered screen, ANSI resolved by xterm.js, scrollback included — the same text `wait_for_text()` matches against |
 | `truncated` / `limits` | which fields were cut, and at what budget. A cut field also says so inline where it stops |
@@ -314,6 +315,16 @@ Two things are dropped, and neither is a security control:
 Both are statements about what belongs in a text dump of an element, and this
 repo's `tests/smoke` grades them directly: its evidence take injects an element
 holding a `<script>` and a `srcdoc` and requires neither in the markup.
+
+**Two shapes of on-screen text the ARIA tree cannot hold are named rather than
+dropped.** A rich-text editor's contents and a painted `aria-hidden` subtree
+are both invisible to `aria_snapshot()` — structurally, not by accident — so
+they go in `aria_omits` (see the table above). Before that they left no trace
+and the file read as a complete account of a screen it had only partly seen.
+
+Measured on one page with seven input shapes filled: the other five come
+through the snapshot normally, **dialogs included**. If you are reading this
+because a value is missing from evidence, the dialog is not the reason.
 
 **Fields are capped** — 12 000 characters of ARIA or screen text, 8 000 of
 markup — and truncation is **marked, never silent**. A TUI's scrollback is

--- a/skills/demo-video/reference/stills.md
+++ b/skills/demo-video/reference/stills.md
@@ -27,6 +27,13 @@ said": the `criteria=` map, the `ac=` tags and the coverage table all work
 exactly as they do in a take, and `timeline.md` comes out with the same
 acceptance section.
 
+**As a gate, run it through `scripts/demo-rehearse`.** That is this mode plus
+`strict=True` — console errors, failed requests and non-zero exits become a
+failing verdict instead of a note in the timeline — under one command that
+refuses an environment variable set to route around it. Nothing is polished
+and no take is recorded until it exits 0 (SKILL.md Process step 2.5); CI runs
+the same command before spending encoder minutes on a take.
+
 ## What it writes, and what it does not
 
 | Written | Not written |

--- a/skills/demo-video/scripts/demo-rehearse
+++ b/skills/demo-video/scripts/demo-rehearse
@@ -1,0 +1,88 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Rehearse a storyboard before anything is polished or recorded.
+
+    <skill-dir>/scripts/demo-rehearse <demo folder>/record.py [more.py ...]
+
+The functional gate of this skill: the same storyboard, driven end to end in
+seconds — pacing zeroed, no screencast, no encode — with `strict=True`, so
+a console error, an uncaught page exception, a failed request, an HTTP >= 400
+or a non-zero exit is a failing verdict rather than a note in a timeline.
+
+A demo of a feature that does not work is not made. Rehearse first; record
+only what rehearsed green ([#385](https://github.com/rogvid/skills/issues/385)).
+
+How it works: there is no third mode. This composes two existing ones —
+`DEMO_VIDEO_STILLS_ONLY=1` (reference/stills.md) and `DEMO_VIDEO_STRICT=1` —
+and execs `uv run` on each storyboard. Everything the recorder already
+guarantees about a stills run holds here: wait timeouts are unchanged, the
+target guard still classifies the target before a browser opens, and the run
+drives the real app and mutates real state.
+
+**An explicit override in the environment is refused**, before anything runs:
+`DEMO_VIDEO_STILLS_ONLY=0` or `DEMO_VIDEO_STRICT=false` passed into this
+script would silently route around the gate while its output still claimed to
+be a rehearsal. Unset the variable instead. (A storyboard that pins
+`stills_only=False` or `strict=False` as a constructor argument wins over any
+environment — the recorder's documented precedence — and this wrapper cannot
+see inside the file. That is the author's assertion to make, and the take's
+own stderr says which mode ran.)
+
+Exit status: 0 when every storyboard rehearsed green; 1 when one failed (the
+first failure stops the run — a broken feature usually fails everywhere, and
+the seconds saved are the point); 2 for a usage error.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+GATE = {
+    "DEMO_VIDEO_STILLS_ONLY": "1",
+    "DEMO_VIDEO_STRICT": "1",
+}
+_FALSE = {"0", "false", "no", "off"}
+
+
+def main(argv: list[str]) -> int:
+    storyboards = [a for a in argv if a not in ("-h", "--help")]
+    if len(storyboards) != len(argv) or not storyboards:
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    for name in GATE:
+        current = os.environ.get(name, "").strip().lower()
+        if current in _FALSE:
+            print(
+                f"demo-rehearse: {name}={current!r} in the environment would "
+                f"route this rehearsal around the gate it exists to be. Unset "
+                f"{name} and run it again.",
+                file=sys.stderr,
+            )
+            return 2
+    env = {**os.environ, **GATE}
+    for path in storyboards:
+        print(f"demo-rehearse: {path}", flush=True)
+        taken = subprocess.run(["uv", "run", path], env=env)
+        if taken.returncode != 0:
+            print(
+                f"demo-rehearse: FAILED — {path} did not rehearse green "
+                f"(exit {taken.returncode}). The feature does not work as the "
+                f"storyboard drives it: read the issues above, fix the app or "
+                f"the storyboard, and re-run. Do not record a take.",
+                file=sys.stderr,
+            )
+            return 1
+    print(
+        f"demo-rehearse: {len(storyboards)} storyboard(s) rehearsed green — "
+        f"cleared to caption, polish and record."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/README.md
+++ b/tests/README.md
@@ -136,7 +136,7 @@ seen red under a planted recorder defect in #351's pull request.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~54 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~55 min, nightly)
 ├── unit               # the browser-free half (~4 s, 568 tests, no dependencies)
 ├── ci-unit            # the .github/scripts helpers, and the two skill
 │                      #   CLIs whose output a person pastes (~2.5 s)
@@ -318,7 +318,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~195 s)
-tests/smoke-inject                # all 73 entries, ~54 min
+tests/smoke-inject                # all 76 entries, ~55 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -1257,15 +1257,26 @@ So the assertions were **written rather than trimmed**, and there are three:
   and named in `truncated`. A cap applied to `aria` and not to `scope_aria` is
   a cap on a third of what a spotlight beat writes.
 
-  **Truncation is the only omission that is marked.** Two shapes of on-screen
-  text never reach the snapshot at all and nothing says so: the contents of a
-  rich-text editor (`contenteditable` with `role="textbox"`, whose accessible
-  value is read off a `value` property a `div` does not have) and anything
-  under `aria-hidden="true"`. Measured with Playwright 1.62.0 against a page
-  filling seven input shapes — the other five, dialog inputs included, come
-  through. That is tracked in
-  [#353](https://github.com/rogvid/skills/issues/353), and it bounds what any
-  evidence-reading tool can do.
+  **Truncation used to be the only omission that was marked.** Two shapes of
+  on-screen text never reach the snapshot at all — the contents of a rich-text
+  editor (`contenteditable` with `role="textbox"`, whose accessible value is
+  read off a `value` property a `div` does not have) and anything under
+  `aria-hidden="true"` — and until
+  [#353](https://github.com/rogvid/skills/issues/353) they left no trace, so
+  the file read as a complete account of a screen it had only partly seen.
+  They now go in `aria_omits`, a field absent when there is nothing to say.
+  Measured with Playwright 1.62.0 against a page filling seven input shapes:
+  the other five, **dialog inputs included**, come through — which is why the
+  shape #353 was filed against could never have been asserted.
+
+  Four injections cover it, and three of them are the *other* direction: a
+  probe that also reports what was never painted buries the two that matter
+  under every icon wrapper on a real page. There is one per visibility guard,
+  because `display:none` trips both and would otherwise leave either deletable
+  in silence — the fixture carries a clipped box for the zero-size test and a
+  `visibility:hidden` box for the computed-style one. The caption-claims lint
+  that will read this field is tracked in
+  [#356](https://github.com/rogvid/skills/issues/356).
 
 Plus the two that never touched masking: a previous take's evidence is cleared
 from the directory on a re-record while another *segment's* files survive, and
@@ -2288,7 +2299,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-73 entries, 15 arms, ~54.5 min of takes
+76 entries, 15 arms, ~54.8 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -2324,7 +2335,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
 | `--polish-only` | 4 | a terminal segment stops saying what it opened on ([#235](https://github.com/rogvid/skills/issues/235)), which is the one account of that frame a demo directory ships: the field gone entirely; the number a plausible constant instead of a reading, which every other statement about the field is happy with; the cover painted a colour that is not the window body, so frame 0 is not the cover at all — #110's own defect, the card raised late, can no longer be planted here: since [#362](https://github.com/rogvid/skills/issues/362) the shared chrome covers frame 0 twice, independently, and breaking either cover alone leaves frame 0 reading 24.0; or the report forgetting that a card was asked for, without which `"bare"` cannot be told from a segment that never wanted one |
 | `--segments-only` | 14 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the sheet stops saying **which clock** it cut them on, so a reviewer cannot tell a corrected sheet from one cut on the raw beat log ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
-| `--evidence-only` | 1 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one |
+| `--evidence-only` | 4 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one. Or evidence goes back to omitting on-screen text in silence ([#353](https://github.com/rogvid/skills/issues/353)): a rich-text editor's contents and a painted `aria-hidden` subtree, neither of which `aria_snapshot()` can carry. The other two entries are the opposite direction — a probe that also reports what was never painted buries the two that matter under every icon wrapper on the page — and there is one per visibility guard, because `display:none` trips both and would leave either deletable in silence |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
 | `--wrapper-only` | 9 | the wrapper take (#358, #360) stops keeping its promises silently: a caption dispatched and never painted in its band; a caption too tall for the band shaved at both edges with no caption_clipped issue saying so (#366's review finding); the caption's appearance repainting pixels inside the app rect, which is the overlap the band exists to remove; evidence captured from the wrapper chrome instead of the app frame, with url, title and aria all plausible; a frame-refused app surfacing as a bare `ERR_BLOCKED_BY_RESPONSE` naming no header; or the block swallowed entirely, so a silently blank window records to the end as a demo — the artifact-lie outcome the issue names outright. Three more are #360's chrome parity, each invisible to every artifact but the encoded frames: the card layer shipping transparent, so the take opens on the slot's white canvas instead of the hold; the card's field nudged off the window body it must equal on the single-encoder path; and a mid-take goto emptying the caption band while the beat log keeps reporting the line |
 | `--failure-only` | 2 | a crash dump that exists and says nothing — an empty `screen.txt`, a marker that names neither the exception nor whether the mp4 is this take's |
@@ -2333,7 +2344,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **17 of `tests/smoke`'s 51 check functions have no entry**, and the harness
+- **17 of `tests/smoke`'s 52 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -617,6 +617,70 @@ class WorkflowGates(unittest.TestCase):
         )
 
 
+REHEARSE_STEP = "Rehearse"
+
+
+class RehearseGate(unittest.TestCase):
+    """Nothing is recorded until it rehearsed green.
+
+    The rehearsal (#385/#387) exists so a broken feature costs seconds instead
+    of an encode — which makes the *ordering* and the *fact passthrough* the
+    two things a refactor can quietly break. A Rehearse step moved after
+    Record rehearses nothing that matters; one missing `DEMO_VIDEO_BASE_URL`
+    has the recorder classify a default target the guard never saw. Both
+    happened to the guard/record pair once (#418's comment above), which is
+    why this reads the file rather than trusting the YAML.
+    """
+
+    def setUp(self):
+        text = WORKFLOW.read_text(encoding="utf-8")
+        self.text = text
+        self.steps = workflow_steps(text)
+        for name in (REHEARSE_STEP, RECORD_STEP):
+            self.assertIn(name, self.steps, f"no {name!r} step in {WORKFLOW}")
+        self.rehearse = step_env(self.steps[REHEARSE_STEP])
+        self.record = step_env(self.steps[RECORD_STEP])
+        # The haystack control: SKILL plus two target facts plus speech off.
+        self.assertGreaterEqual(len(self.rehearse), 4, self.rehearse)
+
+    def test_rehearse_runs_before_record(self):
+        self.assertLess(
+            self.text.index(f"name: {REHEARSE_STEP}"),
+            self.text.index(f"name: {RECORD_STEP}"),
+            "the Rehearse step must run before Record, or it gates nothing",
+        )
+
+    def test_record_is_gated_on_the_rehearsal(self):
+        condition = re.search(r"- name: Record\n\s+if: (.+)", self.text)
+        self.assertIsNotNone(condition, "Record has no `if:` condition")
+        self.assertIn(
+            "steps.rehearse.outputs.status == 'ok'",
+            condition.group(1),
+            "Record does not read the rehearsal's verdict, so a storyboard "
+            "that failed rehearsal would be recorded anyway",
+        )
+
+    def test_every_target_fact_record_exports_rehearse_exports_too(self):
+        wrong = []
+        for env_name in GUARD_FACT_TO_RECORDER_ENV.values():
+            exported = self.record.get(env_name)
+            if exported is None:
+                continue  # WorkflowGates owns the record side of this pairing
+            rehearsed = self.rehearse.get(env_name)
+            if rehearsed is None:
+                wrong.append(
+                    f"Record exports {env_name} but Rehearse does not, so the "
+                    f"rehearsal drives a target the take never will"
+                )
+            elif rehearsed != exported:
+                wrong.append(
+                    f"{env_name} differs between Rehearse ({rehearsed!r}) and "
+                    f"Record ({exported!r}) — the gate and the take can be "
+                    f"given different apps"
+                )
+        self.assertEqual(wrong, [], "\n  - ".join([""] + wrong))
+
+
 # --------------------------------------------------------------------------
 # demo-comment — what the pull request says
 # --------------------------------------------------------------------------

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -633,7 +633,7 @@ class RehearseGate(unittest.TestCase):
     """
 
     def setUp(self):
-        text = WORKFLOW.read_text(encoding="utf-8")
+        text = _WORKFLOW.read_text(encoding="utf-8")
         self.text = text
         self.steps = workflow_steps(text)
         for name in (REHEARSE_STEP, RECORD_STEP):
@@ -4231,19 +4231,48 @@ INJECTIONS = [
         # The regression itself, as it shipped: the guard step permits a
         # private host and the Record step never tells the recorder. Green CI
         # both before and after, because nothing read this file.
+        #
+        # The anchor carries the comment line above it because the same env
+        # line is exported twice now — the Rehearse step (#387) passes the
+        # same facts to the same classifier — and an anchor that matched both
+        # would abort rather than land. The Rehearse side of this pairing has
+        # its own injection below.
         "the Record step stops passing the private opt-in to the recorder",
         "demo-video.yml",
+        "          # keeps the two steps saying the same thing.\n"
         "          DEMO_VIDEO_ALLOW_PRIVATE: ${{ inputs.allow-private-network-target }}\n",
-        "",
+        "          # keeps the two steps saying the same thing.\n",
         ["WorkflowGates.test_every_fact_the_guard_classifies_on_reaches_the_recorder"],
+    ),
+    (
+        # The rehearsal is a second consumer of the same fact: it drives the
+        # recorder that classifies at construction, before any take. Drop its
+        # export alone and the rehearsal can rehearse against a target the
+        # guard never permitted while Record stays correct — which is why
+        # RehearseGate grades the pairing per step and not once for the job.
+        "the Rehearse step stops passing the private opt-in to the recorder",
+        "demo-video.yml",
+        "          SKILL: ${{ steps.helpers.outputs.skill }}\n"
+        "          DEMO_VIDEO_BASE_URL: ${{ inputs.base-url }}\n"
+        "          DEMO_VIDEO_ALLOW_PRIVATE: ${{ inputs.allow-private-network-target }}\n",
+        "          SKILL: ${{ steps.helpers.outputs.skill }}\n"
+        "          DEMO_VIDEO_BASE_URL: ${{ inputs.base-url }}\n",
+        [
+            "RehearseGate.test_every_target_fact_record_exports_rehearse_exports_too",
+        ],
     ),
     (
         # The same disagreement written the other way, and the one a reviewer
         # is likelier to wave through: the variable is there, so the two gates
         # look coupled, and it is pinned to a constant the input cannot move.
+        # Anchored to the Record step's own comment block — the line is
+        # exported twice now (Rehearse passes it too), and this break must
+        # hardcode Record's copy, not Rehearse's.
         "the Record step hardcodes the opt-in instead of reading the input",
         "demo-video.yml",
+        "          # keeps the two steps saying the same thing.\n"
         "          DEMO_VIDEO_ALLOW_PRIVATE: ${{ inputs.allow-private-network-target }}",
+        "          # keeps the two steps saying the same thing.\n"
         '          DEMO_VIDEO_ALLOW_PRIVATE: "false"',
         ["WorkflowGates.test_every_fact_the_guard_classifies_on_reaches_the_recorder"],
     ),

--- a/tests/fixture/index.html
+++ b/tests/fixture/index.html
@@ -431,7 +431,36 @@ if (params.has("evidence")) {
     "font:12px/1.5 ui-monospace,monospace;color:#1c1a17;";
   ev.innerHTML =
     '<div id="ev-spot-attrs" data-token="zz-attr-00000000"\n' +
-    '  data-cfg=\'{"key":"zz-json-00000000"}\'>nothing rendered here</div>';
+    '  data-cfg=\'{"key":"zz-json-00000000"}\'>nothing rendered here</div>' +
+    // Two shapes of on-screen text `aria_snapshot()` structurally cannot
+    // carry (#353), and one control that is not on screen at all.
+    //
+    //   * a rich-text editor. `role="textbox"` promises the tree an
+    //     accessible *value*, read off a `value` property a div does not
+    //     have, so the node renders as `- textbox "…"` and stops there.
+    //   * an `aria-hidden` subtree that is still painted. The attribute
+    //     removes it from the accessibility tree by definition; the pixels
+    //     stay.
+    //   * the same attribute on something `display:none`. Nothing was on
+    //     screen, so nothing was omitted, and a probe that reported this
+    //     would be reporting every icon wrapper on every real page.
+    '<div id="ev-rich" contenteditable="true" role="textbox"\n' +
+    '  aria-label="Notes">zz-rich-00000000</div>' +
+    '<div id="ev-hidden" aria-hidden="true">zz-painted-00000000</div>' +
+    '<div id="ev-unpainted" aria-hidden="true" style="display:none">' +
+    'zz-unpainted-00000000</div>' +
+    // The second unpainted shape, and it is here so the probe's two
+    // visibility guards are gradeable apart. `display:none` is caught by the
+    // computed-style test *and* by the zero-size test; a box clipped to no
+    // height is caught only by the second, and its computed display is
+    // `block` with visibility `visible`.
+    '<div id="ev-clipped" aria-hidden="true"\n' +
+    '  style="height:0;overflow:hidden">zz-clipped-00000000</div>' +
+    // The third, and the one only the computed-style test can catch: a box
+    // with real width and height that is simply not painted. `display:none`
+    // trips both guards, so without this the style test grades nothing.
+    '<div id="ev-invisible" aria-hidden="true"\n' +
+    '  style="visibility:hidden">zz-invisible-00000000</div>';
   document.body.appendChild(ev);
 }
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -1545,6 +1545,21 @@ EVIDENCE_DIR_NAME = "evidence"
 # that code whatever it says. check_evidence_caps() asserts the package's own
 # constants equal these, so widening a cap has to be done on purpose.
 EVIDENCE_SCHEMA_EXPECTED = 1
+# The three shapes `?evidence=1` renders for #353: text the ARIA snapshot
+# structurally cannot carry, and one control that is not on screen at all.
+EVIDENCE_RICH_TEXT = "zz-rich-00000000"
+EVIDENCE_HIDDEN_TEXT = "zz-painted-00000000"
+EVIDENCE_UNPAINTED_TEXT = "zz-unpainted-00000000"
+# The second unpainted shape. `display:none` trips both of the probe's
+# visibility guards, so breaking either alone leaves the other holding and the
+# control cannot tell them apart; a box clipped to no height is caught by the
+# zero-size test only.
+EVIDENCE_CLIPPED_TEXT = "zz-clipped-00000000"
+# The third, and the only shape the computed-style test alone catches: a box
+# with real width and height that is not painted. `display:none` is 0x0 as
+# well, so without this the style test could be deleted and nothing would say.
+EVIDENCE_INVISIBLE_TEXT = "zz-invisible-00000000"
+
 EVIDENCE_LIMITS_EXPECTED = {
     "aria": 12_000,
     "scope_aria": 12_000,
@@ -1553,6 +1568,8 @@ EVIDENCE_LIMITS_EXPECTED = {
     # The chrome's own on-screen text (#361): the caption line and any card,
     # read out of the wrapper document — see reference/review.md.
     "chrome": 8_000,
+    # On-screen text the ARIA snapshot structurally cannot carry (#353).
+    "aria_omits": 12_000,
 }
 EVIDENCE_MARKER = "[demo-video: truncated here,"
 # The most a marker can add past a field's budget, so "cut to the cap" can be
@@ -11148,6 +11165,68 @@ def run_segments(out_root: Path) -> list[str]:
     )
 
 
+def check_evidence_omissions(
+    label: str, index: int, doc: dict, aria: str | None
+) -> list[str]:
+    """Does this beat's evidence say what its ARIA snapshot could not carry?
+
+    **Evidence claims to describe what the beat showed** (#9), and two shapes
+    of visible text never reach `aria_snapshot()` at all: the contents of a
+    rich-text editor (`contenteditable` with `role="textbox"`, whose
+    accessible value is read off a `value` property a `div` does not have) and
+    anything under `aria-hidden="true"`, which the attribute removes from the
+    accessibility tree by definition while the pixels stay on screen. Until
+    issue #353 they left no trace, so the file read as a complete account of a
+    screen it had only partly seen.
+
+    Read off the **unspotlit** beat: this is a property of the page, not of a
+    scope.
+
+    Both directions are graded, because the field can be wrong twice. Silence
+    is the defect #353 is about. A probe that reports *everything* is the same
+    artifact lie pointing the other way, and it is the one that gets the field
+    ignored — `aria-hidden` sits on an icon wrapper somewhere on nearly every
+    real page, and reporting those buries the two that matter.
+    """
+    failures: list[str] = []
+    omits = str(doc.get("aria_omits") or "")
+    aria_text = aria if isinstance(aria, str) else ""
+    for what, needle in (
+        ("a rich-text editor's contents", EVIDENCE_RICH_TEXT),
+        ("a painted aria-hidden subtree", EVIDENCE_HIDDEN_TEXT),
+    ):
+        # The control first, and it is the whole reason this can be graded: if
+        # the snapshot *did* carry it, `aria_omits` would be reporting an
+        # omission that did not happen, and the assertion below would be
+        # measuring the fixture rather than the recorder.
+        if needle in aria_text:
+            failures.append(
+                f"{label}: {needle!r} is in beat {index}'s ARIA tree, so "
+                f"{what} is not omitted after all — this fixture no longer "
+                f"reproduces issue #353 and `aria_omits` is being graded "
+                f"against a page that does not need it"
+            )
+        elif needle not in omits:
+            failures.append(
+                f"{label}: beat {index} shows {what} on screen and neither "
+                f"`aria` nor `aria_omits` contains {needle!r}. Evidence that "
+                f"omits on-screen text without saying so is an artifact "
+                f"describing a screen it only partly saw (issue #353)"
+            )
+    for needle, why in (
+        (EVIDENCE_UNPAINTED_TEXT, "`display:none`, so it was never painted"),
+        (EVIDENCE_CLIPPED_TEXT, "clipped to no height, so it was never painted"),
+        (EVIDENCE_INVISIBLE_TEXT, "`visibility:hidden`, so it was never painted"),
+    ):
+        if needle in omits:
+            failures.append(
+                f"{label}: beat {index}'s `aria_omits` names {needle!r}, "
+                f"which is {why} — nothing was on screen, so nothing was "
+                f"omitted"
+            )
+    return failures
+
+
 def run_evidence(out_root: Path) -> list[str]:
     """The evidence take: what a beat's page text carries, and what it caps.
 
@@ -11350,6 +11429,8 @@ def run_evidence(out_root: Path) -> list[str]:
                 f"{label}: beat {plain_i} carries `{field}` with no spotlight "
                 f"up, and it is the spotlight target's or nothing"
             )
+
+    failures += check_evidence_omissions(label, plain_i, plain, aria)
 
     # -- markup: what was never on screen is not in it ------------------------
     if attrs.get("scope") != EVIDENCE_ATTR_TARGET:

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -144,6 +144,53 @@ class Injection(NamedTuple):
 # The order is the order they run in: cheapest arm first, so a manifest that is
 # going to abort on a stale search string does it in eight seconds.
 INJECTIONS = [
+    # -- evidence says what it could not see (issue #353), ~7 s an entry
+    #
+    # Two entries, and they are the two directions the field can be wrong in.
+    # Silence is the defect the issue is about — evidence claims to describe
+    # what the beat showed, and two shapes of visible text never reach
+    # `aria_snapshot()` — but a probe that reports everything is the same
+    # artifact lie pointing the other way, and it is the one that gets the
+    # field ignored: `aria-hidden` is on an icon wrapper somewhere on nearly
+    # every real page, and reporting those buries the two that matter.
+    Injection(
+        name="evidence stops saying what the snapshot could not carry",
+        module="web.py",
+        old=(
+            "        omits = doc.evaluate(_ARIA_OMITS_JS)\n"
+            "        if omits:\n"
+            '            payload["aria_omits"] = omits'
+        ),
+        new="        pass",
+        arm="--evidence-only",
+        sites=("check_evidence_omissions",),
+        must_contain=("without saying so is an artifact",),
+    ),
+    Injection(
+        name="the omission probe reports text that was never on screen",
+        module="web.py",
+        old="    if (box.width === 0 || box.height === 0) continue;",
+        new="    if (false) continue;",
+        arm="--evidence-only",
+        sites=("check_evidence_omissions",),
+        must_contain=("clipped to no height, so it was never painted",),
+    ),
+    Injection(
+        # The other visibility guard. `display:none` trips this one *and* the
+        # zero-size test above, so the fixture carries a shape for each —
+        # otherwise breaking either leaves the other holding, and the control
+        # cannot say which of them was doing the work.
+        name="the omission probe stops checking whether a subtree is displayed",
+        module="web.py",
+        old=(
+            "    if (style.visibility === 'hidden' || style.display === 'none')"
+            " continue;"
+        ),
+        new="    if (false) continue;",
+        arm="--evidence-only",
+        sites=("check_evidence_omissions",),
+        must_contain=("`visibility:hidden`, so it was never painted",),
+    ),
     # -- stills without a video (issue #372), ~3 s an entry
     #
     # Two entries against one check, and they are the two halves it exists for:


### PR DESCRIPTION
**Fixes #385, fixes #386, fixes #387, fixes #388.**

## What and why

The skill could spend a storyboard's worth of polish plus encoder minutes producing a demo of a feature that does not work — discovered only in step-6 review, which is the multi-week re-record loop. This makes "does it work" a machine-checkable gate that runs before anything is polished or recorded:

- **`skills/demo-video/scripts/demo-rehearse` (#385)** — no new recorder mode: composes the existing `stills_only=True` (full storyboard in seconds, pacing zeroed, no encode) with `strict=True` (console errors / failed requests / non-zero exits fail the run). Refuses `DEMO_VIDEO_STILLS_ONLY=0` / `DEMO_VIDEO_STRICT=false` in its environment — an override would route around the gate silently.
- **SKILL.md Process step 2.5 (#386)** — nothing is caption-polished, spotlighted or recorded until rehearsal exits 0; and every transition a caption will narrate needs a `wait_for` assertion, because a storyboard that only *performs* actions rehearses green over a feature that does nothing.
- **Reusable workflow (#387)** — a Rehearse step runs before Record with the same target facts; a failed rehearsal reddens in seconds naming the storyboard, and nothing is recorded, staged or published. `tests/ci-unit`'s `RehearseGate` pins the ordering, the Record gate on the rehearsal verdict, and the env passthrough.
- **READMEs (#388)**.

## Evidence (assertions seen failing before trusted)

- End to end, healthy path: 50-beat reference storyboard rehearsed green in ~9 s wall, no mp4 written.
- Fault injected (a page throwing `boom: app is broken`): exit 1 in ~2 s, fatal issue named, no mp4. Override injection (`DEMO_VIDEO_STILLS_ONLY=0`): refused at exit 2.
- Each new `ci-unit` assertion was fault-injected against the workflow and seen to fail for the reason it claims (missing env fact → haystack + pairing failures; ungate'd Record → gating failure; mismatched URL input → pairing failure), then restored.

## Checks

`tests/lint` ✓ · `tests/typecheck` ✓ · `tests/unit` 599 ✓ · `tests/ci-unit` 188 ✓ · actionlint ✓ · pre-commit hooks passed on the commit.

## Stated limits

- **Pre-commit hooks deliberately untouched.** They gate this repo's hygiene; the functional gate lives in the skill and its reusable workflow, where a consuming project's feature correctness is decided.
- A storyboard pinning `strict=False`/`stills_only=False` as constructor args wins over any environment (documented recorder precedence) — the wrapper cannot see inside the file; the take's own stderr names the mode that ran.
- A rehearsal may rewrite committed `images/` — hit for real during verification of this very PR against `examples/ticket-queue`, reverted; SKILL.md 2.5 now says commit only after the real take.
- Rehearsal enforces only the assertions the storyboard writes; writing honest ones is the Process rule added in #386.
- Not demoable under AGENTS.md's test (verified by exit codes and CI text, not by watching) — so no video, and `tests/pixel` not run: no chrome or rendered-frame code changed. `tests/smoke` untouched code paths; CI is the gate there.