### PR TITLE
Every logged verb is graded as classified on every push, not post-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,11 +250,13 @@ jobs:
   # **What this job does not see**, which is the cost of the split and is
   # written out rather than implied: eight check functions are reachable only
   # from those three arms, so they grade in `smoke-full` below and not here.
-  # Five have `tests/smoke-inject` entries and are exercised nightly; three —
-  # `check_opening`, `check_opening_gap`, `check_verb_classification` — have no
+  # Five have `tests/smoke-inject` entries and are exercised nightly; two —
+  # `check_opening` (retired with #361) and `check_opening_gap` — have no
   # entry, so between a pull request opening and its merge nothing runs them at
   # all. That is issue #233, and `tests/README.md` carries it under *Known
-  # gaps*. Reviewers of a green pull request have not seen those three pass.
+  # gaps*. A third, `check_verb_classification`, left this list in #392: its
+  # static sweep moved to `tests/unit`, which runs per push above. Reviewers
+  # of a green pull request have not seen those two pass.
   smoke:
     name: smoke (cheap arms, every push)
     runs-on: ubuntu-latest

--- a/tests/README.md
+++ b/tests/README.md
@@ -608,13 +608,20 @@ Four phases — `run_web`, `run_terminal`, `run_content` and `run_terminal_race`
 - `_check_scored_region` — content/terminal; covered by the content entries
 - `_check_occlusion` — content/terminal; no entry, and none before this either
 - `check_opening_gap` — web; **no entry**
-- `check_verb_classification` — content/terminal; **no entry**
 
