### PR TITLE
demo-caption-lint: captions' checkable claims graded against evidence, for free

### DIFF
--- a/skills/demo-video/README.md
+++ b/skills/demo-video/README.md
@@ -78,6 +78,12 @@ and a real terminal session (voice on):
   strict about console errors, failed requests and non-zero exits. A feature
   that does not work fails there and no video of it is made. CI runs the same
   command before spending encoder minutes on a take.
+- **A free check on what captions claim** — `scripts/demo-caption-lint`
+  checks each caption's numbers and quoted UI strings against the per-beat
+  evidence text around it (matched / not found / not checkable), catching
+  the "caption written from what the author knew" class for zero tokens
+  before the blind review round. Advisory by design; grades tokens, not
+  meaning, and says so.
 - **Spoken narration (optional)** — with `ELEVENLABS_API_KEY` set, every
   caption line is synthesized via ElevenLabs and mixed onto the mp4 at the
   moment it appears. Clips are cached; pacing self-adjusts so speech is
@@ -160,6 +166,8 @@ demo-video/
 ├── scripts/
 │   ├── demo-rehearse              # the functional gate: storyboard, fast and
 │   │                              #   strict, before anything is recorded
+│   ├── demo-caption-lint          # captions' numbers and quoted strings,
+│   │                              #   checked against evidence, for free
 │   ├── demo-grade                 # the blind reader's brief, and the verdict
 │   │                              #   comparing it with the ac= tags (step 6b)
 │   ├── demo-shots                 # the take's stills as one pasteable block,

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -466,6 +466,25 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
    what it is for. What every field in `timeline.json` means, and what its
    `content` warnings do and do not claim, is
    [reference/timeline.md](reference/timeline.md).