-The last two are the real cost of the split and are written up under *Known
-gaps*: no injection and no per-push take means nothing exercises them between a
-pull request opening and its merge, and `check_verb_classification` is the
-guard that caught `clear`/`press` going unclassified in #130.
-[#233](https://github.com/rogvid/skills/issues/233) is the entries that would
+(`check_verb_classification` was on this list until
+[#392](https://github.com/rogvid/skills/issues/392) moved it to `tests/unit`:
+the assertion is a static scrape against two frozensets, and grading it
+post-merge behind these arms is how an unclassified `act` reddened main for 33
+hours across nine full-suite runs before anyone could see why. It now runs on
+every push as `VerbClassification.test_every_logged_verb_is_classified`, with
+its own fault-injection entry.)
+
+That last one is the real cost of the split and is written up under *Known
+gaps*: no injection and no per-push take means nothing exercises it between a
+pull request opening and its merge. It is also the guard that caught
+`clear`/`press` going unclassified in #130.
+[#233](https://github.com/rogvid/skills/issues/233) is the entry that would
 close it. (`check_opening` was on this list until #361 retired it with the
 composite hold it graded; the wrapper opening is `check_wrapper_opening`'s,
 which `--wrapper-only` reaches per push.)
@@ -2111,13 +2118,18 @@ region was measured. A warning that blames an overlay is wrong on three of this
 suite's own healthy takes, and a confidently wrong artifact is the thing #97
 exists to remove — the detector must not become an instance of it.
 
-**Every storyboard verb must be classified.** `check_verb_classification()`
-scrapes `@_beat_verb("…")` and `self._beat("…")` out of the package source —
-scraped rather than imported, so an omission cannot hide on both sides — and
-requires each of the 22 verbs to be in exactly one of the recorder's two sets.
-An unclassified verb silently counts as passive, which would quietly switch the
+**Every storyboard verb must be classified.** That assertion lives in
+`tests/unit` since [#392](https://github.com/rogvid/skills/issues/392) —
+`VerbClassification.test_every_logged_verb_is_classified`, which scrapes
+`@_beat_verb("…")` and `self._beat("…")` out of the package source — scraped
+rather than imported, so an omission cannot hide on both sides — and requires
+each verb to be in exactly one of the recorder's two sets, on every push. An
+unclassified verb silently counts as passive, which would quietly switch the
 arm off for a whole class of demo. It aborts if the scrape finds fewer than 15
 verbs, so a broken regex reports itself instead of passing on an empty set.
+It was a smoke-side check until an unclassified `act` proved the point the
+expensive way: nine red full-suite runs on main over 33 hours, because the
+only arms that reached it run post-merge.
 
 Finally, `check_content_healthy()` hangs off *every* graded take — web,
 terminal and the stitched segments demo — asserting that each reports a
@@ -2344,7 +2356,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **17 of `tests/smoke`'s 52 check functions have no entry**, and the harness
+- **16 of `tests/smoke`'s 51 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 
@@ -2367,7 +2379,6 @@ paragraph whose job is to say what this manifest does not cover.
   | `check_take` | `ContentRect` — the rect the picture half is scored over, exactly, on all four numbers (#135/#195). The artifact half — the files exist, are this run's, and are not repeats of one another — is genuinely ungraded |
   | `check_content_healthy` | `ContentRect`, same six tests: the trim reaches the caption bar on both media, does not eat the app, and never comes back zero-sized |
   | `check_caption` | genuinely ungraded as a *picture*. `CaptionTruth` grades which caption a beat is stamped with across a navigation (#134), never that the bar was drawn |
-  | `check_verb_classification` | `VerbClassification` — every classified verb is one a recorder logs, and every verb a recorder logs is classified, with the set size asserted first so neither holds vacuously. **Merge-only since #61**: the only arms that reach it are `--content-only` and `--terminal-only`, so nothing runs it on a pull request |
   | `check_determinism` | genuinely ungraded. It reads the clock, the locale and the motion setting *out of the page*, which is the whole point of it — a constructor that stored the flag and never wired it up satisfies anything asserted on the Python side |
   | `check_merge_offset` | genuinely ungraded as timing. `MergeContent` grades the merge of the content *report* (#121); the per-segment caption timing this measures against two mp4s has no browser-free half. One claim of it is graded: `LogEarlyCause` reads the AST and requires its positive-skew message to come from `log_early_causes()` rather than from its own copy of a verdict (#257) — the wording, not the measurement |
   | `check_opening_gap` | `OpeningWarning` — `held: null` against `held: 0.0`, and the blank floor that keeps the warning readable. **Merge-only since #61**: `--web-only` is the only arm that reaches it |
@@ -2381,14 +2392,14 @@ paragraph whose job is to say what this manifest does not cover.
   | `_check_scene_fallback` | genuinely ungraded — measured straight off `demo.mp4`, because no beat in either storyboard is long enough to provoke it |
   | `_check_unstated_holes` | `HostClockHole` — the whole of it, on a scripted `HostClock`: the complaint, the marker that silences it, the steady-host control and both edge guards (#256). Genuinely ungraded *as a check that runs*: a host that does not step its wall clock produces no hole for it to find, so no arm has ever reached its failure |
 
-  **Two rows above are worse off than the rest, and #61 is why.**
-  `check_opening_gap` and `check_verb_classification` are
+  **One row above is worse off than the rest, and #61 is why.**
+  `check_opening_gap` is
   ungraded by this manifest *and* reachable only from the three arms that no
   longer run per push, so between a pull request opening and its merge nothing
-  exercises them at all. The others in this table are either reached by an arm
+  exercises it at all. The others in this table are either reached by an arm
   `--cheap` still runs or covered by a `tests/unit` class that runs in a
   second. This is the one real cost of the split, it was measured before the
-  split was made, and closing it means giving those two an entry — see
+  split was made, and closing it means giving it an entry — see
   **When each take runs** near the top of this file, and the *Known gaps*
   entry at the bottom.
 
@@ -2416,12 +2427,14 @@ paragraph whose job is to say what this manifest does not cover.
     [#241](https://github.com/rogvid/skills/issues/241), which supersedes
     [#200](https://github.com/rogvid/skills/issues/200) — that issue counted
     two of these eight.
-  - **The three that really are expensive** —
-    `check_opening_gap` on `--web-only` (123 s), `check_verb_classification`
-    and `_check_occlusion` on `--content-only` (148 s).
-    [#233](https://github.com/rogvid/skills/issues/233) covers the first
-    two; `_check_occlusion` is PSNR between two moments of a recording and
-    has neither an issue nor a cheaper arm. (The composite-opening check was
+  - **The two that really are expensive** —
+    `check_opening_gap` on `--web-only` (123 s) and
+    `_check_occlusion` on `--content-only` (148 s).
+    [#233](https://github.com/rogvid/skills/issues/233) covers the first;
+    `_check_occlusion` is PSNR between two moments of a recording and
+    has neither an issue nor a cheaper arm. (The verb-classification sweep
+    was the third until #392 moved it to `tests/unit`, where the same
+    assertion costs microseconds per push. The composite-opening check was
     the fourth, retired with the ffmpeg hold it graded — #361; the wrapper
     opening has entries of its own, reached per push by `--wrapper-only`.)
 
@@ -3334,14 +3347,17 @@ knows is missing is worse than one that is openly absent.
   `DEMO_VIDEO_EVIDENCE=0` env var behind it, are exercised nowhere — every
   take here writes evidence
   ([#48](https://github.com/rogvid/skills/issues/48)).
-- **Two checks are exercised by nothing between a pull request and its
+- **One check is exercised by nothing between a pull request and its
   merge.** `--cheap` is what CI records per push since
   [#61](https://github.com/rogvid/skills/issues/61), and
-  `check_opening_gap` and `check_verb_classification` are reachable only from
+  `check_opening_gap` is reachable only from
   `--web-only`, `--content-only` and `--terminal-only`, which now run on merge.
-  They also have no `tests/smoke-inject` entry, so nightly injection does not
-  cover them either — the merge run is the whole of their exercise, and a
-  reviewer looking at a green pull request has not seen them pass. Five other
+  It also has no `tests/smoke-inject` entry, so nightly injection does not
+  cover it either — the merge run is the whole of its exercise, and a
+  reviewer looking at a green pull request has not seen it pass. (A second,
+  `check_verb_classification`, was in this sentence until #392 moved it to
+  `tests/unit` — the same gap, closed by giving the assertion a home where the
+  per-push cost is microseconds. Five other
   check functions moved to merge-only with them; those five do have injections
   and are exercised nightly. Measured before the split rather than found after
   it, and recorded in

--- a/tests/smoke
+++ b/tests/smoke
@@ -5276,62 +5276,6 @@ def check_opening_gap(out_root: Path) -> list[str]:
     return failures
 
 
-def declared_verbs() -> set[str]:
-    """Every verb name the recorders record a beat under.
-
-    Scraped from the package source rather than imported, on purpose: the point
-    is to catch a verb that exists and is in *neither* of the recorder's two
-    classification sets, and asking the recorder which verbs it has would let
-    the same omission hide on both sides.
-    """
-    found: set[str] = set()
-    for path in (HELPERS_DIR / "demo_recording").glob("*.py"):
-        source = path.read_text()
-        found |= set(re.findall(r'@_beat_verb\(\s*"([a-z_]+)"', source))
-        found |= set(re.findall(r'self\._beat\(\s*"([a-z_]+)"', source))
-    return found
-
-
-def check_verb_classification() -> list[str]:
-    """Every storyboard verb must be classified acting or passive (issue #97).
-
-    The held-picture arm only warns when an *acting* verb ran inside the
-    stretch — that is the whole difference between a detector and a timer. A
-    verb added later and left out of both sets silently becomes passive, and
-    the arm quietly stops noticing a whole class of demo. Free to check, and it
-    needs no recording.
-    """
-    from demo_recording.content import CONTENT_ACTING_VERBS, CONTENT_PASSIVE_VERBS
-
-    declared = declared_verbs()
-    if len(declared) < 15:
-        return [
-            f"content: only {len(declared)} storyboard verbs were found in the "
-            f"package source ({sorted(declared)}) — the scrape is broken, so "
-            f"the classification below is being checked against almost nothing"
-        ]
-    classified = CONTENT_ACTING_VERBS | CONTENT_PASSIVE_VERBS
-    failures = []
-    missing = sorted(declared - classified)
-    if missing:
-        failures.append(
-            f"content: {missing} record beats but are in neither "
-            f"CONTENT_ACTING_VERBS nor CONTENT_PASSIVE_VERBS. An unclassified "
-            f"verb counts as passive, so a held picture spanning it never "
-            f"warns — decide which it is rather than letting it default"
-        )
-    both = sorted(CONTENT_ACTING_VERBS & CONTENT_PASSIVE_VERBS)
-    if both:
-        failures.append(f"content: {both} are classified as both acting and passive")
-    if not failures:
-        print(
-            f"smoke: all {len(declared)} storyboard verbs are classified "
-            f"({len(CONTENT_ACTING_VERBS & declared)} acting, "
-            f"{len(CONTENT_PASSIVE_VERBS & declared)} passive)"
-        )
-    return failures
-
-
 def blanked_copy(mp4: Path, rect: Rect, out: Path) -> bool:
     """`mp4` with `rect` painted flat black — a real recording, blank where the
     app was.
@@ -9049,12 +8993,11 @@ def run_content(out_root: Path) -> list[str]:
         os.chdir(previous)
     if problems:
         return problems
-    return (
-        check_verb_classification()
-        + check_content_pair(takes)
-        + check_content_toured(
-            toured["out_dir"], toured["stderr"], toured["info"]["app"]
-        )
+    # `check_verb_classification()` used to sit in this chain; it moved to
+    # tests/unit (#392) — a static scrape graded microseconds faster on every
+    # push than post-merge behind these arms.
+    return check_content_pair(takes) + check_content_toured(
+        toured["out_dir"], toured["stderr"], toured["info"]["app"]
     )
 
 
@@ -13452,13 +13395,16 @@ def open_output(args: argparse.Namespace) -> tuple[Path, bool]:
 # `--cheap` is to be reachable from *nothing but* these three, which is the
 # same sentence as "this phase costs two minutes".
 #
-# What that costs is written down rather than implied: seven check functions —
-# `check_opening_gap`, `check_verb_classification`,
-# `check_content_pair`, `check_content_toured`, `check_form_pacing`,
-# `_check_occlusion` and `_check_scored_region` — are reachable only from these
-# arms, so under `--cheap` they grade on merge and not on push. Three of them
-# have no `tests/smoke-inject` entry either. `tests/README.md` carries the
-# roster; `tests/unit`'s `CheapArm` is what keeps this comment honest.
+# What that costs is written down rather than implied: six check functions —
+# `check_opening_gap`, `check_content_pair`, `check_content_toured`,
+# `check_form_pacing`, `_check_occlusion` and `_check_scored_region` — are
+# reachable only from these arms, so under `--cheap` they grade on merge and
+# not on push. (`check_verb_classification` was the seventh until #392 moved it
+# to tests/unit: a static scrape graded microseconds faster on every push than
+# post-merge behind these arms — which is how an unclassified verb reddened
+# main for 33 hours before anyone could see why.) Three of them have no
+# `tests/smoke-inject` entry either. `tests/README.md` carries the roster;
+# `tests/unit`'s `CheapArm` is what keeps this comment honest.
 EXPENSIVE_ARMS = ("--web-only", "--content-only", "--terminal-only")
 
 

--- a/tests/unit
+++ b/tests/unit
@@ -1615,6 +1615,33 @@ class VerbClassification(unittest.TestCase):
         # depends on which set is consulted first.
         self.assertEqual(sorted(CONTENT_ACTING_VERBS & CONTENT_PASSIVE_VERBS), [])
 
+    def test_every_logged_verb_is_classified(self):
+        # **The direction that cost main 33 hours of red** (#392): `act`
+        # shipped recording beats while sitting in neither set, and an
+        # unclassified verb silently counts as passive — so the held-picture
+        # arm stopped noticing a whole class of demo without anything saying
+        # so. It lived here only as a recorded-take assertion behind the
+        # expensive arms, which run post-merge; nine full-suite runs paid for
+        # what this test grades in microseconds.
+        logged = logged_verbs()
+        # The vacuous-sweep control first: an empty scrape satisfies
+        # "everything logged is classified" over nothing at all.
+        self.assertGreaterEqual(
+            len(logged),
+            CONTENT_VERB_FLOOR,
+            f"only {len(logged)} verbs were scraped out of the package "
+            f"({sorted(logged)}) — the scrape is broken, not the sets",
+        )
+        unclassified = sorted(logged - (CONTENT_ACTING_VERBS | CONTENT_PASSIVE_VERBS))
+        self.assertEqual(
+            unclassified,
+            [],
+            f"{unclassified} record beats but are in neither "
+            f"CONTENT_ACTING_VERBS nor CONTENT_PASSIVE_VERBS. An unclassified "
+            f"verb counts as passive, so a held picture spanning it never "
+            f"warns — decide which it is rather than letting it default",
+        )
+
 
 class ContentSummaryStreams(unittest.TestCase):
     """Which stream each half of the summary goes to (issue #169).
@@ -14762,6 +14789,18 @@ INJECTIONS = [
         'CONTENT_PASSIVE_VERBS = frozenset(\n    {\n        "caption",',
         'CONTENT_PASSIVE_VERBS = frozenset(\n    {\n        "click",\n        "caption",',
         ["VerbClassification.test_no_verb_is_both_acting_and_passive"],
+    ),
+    (
+        # #392 verbatim, and the direction the smoke-side sweep could only
+        # grade post-merge: `act` recorded beats from inside `CONTENT_ACTING_
+        # VERBS`'s own comment block while sitting in neither set. Deleting it
+        # here is what main looked like for 33 hours — nine ten-minute runs,
+        # every one red on exactly this.
+        "a logged verb is left sitting in neither classification set",
+        "content.py",
+        '        "act",\n        "clear",',
+        '        "clear",',
+        ["VerbClassification.test_every_logged_verb_is_classified"],
     ),
     (
         # The half of #169 that cost an assertion: with the healthy line on


### PR DESCRIPTION
**Fixes #392.**

## The defect this re-homes

`act` shipped (#344) recording beats while sitting in neither of content.py's classification sets. The only check that catches that direction lived in `tests/smoke`'s `check_content_pair`, reachable exclusively from the expensive arms — which run post-merge. Result, measured: main red for **33 hours across nine consecutive ten-minute full-suite runs**, each fix attempt invisible until the next merge. The assertion itself is static: a source scrape against two frozensets.

## What changed

- `tests/unit`: `VerbClassification.test_every_logged_verb_is_classified` — the missing direction, added beside the two the class already carried (classified→logged, no overlap), reusing its scrape and floor. Vacuous-sweep control asserted inside the test.
- `tests/unit --fault-inject`: a new entry replaying #392's exact break (delete `"act",`) — seen landing (`PASS break: a logged verb is left sitting in neither classification set`).
- `tests/smoke`: `check_verb_classification` + `declared_verbs` deleted, call site removed — one home, not two tables to drift.
- Docs: tests/README.md roster/coverage-claim/Known-gaps updated; ci.yml's smoke-job comment now names one remaining merge-only gap instead of three.

## Evidence

- Acceptance criterion, exceeded: reverting `"act",` reddens `tests/unit` in **0.28 s** (5 ms of test); restored green.
- Suite: 600 tests in ~5 s (599 before) — the move costs nothing measurable.
- New injection caught among all 369; `tests/smoke-inject --self-test` green after updating README figures it reads back (16/51 claim, roster rows).
- `tests/smoke --content-only` passes end to end without the moved check.

## Checks

lint ✓ · self-test ✓ · typecheck ✓ · unit 600 ✓ · unit fault-inject 369 ✓ · ci-unit ✓ · actionlint ✓ · smoke --content-only ✓ · hooks passed on commit.

## Stated limits

The genuinely expensive checks stay behind the arms; `check_opening_gap` remains the one merge-only gap with no entry (#233).