+
+   **5.5. Run the caption lint — for free, before anyone reads frames.**
+
+   ```sh
+   <skill dir>/scripts/demo-caption-lint <demo folder>
+   ```
+
+   Each caption's numbers and quoted UI strings are checked against the
+   evidence text of its beat plus a window of neighbours (#356) — both of
+   the field run's round-1 caption contradictions were findable this way
+   without a model, before the blind round spent an agent run. Three states
+   per claim: **matched**; **NOT FOUND** (check the app first — a screen not
+   doing what the caption says is a bug the demo caught, and softening the
+   caption launders it); **not checkable**, with the reason (prose-only
+   claims nothing token-shaped to carry; unreadable evidence). It grades
+   tokens, not meaning — a paraphrase sharing no token is a named limit,
+   not a pass — and it is advisory: exit 0 either way. Step 6 still runs;
+   this is the filter in front of it.
+
 6. **Fresh-agent review (required).** You cannot watch the video, and you
    know too much anyway — have a context-free agent watch it for you. The
    recorder has already written what they need: `frames/`, a PNG per beat
@@ -645,7 +664,8 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
 
 The skill is self-contained: this file, the `reference/` directory it links
 into, the `helpers/demo_recording/` package, `ensure.sh` at the skill root,
-`scripts/demo-rehearse` (the step-2.5 gate), `scripts/demo-grade` (step 6b),
+`scripts/demo-rehearse` (the step-2.5 gate), `scripts/demo-caption-lint`
+(the step-5.5 caption check), `scripts/demo-grade` (step 6b),
 `scripts/demo-shots` (the stills block) and
 `scripts/demo-target-guard` (the target classifier), the vendored `helpers/assets/xterm/` terminal assets, and
 `README.md`. Install it with the `skills` CLI — into the current project:

--- a/skills/demo-video/scripts/demo-caption-lint
+++ b/skills/demo-video/scripts/demo-caption-lint
@@ -1,0 +1,261 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Check each caption's checkable claims against the evidence of its beat.
+
+    <skill-dir>/scripts/demo-caption-lint <demo folder>
+
+The cheap pre-filter over Process step 5 (#356): `evidence/beat-NN.json`
+holds the per-beat text of what was on screen and the timeline holds each
+beat's caption, so a caption claiming something no nearby screen ever said
+is findable without a model, for zero tokens, before the blind review round
+spends an agent run. Both of the field run's round-1 contradictions were
+this shape.
+
+What it grades: **tokens, not meaning** — the numbers a caption states and
+the UI strings it puts in quotes, against the evidence of its own beat plus
+a window of neighbours (one back, three forward, because a caption is
+written to lead the action it introduces). A claim that paraphrases the
+screen shares no token with it; this lint cannot see that, and says so
+rather than passing silently. The blind round stays; this is the filter in
+front of it, not the review.
+
+Three states per claim, the `demo-ticket-check` shape:
+
+- **matched** — the token appears in the window's evidence. Evidence the
+  snapshot structurally cannot carry counts too (`aria_omits`, #353): that
+  text was measured on screen.
+- **not found** — nothing in the window said it. This is the finding the
+  lint exists for, and it may be the app's fault, the storyboard's, or a
+  caption written from what the author knew instead of what the frame shows.
+- **not checkable** — with the reason: prose-only (no number, no quote —
+  nothing a token lint could carry), or no readable evidence beside the
+  beat (missing file, or an `aria_format` that says why).
+
+**Advisory by design**: exit 0 on every path a take can produce, however
+many findings — a lint that reddens on aria quirks trains people to delete
+it. Exit 2 is usage only. Findings are for the author to read before step 6,
+not a gate behind them.
+
+Reads committed working files only (`timeline.json`, `evidence/`); it
+writes nothing and grades nothing but text-to-text correspondence.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+# Caption leads action: one beat back, three forward (review.md's "a caption
+# normally appears a frame or two ahead of the picture that evidences it").
+WINDOW_BACK, WINDOW_FORWARD = 1, 3
+
+NUMBER = re.compile(r"\d+(?:[.,]\d+)*")
+QUOTED = re.compile(r"\"([^\"]{2,})\"|“([^”]{2,})”|'([^']{2,})'|‘([^’]{2,})’")
+DIGITS = re.compile(r"\d+")
+
+
+def _norm(text: str) -> str:
+    return " ".join(text.split()).casefold()
+
+
+def digit_runs(token: str) -> list[str]:
+    """`"1,200"` -> ["1200"], `"0.2s"` -> ["0", "2"] — comparable across
+    separators the caption and the app spell differently."""
+    return DIGITS.findall(token.replace(",", "").replace(".", ""))
+
+
+def claims(caption: str) -> tuple[list[str], list[str]]:
+    """(numbers, quoted strings) a caption stakes on the screen."""
+    numbers = [m.group(0) for m in NUMBER.finditer(caption)]
+    quotes = [
+        next(g for g in m.groups() if g is not None) for m in QUOTED.finditer(caption)
+    ]
+    return numbers, quotes
+
+
+def evidence_texts(
+    directory: Path, index: int, segment: str | None
+) -> tuple[str | None, str | None]:
+    """(joined text, why-not) for one beat's evidence file."""
+    name = f"{segment + '.seg.' if segment else ''}beat-{index:02d}.json"
+    path = directory / name
+    if not path.is_file():
+        return None, f"no evidence file {name}"
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"{name} unreadable ({exc})"
+    parts = [doc.get(k) or "" for k in ("aria", "scope_aria", "chrome", "html")]
+    # On-screen text the snapshot structurally cannot carry (#353). It was
+    # measured off the live DOM, so a claim found here *is* on screen —
+    # matched, not excused.
+    parts += doc.get("aria_omits") or []
+    fmt = doc.get("aria_format") or ""
+    if not any(parts) and "unavailable" in fmt:
+        return None, f"{name}: aria_format says {fmt}"
+    return _norm(" ".join(str(p) for p in parts)), None
+
+
+def window_text(
+    directory: Path,
+    beats: list[dict],
+    position: int,
+) -> tuple[str | None, list[str]]:
+    """Evidence text across the beat's window; (None, reasons) if none read."""
+    texts: list[str] = []
+    reasons: list[str] = []
+    segment = beats[position].get("segment")
+    positions = [b.get("segment_index", b["index"]) for b in beats]
+    here = positions[position]
+    for other, pos in enumerate(positions):
+        if beats[other].get("segment") != segment:
+            continue
+        if not (here - WINDOW_BACK <= pos <= here + WINDOW_FORWARD):
+            continue
+        text, why = evidence_texts(directory, beats[other]["index"], segment)
+        if text is not None:
+            texts.append(text)
+        elif why:
+            reasons.append(why)
+    if texts:
+        return " ".join(texts), []
+    return None, reasons or ["no evidence in the window"]
+
+
+def lint(demo_dir: Path) -> list[tuple[int, str, str, str]]:
+    """(beat index, caption excerpt, claim, verdict+reason) for each finding.
+
+    Every captioned beat produces at least one line: its claims' states, or
+    the single not-checkable line that says the caption stakes nothing this
+    lint can carry.
+    """
+    timeline = demo_dir / "timeline.json"
+    doc = json.loads(timeline.read_text(encoding="utf-8"))
+    beats = [b for b in doc.get("beats", []) if b.get("caption")]
+    evidence_dir = demo_dir / "evidence"
+    out: list[tuple[int, str, str, str]] = []
+    for position, beat in enumerate(beats):
+        caption = beat["caption"]
+        numbers, quotes = claims(caption)
+        excerpt = _norm(caption)[:80]
+        if not numbers and not quotes:
+            out.append(
+                (
+                    beat["index"],
+                    excerpt,
+                    "-",
+                    "not checkable — prose only: no number or quoted string "
+                    "for a token lint to carry (a paraphrase of the screen "
+                    "would look exactly like this)",
+                )
+            )
+            continue
+        text, reasons = window_text(evidence_dir, beats, position)
+        for token in numbers:
+            runs = digit_runs(token)
+            if text is None:
+                out.append(
+                    (
+                        beat["index"],
+                        excerpt,
+                        token,
+                        "not checkable — " + "; ".join(reasons),
+                    )
+                )
+            elif all(run in text for run in runs):
+                out.append((beat["index"], excerpt, token, "matched"))
+            else:
+                out.append(
+                    (
+                        beat["index"],
+                        excerpt,
+                        token,
+                        "NOT FOUND — no nearby evidence carries it",
+                    )
+                )
+        for quote in quotes:
+            needle = _norm(quote)
+            if text is None:
+                out.append(
+                    (
+                        beat["index"],
+                        excerpt,
+                        quote,
+                        "not checkable — " + "; ".join(reasons),
+                    )
+                )
+            elif needle in text:
+                out.append((beat["index"], excerpt, quote, "matched"))
+            else:
+                out.append(
+                    (
+                        beat["index"],
+                        excerpt,
+                        quote,
+                        "NOT FOUND — no nearby evidence says it",
+                    )
+                )
+    return out
+
+
+def main(argv: list[str]) -> int:
+    paths = [a for a in argv if a not in ("-h", "--help")]
+    if len(paths) != 1 or len(paths) != len(argv):
+        print(__doc__.strip(), file=sys.stderr)
+        return 2
+    demo_dir = Path(paths[0])
+    if not (demo_dir / "timeline.json").is_file():
+        print(f"demo-caption-lint: no timeline.json in {demo_dir}", file=sys.stderr)
+        return 2
+    findings = lint(demo_dir)
+    flagged = 0
+    collapsed = 0
+    for position, (index, excerpt, claim, verdict) in enumerate(findings):
+        marked = verdict.startswith(("NOT FOUND", "not checkable"))
+        flagged += verdict.startswith("NOT FOUND")
+        mark = "!!" if marked else "  "
+        # Captions persist across beats, so a prose-only stretch repeats its
+        # line once per beat. A run of identical not-checkables collapses to
+        # one line and a count — the state is still stated, the reader keeps
+        # the signal.
+        if (
+            claim == "-"
+            and findings[position - 1][1] == excerpt
+            and findings[position - 1][2] == "-"
+            and position
+        ):
+            collapsed += 1
+            continue
+        if collapsed:
+            print(f"     (+ {collapsed} more beat(s), same)")
+            collapsed = 0
+        print(f"{mark} beat {index:02d} [{claim}] {verdict}\n     {excerpt!r}")
+    if collapsed:
+        print(f"     (+ {collapsed} more beat(s), same)")
+    counts: dict[str, int] = {}
+    for _, _, _, verdict in findings:
+        state = verdict.split(" — ")[0]
+        counts[state] = counts.get(state, 0) + 1
+    tally = ", ".join(f"{k}: {v}" for k, v in sorted(counts.items()))
+    print(
+        f"demo-caption-lint: {len(findings)} claim(s) — {tally}. "
+        f"This grades tokens, not meaning: 'not found' is where to look, "
+        "'not checkable' is a named limit, and neither blocks anything."
+    )
+    if flagged:
+        print(
+            f"demo-caption-lint: {flagged} claim(s) NOT FOUND — check the "
+            "app first, then the caption. A caption overstating the screen "
+            "is a storyboard fix; a screen not doing what the caption says "
+            "is a bug, and the demo caught it."
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/README.md
+++ b/tests/README.md
@@ -1281,9 +1281,11 @@ So the assertions were **written rather than trimmed**, and there are three:
   under every icon wrapper on a real page. There is one per visibility guard,
   because `display:none` trips both and would otherwise leave either deletable
   in silence — the fixture carries a clipped box for the zero-size test and a
-  `visibility:hidden` box for the computed-style one. The caption-claims lint
-  that will read this field is tracked in
-  [#356](https://github.com/rogvid/skills/issues/356).
+  `visibility:hidden` box for the computed-style one. The caption-claims
+  lint reads this field: `scripts/demo-caption-lint`
+  ([#356](https://github.com/rogvid/skills/issues/356)) treats a claim found
+  only here as matched — on screen — and reserves *not checkable* for text
+  nothing measured.
 
 Plus the two that never touched masking: a previous take's evidence is cleared
 from the directory on a re-record while another *segment's* files survive, and
@@ -3364,6 +3366,13 @@ knows is missing is worse than one that is openly absent.
   [#233](https://github.com/rogvid/skills/issues/233), which names the entries
   that would have closed it and was itself closed as *recorded, not planned* in
   the 2026-08-13 triage above.
+- **The classes of defect that reach a viewer only through the encoded
+  pixels** — chrome a harness measures correctly and a person reads wrong,
+  #291's card among them — remain unwatched for now; a focused pass over
+  them remains open:
+  [#325](https://github.com/rogvid/skills/issues/325). Everything above this
+  line is graded per push; what that pass owns is the part only watching
+  grades.
 - **Nothing checks that the demo is any *good*.** These are liveness checks.
   Pacing, caption wording, whether the story lands — that is what the
   fresh-agent review in `SKILL.md` step 6 is for, and it is not automatable.

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -3461,6 +3461,119 @@ class ShotsBlock(unittest.TestCase):
         self.assertEqual(out, "")
 
 
+# --------------------------------------------------------------------------
+# demo-caption-lint — what a caption stakes on the screen, checked for free
+# --------------------------------------------------------------------------
+
+
+caption_lint = load("demo-caption-lint", _SKILL / "scripts")
+
+
+class CaptionLint(unittest.TestCase):
+    """Numbers and quoted UI strings must appear near their beat (#356).
+
+    The fixture reconstructs the field run's shape — timeline beats with
+    captions beside per-beat evidence files — and holds four claims against
+    the three states: a quoted string and a number nothing nearby says (the
+    field run's "machinery" class, the whole reason this exists), a number
+    its own beat's evidence carries, an on-screen string only `aria_omits`
+    carries (#353's marker, which is why not-found and not-checkable can be
+    told apart at all), and the expected miss: a paraphrase with no shared
+    token, reported as not checkable rather than passed in silence. A lint
+    whose fixture has no expected miss is measuring its fixtures.
+    """
+
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp(prefix="caption-lint-"))
+        self.addCleanup(shutil.rmtree, self.root, True)
+        demo = self.root / "demo"
+        evidence = demo / "evidence"
+        evidence.mkdir(parents=True)
+        self.demo = demo
+        beats = []
+        docs = {}
+        for index, caption in enumerate(
+            [
+                "",
+                'The "Refine machinery" filter narrows the queue to 12 rows.',
+                "The queue holds 5 tickets.",
+                "Filtering is instant.",
+                'Status is "Escalated only".',
+            ]
+        ):
+            beats.append({"index": index, "verb": "caption", "caption": caption})
+            docs[index] = caption
+        (demo / "timeline.json").write_text(json.dumps({"beats": beats}))
+        for index, aria in {
+            1: '- button "Search"\n- textbox "Search"',
+            2: '- row "5 tickets"',
+            3: '- text "instant"',
+            4: '- heading "Queue"',
+        }.items():
+            doc = {"aria_format": "aria-yaml", "aria": aria}
+            if index == 4:
+                # On screen, structurally invisible to the snapshot (#353).
+                doc["aria_omits"] = ['- textbox "Status": Escalated only']
+            (evidence / f"beat-{index:02d}.json").write_text(json.dumps(doc))
+        # Beat 0 is uncaptioned and writes no evidence of its own; the window
+        # around beat 1 must survive that hole.
+
+    def findings(self):
+        return {(f[0], f[2]): f[3] for f in caption_lint.lint(self.demo)}
+
+    def test_a_quoted_string_no_nearby_evidence_says_is_not_found(self):
+        verdict = self.findings()[(1, "Refine machinery")]
+        self.assertTrue(verdict.startswith("NOT FOUND"), verdict)
+
+    def test_a_number_nothing_nearby_carries_is_not_found(self):
+        verdict = self.findings()[(1, "12")]
+        self.assertTrue(verdict.startswith("NOT FOUND"), verdict)
+
+    def test_a_number_its_own_beat_says_is_matched(self):
+        self.assertEqual(self.findings()[(2, "5")], "matched")
+
+    def test_on_screen_text_the_snapshot_cannot_carry_is_matched(self):
+        # Via `aria_omits`, not excused: #353 measured that text off the live
+        # DOM, so it was on screen and the caption may claim it.
+        self.assertEqual(self.findings()[(4, "Escalated only")], "matched")
+
+    def test_a_paraphrase_with_no_shared_token_is_not_checkable(self):
+        # The expected miss. "Instant" paraphrases whatever the app showed;
+        # no token carries it, so the honest answer is a named limit, not a
+        # pass and not a finding.
+        verdict = self.findings()[(3, "-")]
+        self.assertTrue(verdict.startswith("not checkable"), verdict)
+
+    def test_missing_evidence_is_not_checkable_and_says_why(self):
+        # A hole one neighbour covers is still checkable through it — the
+        # window exists for exactly that — so this takes the whole directory.
+        shutil.rmtree(self.demo / "evidence")
+        verdict = self.findings()[(2, "5")]
+        self.assertIn("no evidence file", verdict)
+
+    def test_the_cli_is_advisory_and_names_its_limit(self):
+        done = subprocess.run(
+            [
+                sys.executable,
+                str(_SKILL / "scripts" / "demo-caption-lint"),
+                str(self.demo),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(done.returncode, 0, done.stderr)
+        self.assertIn("tokens, not meaning", done.stdout)
+        self.assertIn("NOT FOUND", done.stdout)
+
+    def test_usage_error_exits_2(self):
+        done = subprocess.run(
+            [sys.executable, str(_SKILL / "scripts" / "demo-caption-lint")],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(done.returncode, 2)
+
+
 class UnmetInTheBlock(unittest.TestCase):
     """`demo-shots` renders a clause the storyboard marks unmet first (#374)."""
 
@@ -3678,6 +3791,21 @@ INJECTIONS = [
         [
             "UnmetInTheBlock.test_the_unmet_still_comes_before_every_other_one",
             "UnmetInTheBlock.test_the_order_sentence_matches_the_order",
+        ],
+    ),
+    (
+        # #356's whole reason to exist, broken in the one direction that is
+        # safe to break silently: a lint that reports every miss as matched
+        # still exits 0, still prints a tidy summary, and flags nothing. The
+        # fixture holds a claim nothing on screen says, so both not-found
+        # assertions must go red for the break to count as noticed.
+        "the caption lint calls every miss a match",
+        "scripts/demo-caption-lint",
+        '                     "NOT FOUND — no nearby evidence carries it")',
+        '                     "matched")',
+        [
+            "CaptionLint.test_a_quoted_string_no_nearby_evidence_says_is_not_found",
+            "CaptionLint.test_a_number_nothing_nearby_carries_is_not_found",
         ],
     ),
     (

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -3801,8 +3801,8 @@ INJECTIONS = [
         # assertions must go red for the break to count as noticed.
         "the caption lint calls every miss a match",
         "scripts/demo-caption-lint",
-        '                     "NOT FOUND — no nearby evidence carries it")',
-        '                     "matched")',
+        '                        "NOT FOUND — no nearby evidence carries it",',
+        '                        "matched",',
         [
             "CaptionLint.test_a_quoted_string_no_nearby_evidence_says_is_not_found",
             "CaptionLint.test_a_number_nothing_nearby_carries_is_not_found",


### PR DESCRIPTION
**Fixes #356.** Unblocked by #353's merge (#384): `aria_omits` is what lets *not found* and *not checkable* be told apart at all.

## What

`skills/demo-video/scripts/demo-caption-lint <demo folder>` — Process step 5.5, before the fresh-agent review. Joins the two artifacts a take already writes (timeline captions, per-beat evidence) and checks each caption's numbers and quoted UI strings against its beat's evidence plus a window of neighbours (one back, three forward — a caption leads the action it introduces). Both of the field run's round-1 contradictions were this shape; this finds them for zero tokens.

- **Three states per claim**, `demo-ticket-check`'s shape: `matched` / `NOT FOUND` / `not checkable` with the reason. Evidence the snapshot structurally cannot carry counts as matched via `aria_omits` — that text was measured on screen.
- **Grades tokens, not meaning**, in those words: a paraphrase sharing no token is a named limit, not a pass.
- **Advisory by design**: exit 0 on every path a take can produce; exit 2 is usage only.

## Acceptance criterion, from the issue

Fixture reconstructs the field run's timeline+evidence shape:
- `"Refine machinery"` + `12` with no nearby evidence saying either → both flagged NOT FOUND (the field run's class)
- `5` where the beat's own aria carries "5 tickets" → matched
- `"Escalated only"` present only under `aria_omits` → matched via the #353 marker
- **The expected miss**: "Filtering is instant." — paraphrase, no shared token → reported `not checkable`, never passed silently. A lint whose corpus catches everything is measuring its fixtures.

## Injection discipline

New fault-inject entry turns every miss into a match — the quiet break, per #392's lesson; still exits 0, still prints a tidy summary. Seen landing: both not-found assertions go red; all 135 injections caught.

Also verified end-to-end against a real take (`2026-07-28-queue-search`): 47 prose-only claims collapse to one line each with a count, exit 0.

## Checks

lint ✓ · self-test ✓ · unit ✓ · ci-unit (188 tests / 135 injections) ✓ · typecheck ✓ · hooks passed on commit.

## Stated limits

- The window is positional, not semantic: a claim evidenced five beats away reads as not-found. The blind round stays; this is the pre-filter.
- Digit-run matching is separator-blind ("1,200" ≡ "1200") but exact on runs — caption "3" beside evidence "13" is correctly not found.
- HTML `evidence.html` (spotlight target markup) participates in matching; it is already capped and stripped of non-rendered text by `_EVIDENCE_HTML_JS`.