### PR TITLE
demo-video: camera push-ins, pace, opening and closing cards, and one voice across a take

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -165,8 +165,14 @@ read them all up front, and do not skip one the text tells you to open.
    evidence — `locator.aria_snapshot()` arrived there, and the older
    `page.accessibility` API it replaced has since been removed.
 3. **Learn how the app runs** (dev server command, port, how to build the
-   frontend, how to seed data). If the project documents this, follow it;
-   otherwise ask. Reuse an already-running server.
+   frontend, how to seed data). **Read `<project root>/.demo-video/context.md`
+   first** — a previous demo session may have written down exactly this, and
+   re-deriving it is the heaviest part of a first demo. If it does not exist,
+   inspect as usual and then **write it**: how to start the server and on
+   which port, how to seed or reset data, auth quirks, selector conventions,
+   anything a fresh session would otherwise have to rediscover. Keep it short
+   and factual, and commit it — it is project knowledge, not session state.
+   Reuse an already-running server.
 4. **Set project defaults in env** (see Configuration) or pass them as
    `Recorder(...)` parameters per storyboard.
 
@@ -228,6 +234,9 @@ three it is not the variable lowercased, so do not infer it:
 | `DEMO_VIDEO_BASE_URL` | `base_url` — app under demo. Classified before the browser opens; a public host is refused | `http://localhost:8000` |
 | `DEMO_VIDEO_ALLOW_PRIVATE` | `allow_private` — permit a private/internal target (`1`/`0`). There is no equivalent for a public one | off |
 | `DEMO_VIDEO_ACCENT_RGB` | `accent_rgb` — cursor/spotlight color, `"235,110,20"` | orange |
+| `DEMO_VIDEO_PACE` | `pace` — multiplier over the holds the recorder computes (caption read time; the defaults of `hold()`, `interlude()`, `criterion()`). Durations the storyboard writes itself are never touched. See **Pacing and perception** | `1.0` |
+| `DEMO_VIDEO_WINDOW_TITLE` | `window_title` — the wrapper window's title bar. Web default: the app's host; terminal default: `terminal_title` | — |
+| `DEMO_VIDEO_INTRO` | `intro` — opt-in opening title card over the wrapper (web takes), taken down by the first `goto()`. Held ~2.8 s (scaled by `pace`), or the whole spoken line when narration is on. Terminal takes already have this as `TerminalRecorder(interlude=…)` | off |
 | `DEMO_VIDEO_TERMINAL_TITLE` | `terminal_title` — web `terminal()` card title | `terminal` |
 | `DEMO_VIDEO_TERMINAL_PROMPT` | `terminal_prompt` — prompt string: web card, and `TerminalRecorder`'s shell PS1 | `$ ` (web card); `❯ ` (`TerminalRecorder`) |
 | `DEMO_VIDEO_TERMINAL_SHELL` | `shell` — shell `TerminalRecorder` launches | `/bin/bash` |
@@ -243,6 +252,8 @@ three it is not the variable lowercased, so do not infer it:
 | `DEMO_VIDEO_EVIDENCE` | `evidence` — write `evidence/beat-NN.json` per beat (`1`/`0`) — see [reference/review.md](reference/review.md) | **on** |
 | `DEMO_VIDEO_VOICE_ID` | `voice_id` — ElevenLabs voice | Sarah (premade) |
 | `DEMO_VIDEO_SPEECH_MODEL` | `speech_model` — ElevenLabs model | `eleven_multilingual_v2` |
+| `DEMO_VIDEO_SPEECH_STABILITY` | `speech_stability` — voice stability pinned on every line, for one consistent speaking rate (without it: 2.1–3.3 words/s across one take) | `0.75` |
+| `DEMO_VIDEO_OUTRO` | `outro` — opt-in closing card, the intro's mirror: voiced with speech on, left up as the take's last frame. Web takes; `TerminalRecorder` refuses it | off |
 | `DEMO_VIDEO_SKILL_DIR` | *no parameter* — where storyboards find this skill | the constant baked into each storyboard |
 | `ELEVENLABS_API_KEY` | *no parameter* — enables speech narration | off |
 
@@ -275,7 +286,7 @@ exception, or a non-zero exit. Both are
 | `clear(selector)` | Empty a field, visibly — click, select what is in it, delete. Its own beat, because emptying a field is something the viewer watches happen |
 | `press(key, hold_s=0.5)` | Press one named key wherever the focus already is — `"Enter"` to submit, `"Escape"` to dismiss, `"Tab"` to move on, `"Control+A"`. Playwright's key names; an unknown one raises. Selector-free on purpose: `Tab` *is* the focus demo and `Escape` acts on whatever is up, and `type_into`/`clear` leave the caret where they put it. Holds `hold_s` so the change is on screen long enough to read |
 | `wait_for(selector)` | Wait for something the app does on its own |
-| `spotlight(selector)` | Ring + enlarge the element the caption discusses; `spotlight()` clears. It eases in *and out* over 250 ms, and the verb waits out its own exit, so the element is back exactly as it was found before the next beat starts (~250 ms per clear on an ordinary take, ~0 under `deterministic=True`, which flattens the transition) |
+| `spotlight(selector)` | Ring + enlarge the element the caption discusses; `spotlight()` clears. It eases in *and out* over 250 ms, and the verb waits out its own exit, so the element is back exactly as it was found before the next beat starts (~250 ms per clear on an ordinary take, ~0 under `deterministic=True`, which flattens the transition). Each spotlight interval also becomes a **camera push-in** (1.3×, eased 0.5 s each way, centred on the element) rendered after the take — see `helpers/demo_recording/camera.py`. The moves land in demo.mp4 automatically; `timeline.json`'s `camera` key publishes the geometry |
 | `terminal(cmd)` / `terminal_output(text)` / `terminal_close()` | A *decorative* on-screen terminal card for off-browser actions **inside a web demo** — a prop, not a real shell. To record an actual CLI/TUI use `TerminalRecorder` (below). |
 | `interlude(text, hold=2.8, style=…)` | Bridge a jump; `hold` is how long the card stays before the storyboard moves on. `style="card"` (default) is a full-screen title card — dark on a terminal take, so a segment can open on it; the window's own body colour on a web one, so the content area becomes the window with the sentence on it (#291) — for real time-skips; `style="light"` is a centered label over a soft scrim with the scene still visible, for short transitions. **`interlude("")` fades out whatever is up, whichever style raised it** — the clear takes no `style` and ignores the one it is given. Leave one up and the take says so on stderr and in `content.warnings`; nothing else will notice (see [reference/limits.md](reference/limits.md)). |
 | `stitch(out_dir, [segments])` | Lossless concat of segment recordings into demo.mp4, **and** merge their beat logs into one `timeline.json` / `timeline.md` beside it. `keep_parts=True` leaves each `.seg.mp4` and its `.seg.timeline.*` on disk for a re-stitch |
@@ -314,6 +325,17 @@ below are encoded in the recorder; the point is to *not fight them*.
   checkbox clicks), `pause()` before the caption so the aggregate gets a
   frame. One run shipped frames reading "1 row selected" beside a toast
   saying "Excluded 3 rows"; both reviewers flagged the jump.
+
+**Pace to the audience.** The floors above are for a viewer seeing the
+feature cold — an executive skimming a PR is not that viewer, and a dev
+pausing to inspect can always rewind. `Recorder(pace=0.5)` (or
+`DEMO_VIDEO_PACE`) halves every hold the recorder *computes*, so the same
+storyboard serves both audiences without being rewritten; `pace > 1`
+slows down for a colder one. Two limits: below ~0.5 a caption outruns
+reading speed, so shorten the lines too, not just the waits — and a
+duration the storyboard writes itself (`pause(2)`, `hold(min_s=…)`,
+`interlude(hold=…)`) is never scaled. A take recorded off the default
+records its `pace` in `timeline.json`.
 
 ## Terminal demos (CLI / TUI)
 
@@ -365,8 +387,10 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
 ## Process
 
 1. **Pick a demo story that is deterministic, and know where the slow
-   parts are.** Prefer flows the app completes on its own in seconds. Seed
-   needed state *before* recording starts. The recorder pins the browser's
+    parts are.** Prefer flows the app completes on its own in seconds. Seed
+    needed state *before* recording starts — reading
+    `.demo-video/context.md` first (Setup step 3), and writing back what you
+    learned if it does not exist yet. The recorder pins the browser's
    timezone and locale for you, and will freeze its clock if you ask
    ([reference/determinism.md](reference/determinism.md) — read it first);
    the app's own randomness and its server data are yours to pin down. If

--- a/skills/demo-video/helpers/demo_recording/camera.py
+++ b/skills/demo-video/helpers/demo_recording/camera.py
@@ -1,0 +1,170 @@
+"""The camera: a post-production push-in over each spotlighted element.
+
+The zoom this replaces was live DOM — `<body>` scaled 1.06 around the
+element's centre while the spotlight was up — and it gave the viewer
+nothing: the element sat at the transform's origin, so it did not move,
+and 6% of a 60 px chip is invisible. What a viewer actually saw was the
+surrounding layout shifting and clipping under the window chrome, which
+reads as jitter, not intent. A camera move has to scale the *composited*
+frame — window chrome included — and the DOM cannot reach past the page
+into the frame around it. That is the limit where editing stops being
+Playwright's job.
+
+So the camera is post-production, Screen Studio's shape: capture raw,
+edit afterwards. `spotlight()` logs each interval as geometry on the
+timeline (the `camera` key in timeline.json, in output-frame pixels);
+and `_convert` renders the filter this module builds — an eased push-in
+to `CAMERA_ZOOM` over each event, centred on the element, by `zoompan`.
+
+**The push is rendered from 1x footage, and that is a measured limit,
+not an oversight.** A 1.3x push on a 1280 px take shows a 984 px crop
+upscaled, so the move is softer than the static footage around it —
+for the half second of the ease, which is how every screen-recorder
+push-in looks. True supersampling was tried and measured out: capture
+at `device_scale_factor=2` produces a 2x canvas with the same 1x
+detail in its top-left corner — Playwright's record_video pipeline
+captures the page surface at CSS resolution and the device scale adds
+no detail to the video. The two honest ways past that are a 2x-CSS
+viewport (doubles every CSS coordinate; responsive apps reflow, which
+changes what the demo shows) or a self-owned CDP screencast capture
+(machinery of its own). Neither is this module's job today.
+
+The take itself stays honest: nothing on screen moves that the app did
+not do. The move is added where motion lives — the encode — from
+geometry the recorder measured while the page was alive, and the
+timeline publishes that geometry so a move can be re-rendered or
+audited without the take.
+
+`zoompan` needs one courtesy: it re-stamps output frames at its `fps`
+rather than following the input's timestamps, and a screencast's webm
+is variable-rate — so `fps` normalizes the stream by PTS first, and
+only then does `zoompan`'s sequential re-stamp become an identity
+mapping. Without that order a gap in the screencast compresses the
+take and the narration mix drifts off its captions.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+# How far the camera pushes in over a spotlighted element. 1.3 is the
+# smallest move that reads as a decision rather than a tremor: the DOM
+# zoom this replaces was 1.06 and measured as nothing (frames either
+# side of a spotlight differ mostly by the outline, not the zoom).
+CAMERA_ZOOM = 1.3
+
+# How long the push-in and the pull-back each take, in seconds. Long
+# enough to read as one motion at 25 fps (12-13 frames), short next to
+# the shortest caption hold.
+CAMERA_EASE_S = 0.5
+
+
+def video_dimensions(path: Path) -> tuple[int, int]:
+    """The pixel size of a recorded file, off ffprobe."""
+    out = subprocess.run(
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=width,height",
+            "-of",
+            "csv=p=0",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    width, height = out.split(",")
+    return int(width), int(height)
+
+
+def _smoothstep(expr: str) -> str:
+    """The ease: smoothstep of a progress expression already shaped so
+    that it rises 0→1 over the push, holds at 1, and falls 1→0 over the
+    pull — `min` of the time from both ends, clamped to 0..1."""
+    u = f"clip({expr},0,1)"
+    return f"{u}*{u}*(3-2*{u})"
+
+
+def camera_filter(
+    events: list[dict],
+    *,
+    src_w: int,
+    src_h: int,
+    out_w: int,
+    out_h: int,
+    fps: int = 25,
+) -> str | None:
+    """The video filter chain that renders this take's camera moves.
+
+    `events` is the timeline's `camera` list: `{"t_start", "t_end",
+    "rect": [x, y, w, h]}`, times in seconds and the rect in
+    **output-frame** pixels — the coordinates a reader maps onto
+    demo.mp4. Rects are scaled up to source pixels here, once, at the
+    only place that knows both sizes. Returns None for a take with no
+    events, and the caller encodes exactly as it did before the camera
+    existed.
+
+    The chain is `fps` (PTS-normalize, see the module note) then one
+    `zoompan` carrying every event: `z` is 1 plus the sum of each
+    event's eased push — events do not overlap, so at most one term is
+    non-zero — and `x`/`y` are the same weights times each event's
+    clamped centred offset. A weight of 0 contributes a literal 0, so
+    between events the camera sits at z=1, x=0, y=0: the identity. The
+    offsets read `zoom`, zoompan's own per-frame value for this frame's
+    z, so the pan and the push stay one motion.
+    """
+    if not events:
+        return None
+    ordered = sorted(events, key=lambda e: e["t_start"])
+    for i in range(len(ordered) - 1):
+        earlier, later = ordered[i], ordered[i + 1]
+        if later["t_start"] < earlier["t_end"]:
+            raise ValueError(
+                "camera events overlap — one spotlight cannot still be "
+                f"open at [{later['t_start']}, {later['t_end']}] when "
+                f"[{earlier['t_start']}, {earlier['t_end']}] is still "
+                "running; the push-in weights would sum past CAMERA_ZOOM"
+            )
+    for event in ordered:
+        x, y, w, h = event["rect"]
+        if w <= 0 or h <= 0:
+            raise ValueError(
+                f"camera event [{event['t_start']}, {event['t_end']}] has a "
+                f"degenerate rect {event['rect']} — nothing to centre on"
+            )
+        if event["t_end"] <= event["t_start"]:
+            raise ValueError(
+                f"camera event ends at {event['t_end']} at or before it "
+                f"starts ({event['t_start']})"
+            )
+    scale_x = src_w / out_w
+    scale_y = src_h / out_h
+    push = f"{CAMERA_ZOOM - 1:.2f}"
+    zooms: list[str] = []
+    xs: list[str] = []
+    ys: list[str] = []
+    for event in ordered:
+        ease = (
+            f"min((time-{event['t_start']:.3f})/{CAMERA_EASE_S},"
+            f"({event['t_end']:.3f}-time)/{CAMERA_EASE_S})"
+        )
+        weight = _smoothstep(ease)
+        cx = (event["rect"][0] + event["rect"][2] / 2) * scale_x
+        cy = (event["rect"][1] + event["rect"][3] / 2) * scale_y
+        zooms.append(weight)
+        xs.append(f"{weight}*clip({cx:.1f}-iw/(2*zoom),0,iw-iw/zoom)")
+        ys.append(f"{weight}*clip({cy:.1f}-ih/(2*zoom),0,ih-ih/zoom)")
+    z = f"1+{push}*({'+'.join(zooms)})"
+    x = "+".join(xs)
+    y = "+".join(ys)
+    return (
+        f"fps={fps},"
+        f"zoompan=z='{z}':x='{x}':y='{y}'"
+        f":d=1:s={out_w}x{out_h}:fps={fps}"
+    )

--- a/skills/demo-video/helpers/demo_recording/chrome.py
+++ b/skills/demo-video/helpers/demo_recording/chrome.py
@@ -188,7 +188,12 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
   #__chrome_band { position: absolute; left: __PAD__px; top: __BANDTOP__px;
     width: __APPW__px; height: __BAND__px; overflow: hidden;
     display: flex; align-items: center; justify-content: center; }
-  #__demo_caption { max-width: 90%; padding: 12px 30px; border-radius: 12px;
+  /* Two stacked caption layers crossfade: `__demoCaption` fades the old
+     line out while the new one fades in, so a caption-to-caption change is
+     a transition instead of a pop. The layers sit on top of each other in
+     the band's centre; only the visible one is measured for clipping. */
+  #__demo_caption, #__demo_caption2 { position: absolute; max-width: 90%;
+    padding: 12px 30px; border-radius: 12px;
     background: rgba(22,20,16,.72); backdrop-filter: blur(3px);
     color: #f7f4ee; text-align: center;
     font: 600 __CAPFONT__px/1.36 system-ui, sans-serif; letter-spacing: .01em;
@@ -244,7 +249,7 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
     <span style="width:44px"></span>
   </div>
   <div id="__chrome_slot"></div>
-  <div id="__chrome_band"><div id="__demo_caption"></div></div>
+  <div id="__chrome_band"><div id="__demo_caption"></div><div id="__demo_caption2"></div></div>
   <div id="__chrome_card">
     <div id="__chrome_hold"></div>
     <div id="__demo_bridge"><div id="__demo_bridge_t"></div></div>
@@ -254,9 +259,24 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
 <div id="__demo_cursor"></div>
 <script>
   window.__demoCaption = (text) => {
-    const el = document.getElementById('__demo_caption');
-    el.textContent = text;
-    el.style.opacity = text ? '1' : '0';
+    // Two stacked layers crossfade. The old line fades out while the new
+    // one fades in — a text-to-text change used to swap instantly under a
+    // steady opacity, which read as a pop between otherwise smooth takes.
+    // Same ids-and-contract as before: `__demo_caption` is whichever layer
+    // is currently visible, the clipped measurement is taken on the layer
+    // about to be shown, and '' fades whatever is up.
+    const band = document.getElementById('__chrome_band');
+    const ids = ['__demo_caption', '__demo_caption2'];
+    const cur = document.getElementById(ids[window.__demoCapLayer || 0]);
+    if (cur.textContent === text) {
+      if (!text) return 0;
+      return Math.max(0, cur.scrollHeight - band.clientHeight);
+    }
+    const nxt = document.getElementById(ids[1 - (window.__demoCapLayer || 0)]);
+    nxt.textContent = text;
+    nxt.style.opacity = text ? '1' : '0';
+    cur.style.opacity = '0';
+    window.__demoCapLayer = 1 - (window.__demoCapLayer || 0);
     // How many pixels of this caption the band cannot show. The band has a
     // fixed height and overflow: hidden — the construction that keeps the
     // app rect caption-free — so a line too tall for it is shaved at the
@@ -264,8 +284,7 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
     // (core.caption reads this return value); the in-page overlay version
     // of this function grows with its text and returns nothing.
     if (!text) return 0;
-    const band = document.getElementById('__chrome_band');
-    return Math.max(0, el.scrollHeight - band.clientHeight);
+    return Math.max(0, nxt.scrollHeight - band.clientHeight);
   };
   // The card and the scrim, band-aware for the same reason __demoCaption
   // above is: this document's versions render in the card layer over the app

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -39,6 +39,7 @@ from types import TracebackType
 
 from playwright.sync_api import Page, sync_playwright
 
+from .camera import camera_filter, video_dimensions
 from .content import (
     content_report,
     media_duration,
@@ -70,7 +71,12 @@ from .failure import (
     render_failure_md,
 )
 from .frames import _FRAME_EDGE_S, _extract, write_beat_frames
-from .narration import mix_plan, tts_clip
+from .narration import (
+    DEFAULT_STABILITY,
+    clip_gain_db,
+    mix_plan,
+    tts_clip,
+)
 from .target import guard_target
 from .timeline import (
     ATTRIBUTION_SLACK_S,
@@ -85,6 +91,7 @@ from .timeline import (
     TIMELINE_SCHEMA,
     StrictTakeFailed,
     _cap_text,
+    capture_clock_shift,
     evidence_name,
     write_timeline,
 )
@@ -642,8 +649,7 @@ class _CaptureClock:
         if abs(self.total) < self.WARN_S:
             return None
         when = ", ".join(
-            f"{step['delta'] * 1000:+.0f} ms at {step['t']:.1f}s"
-            for step in self.steps
+            f"{step['delta'] * 1000:+.0f} ms at {step['t']:.1f}s" for step in self.steps
         )
         return (
             f"demo-video: WARNING — this host's wall clock stepped while the "
@@ -821,6 +827,7 @@ class _DemoBase:
             "_failure_screen",
             "_media_path",
             "_opening_card",
+            "_raise_outro",
             # extension points, each beside the sealed member it extends
             "_watch_extra",
             "_before_shot",
@@ -875,6 +882,7 @@ class _DemoBase:
         speech: bool | None = None,
         voice_id: str | None = None,
         speech_model: str | None = None,
+        speech_stability: float | None = None,
         strict: bool | None = None,
         deterministic: bool | None = None,
         clock: str | None = None,
@@ -884,6 +892,10 @@ class _DemoBase:
         criteria: dict[str, str] | None = None,
         ticket: str | None = None,
         stills_only: bool | None = None,
+        pace: float | None = None,
+        intro: str | None = None,
+        outro: str | None = None,
+        window_title: str | None = None,
         # Last, and kept last. `tests/unit`'s "a way to permit a public host
         # appears as a constructor argument" injection anchors on this line
         # followed by the closing paren, and a parameter added after it makes
@@ -959,6 +971,19 @@ class _DemoBase:
                 )
             accent_rgb = tuple(int(p) for p in parts)  # type: ignore[assignment]
         self._accent = ",".join(str(c) for c in accent_rgb)
+        # The wrapper window's title bar. None means the medium picks its own
+        # default: a web take names the app it is pointed at (its base_url's
+        # host), a terminal take its `terminal_title`.
+        self._window_title = window_title or _env("WINDOW_TITLE")
+        # The opt-in opening title (web medium only — the terminal medium has
+        # its own `interlude=` opening card). Empty string is off, same as
+        # None: an intro that says nothing is no intro.
+        self._intro = (intro or _env("INTRO") or "").strip() or None
+        # The opt-in closing card, same terms. `_outro_up` is what turns the
+        # envelope key on: a take that asked for an outro and lost it to a
+        # late failure does not claim one.
+        self._outro = (outro or _env("OUTRO") or "").strip() or None
+        self._outro_up = False
         self._terminal_title = terminal_title or _env("TERMINAL_TITLE", "terminal")
         self._terminal_prompt = terminal_prompt or _env("TERMINAL_PROMPT", "$ ")
         if viewport is None:
@@ -970,6 +995,31 @@ class _DemoBase:
                 )
             viewport = (int(w), int(h))
         self._size = {"width": viewport[0], "height": viewport[1]}
+        # Audience pacing (SKILL.md, "Pacing and perception"). A multiplier
+        # over the holds this recorder *computes* — the no-speech caption
+        # read time, and the defaults of hold(), interlude() and criterion()
+        # — so one storyboard can serve a hurried viewer (pace < 1) or a
+        # deliberate one (pace > 1) without being rewritten. A duration the
+        # author wrote stays literal: pause(s), hold(min_s=…) and
+        # interlude(hold=…) passed explicitly are requests, not defaults.
+        # stills_only zeroes pacing entirely, so rehearsal speed does not
+        # depend on whatever a take sets here.
+        if pace is None:
+            raw_pace: float | str = _env("PACE", "1.0")
+        else:
+            raw_pace = pace
+        try:
+            pace = float(raw_pace)
+        except (TypeError, ValueError):
+            raise RuntimeError(
+                f"DEMO_VIDEO_PACE must be a number, got {raw_pace!r}"
+            ) from None
+        if pace <= 0:
+            raise RuntimeError(
+                f"DEMO_VIDEO_PACE must be positive, got {pace!r} — a take at "
+                f"pace 0 never shows anything"
+            )
+        self._pace = pace
         # Determinism (see the section above). Opt-in, because the frozen clock
         # and the motion rule change what an app does and mostly do it
         # silently; timezone, locale and reduced motion are pinned regardless.
@@ -987,9 +1037,7 @@ class _DemoBase:
         if speech is None:
             speech = _env_flag("SPEECH")
         if speech is True and not api_key:
-            raise RuntimeError(
-                "speech is forced on but ELEVENLABS_API_KEY is not set"
-            )
+            raise RuntimeError("speech is forced on but ELEVENLABS_API_KEY is not set")
         if speech is True and self.stills_only:
             raise RuntimeError(
                 "speech is forced on for a stills-only run, which encodes no "
@@ -1005,7 +1053,37 @@ class _DemoBase:
         self._speech_model = speech_model or _env(
             "SPEECH_MODEL", "eleven_multilingual_v2"
         )
+        # Pinned voice stability (see narration.DEFAULT_STABILITY for the
+        # measurement behind the default): without it the model's per-sentence
+        # pacing wanders and consecutive lines read as different speeds.
+        if speech_stability is None:
+            raw_stability: float | str = _env(
+                "SPEECH_STABILITY", str(DEFAULT_STABILITY)
+            )
+        else:
+            raw_stability = speech_stability
+        try:
+            speech_stability = float(raw_stability)
+        except (TypeError, ValueError):
+            raise RuntimeError(
+                f"DEMO_VIDEO_SPEECH_STABILITY must be a number, got {raw_stability!r}"
+            ) from None
+        if not 0.0 < speech_stability <= 1.0:
+            raise RuntimeError(
+                f"DEMO_VIDEO_SPEECH_STABILITY must be between 0 and 1, got "
+                f"{speech_stability!r}"
+            )
+        self._speech_stability = speech_stability
         self._tts_dir = self.out_dir / ".tts"
+        # The intro and outro cards are voiced from clips synthesized *here*,
+        # in the constructor — never when the card is raised. The raise runs
+        # on the capture clock, and the round trip paid there was 3.4 s of
+        # silent card at the top of the delivered exec demo (its first line
+        # mixed at t=3.557 for exactly this reason). A card raised over a
+        # take must have its voice already in hand; the cache makes every
+        # run after the first free.
+        self._intro_clip = self._pre_synth(self._intro)
+        self._outro_clip = self._pre_synth(self._outro)
         # Caption font size in px, handed to `chrome_html` by each medium's
         # `_start`. Both media record at true pixel size, so this is the
         # size on screen in the chrome's caption band. (The deleted
@@ -1023,6 +1101,12 @@ class _DemoBase:
         # over- or under-run by the size of the step.
         self._line_end = 0.0  # when the current line stops speaking
         self._t0 = 0.0  # when video capture started
+        # The camera (see camera.py): each spotlight interval as geometry,
+        # pushed in after the take, in _convert. An open event is the
+        # spotlight on screen right now; it closes when the next spotlight
+        # clears it, or with the take.
+        self._camera: list[dict] = []
+        self._camera_open: dict | None = None
         # ...and the one clock in here that is *not* monotonic, because the
         # video is on it and nothing else can reach it. See _CaptureClock.
         self._capture_clock = _CaptureClock()
@@ -1090,8 +1174,7 @@ class _DemoBase:
         # user expected voice (usually the key just isn't in this process's
         # env) is otherwise a confusing surprise only noticed after the fact.
         if self._speech:
-            print(f"demo-video: narration ON (voice {self._voice_id})",
-                  file=sys.stderr)
+            print(f"demo-video: narration ON (voice {self._voice_id})", file=sys.stderr)
         elif self.stills_only:
             print(
                 "demo-video: narration OFF — a stills-only run encodes no "
@@ -1214,7 +1297,6 @@ class _DemoBase:
         """
         return None
 
-
     # -- context manager ----------------------------------------------------
 
     def __enter__(self) -> "_DemoBase":
@@ -1238,9 +1320,7 @@ class _DemoBase:
             # a second flag somebody has to remember to check.
             self._context = self._browser.new_context(
                 viewport=self._size,
-                record_video_dir=(
-                    None if self.stills_only else str(self._video_dir)
-                ),
+                record_video_dir=(None if self.stills_only else str(self._video_dir)),
                 record_video_size=None if self.stills_only else self._size,
                 locale=self._locale,
                 timezone_id=self._timezone_id,
@@ -1314,6 +1394,21 @@ class _DemoBase:
         #     the `with` that carries an exception, for exactly that reason.
         if exc_type is None:
             self._finish_line(tail=0.5)  # don't end mid-sentence
+            # The opt-in closing card, while the page is alive and the
+            # capture still running — the mirror of the intro, at the other
+            # end. Never fatal: a take that recorded everything and lost its
+            # outro to a late failure is a take without an outro, not a take
+            # to throw away; the envelope key is what says whether it happened.
+            if exc_type is None:
+                try:
+                    self._raise_outro()
+                except Exception:  # noqa: BLE001 - the take is already on disk
+                    pass
+        # A spotlight still on at the take's end is a camera event with no
+        # end; it ends with the take. On the failure path too — the timeline
+        # is written either way, and an open event it never mentions would
+        # describe a push the mp4 does not contain.
+        self._camera_close()
         # The last thing asked of the live page, and it has to be here rather
         # than beside the rest of the picture check: `_measure_content` runs
         # after the browser is gone, off a file, and the one occlusion nothing
@@ -1615,8 +1710,10 @@ class _DemoBase:
                 return  # log/info/debug is an app talking, not an app failing
             where = message.location or {}
             self._note_issue(
-                kind, message.text,
-                url=where.get("url") or None, line=where.get("lineNumber"),
+                kind,
+                message.text,
+                url=where.get("url") or None,
+                line=where.get("lineNumber"),
             )
         except Exception:  # noqa: BLE001 - a diagnostic must not kill a take
             pass
@@ -1633,7 +1730,8 @@ class _DemoBase:
             self._note_issue(
                 "request_failed",
                 f"{request.failure or 'request failed'} — {request.url}",
-                url=request.url, method=request.method,
+                url=request.url,
+                method=request.method,
             )
         except Exception:  # noqa: BLE001 - a diagnostic must not kill a take
             pass
@@ -1645,8 +1743,10 @@ class _DemoBase:
             if response.status < 400:
                 return
             self._note_issue(
-                "http_error", f"HTTP {response.status} {response.url}",
-                url=response.url, status=response.status,
+                "http_error",
+                f"HTTP {response.status} {response.url}",
+                url=response.url,
+                status=response.status,
             )
         except Exception:  # noqa: BLE001 - a diagnostic must not kill a take
             pass
@@ -1692,8 +1792,7 @@ class _DemoBase:
         recorded = [i for i in self._issues if i["kind"] in STRICT_KINDS]
         shown = recorded[:5]
         lines = [
-            f"  {i['kind']} in {self._issue_where(i)}: {i['message']}"
-            for i in shown
+            f"  {i['kind']} in {self._issue_where(i)}: {i['message']}" for i in shown
         ]
         if not shown:
             lines.append(
@@ -1871,7 +1970,6 @@ class _DemoBase:
         """Whitespace collapsed to single spaces, ends trimmed."""
         return " ".join(text.split())
 
-
     def _evidence_doc(self, beat: dict, payload: dict) -> dict:
         """One evidence document: the envelope, the payload, then the caps.
 
@@ -1894,8 +1992,16 @@ class _DemoBase:
             "media": self._media_name(),
             "beat": {
                 key: beat.get(key)
-                for key in ("index", "t_start", "t_end", "verb", "selector",
-                            "caption", "still", "evidence")
+                for key in (
+                    "index",
+                    "t_start",
+                    "t_end",
+                    "verb",
+                    "selector",
+                    "caption",
+                    "still",
+                    "evidence",
+                )
             },
         }
         doc.update(payload)
@@ -1923,8 +2029,10 @@ class _DemoBase:
             return
         out = self.out_dir / EVIDENCE_DIR
         self._evidence_docs = [
-            (out / evidence_name(beat["index"], self.segment),
-             self._evidence_doc(beat, payload))
+            (
+                out / evidence_name(beat["index"], self.segment),
+                self._evidence_doc(beat, payload),
+            )
             for beat, payload in self._evidence
         ]
 
@@ -1950,14 +2058,14 @@ class _DemoBase:
     def _clear_stale_evidence(self, keep: set[Path] | None = None) -> None:
         """Delete evidence a previous take into this directory left behind.
 
-        Re-recording into the same folder is how this skill is *meant* to be
-        used — `record.py` is committed precisely so it can be re-run — and a
-take with fewer beats than the last one would otherwise leave the
-        previous take's files sitting beside its own, named for beats this
-        take never recorded. Nothing else here has that shape: the mp4 is
-        overwritten, and a still is only kept because it might be a committed
-        guide. Evidence is never committed, so
-        there is no such thing as one worth keeping.
+                Re-recording into the same folder is how this skill is *meant* to be
+                used — `record.py` is committed precisely so it can be re-run — and a
+        take with fewer beats than the last one would otherwise leave the
+                previous take's files sitting beside its own, named for beats this
+                take never recorded. Nothing else here has that shape: the mp4 is
+                overwritten, and a still is only kept because it might be a committed
+                guide. Evidence is never committed, so
+                there is no such thing as one worth keeping.
         """
         for path in self._stale_evidence(keep):
             try:
@@ -2044,9 +2152,7 @@ take with fewer beats than the last one would otherwise leave the
             "generated_by": "demo-video",
             "recorder": type(self).__name__,
             "segment": self.segment,
-            "when": _dt.datetime.now(_dt.timezone.utc).isoformat(
-                timespec="seconds"
-            ),
+            "when": _dt.datetime.now(_dt.timezone.utc).isoformat(timespec="seconds"),
             "failure": failure,
             # The failing beat in full, not just its index: this file is meant
             # to answer "which beat, and what was on screen" without anyone
@@ -2113,7 +2219,10 @@ take with fewer beats than the last one would otherwise leave the
         doc["media_written_by_this_take"] = self._converted
         written = 0
         for path, text in [
-            (out / "failure.json", json.dumps(doc, indent=2, ensure_ascii=False) + "\n"),
+            (
+                out / "failure.json",
+                json.dumps(doc, indent=2, ensure_ascii=False) + "\n",
+            ),
             (out / "failure.md", render_failure_md(doc)),
             *self._failure_docs,
         ]:
@@ -2261,7 +2370,24 @@ take with fewer beats than the last one would otherwise leave the
         except Exception:  # noqa: BLE001 - a diagnostic must not kill a take
             return
         if isinstance(up, list):
-            self._overlay_note = overlay_warning([str(i) for i in up])
+            ids = [str(i) for i in up]
+            if self._outro_up:
+                # The outro card is this take's deliberate last frame, raised
+                # by the recorder itself seconds ago. Warning "an overlay the
+                # recorder left up" about the take's own ending would be the
+                # probe grading its own feature. The bridge is not waived: an
+                # outro never raises one, so a bridge up here is still a bug.
+                ids = [i for i in ids if i != INTERLUDE_ID]
+            if ids:
+                self._overlay_note = overlay_warning(ids)
+
+    def _raise_outro(self) -> None:
+        """The opt-in closing card (`Recorder(outro=…)`, off by default).
+
+        A no-op in the base: the card machinery is the wrapper document's,
+        and only a medium that builds one can raise anything over it.
+        """
+        return None
 
     def _opening_card(self) -> dict | None:
         """What this take's **first frame** showed, for a medium that can say.
@@ -2468,6 +2594,29 @@ take with fewer beats than the last one would otherwise leave the
             "issues": issues,
             "issue_count": self._issue_count,
         }
+        # Present only when this take moved off the default pacing, for the
+        # same reason `mode` and `failure` are absent on an ordinary take:
+        # absence is the signal, and a reader skimming a fast take's
+        # timeline.json sees why it is fast instead of guessing.
+        if self._pace != 1.0:
+            doc["pace"] = self._pace
+        # Same absence-as-signal: a take that opened on an intro card says so,
+        # and carries the sentence that was on it — the one string a reader of
+        # frame 0 cannot recover from the beat table, which never shows it.
+        if self._intro:
+            doc["intro"] = self._intro
+        # Presence is the signal, and the signal is also the honesty: an
+        # outro that was asked for but never raised (a late TTS failure) is
+        # a take without one, and this key is what says so.
+        if self._outro_up:
+            doc["outro"] = self._outro
+        # The camera moves this take's mp4 was rendered with (see camera.py).
+        # Presence is the signal, like intro and outro: a take without
+        # push-ins reads as it always did. The rects are in output-frame
+        # pixels — the coordinates a reader maps onto demo.mp4 — so the
+        # moves can be re-rendered, audited, or graded without the take.
+        if self._camera:
+            doc["camera"] = [dict(event) for event in self._camera]
         # Both of these are the `failure` construction below, for the same
         # reason: **presence is the signal** (issue #372).
         #
@@ -2710,14 +2859,17 @@ take with fewer beats than the last one would otherwise leave the
         if self._speech:
             return 0.4
         words = len(text.split())
-        return min(6.0, max(1.4, 0.6 + words * 0.34))
+        return min(6.0, max(1.4, 0.6 + words * 0.34)) * self._pace
 
-    def interlude(self, text: str, hold: float = 2.8, style: str = "card") -> None:
+    def interlude(
+        self, text: str, hold: float | None = None, style: str = "card"
+    ) -> None:
         """Bridge a jump in the demo; "" takes it down, whichever style is up.
 
         With speech enabled the line is spoken too, and `hold` is how long the
         card stays before the storyboard moves on (a clear always takes 0.6 s,
-        long enough for the fade).
+        long enough for the fade). The default hold — 2.8 s — is scaled by
+        this take's `pace`; an explicit `hold` stays literal.
 
         style="card" (default) is a full-screen title card — right for real
         time-skips (minutes of background work) between segments. style="light"
@@ -2744,7 +2896,7 @@ take with fewer beats than the last one would otherwise leave the
                     "() => { window.__demoInterlude(''); window.__demoBridge(''); }"
                 )
             self._start_line(clip)
-            self.pause(hold if text else 0.6)
+            self.pause((2.8 * self._pace if hold is None else hold) if text else 0.6)
 
     def criterion(self, ac: str, hold: float | None = None) -> None:
         """Put a declared acceptance criterion's own sentence on screen.
@@ -2793,28 +2945,36 @@ take with fewer beats than the last one would otherwise leave the
     def _criterion_hold(self, text: str) -> float:
         """How long a clause stays up when the storyboard does not say.
 
-        Read speed over the clause, bounded by the two constants — and never
-        less than what is left of the line being spoken, because a card that
-        leaves mid-sentence while the voice is still reading the clause is the
-        one failure this verb exists to remove.
+        Read speed over the clause, bounded by the two constants and scaled
+        by `pace` like every other computed hold — never less than what is
+        left of the line being spoken, because a card that leaves mid-sentence
+        while the voice is still reading the clause is the one failure this
+        verb exists to remove.
         """
-        reading = min(
-            CRITERION_HOLD_MAX_S,
-            max(CRITERION_HOLD_MIN_S, 0.6 + len(text.split()) * 0.34),
+        reading = (
+            min(
+                CRITERION_HOLD_MAX_S,
+                max(CRITERION_HOLD_MIN_S, 0.6 + len(text.split()) * 0.34),
+            )
+            * self._pace
         )
         return max(reading, self._line_end - time.monotonic())
 
     @_beat_verb("hold")
-    def hold(self, min_s: float = 1.5) -> None:
+    def hold(self, min_s: float | None = None) -> None:
         """Keep the current frame up until the narration for the current
         caption finishes speaking — so a spotlight or highlight stays on
         screen for the whole spoken line instead of flashing. Holds at least
         `min_s` (a perception floor: ~1.5 s to notice and fixate on a change),
         which is also what governs pacing when narration is off. Use it right
-        after setting a spotlight/emphasis."""
-        remaining = self._line_end - time.monotonic()
-        self._idle(max(min_s, remaining))
+        after setting a spotlight/emphasis.
 
+        The floor is 1.5 s scaled by this take's `pace` when `min_s` is not
+        passed; an explicit `min_s` is the author's number and stays literal.
+        """
+        floor = 1.5 * self._pace if min_s is None else min_s
+        remaining = self._line_end - time.monotonic()
+        self._idle(max(floor, remaining))
 
     def _before_shot(self) -> None:
         """Bring the screen up to date before a still is taken.
@@ -2876,17 +3036,87 @@ take with fewer beats than the last one would otherwise leave the
             self.page.screenshot(path=str(path))
         return path
 
+    # -- camera (see camera.py) ----------------------------------------------
+
+    def _camera_raise(self, rect: dict) -> None:
+        """Open a camera event over the element just spotlighted. `rect` is
+        the spotlight's own measurement of where the element sits in the
+        recorded frame, in output-frame pixels."""
+        self._camera_open = {
+            "t_start": round(time.monotonic() - self._t0, 3),
+            "rect": [rect["x"], rect["y"], rect["w"], rect["h"]],
+        }
+
+    def _camera_close(self, t_end: float | None = None) -> None:
+        """End the open camera event, at `t_end` (now, unless given — the
+        spotlight's clear hands in the moment the pull *starts*, because its
+        evaluate waits out the fade). A degenerate event is dropped: a
+        camera move with no length is not a move, and the timeline carries
+        only what the mp4 will show."""
+        if self._camera_open is None:
+            return
+        event = dict(self._camera_open)
+        self._camera_open = None
+        end = round(time.monotonic() - self._t0, 3) if t_end is None else round(t_end, 3)
+        if end > event["t_start"]:
+            event["t_end"] = end
+            self._camera.append(event)
+
+    def _camera_on_the_video_clock(self, record: object) -> list[dict]:
+        """The camera events moved onto the clock the video is on.
+
+        The events' times are beat-log instants — `time.monotonic()` minus
+        `_t0` — and the video is stamped with the wall clock, so a host that
+        stepped puts every event after the step that far ahead of the frames
+        it names. The narration mix corrects its lines through
+        `capture_clock_shift` (issue #226); the moves ride the same
+        correction. An interval the step swallowed whole is dropped rather
+        than rendered as a push with no length. The list is replaced, so the
+        timeline this take writes describes the moves demo.mp4 actually
+        carries."""
+        place, _ = capture_clock_shift(record)
+        corrected = []
+        for event in self._camera:
+            moved = dict(event)
+            moved["t_start"] = round(place(event["t_start"]).at, 3)
+            moved["t_end"] = round(place(event["t_end"]).at, 3)
+            if moved["t_end"] > moved["t_start"]:
+                corrected.append(moved)
+        return corrected
+
     # -- speech (ElevenLabs narration) --------------------------------------
 
-    def _prepare_line(self, text: str) -> Path | None:
-        """Synthesize (or fetch cached) audio for a narration line, and wait
-        out the previous line — never speak two lines at once, never show a
-        caption while the voice is still on the previous one."""
+    def _pre_synth(self, text: str | None) -> Path | None:
+        """Synthesize a card's line off the clock — the constructor calls this
+        for the intro and outro, whose raises happen on the capture clock."""
+        if not (self._speech and text):
+            return None
+        return tts_clip(
+            text,
+            self._tts_dir,
+            self._voice_id,
+            self._speech_model,
+            self._api_key,
+            stability=self._speech_stability,
+        )
+
+    def _prepare_line(self, text: str, preset: Path | None = None) -> Path | None:
+        """Resolve the audio for a narration line, and wait out the previous
+        line — never speak two lines at once, never show a caption while the
+        voice is still on the previous one. `preset` is a clip already
+        synthesized off the clock (a card's line); when it is handed in there
+        is nothing left to synthesize and none is paid for."""
         clip = None
-        if self._speech and text:
+        if preset is not None:
+            clip = preset
+        elif self._speech and text:
             clip = tts_clip(
-                text, self._tts_dir, self._voice_id, self._speech_model,
+                text,
+                self._tts_dir,
+                self._voice_id,
+                self._speech_model,
                 self._api_key,
+                stability=self._speech_stability,
             )
         self._finish_line()
         return clip
@@ -2907,7 +3137,49 @@ take with fewer beats than the last one would otherwise leave the
 
     def _convert(self, webm: Path) -> None:
         mp4 = self._media_path()
-        cmd = ["ffmpeg", "-y", "-loglevel", "error", "-i", str(webm)]
+        # The camera (see camera.py): one eased push-in per spotlight
+        # interval, rendered here, in the same encode as the narration mix.
+        # A take with no spotlight intervals builds no chain and encodes
+        # exactly as it did before the camera existed.
+        #
+        # **The camera renders in its own pass, and that is load-bearing.**
+        # The mix below maps video straight from its input and filters only
+        # audio — one graph output, `-shortest` cutting the pad. Adding the
+        # camera chain as a second graph output next to that audio made
+        # ffmpeg buffer the whole video through the interleaving queue:
+        # measured at 2.8 GB resident and "No space left on device" on a
+        # 54 s take, and a plain `fps,scale` video branch hangs the same
+        # way, so it is the two-output shape, not zoompan. A video-only
+        # pre-pass is a single-output graph — the shape the mix always
+        # used — and the mix then reads its frames like any other input.
+        source = webm
+        if self._camera:
+            self._camera = self._camera_on_the_video_clock(
+                self._capture_clock.report()
+            )
+        if self._camera:
+            src_w, src_h = video_dimensions(webm)
+            chain = camera_filter(
+                self._camera,
+                src_w=src_w,
+                src_h=src_h,
+                out_w=self._size["width"],
+                out_h=self._size["height"],
+            )
+            source = webm.with_suffix(".camera.mp4")
+            subprocess.run(
+                [
+                    "ffmpeg", "-y", "-loglevel", "error",
+                    "-i", str(webm),
+                    "-filter_complex", f"[0:v]{chain}[v]",
+                    "-map", "[v]",
+                    "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "16",
+                    "-r", "25",
+                    str(source),
+                ],
+                check=True,
+            )
+        cmd = ["ffmpeg", "-y", "-loglevel", "error", "-i", str(source)]
         narration: dict | None = None
         if self._speech:
             # Mix each narration clip in at the moment its line appeared —
@@ -2922,14 +3194,31 @@ take with fewer beats than the last one would otherwise leave the
             # stitch()'s lossless concat sees uniform streams.
             if self._lines:
                 plan, clock = mix_plan(
-                    [off for off, _ in self._lines], self._capture_clock.report()
+                    [off for off, _ in self._lines],
+                    self._capture_clock.report(),
+                    # The clips' own lengths: without them the corrected
+                    # placements cannot be serialized, and a backward step
+                    # between two lines mixes one voice over another
+                    # (measured at 1.6 s of overlap on a −1.65 s step).
+                    [media_duration(clip) for _, clip in self._lines],
                 )
                 narration = {"lines": plan, "clock_correction": clock}
                 for _, clip in self._lines:
                     cmd += ["-i", str(clip)]
+                # Per-clip gain to one loudness target. ElevenLabs returns
+                # clips at whatever level the model produced, and mixed as-is
+                # consecutive lines sit at audibly different levels. Measured
+                # per clip, applied here where the mix is built; a clip that
+                # cannot be measured gains nothing and says so in its line.
+                gains = [clip_gain_db(clip) for _, clip in self._lines]
+                for line, gain in zip(plan, gains, strict=True):
+                    if abs(gain) >= 0.1:
+                        line["gain_db"] = gain
                 delayed = ";".join(
-                    f"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}:all=1[a{i}]"
-                    for i, line in enumerate(plan)
+                    f"[{i + 1}:a]"
+                    + (f"volume={gain:.2f}dB," if abs(gain) >= 0.1 else "")
+                    + f"adelay={int(round(line['at'] * 1000))}:all=1[a{i}]"
+                    for i, (line, gain) in enumerate(zip(plan, gains, strict=True))
                 )
                 inputs = "".join(f"[a{i}]" for i in range(len(self._lines)))
                 # aformat pins the layout: mixed mono TTS clips would
@@ -2942,13 +3231,39 @@ take with fewer beats than the last one would otherwise leave the
                     "apad[aud]"
                 )
             else:
-                cmd += ["-f", "lavfi", "-i",
-                        "anullsrc=channel_layout=stereo:sample_rate=44100"]
+                cmd += [
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "anullsrc=channel_layout=stereo:sample_rate=44100",
+                ]
                 filt = "[1:a]apad[aud]"
-            cmd += ["-filter_complex", filt, "-map", "0:v", "-map", "[aud]",
-                    "-c:a", "aac", "-b:a", "160k", "-shortest"]
-        cmd += ["-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "23",
-                "-r", "25", "-movflags", "+faststart", str(mp4)]
+            cmd += [
+                "-filter_complex",
+                filt,
+                "-map",
+                "0:v",
+                "-map",
+                "[aud]",
+                "-c:a",
+                "aac",
+                "-b:a",
+                "160k",
+                "-shortest",
+            ]
+        cmd += [
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-crf",
+            "23",
+            "-r",
+            "25",
+            "-movflags",
+            "+faststart",
+            str(mp4),
+        ]
         subprocess.run(cmd, check=True)
         self._postprocess(mp4)
         # Only now. Everything that reads `duration`, extracts a review frame,

--- a/skills/demo-video/helpers/demo_recording/narration.py
+++ b/skills/demo-video/helpers/demo_recording/narration.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
+import subprocess
 import time
 import urllib.error
 import urllib.request
@@ -102,7 +104,9 @@ TTS_API_BASE = "https://api.elevenlabs.io/v1/text-to-speech"
 
 
 def mix_plan(
-    offsets: Sequence[float], record: object
+    offsets: Sequence[float],
+    record: object,
+    durations: Sequence[float] | None = None,
 ) -> tuple[list[dict], dict]:
     """Where each narration line goes in the encoded media. -> (lines, state)
 
@@ -112,6 +116,22 @@ def mix_plan(
     video, and what the mix delays the clip by). `state` is the three-state
     clock record — see the section above; a caller that drops it publishes a
     demo whose audio placement cannot be told from a guess.
+
+    **`durations`, when given, are the clips' own lengths in the same order,
+    and the corrected placements are then serialized**: the recorder never
+    spoke two lines at once — each started after the previous ended, on the
+    monotonic clock the beats keep — but a backward step between two lines
+    compresses the video without compressing the clip, and the corrected
+    onset of the later line can land inside its predecessor. Measured on a
+    real take: a −1.65 s step put a line 1.6 s inside the voice before it —
+    double-talk for the length of a whole clause, not the fraction of a
+    second an earlier measurement had priced the overlap at. A line that
+    would start inside its predecessor starts at its predecessor's end
+    instead, and carries `held` — the seconds it starts later than the
+    stepped clock would put it. That is a voice trailing its caption by the
+    step, traded for two voices at once; `held` is what says the trade was
+    made, and the caller that omits `durations` gets the unserialized
+    placement exactly as before.
 
     `at` never goes below zero, and **a line that hit that floor says so** —
     though since #256 nothing this recorder writes can hit it: a step's own
@@ -146,7 +166,8 @@ def mix_plan(
     """
     place, state = capture_clock_shift(record)
     lines = []
-    for off in offsets:
+    prev_end = 0.0
+    for i, off in enumerate(offsets):
         placed = place(off)
         want = placed.at
         # Rounded *before* the test, not after. A `want` of −5e-5 is a
@@ -154,25 +175,80 @@ def mix_plan(
         # and a `clamped: 0.0` beside it would be a line claiming its `at` is
         # not `t` plus the steps before it when it is. Same for `no_video`.
         clamped = round(-want, 3) if want < 0 else 0.0
-        line = {"t": round(float(off), 3), "at": round(max(0.0, want), 3)}
+        at = max(0.0, want)
+        # The serialization, after the clock correction and the floor: a line
+        # that would start inside its predecessor starts when its predecessor
+        # ends. `held` is absent from lines placed genuinely — including ones
+        # whose shortfall rounds away to nothing, same rule as `clamped`.
+        held = 0.0
+        if durations is not None and at < prev_end:
+            held = round(prev_end - at, 3)
+            at = prev_end
+        line = {"t": round(float(off), 3), "at": round(at, 3)}
         if clamped:
             line["clamped"] = clamped
         if round(placed.lost, 3):
             line["no_video"] = round(placed.lost, 3)
+        if held:
+            line["held"] = held
         lines.append(line)
+        if durations is not None:
+            prev_end = at + float(durations[i])
     return lines, state
 
 
-def _tts_key(text: str, voice_id: str, model_id: str) -> str:
-    """The cache filename stem for one line, in one voice, from one model.
+#: ElevenLabs voice stability pinned on every synthesis. The model's default
+#: lets per-sentence pacing wander — measured 2.1 to 3.3 words/s across the
+#: five clips of one take, which a listener reads as some lines being sped up.
+#: Higher stability trades expressiveness for consistency; it is a recorder
+#: constant rather than a per-take knob until someone asks for the knob.
+DEFAULT_STABILITY = 0.75
 
-    **All three inputs are in the key, and that is the contract.** Switching
+
+#: The mean level every narration clip is mixed to. ElevenLabs returns clips
+#: at whatever level the model produced; mixed as-is, consecutive lines sit at
+#: audibly different loudnesses, which reads as a production fault even when
+#: nobody can name it. One target, measured per clip, gained per clip.
+LOUDNESS_TARGET_DB = -20.0
+
+
+def clip_gain_db(path: Path, target: float = LOUDNESS_TARGET_DB) -> float:
+    """The gain in dB that puts a clip's mean level at `target`.
+
+    Measured with ffmpeg's `volumedetect`, not assumed: the correction is
+    per clip, because the variance is per clip. A clip that cannot be
+    measured (or has no audio to measure) gains nothing — a silent mix of a
+    clip at the wrong level beats a take that died in the mix.
+    """
+    probe = subprocess.run(
+        ["ffmpeg", "-v", "info", "-i", str(path), "-af", "volumedetect",
+         "-f", "null", "-"],
+        capture_output=True, text=True,
+    )
+    found = re.search(r"mean_volume:\s*(-?\d+\.?\d*) dB", probe.stderr)
+    if not found:
+        return 0.0
+    return round(target - float(found.group(1)), 2)
+
+
+def _tts_key(
+    text: str, voice_id: str, model_id: str, stability: float = DEFAULT_STABILITY
+) -> str:
+    """The cache filename stem for one line, in one voice, one model, one
+    voice stability.
+
+    **All four inputs are in the key, and that is the contract.** Switching
     voice or model has to re-generate rather than replay the old audio — a
     cache that keyed on text alone would hand a take recorded in one voice the
     clips of another, and nothing downstream would notice: the mp4 would come
     out with a full, correctly-timed audio track in the wrong voice.
+    Stability is the same shape of input: it changes how the line is *spoken*,
+    so a stability change that replayed old clips would silently keep the
+    pacing the stability change was made to fix.
     """
-    joined = TTS_KEY_SEP.join((voice_id, model_id, text))
+    joined = TTS_KEY_SEP.join(
+        (voice_id, model_id, text, f"stability={stability:.2f}")
+    )
     return hashlib.sha256(joined.encode()).hexdigest()[:TTS_KEY_CHARS]
 
 
@@ -182,6 +258,7 @@ def tts_clip(
     voice_id: str,
     model_id: str,
     api_key: str,
+    stability: float = DEFAULT_STABILITY,
 ) -> Path:
     """Synthesize one narration line with ElevenLabs, cached by content.
 
@@ -189,14 +266,28 @@ def tts_clip(
     `api_key` is not read at all on a hit. That is what lets `tests/smoke`
     grade the pacing and the audio mix without a key or a network: seed the
     cache with clips of known duration and every line is a hit.
+
+    `stability` is pinned on every request (and in the cache key) so the
+    model's per-sentence pacing stays inside a band a listener reads as one
+    voice — measured without it at 2.1 to 3.3 words/s across one take's five
+    clips, which reads as some lines being sped up.
     """
     cache_dir.mkdir(parents=True, exist_ok=True)
-    clip = cache_dir / f"{_tts_key(text, voice_id, model_id)}.mp3"
+    clip = cache_dir / f"{_tts_key(text, voice_id, model_id, stability)}.mp3"
     if clip.exists():
         return clip
     req = urllib.request.Request(
         f"{TTS_API_BASE}/{voice_id}?output_format=mp3_44100_128",
-        data=json.dumps({"text": text, "model_id": model_id}).encode(),
+        data=json.dumps(
+            {
+                "text": text,
+                "model_id": model_id,
+                "voice_settings": {
+                    "stability": stability,
+                    "similarity_boost": 0.75,
+                },
+            }
+        ).encode(),
         headers={"xi-api-key": api_key, "Content-Type": "application/json"},
     )
     for attempt in range(TTS_ATTEMPTS):

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -46,15 +46,25 @@ _ASSETS = Path(__file__).parent.parent / "assets" / "xterm"
 # (#355's design record): the window frame around it comes from chrome.py,
 # shared with the web recorder since #362.
 _TERM_THEME = {
-    "background": "#181825", "foreground": "#cdd6f4",
+    "background": "#181825",
+    "foreground": "#cdd6f4",
     "cursorAccent": "#181825",
     "selectionBackground": "#414458",
-    "black": "#45475a", "red": "#f38ba8", "green": "#a6e3a1",
-    "yellow": "#f9e2af", "blue": "#89b4fa", "magenta": "#f5c2e7",
-    "cyan": "#94e2d5", "white": "#bac2de",
-    "brightBlack": "#585b70", "brightRed": "#f38ba8", "brightGreen": "#a6e3a1",
-    "brightYellow": "#f9e2af", "brightBlue": "#89b4fa",
-    "brightMagenta": "#f5c2e7", "brightCyan": "#94e2d5",
+    "black": "#45475a",
+    "red": "#f38ba8",
+    "green": "#a6e3a1",
+    "yellow": "#f9e2af",
+    "blue": "#89b4fa",
+    "magenta": "#f5c2e7",
+    "cyan": "#94e2d5",
+    "white": "#bac2de",
+    "brightBlack": "#585b70",
+    "brightRed": "#f38ba8",
+    "brightGreen": "#a6e3a1",
+    "brightYellow": "#f9e2af",
+    "brightBlue": "#89b4fa",
+    "brightMagenta": "#f5c2e7",
+    "brightCyan": "#94e2d5",
     "brightWhite": "#a6adc8",
 }
 
@@ -172,10 +182,22 @@ OPENING_STRIP = (0.01, 0.04, 0.90, 0.16)  # x, y, w, h as fractions of the app r
 # Named keys -> the bytes a terminal program expects. Ctrl-<letter> is
 # handled generically (C-a..C-z -> 0x01..0x1a).
 _KEYMAP = {
-    "Enter": "\r", "Return": "\r", "Tab": "\t", "Space": " ",
-    "Escape": "\x1b", "Esc": "\x1b", "Backspace": "\x7f", "Delete": "\x1b[3~",
-    "Up": "\x1b[A", "Down": "\x1b[B", "Right": "\x1b[C", "Left": "\x1b[D",
-    "Home": "\x1b[H", "End": "\x1b[F", "PageUp": "\x1b[5~", "PageDown": "\x1b[6~",
+    "Enter": "\r",
+    "Return": "\r",
+    "Tab": "\t",
+    "Space": " ",
+    "Escape": "\x1b",
+    "Esc": "\x1b",
+    "Backspace": "\x7f",
+    "Delete": "\x1b[3~",
+    "Up": "\x1b[A",
+    "Down": "\x1b[B",
+    "Right": "\x1b[C",
+    "Left": "\x1b[D",
+    "Home": "\x1b[H",
+    "End": "\x1b[F",
+    "PageUp": "\x1b[5~",
+    "PageDown": "\x1b[6~",
 }
 
 # Exit-status side channel.
@@ -219,8 +241,6 @@ _EXIT_OSC = "\x1b]777;demo-video-exit;"
 _EXIT_RE = re.compile(re.escape(_EXIT_OSC) + r"(-?\d+);(\d+)\x07")
 
 
-
-
 class TerminalRecorder(_DemoBase):
     """Records a terminal session (CLI, REPL, or full-screen TUI).
 
@@ -256,6 +276,7 @@ class TerminalRecorder(_DemoBase):
         speech: bool | None = None,
         voice_id: str | None = None,
         speech_model: str | None = None,
+        speech_stability: float | None = None,
         strict: bool | None = None,
         deterministic: bool | None = None,
         clock: str | None = None,
@@ -265,6 +286,10 @@ class TerminalRecorder(_DemoBase):
         criteria: dict[str, str] | None = None,
         ticket: str | None = None,
         stills_only: bool | None = None,
+        pace: float | None = None,
+        intro: str | None = None,
+        outro: str | None = None,
+        window_title: str | None = None,
         allow_private: bool | None = None,
         type_delay_ms: int = 45,
         interlude: str | None = None,
@@ -273,15 +298,47 @@ class TerminalRecorder(_DemoBase):
         # A branded, distinctive default prompt so wait_for_prompt's marker
         # is unlikely to collide with command output.
         prompt = terminal_prompt or _env("TERMINAL_PROMPT") or "❯ "
+        # This medium's opening card is `interlude=`, raised before capture
+        # and cleared by its own hold. An `intro=` accepted and ignored here
+        # would be a setting that does nothing, so it is refused with the way
+        # out named — the same posture as every other authoring error.
+        if intro is not None:
+            raise RuntimeError(
+                "TerminalRecorder has no intro= — open on a title card with "
+                "TerminalRecorder(interlude=...) instead, which this medium "
+                "raises before capture starts and clears itself"
+            )
+        if outro is not None:
+            raise RuntimeError(
+                "TerminalRecorder has no outro= — close on a card with "
+                "rec.interlude(...) and leave it up, which this medium "
+                "records as the segment's last frame"
+            )
         super().__init__(
-            out_dir, segment=segment, accent_rgb=accent_rgb,
-            terminal_title=terminal_title, terminal_prompt=prompt,
-            viewport=viewport, speech=speech, voice_id=voice_id,
-            speech_model=speech_model, strict=strict,
-            deterministic=deterministic, clock=clock,
-            timezone_id=timezone_id, locale=locale, evidence=evidence,
-            criteria=criteria, ticket=ticket, allow_private=allow_private,
+            out_dir,
+            segment=segment,
+            accent_rgb=accent_rgb,
+            terminal_title=terminal_title,
+            terminal_prompt=prompt,
+            viewport=viewport,
+            speech=speech,
+            voice_id=voice_id,
+            speech_model=speech_model,
+            speech_stability=speech_stability,
+            strict=strict,
+            deterministic=deterministic,
+            clock=clock,
+            timezone_id=timezone_id,
+            locale=locale,
+            evidence=evidence,
+            criteria=criteria,
+            ticket=ticket,
+            allow_private=allow_private,
             stills_only=stills_only,
+            pace=pace,
+            intro=intro,
+            outro=outro,
+            window_title=window_title,
         )
         self._shell = shell or _env("TERMINAL_SHELL") or "/bin/bash"
         fs = font_size
@@ -330,6 +387,12 @@ class TerminalRecorder(_DemoBase):
             )
         )
 
+    def _chrome_title(self) -> str:
+        """What the wrapper window's title bar says: the take's
+        `window_title` when it has one, this medium's branded
+        `terminal_title` when it does not."""
+        return self._window_title or self._terminal_title
+
     def _start(self) -> None:
         # The chrome document first, so the recorded pixels are the shared
         # window from the earliest paint after frame 0's hold. `self._geom`
@@ -339,7 +402,7 @@ class TerminalRecorder(_DemoBase):
         self.page.set_content(
             chrome_html(
                 self._geom,
-                title=self._terminal_title,
+                title=self._chrome_title(),
                 window_body=TERM_WINDOW_BODY,
                 accent=self._accent,
                 caption_font_px=self._caption_font_px,
@@ -354,9 +417,7 @@ class TerminalRecorder(_DemoBase):
             # else this method does: its fade runs over the opening hold's
             # flat field (the card layer stacks above the hold), never over
             # the recorder's setup — #110's point, on #360's machinery.
-            self.page.evaluate(
-                "t => window.__demoInterlude(t)", self._opening
-            )
+            self.page.evaluate("t => window.__demoInterlude(t)", self._opening)
 
         master, slave = pty.openpty()
         self._fd = master
@@ -375,8 +436,12 @@ class TerminalRecorder(_DemoBase):
         # interactive shell (job control, line editing) as a user would see.
         self._proc = subprocess.Popen(
             [self._shell, "--norc", "--noprofile", "-i"],
-            stdin=slave, stdout=slave, stderr=slave,
-            start_new_session=True, env=env, close_fds=True,
+            stdin=slave,
+            stdout=slave,
+            stderr=slave,
+            start_new_session=True,
+            env=env,
+            close_fds=True,
         )
         os.close(slave)
         flags = fcntl.fcntl(master, fcntl.F_GETFL)
@@ -398,9 +463,11 @@ class TerminalRecorder(_DemoBase):
         self.page.add_script_tag(content=_TERM_MOUNT_JS)
         dims = self.page.evaluate(
             "o => window.__demoTermInit(o)",
-            {"theme": _TERM_THEME,
-             "cursor": f"rgb({self._accent})",
-             "fontSize": self._font_size},
+            {
+                "theme": _TERM_THEME,
+                "cursor": f"rgb({self._accent})",
+                "fontSize": self._font_size,
+            },
         )
         self._set_winsize(int(dims["rows"]), int(dims["cols"]))
         self._read_host_box()
@@ -445,8 +512,10 @@ class TerminalRecorder(_DemoBase):
             return
         if box:
             self._host_box = (
-                int(box["x"]), int(box["y"]),
-                int(box["width"]), int(box["height"]),
+                int(box["x"]),
+                int(box["y"]),
+                int(box["width"]),
+                int(box["height"]),
             )
 
     def _opening_card_rect(self) -> tuple[int, int, int, int] | None:
@@ -542,8 +611,7 @@ class TerminalRecorder(_DemoBase):
             self._start_line(clip)
             self.pause(self._opening_hold)
             self.page.evaluate(
-                "() => { window.__demoChromeHoldClear();"
-                " window.__demoInterlude(''); }"
+                "() => { window.__demoChromeHoldClear(); window.__demoInterlude(''); }"
             )
             self.pause(0.6)
 
@@ -577,7 +645,8 @@ class TerminalRecorder(_DemoBase):
         # so a TUI already running re-lays-out to the new size.
         if self._fd is not None:
             fcntl.ioctl(
-                self._fd, termios.TIOCSWINSZ,
+                self._fd,
+                termios.TIOCSWINSZ,
                 struct.pack("HHHH", rows, cols, 0, 0),
             )
 
@@ -616,7 +685,6 @@ class TerminalRecorder(_DemoBase):
         if text:
             self.page.evaluate("d => window.__termWrite(d)", text)
 
-
     def _failure_screen(self) -> str | None:
         """The rendered terminal buffer, for `failure/screen.txt` (issue #11).
 
@@ -645,7 +713,7 @@ class TerminalRecorder(_DemoBase):
         kept: list[str] = []
         cut = 0
         for match in _EXIT_RE.finditer(text):
-            kept.append(text[cut:match.start()])
+            kept.append(text[cut : match.start()])
             cut = match.end()
             self._record_exit_code(int(match.group(1)), int(match.group(2)))
         rest = text[cut:]
@@ -694,7 +762,9 @@ class TerminalRecorder(_DemoBase):
             self._note_issue(
                 "nonzero_exit",
                 f"{command!r} exited {code}",
-                beat=beat, exit_code=code, command=command,
+                beat=beat,
+                exit_code=code,
+                command=command,
             )
 
     def _hold_frame(self, seconds: float) -> None:

--- a/skills/demo-video/helpers/demo_recording/timeline.py
+++ b/skills/demo-video/helpers/demo_recording/timeline.py
@@ -1102,6 +1102,25 @@ def _narration_md(narration: object) -> list[str]:
         if holed
         else ""
     )
+    # ...and the lines serialization moved. A third sentence and never folded
+    # into the other two: `clamped` and `no_video` are lines the *clock* put
+    # somewhere other than their log instant; this one is the mix refusing to
+    # speak twice at once after that placement. Different cause, different
+    # thing a listener hears.
+    held_lines = [line for line in lines if line.get("held")]
+    tail += (
+        f" **{len(held_lines)} of them {'was' if len(held_lines) == 1 else 'were'} "
+        f"held back past the line before it**: a backward step compresses the "
+        f"video but not the clip, and the corrected onsets would have mixed two "
+        f"voices over each other — measured at 1.6 s of double-talk after a "
+        f"−1.65 s step. `held` is how many seconds later "
+        f"{'that clip' if len(held_lines) == 1 else 'those clips'} start{'s' if len(held_lines) == 1 else ''} "
+        f"than the stepped clock would put "
+        f"{'it' if len(held_lines) == 1 else 'them'}; the price is a voice "
+        f"trailing its caption by that much, not two at once."
+        if held_lines
+        else ""
+    )
     return [
         f"**The {len(lines)} spoken line(s) were mixed where the host's "
         f"stepped clock puts them in the video**, not at the beat-log offsets "

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -38,7 +38,12 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from urllib.parse import urlparse
 
-from .chrome import chrome_geometry, chrome_html, opening_hold_script
+from .chrome import (
+    CURSOR_ID,
+    chrome_geometry,
+    chrome_html,
+    opening_hold_script,
+)
 from .content import content_rect
 from .core import (
     WEB_WINDOW_BODY,
@@ -125,6 +130,11 @@ window.__demoTerminalHide = () => {
 # wants the result dwelt on says `hold()` after it, as it does after a click.
 PRESS_HOLD_S = 0.5
 
+#: How long the opt-in intro card holds before the storyboard's first beat,
+#: before `pace` scales it. Reading time for a short title, same scale the
+#: interlude default sits on.
+INTRO_HOLD_S = 2.8
+
 # How long `clear()` leaves the selection highlight up before deleting it.
 #
 # The highlight is the only thing on screen that explains where the text went.
@@ -206,6 +216,23 @@ window.__demoSpotlight = async (el) => {
   el.style.borderRadius = '6px';
   el.style.background = 'rgba(__ACCENT__,.10)';
   el.style.transform = 'scale(1.02)';
+  // Where the element sits in the recorded frame — the app iframe's
+  // position in the wrapper plus the element's viewport rect, rounded to
+  // whole pixels. Returned to `spotlight()`, which opens a camera event
+  // over it (camera.py): the push-in is rendered after the take, because
+  // a DOM transform cannot reach past the window chrome into the
+  // composited frame — the page zoom this replaced scaled the page
+  // inside the window and read as layout jitter, not as a move.
+  const f = window.frameElement
+    ? window.frameElement.getBoundingClientRect()
+    : { left: 0, top: 0 };
+  const r = el.getBoundingClientRect();
+  return {
+    x: Math.round(f.left + r.left),
+    y: Math.round(f.top + r.top),
+    w: Math.round(r.width),
+    h: Math.round(r.height),
+  };
 };
 window.__demoSpotlightClear = () => {
   const el = window.__spotEl;
@@ -240,7 +267,6 @@ window.__demoSpotlightClear = () => {
   });
 };
 """
-
 
 
 # What the recorder's own chrome is saying on screen, read out of the wrapper
@@ -406,7 +432,6 @@ _EVIDENCE_HTML_JS = r"""(el) => {
 }"""
 
 
-
 class Recorder(_DemoBase):
     """Playwright page wrapper that records video and captures guide stills.
 
@@ -434,6 +459,7 @@ class Recorder(_DemoBase):
         speech: bool | None = None,
         voice_id: str | None = None,
         speech_model: str | None = None,
+        speech_stability: float | None = None,
         strict: bool | None = None,
         deterministic: bool | None = None,
         clock: str | None = None,
@@ -443,21 +469,41 @@ class Recorder(_DemoBase):
         criteria: dict[str, str] | None = None,
         ticket: str | None = None,
         stills_only: bool | None = None,
+        pace: float | None = None,
+        intro: str | None = None,
+        outro: str | None = None,
+        window_title: str | None = None,
         allow_private: bool | None = None,
     ) -> None:
         super().__init__(
-            out_dir, segment=segment, accent_rgb=accent_rgb,
-            terminal_title=terminal_title, terminal_prompt=terminal_prompt,
-            viewport=viewport, speech=speech, voice_id=voice_id,
-            speech_model=speech_model, strict=strict,
-            deterministic=deterministic, clock=clock,
-            timezone_id=timezone_id, locale=locale, evidence=evidence,
-            criteria=criteria, ticket=ticket, allow_private=allow_private,
+            out_dir,
+            segment=segment,
+            accent_rgb=accent_rgb,
+            terminal_title=terminal_title,
+            terminal_prompt=terminal_prompt,
+            viewport=viewport,
+            speech=speech,
+            voice_id=voice_id,
+            speech_model=speech_model,
+            speech_stability=speech_stability,
+            strict=strict,
+            deterministic=deterministic,
+            clock=clock,
+            timezone_id=timezone_id,
+            locale=locale,
+            evidence=evidence,
+            criteria=criteria,
+            ticket=ticket,
+            allow_private=allow_private,
             stills_only=stills_only,
+            pace=pace,
+            intro=intro,
+            outro=outro,
+            window_title=window_title,
         )
-        self.base_url = (
-            base_url or _env("BASE_URL", "http://localhost:8000")
-        ).rstrip("/")
+        self.base_url = (base_url or _env("BASE_URL", "http://localhost:8000")).rstrip(
+            "/"
+        )
         # The base checked `DEMO_VIDEO_BASE_URL`; this checks what this take
         # actually resolved, which is the explicit argument when there is one.
         # Still before a browser exists — `__enter__` is what launches one.
@@ -511,9 +557,7 @@ class Recorder(_DemoBase):
         geom = getattr(self, "_geom", None)
         if not geom:
             return None
-        return content_rect(
-            (geom["appx"], geom["appy"], geom["appw"], geom["apph"])
-        )
+        return content_rect((geom["appx"], geom["appy"], geom["appw"], geom["apph"]))
 
     @property
     def app(self):
@@ -558,8 +602,9 @@ class Recorder(_DemoBase):
             )
         )
         context.add_init_script(
-            _TERMINAL_JS.replace("__TERM_TITLE__", self._terminal_title)
-            .replace("__TERM_PROMPT__", self._terminal_prompt)
+            _TERMINAL_JS.replace("__TERM_TITLE__", self._terminal_title).replace(
+                "__TERM_PROMPT__", self._terminal_prompt
+            )
         )
         context.add_init_script(
             _SPOTLIGHT_JS.replace("__ACCENT__", self._accent)
@@ -608,6 +653,12 @@ class Recorder(_DemoBase):
         # is a statement about a mask and about nothing else.
         page.on("framenavigated", self._note_navigation)
 
+    def _chrome_title(self) -> str:
+        """What the wrapper window's title bar says: the take's
+        `window_title` when it has one, the app's host when it does not —
+        a demo of `http://localhost:3000` opens titled for what it demos."""
+        return self._window_title or urlparse(self.base_url).netloc or "app"
+
     def _start(self) -> None:
         """Build the wrapper page on the recorded page itself (issue #358).
 
@@ -618,11 +669,10 @@ class Recorder(_DemoBase):
         shape `_content_rect` and every other geometry consumer reads.
         """
         self._geom = chrome_geometry(self._size["width"], self._size["height"])
-        title = urlparse(self.base_url).netloc or "app"
         self.page.set_content(
             chrome_html(
                 self._geom,
-                title=title,
+                title=self._chrome_title(),
                 window_body=WEB_WINDOW_BODY,
                 accent=self._accent,
                 caption_font_px=self._caption_font_px,
@@ -656,6 +706,66 @@ class Recorder(_DemoBase):
                 "returned no frame for it — the take cannot drive the app"
             )
         self._app_frame = frame
+        self._raise_intro()
+
+    def _raise_intro(self) -> None:
+        """The opt-in opening title (`Recorder(intro=…)`, off by default).
+
+        What is being presented, up over the wrapper from the take's first
+        seconds — before the app has loaded, which is the point: the card
+        covers the load instead of delaying it. The first `goto()` takes it
+        down (the same evaluate that clears the recorder's cards on every
+        navigation), so a storyboard needs nothing extra to end the intro.
+
+        **Voiced when speech is on**, like any caption — a silent card over a
+        narrated take reads as broken audio. The card rides the whole spoken
+        line (criterion()'s pattern): held `INTRO_HOLD_S` scaled by `pace`,
+        and never less than what is left of the line, so the voice never
+        outlives the card it belongs to. With speech off the line is empty
+        and the hold is just the reading time. The line's clip was
+        synthesized in the constructor, off the capture clock — the raise
+        starts the voice the moment the card is up, with no round trip of
+        dead air between them.
+        """
+        if not self._intro:
+            return
+        self.page.evaluate("t => window.__demoInterlude(t)", self._intro)
+        clip = self._prepare_line(self._intro, self._intro_clip)
+        self._start_line(clip)
+        hold = INTRO_HOLD_S * self._pace
+        remaining = self._line_end - time.monotonic()
+        self._idle(max(hold, remaining))
+
+    def _raise_outro(self) -> None:
+        """The opt-in closing card (`Recorder(outro=…)`, off by default).
+
+        The intro's mirror at the other end of the take: raised over the
+        wrapper by `__exit__` while the capture is still running, voiced when
+        speech is on, and **deliberately left up** — it is the take's last
+        frame, the way the opening hold was its first. The overlay probe
+        waives the card it raised (core's `_note_overlays_up`), so a take
+        that ends on its outro is clean, not "an overlay left up".
+        """
+        if not self._outro:
+            return
+        self.page.evaluate("t => window.__demoInterlude(t)", self._outro)
+        # The cursor is wherever the story last left it — over the closing
+        # card that is a stray dot parked on the take's final frame. It goes
+        # as the card goes up, not after the hold, or it rides the card the
+        # whole time. The pointer leaves with the take.
+        self.page.evaluate(
+            "id => { const c = document.getElementById(id);"
+            " if (c) c.style.display = 'none'; }",
+            CURSOR_ID,
+        )
+        clip = self._prepare_line(self._outro, self._outro_clip)
+        self._start_line(clip)
+        hold = INTRO_HOLD_S * self._pace
+        remaining = self._line_end - time.monotonic()
+        self._idle(max(hold, remaining))
+        # Only after the hold: the envelope key and the probe waiver both
+        # hang on this, so a raise that failed halfway claims nothing.
+        self._outro_up = True
 
     def _failure_screen(self) -> str | None:
         """The page's accessibility tree, for `failure/screen.txt` (issue #11).
@@ -693,7 +803,6 @@ class Recorder(_DemoBase):
         head.append(f"aria_format: {aria_format}")
         return "\n".join([*head, "", aria or "(no accessibility snapshot)"])
 
-
     def _note_navigation(self, frame) -> None:
         """A frame navigated. Nothing reads this, and that is deliberate.
 
@@ -708,7 +817,6 @@ class Recorder(_DemoBase):
         self._navigated = True
 
     # -- evidence (issue #9) ------------------------------------------------
-
 
     def _aria(self, locator) -> tuple[str | None, str]:
         """(snapshot, format) for one locator's accessibility tree.
@@ -969,9 +1077,16 @@ class Recorder(_DemoBase):
         # functions are context init scripts, which Playwright evaluates in
         # every frame, so they exist in the app iframe too — and the element
         # being lit lives there.
+        #
+        # The camera pulls back when the pull *starts*, not when the fade
+        # lands: the clear's `evaluate` waits out the exit transition, and
+        # an event that ended when it returned would hold the push ~250 ms
+        # past the spotlight that justified it.
+        self._camera_close(time.monotonic() - self._t0)
         self._target().evaluate("() => window.__demoSpotlightClear()")
+        rect = None
         if selector:
-            self._target().locator(selector).first.evaluate(
+            rect = self._target().locator(selector).first.evaluate(
                 "el => window.__demoSpotlight(el)"
             )
         # Set after the highlight actually landed, so a selector that matched
@@ -979,6 +1094,8 @@ class Recorder(_DemoBase):
         # evidence — a scope naming an element that is not there would put
         # `"html": null` in the file with no explanation.
         self._spotlit = selector or None
+        if rect:
+            self._camera_raise(rect)
         self.pause(0.3)
 
     def _glide(self, x: float, y: float, steps: int) -> None:
@@ -1004,9 +1121,7 @@ class Recorder(_DemoBase):
             xi = sx + (x - sx) * i / steps
             yi = sy + (y - sy) * i / steps
             self.page.mouse.move(xi, yi)
-            self.page.evaluate(
-                "([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi]
-            )
+            self.page.evaluate("([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi])
         self._cursor_at = (x, y)
 
     def _cursor_pressed(self, down: bool) -> None:
@@ -1020,9 +1135,7 @@ class Recorder(_DemoBase):
         box = self._target().locator(selector).first.bounding_box()
         if box is None:
             raise RuntimeError(f"no visible element for {selector!r}")
-        self._glide(
-            box["x"] + box["width"] / 2, box["y"] + box["height"] / 2, steps=30
-        )
+        self._glide(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2, steps=30)
 
     @_beat_verb("click")
     def click(self, selector: str) -> None:

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -216,20 +216,22 @@ window.__demoSpotlight = async (el) => {
   el.style.borderRadius = '6px';
   el.style.background = 'rgba(__ACCENT__,.10)';
   el.style.transform = 'scale(1.02)';
-  // Where the element sits in the recorded frame — the app iframe's
-  // position in the wrapper plus the element's viewport rect, rounded to
-  // whole pixels. Returned to `spotlight()`, which opens a camera event
-  // over it (camera.py): the push-in is rendered after the take, because
-  // a DOM transform cannot reach past the window chrome into the
-  // composited frame — the page zoom this replaced scaled the page
+  // Where the element sits **in the app's own viewport**, rounded to whole
+  // pixels. `spotlight()` moves it into the recorded frame's coordinates and
+  // opens a camera event over it (camera.py): the push-in is rendered after
+  // the take, because a DOM transform cannot reach past the window chrome
+  // into the composited frame — the page zoom this replaced scaled the page
   // inside the window and read as layout jitter, not as a move.
-  const f = window.frameElement
-    ? window.frameElement.getBoundingClientRect()
-    : { left: 0, top: 0 };
+  //
+  // The wrapper's offset is added in Python, not here: this script runs in
+  // the app frame, which is cross-origin to the wrapper whenever the demo is
+  // not served from the recorder's own origin, and `window.frameElement` is
+  // null across that boundary. Reading it here put the push 156 px from the
+  // element it was aimed at — measured on tests/smoke's spotlight take.
   const r = el.getBoundingClientRect();
   return {
-    x: Math.round(f.left + r.left),
-    y: Math.round(f.top + r.top),
+    x: Math.round(r.left),
+    y: Math.round(r.top),
     w: Math.round(r.width),
     h: Math.round(r.height),
   };
@@ -1095,8 +1097,27 @@ class Recorder(_DemoBase):
         # `"html": null` in the file with no explanation.
         self._spotlit = selector or None
         if rect:
-            self._camera_raise(rect)
+            self._camera_raise(self._frame_rect(rect))
         self.pause(0.3)
+
+    def _frame_rect(self, rect: dict) -> dict:
+        """An app-document rect, moved into the recorded frame's coordinates.
+
+        The app records inside the wrapper's content slot at true pixel size
+        (#358, cutover #361), so the mapping is the slot's offset and no
+        scale — the same one `tests/_pixels.to_video_rect` applies from the
+        other side. It is done here rather than in the page because the app
+        frame is cross-origin to the wrapper whenever the demo is not served
+        from the recorder's own origin, and `window.frameElement` is null
+        across that boundary.
+        """
+        geom = getattr(self, "_geom", None) or {"appx": 0, "appy": 0}
+        return {
+            "x": int(rect["x"]) + int(geom["appx"]),
+            "y": int(rect["y"]) + int(geom["appy"]),
+            "w": int(rect["w"]),
+            "h": int(rect["h"]),
+        }
 
     def _glide(self, x: float, y: float, steps: int) -> None:
         """Move the pointer to page coordinates `(x, y)`, dot included.

--- a/skills/demo-video/reference/narration.md
+++ b/skills/demo-video/reference/narration.md
@@ -34,6 +34,18 @@ needed; captions are the narration script.
   the previous spoken line.
 - Write captions for the ear as well as the eye: short sentences, no
   markup, nothing you wouldn't say aloud.
+- **The voice is pinned and normalized.** Every synthesis request carries a
+  fixed voice `stability` (`DEFAULT_STABILITY`, in the cache key like voice
+  and model), because unpinned the model's per-sentence pacing wanders —
+  measured at 2.1 to 3.3 words/s across one take's five clips, which reads
+  as some lines being sped up. And at mix time every clip is gained to one
+  loudness target (`LOUDNESS_TARGET_DB`), measured per clip with
+  `volumedetect`, because ElevenLabs returns clips at whatever level the
+  model produced and consecutive lines at audibly different levels read as
+  a production fault. Each line's `gain_db` is in `timeline.json`'s
+  `narration` when a correction of 0.1 dB or more was applied; a clip that
+  could not be measured gains nothing. The audio is never re-timed or
+  re-spoken — tempo is untouched end to end.
 - **A clip is mixed where its line is in the *video*, not where the beat
   log put it.** The log is `time.monotonic()` and the recording is stamped
   with the host's wall clock, so a host that steps that clock while a take
@@ -60,15 +72,20 @@ needed; captions are the narration script.
   any more, because an instant is never placed earlier than the step that
   moved it. The floor stays only because `adelay` cannot express a negative
   delay for a malformed record.
-- **A backward step between two lines can make their clips overlap, and that
-  is the correction working.** The step shortens the *video*; it does not
-  shorten the clip. The recorder waited line 1 out before starting line 2 in
-  monotonic time, but the seconds the step deleted are not in the file to wait
-  through, so line 2's corrected onset can land while line 1 is still
-  speaking — measured once at 0.4 s of overlap after a −1.07 s step. Two
-  voices for a fraction of a second is the price of both lines matching their
-  captions; the alternative is every line after the step trailing its caption
-  by the whole step. If a take comes back with audible double-talk, look at
+- **A backward step between two lines would make their clips overlap, and the
+  mix refuses.** The step shortens the *video*; it does not shorten the clip.
+  The recorder waited line 1 out before starting line 2 in monotonic time, but
+  the seconds the step deleted are not in the file to wait through, so line
+  2's corrected onset can land while line 1 is still speaking — measured first
+  at 0.4 s of overlap after a −1.07 s step and accepted then as the price of
+  sync, then re-measured at **1.6 s of double-talk** after a −1.65 s step,
+  which is not a price anyone pays knowingly. The mix now serializes the
+  corrected placements: a line that would start inside its predecessor starts
+  at its predecessor's end instead, and carries `held` — the seconds it starts
+  later than the stepped clock would put it. The trade is explicit: that
+  line's voice trails its caption by `held`, rather than two voices at once.
+  `timeline.md` names held lines in the same paragraph as the clock
+  correction. If a take comes back with a voice arriving late, look at
   `capture_clock.steps` before you look at the storyboard.
 - Verify audio like you verify frames: `ffprobe` shows the aac stream;
   `ffmpeg -af silencedetect` should show speech blocks spanning the video;

--- a/tests/README.md
+++ b/tests/README.md
@@ -136,7 +136,7 @@ seen red under a planted recorder defect in #351's pull request.
 ```
 tests/
 ├── smoke              # the recorder, end to end (~10 min, needs Chromium + ffmpeg)
-├── smoke-inject       # proves smoke's assertions can still fail (~55 min, nightly)
+├── smoke-inject       # proves smoke's assertions can still fail (~56 min, nightly)
 ├── unit               # the browser-free half (~4 s, 568 tests, no dependencies)
 ├── ci-unit            # the .github/scripts helpers, and the two skill
 │                      #   CLIs whose output a person pastes (~2.5 s)
@@ -318,7 +318,7 @@ grades, the manifest that proves it can still fail:
 tests/smoke-inject --self-test    # the harness's own guards (instant)
 tests/smoke-inject --list         # every entry, its arm and what it costs
 tests/smoke-inject --arm coverage # one arm's entries (~195 s)
-tests/smoke-inject                # all 76 entries, ~55 min
+tests/smoke-inject                # all 78 entries, ~56 min
 ```
 
 Those three figures, and every number in **The injection manifest** below, are
@@ -636,7 +636,7 @@ argument for keeping them is cost per check function moved. Dropping one from
 | arm | seconds | check functions it would move | seconds per check moved |
 |---|---|---|---|
 | segments | 29 | 11 | 2.6 |
-| polish | 26 | 3 | 8.7 |
+| polish | 26 | 4 | 6.5 |
 | overlay | 31 | 1 | 31 |
 | failure | 48 | 1 | 48 |
 | the three expensive arms | 457 | 8 | 57 |
@@ -644,11 +644,12 @@ argument for keeping them is cost per check function moved. Dropping one from
 Every one of the four buys check coverage more cheaply than the arms the
 decision *did* move, so a second cut inside the cheap tier would be a worse
 trade than the first one, made on no measurement. Two specifics on top of the
-ratio: two of `--polish-only`'s three functions (`check_opening_card`,
+ratio: two of `--polish-only`'s four functions (`check_opening_card`,
 `check_spotlight_transitions`) have no injection anywhere, so the per-push run
-is their only exercise in the repo — the third,
-`check_reported_opening_card`, is the arm's own four entries
-([#235](https://github.com/rogvid/skills/issues/235)); and `--failure-only` is the only thing that
+is their only exercise in the repo — the other two,
+`check_reported_opening_card` and `check_camera_push`, are the arm's own six
+entries ([#235](https://github.com/rogvid/skills/issues/235), and the camera's
+two); and `--failure-only` is the only thing that
 runs the recorder's exception paths, which is where the catalogue's
 *clean-path-only assertion* lives. `--failure-only` is nonetheless the one to
 revisit first if the per-push budget ever binds — it is 22% of `--cheap` for
@@ -2313,7 +2314,7 @@ easy to break. This is what `tests/smoke-inject --list` reports today, quoted
 rather than remembered:
 
 ```
-76 entries, 15 arms, ~54.8 min of takes
+78 entries, 15 arms, ~55.7 min of takes
 ```
 
 That figure is `--list`'s **estimate** — each entry's arm from the table above,
@@ -2347,7 +2348,7 @@ paragraph whose job is to say what this manifest does not cover.
 | `--stills-only` | 2 | the mode that skips the video stops being either of the two things it claims ([#372](https://github.com/rogvid/skills/issues/372)): a run that declines the screencast and gets one anyway, leaving a real `demo.mp4` in a folder whose timeline says `media: null` — the artifact-lie outcome, and the only half a browser is needed for; or a run that records nothing and paces the storyboard anyway, which is correct and pointless. Either alone is satisfied by the wrong fix, which is why there are two. The pictures the mode produces are graded in `tests/pixel` (`stills-match`) and its artifact shape in `tests/unit` (`StillsOnly`) |
 | `--determinism-only` | 3 | a re-recording stops reproducing: the cursor dot parked on-screen so it ships in every still with no pointer verb run, a frozen clock that freezes at the wall time, an animation still moving when the still is taken |
 | `--issues-only` | 2 | what the recorder saw behind the pixels stops being true: a problem that fired with no beat open acquires a confident beat index and caption, or a command's exit status lands on the wrong `run()` beat and a failure is recorded as a success |
-| `--polish-only` | 4 | a terminal segment stops saying what it opened on ([#235](https://github.com/rogvid/skills/issues/235)), which is the one account of that frame a demo directory ships: the field gone entirely; the number a plausible constant instead of a reading, which every other statement about the field is happy with; the cover painted a colour that is not the window body, so frame 0 is not the cover at all — #110's own defect, the card raised late, can no longer be planted here: since [#362](https://github.com/rogvid/skills/issues/362) the shared chrome covers frame 0 twice, independently, and breaking either cover alone leaves frame 0 reading 24.0; or the report forgetting that a card was asked for, without which `"bare"` cannot be told from a segment that never wanted one |
+| `--polish-only` | 6 | a terminal segment stops saying what it opened on ([#235](https://github.com/rogvid/skills/issues/235)), which is the one account of that frame a demo directory ships: the field gone entirely; the number a plausible constant instead of a reading, which every other statement about the field is happy with; the cover painted a colour that is not the window body, so frame 0 is not the cover at all — #110's own defect, the card raised late, can no longer be planted here: since [#362](https://github.com/rogvid/skills/issues/362) the shared chrome covers frame 0 twice, independently, and breaking either cover alone leaves frame 0 reading 24.0; or the report forgetting that a card was asked for, without which `"bare"` cannot be told from a segment that never wanted one . The other two are the camera's push-in over a spotlight ([camera.py](../skills/demo-video/helpers/demo_recording/camera.py)), and they are the two halves of one move: a push rendered at a zoom of 1.0, which leaves every frame the frame it always was — the exact failure of the DOM zoom this camera replaced, and one no artifact can report — and a push whose ease only rises, so the camera never pulls back and every frame from that spotlight to the last is a crop of the take |
 | `--segments-only` | 14 | the merge renumbers `segment_index`, so `(segment, segment_index)` stops naming the same beat across a stitch ([#22](https://github.com/rogvid/skills/issues/22)); every review frame is cut at its beat's start instead of its midpoint, and the sheet is caption fade-ins; the sheet stops saying **which clock** it cut them on, so a reviewer cannot tell a corrected sheet from one cut on the raw beat log ([#229](https://github.com/rogvid/skills/issues/229)); the take stops recording the clock `demo.mp4` is actually on — the field gone, a step invented, the total disagreeing with its own steps, or the beat log stamped half a second off the frames and nothing saying so ([#215](https://github.com/rogvid/skills/issues/215)); or the *merge* stops carrying that clock — no merged record at all, every capture boundary at zero, a step belonging to no capture, or a part's own record never reaching the segment it was measured in ([#225](https://github.com/rogvid/skills/issues/225)); or the record stops saying **how well it watched** — the `measured` flag gone, the flag disagreeing with the `max_gap` it is derived from, or the recorder refusing to report on a host it could have measured, which is the failure that looks like silence ([#247](https://github.com/rogvid/skills/issues/247)) |
 | `--evidence-only` | 4 | one capture of the page is stamped onto every beat, so what a beat's evidence describes is not what that beat showed — [#9](https://github.com/rogvid/skills/issues/9)'s acceptance criterion, on a 7 s arm instead of a 123 s one. Or evidence goes back to omitting on-screen text in silence ([#353](https://github.com/rogvid/skills/issues/353)): a rich-text editor's contents and a painted `aria-hidden` subtree, neither of which `aria_snapshot()` can carry. The other two entries are the opposite direction — a probe that also reports what was never painted buries the two that matter under every icon wrapper on the page — and there is one per visibility guard, because `display:none` trips both and would leave either deletable in silence |
 | `--overlay-only` | 4 | the four breaks [#170](https://github.com/rogvid/skills/pull/170) performed by hand: the pre-fix `interlude("")` dispatch, the overlay probe silent, the probe reporting everything, and the healthy "shows a picture" line disappearing — the control without which "the covered take does not say it" is satisfied by a recorder that stopped saying it about anything |
@@ -2358,7 +2359,7 @@ paragraph whose job is to say what this manifest does not cover.
 
 ### What it does **not** cover
 
-- **16 of `tests/smoke`'s 51 check functions have no entry**, and the harness
+- **16 of `tests/smoke`'s 52 check functions have no entry**, and the harness
   prints every one of them as `ungraded` at the end of a run rather than
   leaving the boundary to somebody's memory.
 

--- a/tests/smoke
+++ b/tests/smoke
@@ -1713,6 +1713,10 @@ NARRATION_KEY = "not-a-real-key-and-must-never-be-used"
 NARRATION_VOICE_ID = "EXAVITQu4vr4xnSDxMaL"
 NARRATION_MODEL_ID = "eleven_multilingual_v2"
 NARRATION_KEY_CHARS = 20
+# The pinned voice stability, in the request format the key interpolates —
+# hand-copied like the two defaults above, and stale the same way if
+# `DEFAULT_STABILITY` moves.
+NARRATION_STABILITY = "0.75"
 
 # (line, clip seconds). The first is deliberately *long* against its beat's
 # hold, so the recorder has to wait it out and the wait is visible in the beat
@@ -3017,7 +3021,11 @@ def check_merged_capture_clock(
 
 
 _CAPTION_JS = """() => {
-  const el = document.getElementById('__demo_caption');
+  // Two stacked layers crossfade (chrome.py). The one the recorder just set
+  // is `__demoCapLayer`'s — reading the visible layer instead would grade
+  // the previous line for the ~0.3 s the fade is running.
+  const ids = ['__demo_caption', '__demo_caption2'];
+  const el = document.getElementById(ids[window.__demoCapLayer || 0]);
   if (!el) return null;
   return [el.textContent, getComputedStyle(el).opacity];
 }"""
@@ -11503,7 +11511,10 @@ def seed_tts_cache(out_dir: Path) -> dict[str, Path]:
     tts.mkdir(parents=True, exist_ok=True)
     seeded: dict[str, Path] = {}
     for text, seconds in NARRATION_LINES:
-        joined = f"{NARRATION_VOICE_ID}|{NARRATION_MODEL_ID}|{text}"
+        joined = (
+            f"{NARRATION_VOICE_ID}|{NARRATION_MODEL_ID}|{text}"
+            f"|stability={NARRATION_STABILITY}"
+        )
         key = hashlib.sha256(joined.encode()).hexdigest()[:NARRATION_KEY_CHARS]
         clip = tts / f"{key}.mp3"
         subprocess.run(

--- a/tests/smoke
+++ b/tests/smoke
@@ -1414,6 +1414,44 @@ SPOTLIGHT_DURATION_S = (5.0, 30.0)
 # from different sides is how a determinism flip stays impossible to miss.
 MIN_SPOTLIGHT_CLEAR_S = 0.45
 
+# ## The camera's push-in (helpers/demo_recording/camera.py)
+#
+# Read in the strip of window chrome *above* the app rect, which is the one
+# region of the frame the page cannot reach. That is the whole difference
+# between this camera and the DOM zoom it replaced: `<body>` scaled around the
+# element moved nothing outside the app, while a push-in scales the composited
+# frame, chrome included. Reading the app rect instead would grade the
+# spotlight, which lights the same element over the same frames.
+#
+# Mean absolute luma over the reduced strip, measured on a real take: 0.06
+# across the quiet before the push, 33.8 into the held zoom, 0.45 once the
+# pull-back has landed. The floors sit well inside each of those, so the
+# reading separates a push from a still frame without depending on how far
+# from the frame's centre this fixture's element happens to sit.
+CAMERA_PUSH_MIN = 8.0
+CAMERA_STILL_MAX = 1.5
+
+# How much chrome has to sit above the app rect before that strip means
+# anything. A geometry that leaves less is not a broken camera, and the check
+# says so rather than reading app pixels and calling them chrome.
+CAMERA_STRIP_MIN_H = 24
+
+# The event has to be long enough for the push to reach full zoom and come
+# back — two eases, plus something to sample in the middle of.
+CAMERA_MIN_EVENT_S = 1.2
+
+# How long after the event the pull-back is read. The ease *ends* at `t_end`
+# (the pull starts before it, because `spotlight()`'s clear waits out its own
+# fade), so this is clear of the move; it is also clear of the spotlight's own
+# 250 ms exit, which repaints the app rect but never the chrome above it.
+CAMERA_AFTER_S = 0.4
+
+# How far the event's rect may sit from the element this take spotlighted,
+# centre to centre. Both are the same box in the same coordinates — the
+# recorder's own measurement and this file's — so the bar is for rounding and
+# for a fixture whose element moves a pixel, not for a difference of opinion.
+CAMERA_CENTRE_BAR_PX = 20.0
+
 # ## The card a terminal segment opens on (issue #110)
 #
 # `TerminalRecorder.__enter__` starts capturing before a storyboard can paint
@@ -8203,6 +8241,158 @@ def check_spotlight_transitions(
     return failures
 
 
+def _strip_frame(mp4: Path, strip: Rect, at: float) -> bytes | None:
+    """One frame of `strip`, at `at` seconds. `None` if the video is short."""
+    frames = gray_frames(mp4, rect=strip, start=at, duration=0.08)
+    return frames[0] if frames else None
+
+
+def check_camera_push(
+    out_dir: Path, info: dict, clock: HostClock | None = None
+) -> list[str]:
+    """The spotlight's camera move is in the encoded video, not only in JSON.
+
+    `camera.py` replaced a live DOM zoom that scaled `<body>` around the
+    element's own centre — the element therefore did not move, 6% of a 60 px
+    chip was invisible, and what a viewer saw was the layout jittering around
+    it. The push-in that replaced it scales the *composited* frame, so the
+    reading that separates the two is taken where the page cannot reach: the
+    strip of window chrome above the app rect.
+
+    Three statements about that strip, each broken by a different mistake:
+
+      * it is **still** in the quiet before the event — the control, without
+        which "the chrome moved" is a claim about a take that never sits still
+      * it has **moved** at the held zoom — the push itself
+      * it is **back** once the event has ended — the pull, and the reason a
+        camera that pushed in and stayed there is not a passing answer
+
+    Plus the two the pixels cannot make: the take logged exactly one event
+    (one spotlight interval), and that event is aimed at the element the
+    storyboard lit rather than at something else on the page.
+
+    The event's times come off `timeline.json`, where the recorder has already
+    moved them onto the video's clock (`_camera_on_the_video_clock`) — the
+    same correction the narration mix applies, for the same reason.
+    """
+    mp4 = out_dir / "demo.mp4"
+    doc = json.loads((out_dir / "timeline.json").read_text())
+    events = doc.get("camera") or []
+    if len(events) != 1:
+        return [
+            f"spotlight: the take logged {len(events)} camera event(s), "
+            f"expected 1 — one spotlight interval is one push-in, so there is "
+            f"no move in demo.mp4 to measure (timeline.json's `camera`)"
+        ]
+    event = events[0]
+    t_start, t_end = float(event["t_start"]), float(event["t_end"])
+    failures: list[str] = []
+    # Aimed at the element, before anything is read off the frames: a push
+    # centred somewhere else is still a push, and every reading below would
+    # pass while the viewer's eye was pulled to the wrong part of the screen.
+    ex, ey, ew, eh = (float(v) for v in event["rect"])
+    tx, ty, tw, th = info["rect"]
+    off = math.dist((ex + ew / 2, ey + eh / 2), (tx + tw / 2, ty + th / 2))
+    if off > CAMERA_CENTRE_BAR_PX:
+        failures.append(
+            f"spotlight: the camera event is centred "
+            f"{off:.1f}px from the element the take spotlighted, over the "
+            f"{CAMERA_CENTRE_BAR_PX}px bar — the move is aimed at "
+            f"{event['rect']}, the element is at {list(info['rect'])}"
+        )
+    appy = info["app"][1]
+    if appy < CAMERA_STRIP_MIN_H:
+        return failures + [
+            f"spotlight: the wrapper leaves {appy}px of chrome above the app "
+            f"rect, under the {CAMERA_STRIP_MIN_H}px this reading needs — the "
+            f"strip would be app pixels, which the page moves on its own"
+        ]
+    # A step inside the interval is not a camera defect and cannot be read as
+    # one: the recorder corrects the event onto the video's clock, and the
+    # video really is that much shorter — a 1.23 s backward step measured on
+    # this repo's WSL host turned a 1.88 s push into 0.85 s of frames, which
+    # never reaches full zoom no matter what the filter says. Said out loud
+    # rather than dropped silently, and the centre reading above still stands:
+    # it is geometry, and no clock touches it.
+    stepped_through = [
+        at
+        for at, _delta in (clock.steps if clock is not None else [])
+        if t_start - MAX_CLOCK_STEP_TIME_DISAGREEMENT_S
+        <= at
+        <= t_end + MAX_CLOCK_STEP_TIME_DISAGREEMENT_S
+    ]
+    if stepped_through:
+        print(
+            f"smoke: spotlight camera not measured — this host's wall clock "
+            f"stepped at {', '.join(f'{at:.2f}s' for at in stepped_through)}, "
+            f"inside the {t_start:.2f}-{t_end:.2f}s the push runs over, so the "
+            f"video holds fewer seconds of it than the recorder rendered"
+        )
+        return failures
+    if t_end - t_start < CAMERA_MIN_EVENT_S:
+        return failures + [
+            f"spotlight: the camera event runs {t_end - t_start:.2f}s, under "
+            f"the {CAMERA_MIN_EVENT_S}s two eases need — the push never "
+            f"reaches full zoom, so a frame from the middle of it is not the "
+            f"held zoom and this reading is about nothing"
+        ]
+    strip: Rect = (0, 0, info["size"][0], appy)
+    quiet = _strip_frame(mp4, strip, t_start - 0.8)
+    before = _strip_frame(mp4, strip, t_start - 0.25)
+    held = _strip_frame(mp4, strip, (t_start + t_end) / 2)
+    after = _strip_frame(mp4, strip, t_end + CAMERA_AFTER_S)
+    missing = [
+        name
+        for name, frame in (
+            ("quiet", quiet),
+            ("before", before),
+            ("held", held),
+            ("after", after),
+        )
+        if frame is None
+    ]
+    if missing:
+        return failures + [
+            f"spotlight: the video has no frame at the {', '.join(missing)} "
+            f"instant(s) of a camera event running {t_start:.2f}-{t_end:.2f}s "
+            f"— the recording is shorter than the event it claims to carry"
+        ]
+    still = frame_difference(quiet, before)
+    pushed = frame_difference(before, held)
+    pulled = frame_difference(before, after)
+    if still > CAMERA_STILL_MAX:
+        failures.append(
+            f"spotlight: the chrome strip above the app moved {still:.2f} mean "
+            f"luma in the quiet before the push, over the {CAMERA_STILL_MAX} "
+            f"bar — this is the control, and until it holds, the {pushed:.2f} "
+            f"read into the push is not evidence of a camera move"
+        )
+    if pushed < CAMERA_PUSH_MIN:
+        failures.append(
+            f"spotlight: the chrome strip above the app moved {pushed:.2f} "
+            f"mean luma between the frame before the event and the held zoom, "
+            f"under the {CAMERA_PUSH_MIN} bar. Nothing outside the app rect "
+            f"moved, which is what the DOM zoom this replaced did (camera.py) "
+            f"— the push is either not being rendered into demo.mp4 or is too "
+            f"small to see"
+        )
+    if pulled > CAMERA_STILL_MAX:
+        failures.append(
+            f"spotlight: the chrome strip is still {pulled:.2f} mean luma "
+            f"from where it was, {CAMERA_AFTER_S}s after the event ended and "
+            f"over the {CAMERA_STILL_MAX} bar — the camera pushed in and did "
+            f"not come back, so every frame after this spotlight is a crop of "
+            f"the take"
+        )
+    if not failures:
+        print(
+            f"smoke: spotlight camera pushed in and back (chrome strip moved "
+            f"{pushed:.2f} mean luma at the held zoom, {still:.2f} in the "
+            f"quiet before it, {pulled:.2f} once it pulled back)"
+        )
+    return failures
+
+
 def check_opening_card(out_dir: Path, info: dict) -> list[str]:
     """A terminal segment opens on its cover, not on a bare slot (#110).
 
@@ -8889,6 +9079,9 @@ def run_spotlight(out_root: Path) -> list[str]:
         problems
         + _check_video("spotlight", mp4, SPOTLIGHT_DURATION_S, keep_top(info["app"]))
         + check_spotlight_transitions(out_dir, info, clock)
+        # The same interval, one layer out: what the spotlight put on the page
+        # is graded above, and what the camera did to the frame around it here.
+        + check_camera_push(out_dir, info, clock)
         + check_healthy("spotlight", out_dir)
     )
 

--- a/tests/smoke-inject
+++ b/tests/smoke-inject
@@ -205,9 +205,8 @@ INJECTIONS = [
         name="a stills-only run records a video after all",
         module="core.py",
         old=(
-            "                record_video_dir=(\n"
-            "                    None if self.stills_only else str(self._video_dir)\n"
-            "                ),"
+            "                record_video_dir=(None if self.stills_only"
+            " else str(self._video_dir)),"
         ),
         new="                record_video_dir=str(self._video_dir),",
         arm="--stills-only",
@@ -341,9 +340,9 @@ INJECTIONS = [
         # reason the loud bar means anything, and it had never been seen fail.
         name="every narration clip is mixed in at the start of the take",
         module="core.py",
-        old="                    f\"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}"
+        old="                    + f\"adelay={int(round(line['at'] * 1000))}"
         ':all=1[a{i}]"',
-        new='                    f"[{i + 1}:a]adelay=0:all=1[a{i}]"',
+        new='                    + f"adelay=0:all=1[a{i}]"',
         arm="--narration-only",
         sites=("check_narration_audio",),
         must_contain=("audio is playing where no line was spoken",),
@@ -364,10 +363,10 @@ INJECTIONS = [
         # answering instead. 250 ms is the middle of it.
         name="every narration clip is mixed 250 ms from where the record says",
         module="core.py",
-        old="                    f\"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}"
+        old="                    + f\"adelay={int(round(line['at'] * 1000))}"
         ':all=1[a{i}]"',
-        new="                    f\"[{i + 1}:a]adelay={int(round(line['at'] * 1000))"
-        ' + 250}:all=1[a{i}]"',
+        new="                    + f\"adelay={int(round(line['at'] * 1000)) + 250}"
+        ':all=1[a{i}]"',
         arm="--narration-only",
         sites=("check_narration_placement",),
         must_contain=("voice is that far from the caption it was spoken for",),
@@ -801,6 +800,39 @@ INJECTIONS = [
         sites=("check_reported_opening_card",),
         must_contain=("cannot be told from a segment that never asked for a card",),
     ),
+    # -- the camera's push-in (camera.py), 26 s an entry ----------------------
+    #
+    # Two entries against one check, and they are the two halves of one move.
+    # The first breaks the push: the chain still renders, the timeline still
+    # publishes the geometry, and every frame is the frame it always was —
+    # which is exactly the failure the DOM zoom this camera replaced had, and
+    # exactly the one no artifact can report. The second breaks the pull, the
+    # half a "did it move" reading passes without ever asking about: a camera
+    # that pushes in and stays there is a take cropped from that spotlight to
+    # its last frame.
+    Injection(
+        name="the camera renders a push that moves nothing",
+        module="camera.py",
+        old="CAMERA_ZOOM = 1.3",
+        new="CAMERA_ZOOM = 1.0",
+        arm="--polish-only",
+        sites=("check_camera_push",),
+        must_contain=("moved, which is what the DOM zoom this replaced did ",),
+    ),
+    Injection(
+        name="the camera pushes in and never pulls back",
+        module="camera.py",
+        old=(
+            "        ease = (\n"
+            "            f\"min((time-{event['t_start']:.3f})/{CAMERA_EASE_S},\"\n"
+            "            f\"({event['t_end']:.3f}-time)/{CAMERA_EASE_S})\"\n"
+            "        )"
+        ),
+        new=("        ease = f\"(time-{event['t_start']:.3f})/{CAMERA_EASE_S}\""),
+        arm="--polish-only",
+        sites=("check_camera_push",),
+        must_contain=("the chrome strip is still ",),
+    ),
     # -- the clock demo.mp4 is on (issues #18/#215), 29 s an entry ------------
     #
     # Chromium stamps every screencast frame with the host's *wall* clock and
@@ -1046,8 +1078,8 @@ INJECTIONS = [
         # that showed them.
         name="every beat's evidence describes the first beat's page",
         module="core.py",
-        old="             self._evidence_doc(beat, payload))",
-        new="             self._evidence_doc(beat, self._evidence[0][1]))",
+        old="                self._evidence_doc(beat, payload),",
+        new="                self._evidence_doc(beat, self._evidence[0][1]),",
         arm="--evidence-only",
         sites=("check_evidence",),
         must_contain=(
@@ -1074,8 +1106,14 @@ INJECTIONS = [
     Injection(
         name="the end-of-take overlay probe reports nothing",
         module="core.py",
-        old="            self._overlay_note = overlay_warning([str(i) for i in up])",
-        new="            self._overlay_note = overlay_warning([])",
+        old=(
+            "            if ids:\n"
+            "                self._overlay_note = overlay_warning(ids)"
+        ),
+        new=(
+            "            if False:\n"
+            "                self._overlay_note = overlay_warning(ids)"
+        ),
         arm="--overlay-only",
         sites=("check_overlay_pair",),
         must_contain=(
@@ -1087,8 +1125,14 @@ INJECTIONS = [
     Injection(
         name="the overlay probe reports an overlay on every take",
         module="core.py",
-        old="            self._overlay_note = overlay_warning([str(i) for i in up])",
-        new='            self._overlay_note = overlay_warning(["__demo_bridge"])',
+        old=(
+            "            if ids:\n"
+            "                self._overlay_note = overlay_warning(ids)"
+        ),
+        new=(
+            "            if True:\n"
+            '                self._overlay_note = overlay_warning(["__demo_bridge"])'
+        ),
         arm="--overlay-only",
         sites=("check_overlay_pair",),
         must_contain=("the recorder reported an overlay still up on ",),
@@ -1112,8 +1156,8 @@ INJECTIONS = [
         # stays perfect, and only the pixels can say the band held nothing.
         name="the wrapper caption is dispatched and never painted in the band",
         module="chrome.py",
-        old="    el.textContent = text;\n    el.style.opacity = text ? '1' : '0';",
-        new="    el.textContent = '';\n    el.style.opacity = '0';",
+        old="    nxt.textContent = text;\n    nxt.style.opacity = text ? '1' : '0';",
+        new="    nxt.textContent = '';\n    nxt.style.opacity = '0';",
         arm="--wrapper-only",
         sites=("check_wrapper_band",),
         must_contain=("never painted in its band",),
@@ -1126,15 +1170,11 @@ INJECTIONS = [
         # assertion.
         name="the caption's appearance repaints pixels inside the app rect",
         module="chrome.py",
-        old=(
-            "  window.__demoCaption = (text) => {\n"
-            "    const el = document.getElementById('__demo_caption');"
-        ),
+        old="  window.__demoCaption = (text) => {\n",
         new=(
             "  window.__demoCaption = (text) => {\n"
             "    document.getElementById('__chrome_slot').style.opacity ="
             " text ? '0.75' : '1';\n"
-            "    const el = document.getElementById('__demo_caption');"
         ),
         arm="--wrapper-only",
         sites=("check_wrapper_band",),
@@ -1182,8 +1222,7 @@ INJECTIONS = [
         module="chrome.py",
         old=(
             "    if (!text) return 0;\n"
-            "    const band = document.getElementById('__chrome_band');\n"
-            "    return Math.max(0, el.scrollHeight - band.clientHeight);"
+            "    return Math.max(0, nxt.scrollHeight - band.clientHeight);"
         ),
         new="    return 0;",
         arm="--wrapper-only",

--- a/tests/unit
+++ b/tests/unit
@@ -172,6 +172,7 @@ sys.modules["playwright.sync_api"] = _pw_sync
 
 import demo_recording.core as core_module  # noqa: E402
 import demo_recording.frames as frames_module  # noqa: E402
+from demo_recording.camera import camera_filter  # noqa: E402
 from demo_recording.chrome import (  # noqa: E402
     chrome_geometry,
     chrome_html,
@@ -5477,7 +5478,7 @@ class TerminalStill(unittest.TestCase):
             super().__init__()
             self.log = log
 
-        def screenshot(self, path: str) -> None:
+        def screenshot(self, path: str, **kwargs) -> None:
             self.log.append("screenshot")
 
     class Rec(TermRec):
@@ -6068,15 +6069,19 @@ class ActBeat(unittest.TestCase):
     def test_the_beat_spans_the_block(self):
         rec = recorder(self)
         with rec.act(self.LABEL):
-            # Long enough to survive the record's 3-decimal rounding: an act
-            # that opened its beat after the block, or closed it before, would
-            # collapse this span to zero.
             time.sleep(0.02)
             inside = round(time.monotonic() - rec._t0, 3)
         beat = rec._beats[-1]
         self.assertLess(beat["t_start"], beat["t_end"])
         self.assertLessEqual(beat["t_start"], inside)
         self.assertLessEqual(inside, beat["t_end"])
+        # The span, not just the ordering: a beat opened *after* the block —
+        # the injection this guards against — sits microseconds from its own
+        # end, and under load that epsilon has been known to round above the
+        # 3-decimal zero and slip past the assertLess above. A beat that
+        # spans a 20 ms block covers all but the rounding of it; one that
+        # does not, cannot.
+        self.assertGreaterEqual(beat["t_end"] - beat["t_start"], 0.015)
 
     def test_the_act_beat_is_captured_for_evidence_like_any_verb(self):
         # recorder() pins evidence=False for the rest of the suite, so this
@@ -6478,6 +6483,753 @@ class CriterionHold(unittest.TestCase):
         # is satisfied by a hold that is *always* whatever `_line_end` says,
         # including a negative one.
         self.assertEqual(self.held_for("It works.", spoken=-30.0), CRITERION_HOLD_MIN_S)
+
+
+class Pace(unittest.TestCase):
+    """One multiplier over the holds the recorder *computes*.
+
+    The knob exists so one storyboard can serve a hurried viewer and a
+    deliberate one without being rewritten. What the tests pin: the computed
+    holds scale; a duration the storyboard author wrote does not; and a take
+    that moved off the default says so in its own timeline. The line between
+    the two is the whole design — `pause(2)` is a request, not a suggestion.
+    """
+
+    class Held(WebRec):
+        """A recorder that writes down what it was asked to hold for."""
+
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.held: list[float] = []
+
+        def _hold_frame(self, seconds: float) -> None:
+            self.held.append(seconds)
+
+    WORDS = "one two three four five six seven eight nine ten"
+
+    def paced(self, pace):
+        settings = {} if pace is None else {"pace": pace}
+        return recorder(self, cls=self.Held, page=DrawingPage(), **settings)
+
+    @staticmethod
+    def base_hold(text: str) -> float:
+        words = len(text.split())
+        return min(6.0, max(1.4, 0.6 + words * 0.34))
+
+    def test_the_default_pace_is_one_and_holds_what_the_formula_says(self):
+        rec = self.paced(None)
+        self.assertEqual(rec._pace, 1.0)
+        self.assertAlmostEqual(
+            rec._caption_hold(self.WORDS), self.base_hold(self.WORDS)
+        )
+
+    def test_a_computed_caption_hold_scales_both_ways(self):
+        self.assertAlmostEqual(
+            self.paced(0.5)._caption_hold(self.WORDS),
+            0.5 * self.base_hold(self.WORDS),
+        )
+        self.assertAlmostEqual(
+            self.paced(2.0)._caption_hold(self.WORDS),
+            2.0 * self.base_hold(self.WORDS),
+        )
+
+    def test_the_criterion_card_scales_with_it(self):
+        clause = " ".join(["queue"] * 7)  # reading speed governs at 7 words
+        rec = recorder(
+            self,
+            cls=self.Held,
+            page=DrawingPage(),
+            pace=0.5,
+            criteria={"AC-1": clause},
+        )
+        rec.criterion("AC-1")
+        self.assertEqual(len(rec.held), 1)
+        self.assertAlmostEqual(rec.held[0], 0.5 * (0.6 + 7 * 0.34))
+
+    def test_an_authored_duration_is_not_touched(self):
+        rec = self.paced(0.5)
+        rec.pause(2.0)
+        rec.hold(min_s=3.0)
+        rec.interlude("A bridge.", hold=4.0)
+        self.assertEqual(rec.held[0], 2.0, "pause() is the author's number")
+        self.assertEqual(rec.held[1], 3.0, "an explicit min_s is too")
+        self.assertEqual(rec.held[2], 4.0, "an explicit interlude hold is too")
+
+    def test_the_computed_defaults_scale_and_the_clear_does_not(self):
+        rec = self.paced(0.5)
+        rec.hold()
+        rec.interlude("A bridge.")
+        n = len(rec.held)
+        rec.interlude("")
+        self.assertAlmostEqual(rec.held[0], 0.75, msg="hold()'s 1.5 s floor")
+        self.assertAlmostEqual(rec.held[1], 1.4, msg="interlude()'s 2.8 s default")
+        self.assertAlmostEqual(rec.held[n], 0.6, msg="the clear keeps its fade")
+
+    def test_zero_negative_and_non_numbers_are_refused_at_construction(self):
+        for pace in (0, -1, "quick"):
+            with self.subTest(pace=pace):
+                with self.assertRaises(RuntimeError) as refused:
+                    self.paced(pace)
+                self.assertIn("DEMO_VIDEO_PACE", str(refused.exception))
+
+    def test_the_environment_can_set_it(self):
+        # Saved and restored by hand: `target_env` pins exactly the two target
+        # variables, and a pace left in the environment would re-pace every
+        # later take in this suite.
+        saved = os.environ.get("DEMO_VIDEO_PACE")
+        os.environ["DEMO_VIDEO_PACE"] = "0.75"
+        try:
+            rec = recorder(self, cls=self.Held, page=DrawingPage())
+        finally:
+            if saved is None:
+                os.environ.pop("DEMO_VIDEO_PACE", None)
+            else:
+                os.environ["DEMO_VIDEO_PACE"] = saved
+        self.assertEqual(rec._pace, 0.75)
+
+    def test_a_take_that_moved_off_the_default_says_so_in_its_timeline(self):
+        doc = self.paced(0.5)._timeline_doc()
+        self.assertEqual(doc["pace"], 0.5)
+
+    def test_the_default_take_does_not_carry_the_key(self):
+        doc = self.paced(None)._timeline_doc()
+        self.assertNotIn("pace", doc)
+
+
+class WindowTitle(unittest.TestCase):
+    """What the wrapper window's title bar says, and who decides it.
+
+    A web take used to open titled after wherever it was pointed — every
+    localhost demo read `localhost`, telling the viewer nothing. The knob
+    is one string; what the tests pin is the fallback order: the take's
+    `window_title`, then the medium's own answer (the app's host on the
+    web, the branded `terminal_title` in a terminal), then nothing.
+    """
+
+    def web(self, **settings):
+        return recorder(self, cls=WebRec, page=DrawingPage(), **settings)
+
+    def term(self, **settings):
+        return recorder(self, cls=TermRec, page=DrawingPage(), **settings)
+
+    def test_a_web_take_opens_titled_for_the_app_it_demos(self):
+        # The control: without the knob the bar still names the host, which
+        # is at least *an* answer — the regression graded here is the
+        # fallback vanishing, not the knob existing.
+        self.assertEqual(self.web()._chrome_title(), "localhost:8000")
+
+    def test_an_explicit_window_title_wins_on_both_media(self):
+        self.assertEqual(
+            self.web(window_title="Acme Console")._chrome_title(), "Acme Console"
+        )
+        self.assertEqual(
+            self.term(terminal_title="upstream")._chrome_title(), "upstream"
+        )
+        self.assertEqual(
+            self.term(
+                window_title="Acme Console", terminal_title="upstream"
+            )._chrome_title(),
+            "Acme Console",
+            "the take's title outranks the medium's branding",
+        )
+
+    def test_the_environment_sets_it(self):
+        saved = os.environ.get("DEMO_VIDEO_WINDOW_TITLE")
+        os.environ["DEMO_VIDEO_WINDOW_TITLE"] = "Queue Demo"
+        try:
+            rec = self.web()
+        finally:
+            if saved is None:
+                os.environ.pop("DEMO_VIDEO_WINDOW_TITLE", None)
+            else:
+                os.environ["DEMO_VIDEO_WINDOW_TITLE"] = saved
+        self.assertEqual(rec._chrome_title(), "Queue Demo")
+
+
+class Intro(unittest.TestCase):
+    """The opt-in opening title card, and the ways it stays opt-in.
+
+    Off by default — a demo that opens on a title card spends its opening
+    seconds not showing the app, which is a choice the storyboard author
+    makes, not the recorder. What the tests pin: nothing is raised or held
+    without one; an intro is raised over the wrapper and held at reading
+    speed scaled by `pace`; and a take that opened on one says so in its
+    own timeline.
+    """
+
+    class Held(WebRec):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.held: list[float] = []
+
+        def _hold_frame(self, seconds: float) -> None:
+            self.held.append(seconds)
+
+    def held(self, **settings):
+        return recorder(self, cls=self.Held, page=DrawingPage(), **settings)
+
+    def test_the_default_take_raises_nothing_and_holds_nothing(self):
+        rec = self.held()
+        rec._raise_intro()
+        self.assertEqual(rec.held, [])
+        raised = [a for s, a in rec.page.drawn if "__demoInterlude" in s]
+        self.assertEqual(raised, [])
+
+    def test_an_intro_is_raised_over_the_wrapper_and_paced(self):
+        rec = self.held(intro="The support queue, in twenty seconds.")
+        rec._raise_intro()
+        raised = [a for s, a in rec.page.drawn if "__demoInterlude" in s]
+        self.assertEqual(raised, ["The support queue, in twenty seconds."])
+        self.assertAlmostEqual(rec.held, [2.8])
+
+    def test_pace_scales_the_intro_hold(self):
+        rec = self.held(intro="Quick.", pace=0.5)
+        rec._raise_intro()
+        self.assertAlmostEqual(rec.held, [1.4])
+
+    def test_a_voiced_intro_holds_the_card_for_the_whole_line(self):
+        # What `_start_line` does for a real narration clip, without one: the
+        # line is now known to end five seconds from here, and the card must
+        # still be up when it does — a voice outliving its card is the one
+        # failure this verb shape exists to remove.
+        rec = self.held(intro="Hello.")
+        rec._start_line = lambda clip: setattr(  # type: ignore[method-assign]
+            rec, "_line_end", time.monotonic() + 5.0
+        )
+        rec._raise_intro()
+        self.assertEqual(len(rec.held), 1)
+        self.assertAlmostEqual(rec.held[0], 5.0, delta=0.01)
+
+    def test_a_voiced_intro_starts_its_line_off_the_preset_no_synth_on_the_clock(self):
+        # The clip was synthesized in the constructor; the raise must go
+        # card-up then line-start with nothing in between. A synthesis round
+        # trip paid here was 3.4 s of silent card at the top of the delivered
+        # exec demo — the one failure this wiring exists to keep dead.
+        rec = self.held(intro="Hello.")
+        rec._speech = True
+        rec._intro_clip = Path("/tmp/opencode/intro.mp3")
+        order: list[str] = []
+        rec.page.evaluate = lambda script, arg=None, **kw: order.append("card")  # type: ignore[method-assign]
+        rec._start_line = lambda clip: order.append(f"start:{clip}")  # type: ignore[method-assign]
+        was_clip = core_module.tts_clip
+
+        def explode(*args, **kwargs):
+            raise AssertionError("synthesis paid on the capture clock")
+
+        core_module.tts_clip = explode  # type: ignore[assignment]
+        try:
+            rec._raise_intro()
+        finally:
+            core_module.tts_clip = was_clip  # type: ignore[assignment]
+        self.assertEqual(order[0], "card")
+        self.assertEqual(
+            order[1],
+            "start:/tmp/opencode/intro.mp3",
+            "the preset clip was not the line",
+        )
+
+    def test_card_lines_are_synthesized_in_the_constructor_off_the_clock(self):
+        # Behaviour: `_pre_synth` synthesizes exactly when speech is on and
+        # the text is real. Wiring: the constructor assigns both card clips
+        # from it — and the constructor runs before any browser exists, so
+        # "in the constructor" is "off the capture clock" by construction.
+        rec = self.held(intro="Hello.", outro="Bye.")
+        rec._speech = True
+        calls: list[str] = []
+        was_clip = core_module.tts_clip
+        core_module.tts_clip = (  # type: ignore[assignment]
+            lambda text, *a, **k: calls.append(text) or Path("/tmp/opencode/x.mp3")
+        )
+        try:
+            self.assertEqual(rec._pre_synth("Hello."), Path("/tmp/opencode/x.mp3"))
+            self.assertIsNone(rec._pre_synth(None))
+            # (Whitespace never reaches here: the constructor strips the
+            # card texts to None before this is called.)
+        finally:
+            core_module.tts_clip = was_clip  # type: ignore[assignment]
+        self.assertEqual(calls, ["Hello."])
+        src = inspect.getsource(_DemoBase.__init__)
+        self.assertIn("self._intro_clip = self._pre_synth(self._intro)", src)
+        self.assertIn("self._outro_clip = self._pre_synth(self._outro)", src)
+
+    def test_a_preset_line_is_used_not_synthesized_again(self):
+        rec = recorder(self, page=DrawingPage())
+        rec._speech = True
+        was_clip = core_module.tts_clip
+
+        def explode(*args, **kwargs):
+            raise AssertionError("a preset line must not synthesize again")
+
+        core_module.tts_clip = explode  # type: ignore[assignment]
+        try:
+            clip = rec._prepare_line("Hello.", preset=Path("/tmp/opencode/p.mp3"))
+        finally:
+            core_module.tts_clip = was_clip  # type: ignore[assignment]
+        self.assertEqual(clip, Path("/tmp/opencode/p.mp3"))
+
+    def test_an_empty_intro_is_no_intro(self):
+        rec = self.held(intro="   ")
+        rec._raise_intro()
+        self.assertEqual(rec.held, [])
+        self.assertIsNone(rec._intro)
+
+    def test_the_environment_can_set_it(self):
+        saved = os.environ.get("DEMO_VIDEO_INTRO")
+        os.environ["DEMO_VIDEO_INTRO"] = "From the environment."
+        try:
+            rec = self.held()
+        finally:
+            if saved is None:
+                os.environ.pop("DEMO_VIDEO_INTRO", None)
+            else:
+                os.environ["DEMO_VIDEO_INTRO"] = saved
+        rec._raise_intro()
+        raised = [a for s, a in rec.page.drawn if "__demoInterlude" in s]
+        self.assertEqual(raised, ["From the environment."])
+
+    def test_a_take_that_opened_on_one_says_so_in_its_timeline(self):
+        doc = self.held(intro="The support queue.")._timeline_doc()
+        self.assertEqual(doc["intro"], "The support queue.")
+
+    def test_the_default_take_does_not_carry_the_key(self):
+        doc = self.held()._timeline_doc()
+        self.assertNotIn("intro", doc)
+
+    def test_the_terminal_medium_refuses_it_and_names_its_own_card(self):
+        # Accepted-and-ignored is the worst of both: the storyboard reads as
+        # if it asked for an intro and the take ships without one. Refused at
+        # the constructor, with this medium's own opening card named.
+        with self.assertRaises(RuntimeError) as refused:
+            recorder(self, cls=TermRec, page=DrawingPage(), intro="Hi")
+        self.assertIn("interlude=", str(refused.exception))
+
+
+class Outro(unittest.TestCase):
+    """The opt-in closing card, and the honesty of its record.
+
+    The intro's mirror, with one asymmetry that matters: the outro card is
+    **left up** — it is the take's last frame, not something to take down —
+    so the overlay probe has to waive the very card the feature raised, or
+    every outro take would end with a warning about its own ending. And the
+    envelope key hangs on `_outro_up`, not on the parameter: an outro that
+    was asked for and lost to a late failure claims nothing.
+    """
+
+    class Held(WebRec):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.held: list[float] = []
+
+        def _hold_frame(self, seconds: float) -> None:
+            self.held.append(seconds)
+
+    def held(self, **settings):
+        return recorder(self, cls=self.Held, page=DrawingPage(), **settings)
+
+    def test_an_outro_is_raised_voiced_and_left_up(self):
+        rec = self.held(outro="Filtered. In twenty seconds.")
+        rec._raise_outro()
+        raised = [a for s, a in rec.page.drawn if "__demoInterlude" in s]
+        self.assertEqual(raised, ["Filtered. In twenty seconds."])
+        self.assertAlmostEqual(rec.held, [2.8])
+        self.assertIs(rec._outro_up, True)
+
+    def test_the_cursor_dot_leaves_with_the_take(self):
+        # Wherever the story last parked the pointer, there it sits — over
+        # the closing card, on the take's final frame. The dot is hidden as
+        # the card goes up.
+        rec = self.held(outro="Bye.")
+        rec._raise_outro()
+        hides = [
+            (s, a) for s, a in rec.page.drawn if a == "__demo_cursor" and "none" in s
+        ]
+        self.assertEqual(len(hides), 1, "the cursor dot was not hidden once")
+        self.assertEqual(hides[0][1], "__demo_cursor")
+
+    def test_no_outro_raises_nothing_and_claims_nothing(self):
+        rec = self.held()
+        rec._raise_outro()
+        self.assertEqual(rec.held, [])
+        self.assertIs(rec._outro_up, False)
+        self.assertNotIn("outro", rec._timeline_doc())
+        self.assertEqual(
+            [s for s, a in rec.page.drawn if "__demo_cursor" in s],
+            [],
+            "a take with no outro must not touch the cursor",
+        )
+
+    def test_a_take_that_ended_on_one_says_so_in_its_timeline(self):
+        rec = self.held(outro="Filtered. In twenty seconds.")
+        rec._raise_outro()
+        self.assertEqual(rec._timeline_doc()["outro"], "Filtered. In twenty seconds.")
+
+    def test_an_outro_that_failed_to_raise_claims_nothing(self):
+        # The swallow lives in `__exit__` — a take that recorded everything
+        # must not die at second fourteen over a TTS blip — but the swallow
+        # must not leave the envelope claiming a card the frames never show.
+        rec = self.held(outro="Bye.")
+
+        def refuse(*args, **kwargs):
+            raise RuntimeError("the page is gone")
+
+        rec.page.evaluate = refuse  # type: ignore[method-assign]
+        with self.assertRaises(RuntimeError):
+            rec._raise_outro()
+        self.assertIs(rec._outro_up, False)
+        self.assertNotIn("outro", rec._timeline_doc())
+
+    def test_the_probe_waives_the_outro_card_and_nothing_else(self):
+        rec = self.held(outro="Bye.")
+        rec._raise_outro()
+        rec.page.evaluate = lambda script, arg=None, **kw: [  # type: ignore[method-assign]
+            "__demo_interlude"
+        ]
+        rec._note_overlays_up()
+        self.assertIsNone(
+            rec._overlay_note, "the take's own ending is not a left-up overlay"
+        )
+        rec.page.evaluate = lambda script, arg=None, **kw: [  # type: ignore[method-assign]
+            "__demo_interlude",
+            "__demo_bridge",
+        ]
+        rec._note_overlays_up()
+        assert rec._overlay_note is not None
+        self.assertIn("bridge", rec._overlay_note)
+
+    def test_the_terminal_medium_refuses_it_and_names_its_own_ending(self):
+        with self.assertRaises(RuntimeError) as refused:
+            recorder(self, cls=TermRec, page=DrawingPage(), outro="Bye")
+        self.assertIn("interlude(", str(refused.exception))
+
+
+class VoiceSettings(unittest.TestCase):
+    """Voice stability, pinned per line, and the cache key that knows it.
+
+    Without a pinned stability the model's per-sentence pacing wanders —
+    measured 2.1 to 3.3 words/s across one take's five clips, which a
+    listener reads as some lines being sped up. The knob is a recorder
+    constant by default; what the tests pin is that it reaches the
+    synthesis request and the cache key, because a stability change that
+    replayed old clips would silently keep the pacing it was made to fix.
+    """
+
+    def test_stability_is_part_of_the_cache_key(self):
+        a = _tts_key("line", "voice", "model", stability=0.5)
+        b = _tts_key("line", "voice", "model", stability=0.75)
+        self.assertNotEqual(a, b, "a stability change would replay old clips")
+
+    def test_the_recorder_pins_one_and_the_environment_can_set_it(self):
+        self.assertEqual(recorder(self, page=DrawingPage())._speech_stability, 0.75)
+        saved = os.environ.get("DEMO_VIDEO_SPEECH_STABILITY")
+        os.environ["DEMO_VIDEO_SPEECH_STABILITY"] = "0.9"
+        try:
+            rec = recorder(self, page=DrawingPage())
+        finally:
+            if saved is None:
+                os.environ.pop("DEMO_VIDEO_SPEECH_STABILITY", None)
+            else:
+                os.environ["DEMO_VIDEO_SPEECH_STABILITY"] = saved
+        self.assertEqual(rec._speech_stability, 0.9)
+
+    def test_out_of_range_and_non_numbers_are_refused_at_construction(self):
+        for bad in (0, 1.5, "loud"):
+            with self.subTest(bad=bad):
+                with self.assertRaises(RuntimeError) as refused:
+                    recorder(self, page=DrawingPage(), speech_stability=bad)
+                self.assertIn("DEMO_VIDEO_SPEECH_STABILITY", str(refused.exception))
+
+    def test_synthesis_requests_carry_the_pinned_stability(self):
+        captured: dict = {}
+        was_clip = core_module.tts_clip
+        was_dur = core_module.media_duration
+        core_module.tts_clip = (  # type: ignore[assignment]
+            lambda text, cache_dir, voice_id, model_id, api_key, stability=0.5: (
+                captured.update(stability=stability) or Path("/nonexistent/clip.mp3")
+            )
+        )
+        core_module.media_duration = lambda clip: 1.0  # type: ignore[assignment]
+        try:
+            # `recorder()` pins speech off (a suite that inherits the key
+            # grades the box); the seam under test is `_prepare_line`'s call,
+            # so speech is forced on the instance instead.
+            rec = recorder(self, page=DrawingPage())
+            rec._speech = True
+            rec._prepare_line("Hello there.")
+        finally:
+            core_module.tts_clip = was_clip  # type: ignore[assignment]
+            core_module.media_duration = was_dur  # type: ignore[assignment]
+        self.assertEqual(captured["stability"], 0.75)
+
+
+class CaptionCrossfade(unittest.TestCase):
+    """The caption band crossfades between lines instead of popping.
+
+    A caption-to-caption change used to swap text under a steady opacity —
+    instant, while everything else in the take eased. Two stacked layers
+    fade the old line out as the new one fades in; what is graded here is
+    the wiring, and the pixels are `tests/pixel`'s.
+    """
+
+    def html(self) -> str:
+        return chrome_html(
+            chrome_geometry(1280, 720), title="t", window_body="#0b0c1d", accent="1,2,3"
+        )
+
+    def test_two_stacked_layers_exist_and_share_the_caption_style(self):
+        html = self.html()
+        for element_id in ("__demo_caption", "__demo_caption2"):
+            self.assertIn(f'id="{element_id}"', html)
+        found = re.search(r"#__demo_caption, #__demo_caption2 \{([^}]*)\}", html)
+        self.assertIsNotNone(found, "the two caption layers do not share one rule")
+        # Stacked, not side by side: the band is a flex row, and two
+        # in-flow layers would sit next to each other and half off-screen.
+        self.assertIn("position: absolute", found.group(1))
+
+    def test_the_swap_toggles_layers_and_measures_the_incoming_one(self):
+        found = re.search(
+            r"window\.__demoCaption = \(text\) => \{.*return Math\.max\(0, nxt\.scrollHeight",
+            self.html(),
+            re.S,
+        )
+        self.assertIsNotNone(found, "__demoCaption is not the crossfading version")
+        script = found.group(0)
+        self.assertIn("ids[1 - (window.__demoCapLayer", script)
+        self.assertIn("cur.style.opacity = '0'", script)
+        # The clipping measurement is taken on the layer about to be shown —
+        # a measurement of the outgoing layer would grade the wrong text.
+        self.assertIn("nxt.scrollHeight", script)
+
+
+class CameraMove(unittest.TestCase):
+    """The camera: spotlight intervals rendered as post-production push-ins.
+
+    The DOM zoom this replaced scaled the page inside the window — the
+    element sat at the transform's origin, so it did not move, and the
+    viewer got layout jitter instead of a move. The camera is rendered
+    after the take, by `zoompan`, from geometry the spotlight logged
+    while the page was alive. What is graded here:
+    the chain's shape (one zoompan, eased, centred on the element, at
+    the output size), the refusals (overlap, degenerate rects), the
+    wiring (close-with-the-take, the timeline key) — and one real
+    encode, because a filter string that parses is not a filter string
+    that moves.
+    """
+
+    def event(self, **over: object) -> dict:
+        event: dict = {"t_start": 1.0, "t_end": 3.0, "rect": [500, 250, 280, 60]}
+        event.update(over)
+        return event
+
+    def chain(self, events: list[dict] | None = None) -> str:
+        return camera_filter(
+            events if events is not None else [self.event()],
+            src_w=2560,
+            src_h=1440,
+            out_w=1280,
+            out_h=720,
+        )
+
+    def test_no_events_build_no_chain(self):
+        self.assertIsNone(
+            camera_filter([], src_w=2560, src_h=1440, out_w=1280, out_h=720)
+        )
+
+    def test_one_zoompan_carrying_the_event_at_the_output_size(self):
+        chain = self.chain()
+        self.assertTrue(chain.startswith("fps=25,"), "the PTS normalize is missing")
+        self.assertIn("zoompan=", chain)
+        self.assertIn(":d=1:", chain)
+        self.assertIn("s=1280x720", chain)
+
+    def test_the_push_eases_in_and_back(self):
+        u = "clip(min((time-1.000)/0.5,(3.000-time)/0.5),0,1)"
+        self.assertIn(f"{u}*{u}*(3-2*{u})", self.chain())
+
+    def test_the_camera_centres_on_the_element_not_the_frame(self):
+        # rect x 500..780, y 250..310 in output px; at 2x source scale the
+        # centre is (1280.0, 560.0) in source pixels — not (iw/2, ih/2).
+        chain = self.chain()
+        self.assertIn("*clip(1280.0-iw/(2*zoom),0,iw-iw/zoom)", chain)
+        self.assertIn("*clip(560.0-ih/(2*zoom),0,ih-ih/zoom)", chain)
+        self.assertNotIn("iw/2-", chain)
+
+    def test_overlapping_events_are_refused(self):
+        with self.assertRaises(ValueError):
+            self.chain([self.event(), self.event(t_start=2.0, t_end=4.0)])
+
+    def test_a_degenerate_rect_is_refused(self):
+        with self.assertRaises(ValueError):
+            self.chain([self.event(rect=[500, 250, 0, 60])])
+        with self.assertRaises(ValueError):
+            self.chain([self.event(t_end=1.0)])
+
+    def test_a_real_encode_pushes_and_pulls(self):
+        # A static source — a white box on black — so every difference
+        # between two frames is the camera's, never the app's. The frame
+        # before the push and the held frame must differ (finite PSNR);
+        # identical frames would mean the chain parsed and moved nothing,
+        # which is exactly what the DOM zoom this replaces did.
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        work = Path(tmp.name)
+        chain = camera_filter(
+            [{"t_start": 1.0, "t_end": 3.0, "rect": [130, 50, 60, 80]}],
+            src_w=640,
+            src_h=360,
+            out_w=320,
+            out_h=180,
+        )
+        mp4 = work / "cam.mp4"
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-y",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=black:size=640x360:rate=25:duration=4,"
+                "drawbox=x=260:y=100:w=120:h=160:color=white:t=fill",
+                "-filter_complex",
+                chain,
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                str(mp4),
+            ],
+            check=True,
+        )
+        before, held = work / "a.png", work / "b.png"
+        for name, at in ((before, "0.2"), (held, "2.0")):
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-loglevel",
+                    "error",
+                    "-ss",
+                    at,
+                    "-i",
+                    str(mp4),
+                    "-frames:v",
+                    "1",
+                    str(name),
+                ],
+                check=True,
+            )
+        psnr = subprocess.run(
+            [
+                "ffmpeg",
+                "-i",
+                str(before),
+                "-i",
+                str(held),
+                "-filter_complex",
+                "psnr",
+                "-f",
+                "null",
+                "-",
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stderr
+        found = re.search(r"average:(\S+)", psnr)
+        self.assertIsNotNone(found, f"no PSNR in ffmpeg output: {psnr[-400:]}")
+        self.assertNotIn(
+            "inf", found.group(1), "the camera did not move: frames identical"
+        )
+
+    def test_a_spotlight_left_open_closes_with_the_take(self):
+        src = inspect.getsource(_DemoBase.__exit__)
+        self.assertIn("self._camera_close()", src)
+
+    def test_the_moves_ride_the_same_clock_correction_as_the_voice(self):
+        # The events' times are monotonic beat-log instants and the video is
+        # on the wall clock: a backward step puts every event after it that
+        # far ahead of the frames it names — the same exposure the narration
+        # mix corrects for (issue #226). A −1.0 s step at t=2 moves an event
+        # at [3, 5] to [2, 4] in the video.
+        rec = recorder(self, page=DrawingPage())
+        rec._camera = [
+            {"t_start": 3.0, "t_end": 5.0, "rect": [10, 20, 30, 40]},
+            {"t_start": 0.5, "t_end": 1.5, "rect": [1, 2, 3, 4]},
+        ]
+        moved = rec._camera_on_the_video_clock(clock_record((2.0, -1.0)))
+        self.assertEqual(moved[0]["t_start"], 2.0)
+        self.assertEqual(moved[0]["t_end"], 4.0)
+        # Before the step: untouched.
+        self.assertEqual(moved[1]["t_start"], 0.5)
+
+    def test_an_interval_a_step_swallowed_whole_is_dropped(self):
+        # A −3.0 s step at t=1 clamps every instant inside the hole to the
+        # moment the video starts again: an event at [1.5, 2.0] collapses to
+        # a point, and a push with no length is not a move.
+        rec = recorder(self, page=DrawingPage())
+        rec._camera = [
+            {"t_start": 1.5, "t_end": 2.0, "rect": [1, 2, 3, 4]},
+            {"t_start": 4.0, "t_end": 6.0, "rect": [5, 6, 7, 8]},
+        ]
+        moved = rec._camera_on_the_video_clock(clock_record((1.0, -3.0)))
+        self.assertEqual(len(moved), 1)
+        self.assertEqual(moved[0]["t_start"], 1.0)
+
+    def test_camera_events_open_and_close_and_land_on_the_timeline(self):
+        rec = recorder(self, page=DrawingPage())
+        rec._t0 = time.monotonic() - 10.0
+        rec._camera_raise({"x": 500, "y": 250, "w": 280, "h": 60})
+        self.assertEqual(len(rec._camera), 0, "an open event is not yet a move")
+        self.assertEqual(rec._camera_open["rect"], [500, 250, 280, 60])
+        rec._camera_close(time.monotonic() - rec._t0 + 2.0)
+        self.assertEqual(len(rec._camera), 1)
+        self.assertGreater(rec._camera[0]["t_end"], rec._camera[0]["t_start"])
+        self.assertIn("camera", rec._timeline_doc())
+        self.assertEqual(rec._timeline_doc()["camera"], rec._camera)
+
+    def test_a_degenerate_event_claims_nothing(self):
+        rec = recorder(self, page=DrawingPage())
+        rec._t0 = time.monotonic()
+        rec._camera_raise({"x": 1, "y": 2, "w": 3, "h": 4})
+        rec._camera_close(time.monotonic() - rec._t0)  # same instant
+        self.assertEqual(rec._camera, [])
+        self.assertNotIn("camera", rec._timeline_doc())
+
+    def test_a_take_with_no_camera_claims_no_camera(self):
+        rec = recorder(self, page=DrawingPage())
+        self.assertNotIn("camera", rec._timeline_doc())
+
+    def test_spotlight_opens_a_camera_event_over_the_element(self):
+        # The verb wiring, browser-free: the rect the page returns opens an
+        # event, and the next clear — the next spotlight's or an explicit
+        # one — is what ends it.
+        rec = recorder(self, page=DrawingPage())
+        rec._t0 = time.monotonic() - 5.0
+        rec._target = lambda: rec.page  # type: ignore[method-assign]
+        rec.page.evaluate = lambda script, arg=None, **kw: None  # type: ignore[method-assign]
+
+        class _First:
+            def evaluate(self, _script: str):
+                return {"x": 10, "y": 20, "w": 30, "h": 40}
+
+        class _Locator:
+            first = _First()
+
+        rec.page.locator = lambda _sel: _Locator()  # type: ignore[method-assign]
+        rec.spotlight("#box")
+        self.assertIsNone(
+            rec._camera[0] if rec._camera else None,
+            "an open event is not yet a move",
+        )
+        self.assertEqual(rec._camera_open["rect"], [10, 20, 30, 40])
+        # Real time between raise and clear: both ends round to 3 decimals,
+        # and a sub-millisecond take would be a degenerate event by the same
+        # rule the recorder itself applies.
+        time.sleep(0.005)
+        rec.spotlight(None)
+        self.assertEqual(len(rec._camera), 1)
+        self.assertGreater(rec._camera[0]["t_end"], rec._camera[0]["t_start"])
 
 
 # --------------------------------------------------------------------------
@@ -8885,7 +9637,13 @@ class NarrationMix(unittest.TestCase):
     artifact-lies shape the record exists to prevent.
     """
 
-    def mixed(self, clock: object, *offsets: float) -> tuple[list[int], object]:
+    def mixed(
+        self,
+        clock: object,
+        *offsets: float,
+        duration: float = 0.3,
+        gain: float = 0.0,
+    ) -> tuple[list[int], object]:
         """(the adelay ms ffmpeg was really handed, the take's own record)."""
         rec = recorder(self, cls=TermRec)
         rec._speech = True
@@ -8894,6 +9652,14 @@ class NarrationMix(unittest.TestCase):
         rec._lines = [
             (off, Path(f"/nonexistent/line-{n}.mp3")) for n, off in enumerate(offsets)
         ]
+        # The clips do not exist here, and the mix needs two things from
+        # them — their lengths, for the serialization, and their loudness
+        # gain, for the volume filter. Both scripted like the clock is;
+        # the gain defaults to zero so the tests above read unchanged.
+        was_duration = core_module.media_duration
+        core_module.media_duration = lambda clip: duration  # type: ignore[assignment]
+        was_gain = core_module.clip_gain_db
+        core_module.clip_gain_db = lambda clip: gain  # type: ignore[assignment]
         seen: list[list[str]] = []
 
         def run(cmd, **kwargs):
@@ -8908,10 +9674,15 @@ class NarrationMix(unittest.TestCase):
                 rec._convert(Path(rec.out_dir) / "take.webm")
         finally:
             core_module.subprocess.run = was
+            core_module.media_duration = was_duration  # type: ignore[assignment]
+            core_module.clip_gain_db = was_gain  # type: ignore[assignment]
         self.assertEqual(len(seen), 1, f"expected one ffmpeg call, got {seen!r}")
         cmd = seen[0]
         self.assertIn("-filter_complex", cmd, "the mix went in without a filter graph")
         graph = cmd[cmd.index("-filter_complex") + 1]
+        # Kept for the tests that assert on the filter graph itself rather
+        # than on the delays parsed out of it.
+        self.graph = graph
         return [int(ms) for ms in re.findall(r"adelay=(-?\d+):", graph)], rec._narration
 
     # -- the instant each clip is delayed by --------------------------------
@@ -8930,6 +9701,31 @@ class NarrationMix(unittest.TestCase):
         # is the whole defect, moved from one clock to the other.
         delays, _record = self.mixed(clock_record((4.0, -0.78)), 0.5, 2.0)
         self.assertEqual(delays, [500, 2000])
+
+    def test_two_lines_a_step_would_overlap_are_serialized_in_the_real_mix(self):
+        # The take that earned the rule: corrected onsets 0.5 and 1.22, clips
+        # a second long — the second voice would start 0.28 s inside the
+        # first. The ffmpeg command is the proof, not the published record: a
+        # document that printed a serialized `at` over a clip mixed somewhere
+        # else would be the artifact-lies shape again.
+        delays, record = self.mixed(clock_record((1.0, -0.78)), 0.5, 2.0, duration=1.0)
+        self.assertEqual(delays, [500, 1500])
+        self.assertEqual(record["lines"][1]["held"], 0.28)
+
+    def test_every_clip_is_gained_to_the_one_loudness_target(self):
+        # Read off the ffmpeg command, for the same reason the delays are:
+        # a record claiming a gain the mix never applied would be the
+        # artifact-lies shape. The graph carries one volume filter per
+        # input, ahead of its delay — and the record names the gain, so a
+        # reader can audit both against each other.
+        delays, record = self.mixed(clock_record(), 0.5, 2.0, gain=2.5)
+        self.assertEqual(delays, [500, 2000])
+        self.assertIn("volume=2.50dB,", self.graph)
+        self.assertEqual([line.get("gain_db") for line in record["lines"]], [2.5, 2.5])
+
+    def test_a_clip_already_at_the_target_gains_nothing_and_says_nothing(self):
+        _delays, record = self.mixed(clock_record(), 0.5, gain=0.0)
+        self.assertEqual([line for line in record["lines"] if "gain_db" in line], [])
 
     def test_steps_that_cancel_still_move_a_line_mixed_between_them(self):
         # The host this work exists for moves in *pulses* — up 0.9 s, back down
@@ -8975,6 +9771,16 @@ class NarrationMix(unittest.TestCase):
         # first frame — the recorder's own sampler starts at `_t0` and does not
         # produce one, so this is a record shape only a reader has to survive,
         # and `adelay` losing the whole audio track is why it still does.
+        #
+        # This outcome now has **two enforcers** — the placement floor, and
+        # the serialization a caller with durations gets, which pushes any
+        # negative placement up to its predecessor's end (zero for a first
+        # line) — so no single break makes this delay nonzero and no single
+        # injection lands on it. Each mechanism is graded where it is the
+        # only one: the floor through `MixSerialization`'s no-durations test,
+        # the serialization through its own; what this test pins is the
+        # observable contract a listener hears — the clip at zero, the track
+        # alive.
         delays, _record = self.mixed(clock_record((-0.5, -0.78)), 0.5, 2.0)
         self.assertEqual(delays, [0, 1220])
 
@@ -9065,6 +9871,11 @@ class NarrationMix(unittest.TestCase):
         rec._speech = True
         rec._capture_clock = _ScriptedClock(clock_record((1.0, -0.78)))
         rec._lines = [(0.5, Path("/nonexistent/line-0.mp3"))]
+        # The clips' durations are read for the serialization; scripted like
+        # in `mixed` above, so the failure this test grades is ffmpeg's and
+        # not ffprobe's.
+        was_duration = core_module.media_duration
+        core_module.media_duration = lambda clip: 0.3  # type: ignore[assignment]
 
         def run(cmd, **kwargs):
             raise subprocess.CalledProcessError(1, cmd)
@@ -9076,6 +9887,7 @@ class NarrationMix(unittest.TestCase):
                 rec._convert(Path(rec.out_dir) / "take.webm")
         finally:
             core_module.subprocess.run = was
+            core_module.media_duration = was_duration  # type: ignore[assignment]
         self.assertIsNone(rec._narration)
 
     def test_the_timeline_carries_the_record_the_mix_wrote(self):
@@ -9128,6 +9940,65 @@ class NarrationMixPlan(unittest.TestCase):
         self.assertEqual([line["at"] for line in lines], [0.5, 2.9])
 
 
+class MixSerialization(unittest.TestCase):
+    """The corrected placements never speak twice at once.
+
+    A backward step between two lines compresses the video without
+    compressing the clip, so the corrected onsets can invert the gap the
+    recorder kept. Measured on the take that earned this: a −1.65 s step put
+    one voice 1.6 s inside the one before it. The mix serializes when the
+    caller can say how long the clips are, and marks what it moved.
+    """
+
+    # The shape of that take: the step lands between the third line and the
+    # fourth, and the corrected fourth onset lands inside the third clip.
+    RECORD = clock_record((10.0, -1.65))
+    OFFSETS = [1.4, 4.8, 9.43, 12.18]
+    DURATIONS = [1.4, 2.6, 2.74, 1.4]
+
+    def plan(self, durations):
+        return mix_plan(self.OFFSETS, self.RECORD, durations)
+
+    def test_a_line_that_would_start_inside_its_predecessor_starts_at_its_end(self):
+        lines, _state = self.plan(self.DURATIONS)
+        # The third clip runs 9.43 + 2.74 = 12.17 in the video; the fourth
+        # line's corrected onset is 12.18 − 1.65 = 10.53 — 1.64 s inside it.
+        self.assertEqual(lines[3]["at"], 12.17)
+        self.assertAlmostEqual(lines[3]["held"], 1.64)
+
+    def test_lines_that_do_not_collide_are_placed_and_marked_as_before(self):
+        lines, _state = self.plan(self.DURATIONS)
+        self.assertEqual([line["at"] for line in lines[:3]], [1.4, 4.8, 9.43])
+        self.assertEqual([line for line in lines[:3] if "held" in line], [])
+
+    def test_without_durations_the_placements_are_exactly_as_before(self):
+        # The legacy call: a caller that cannot say how long the clips are
+        # gets the old behavior, overlap included — not a serialization
+        # guessed from nothing.
+        lines, _state = self.plan(None)
+        self.assertEqual(lines[3]["at"], 10.53)
+        self.assertNotIn("held", lines[3])
+
+    def test_no_step_no_held_key_even_when_lines_are_tight(self):
+        # Durations that do not collide: a real take cannot produce a
+        # collision without a step — the recorder waits each line out on the
+        # same clock the mix places them at — so the no-step control has to
+        # be a clean one.
+        lines, _state = mix_plan([0.5, 1.2], clock_record(), [0.5, 0.5])
+        self.assertEqual([line["at"] for line in lines], [0.5, 1.2])
+        self.assertEqual([line for line in lines if "held" in line], [])
+
+    def test_the_floor_survives_for_a_caller_that_passes_no_durations(self):
+        # The floor's own grade, on the path where serialization cannot mask
+        # it: no durations, nothing pushes a negative placement anywhere, and
+        # the line lands at zero with `clamped` saying what was swallowed.
+        # (`adelay` refuses a negative delay and takes the whole audio track
+        # with it — that is what this floor exists to stop.)
+        lines, _state = mix_plan([0.5], clock_record((-0.5, -0.78)))
+        self.assertEqual(lines[0]["at"], 0.0)
+        self.assertEqual(lines[0]["clamped"], 0.28)
+
+
 class NarrationTimelineNote(unittest.TestCase):
     """What `timeline.md` says about where the voice went (issue #226).
 
@@ -9146,6 +10017,30 @@ class NarrationTimelineNote(unittest.TestCase):
 
     def record(self, state: dict) -> dict:
         return {"lines": [{"t": 0.5, "at": 0.5}], "clock_correction": state}
+
+    def test_a_held_line_is_named_and_its_price_is_stated(self):
+        # The serialization's own sentence, never folded into the clamped or
+        # no_video ones: those are lines the clock misplaced, this is the mix
+        # refusing to speak twice at once. A listener hears a late voice and
+        # this paragraph is where they learn the recorder did it on purpose.
+        text = render_timeline_md(
+            self.doc(
+                {
+                    "lines": [
+                        {"t": 9.43, "at": 9.43},
+                        {"t": 12.18, "at": 12.17, "held": 1.64},
+                    ],
+                    "clock_correction": {
+                        "applied": True,
+                        "total": -1.65,
+                        "steps": 1,
+                        "note": None,
+                    },
+                }
+            )
+        )
+        self.assertIn("held back past the line before it", text)
+        self.assertIn("`held` is how many seconds later", text)
 
     def test_a_mix_that_could_not_be_corrected_says_so_above_the_table(self):
         text = render_timeline_md(
@@ -12389,8 +13284,8 @@ INJECTIONS = [
         # environment, which is most of them.
         "the web recorder accepts a base setting and drops it",
         "web.py",
-        "criteria=criteria, ticket=ticket, allow_private=allow_private,\n            stills_only=stills_only,",
-        "criteria=criteria, ticket=ticket, allow_private=allow_private,",
+        "            allow_private=allow_private,\n            stills_only=stills_only,\n            pace=pace,",
+        "            allow_private=allow_private,\n            pace=pace,",
         ["StillsOnly.test_both_media_take_every_setting_the_base_offers"],
     ),
     # -- the pixel loop's cache key (tests/pixel, #350) -----------------------
@@ -12474,10 +13369,8 @@ INJECTIONS = [
         # are driven by a scripted record.
         "every narration clip is mixed at its beat-log offset",
         "core.py",
-        "                    f\"[{i + 1}:a]adelay={int(round(line['at'] * 1000))}"
-        ':all=1[a{i}]"',
-        "                    f\"[{i + 1}:a]adelay={int(round(line['t'] * 1000))}"
-        ':all=1[a{i}]"',
+        "                    + f\"adelay={int(round(line['at'] * 1000))}:all=1[a{i}]\"",
+        "                    + f\"adelay={int(round(line['t'] * 1000))}:all=1[a{i}]\"",
         [
             "NarrationMix.test_a_line_is_mixed_where_its_own_offset_sits_in_the_video",
             "NarrationMix.test_steps_that_cancel_still_move_a_line_mixed_between_them",
@@ -12529,11 +13422,12 @@ INJECTIONS = [
         # one line — it costs the take its whole audio track.
         "a line the clock stepped past is given a negative delay",
         "narration.py",
-        '        line = {"t": round(float(off), 3), "at": round(max(0.0, want), 3)}',
-        '        line = {"t": round(float(off), 3), "at": round(want, 3)}',
+        "        at = max(0.0, want)",
+        "        at = want",
         [
-            "NarrationMix.test_a_step_bigger_than_a_lines_offset_starts_the_clip_at_zero",
             "NarrationMix.test_a_clamped_line_says_how_much_of_its_correction_it_lost",
+            "MixSerialization."
+            "test_the_floor_survives_for_a_caller_that_passes_no_durations",
         ],
     ),
     (
@@ -14309,8 +15203,10 @@ INJECTIONS = [
     (
         "the narration cache keys on the line alone, ignoring the voice",
         "narration.py",
-        "TTS_KEY_SEP.join((voice_id, model_id, text))",
-        "text",
+        "joined = TTS_KEY_SEP.join(\n"
+        '        (voice_id, model_id, text, f"stability={stability:.2f}")\n'
+        "    )",
+        "joined = text",
         ["TtsKey.test_each_of_the_three_inputs_changes_the_key_on_its_own"],
     ),
     (
@@ -14320,15 +15216,23 @@ INJECTIONS = [
         # each input", which is the claim the test actually makes.
         "the narration cache key drops the model but keeps the voice",
         "narration.py",
-        "TTS_KEY_SEP.join((voice_id, model_id, text))",
-        "TTS_KEY_SEP.join((voice_id, text))",
+        "joined = TTS_KEY_SEP.join(\n"
+        '        (voice_id, model_id, text, f"stability={stability:.2f}")\n'
+        "    )",
+        "joined = TTS_KEY_SEP.join(\n"
+        '        (voice_id, text, f"stability={stability:.2f}")\n'
+        "    )",
         ["TtsKey.test_each_of_the_three_inputs_changes_the_key_on_its_own"],
     ),
     (
-        "the three fields are joined with nothing between them",
+        "the fields are joined with nothing between them",
         "narration.py",
-        "TTS_KEY_SEP.join((voice_id, model_id, text))",
-        '"".join((voice_id, model_id, text))',
+        "joined = TTS_KEY_SEP.join(\n"
+        '        (voice_id, model_id, text, f"stability={stability:.2f}")\n'
+        "    )",
+        'joined = "".join(\n'
+        '        (voice_id, model_id, text, f"stability={stability:.2f}")\n'
+        "    )",
         ["TtsKey.test_moving_a_field_boundary_changes_the_key"],
     ),
     (
@@ -15192,9 +16096,7 @@ INJECTIONS = [
         # browser-free half of the same drive.
         "the glide moves the pointer and never the dot",
         "web.py",
-        "            self.page.evaluate(\n"
-        '                "([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi]\n'
-        "            )",
+        '            self.page.evaluate("([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi])',
         "            pass  # the dot is never told",
         ["CursorDrive.test_the_dot_rides_every_pointer_step_and_ends_at_the_target"],
     ),
@@ -15204,8 +16106,8 @@ INJECTIONS = [
         # so an offset here is the one way left for them to disagree.
         "the dot is commanded off the pointer's own path",
         "web.py",
-        '                "([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi]',
-        '                "([x, y]) => window.__demoChromeCursor(x, y)", [xi + 30, yi]',
+        '            self.page.evaluate("([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi])',
+        '            self.page.evaluate("([x, y]) => window.__demoChromeCursor(x, y)", [xi + 30, yi])',
         ["CursorDrive.test_the_dot_rides_every_pointer_step_and_ends_at_the_target"],
     ),
     (
@@ -15916,9 +16818,12 @@ INJECTIONS = [
         # to remove wearing the clothes of the fix.
         "every clause is held for the floor, whatever it takes to read",
         "core.py",
-        "        reading = min(\n"
-        "            CRITERION_HOLD_MAX_S,\n"
-        "            max(CRITERION_HOLD_MIN_S, 0.6 + len(text.split()) * 0.34),\n"
+        "        reading = (\n"
+        "            min(\n"
+        "                CRITERION_HOLD_MAX_S,\n"
+        "                max(CRITERION_HOLD_MIN_S, 0.6 + len(text.split()) * 0.34),\n"
+        "            )\n"
+        "            * self._pace\n"
         "        )",
         "        reading = CRITERION_HOLD_MIN_S",
         [
@@ -16002,8 +16907,7 @@ INJECTIONS = [
         # last frame, #91's shape with the recorder's own furniture.
         "the opening card's clear leaves the hold standing",
         "terminal.py",
-        '                "() => { window.__demoChromeHoldClear();"\n'
-        "                \" window.__demoInterlude(''); }\"",
+        "                \"() => { window.__demoChromeHoldClear(); window.__demoInterlude(''); }\"",
         "                \"() => { window.__demoInterlude(''); }\"",
         [
             "TerminalChrome."
@@ -16034,8 +16938,8 @@ INJECTIONS = [
         # storyboards this repo runs least.
         "TerminalRecorder drops the ticket on the way to its base class",
         "terminal.py",
-        "            criteria=criteria, ticket=ticket, allow_private=allow_private,",
-        "            criteria=criteria, allow_private=allow_private,",
+        "            criteria=criteria,\n            ticket=ticket,\n",
+        "            criteria=criteria,\n",
         ["BeatLog.test_the_terminal_recorder_carries_the_ticket_to_its_own_envelope"],
     ),
     (
@@ -16045,8 +16949,8 @@ INJECTIONS = [
         # is a second injection rather than an assurance.
         "Recorder drops the ticket on the way to its base class",
         "web.py",
-        "            criteria=criteria, ticket=ticket, allow_private=allow_private,",
-        "            criteria=criteria, allow_private=allow_private,",
+        "            criteria=criteria,\n            ticket=ticket,\n",
+        "            criteria=criteria,\n",
         ["BeatLog.test_the_envelope_names_the_ticket_the_storyboard_recorded_against"],
     ),
     (
@@ -16813,6 +17717,399 @@ INJECTIONS = [
         "                )",
         "            pass",
         ["StitchedHold.test_the_hold_instant_is_shifted_with_its_beat"],
+    ),
+    # -- pace, the audience-pacing multiplier --------------------------------
+    (
+        "the caption read-time stops scaling with pace",
+        "core.py",
+        "        return min(6.0, max(1.4, 0.6 + words * 0.34)) * self._pace",
+        "        return min(6.0, max(1.4, 0.6 + words * 0.34))",
+        ["Pace.test_a_computed_caption_hold_scales_both_ways"],
+    ),
+    (
+        "hold()'s floor stops scaling when the storyboard passes no min_s",
+        "core.py",
+        "        floor = 1.5 * self._pace if min_s is None else min_s",
+        "        floor = 1.5 if min_s is None else min_s",
+        ["Pace.test_the_computed_defaults_scale_and_the_clear_does_not"],
+    ),
+    (
+        "interlude()'s default hold stops scaling",
+        "core.py",
+        "            self.pause((2.8 * self._pace if hold is None else hold) if text else 0.6)",
+        "            self.pause((2.8 if hold is None else hold) if text else 0.6)",
+        ["Pace.test_the_computed_defaults_scale_and_the_clear_does_not"],
+    ),
+    (
+        "the criterion card's reading time stops scaling",
+        "core.py",
+        "                max(CRITERION_HOLD_MIN_S, 0.6 + len(text.split()) * 0.34),\n"
+        "            )\n"
+        "            * self._pace",
+        "                max(CRITERION_HOLD_MIN_S, 0.6 + len(text.split()) * 0.34),\n"
+        "            )\n"
+        "            * 1.0",
+        ["Pace.test_the_criterion_card_scales_with_it"],
+    ),
+    (
+        "an off-default pace is computed but never written to the timeline",
+        "core.py",
+        "        if self._pace != 1.0:",
+        "        if False:",
+        ["Pace.test_a_take_that_moved_off_the_default_says_so_in_its_timeline"],
+    ),
+    (
+        "a non-positive pace is accepted and silently paces nothing",
+        "core.py",
+        "        if pace <= 0:",
+        "        if False:",
+        ["Pace.test_zero_negative_and_non_numbers_are_refused_at_construction"],
+    ),
+    (
+        "DEMO_VIDEO_PACE in the environment is ignored",
+        "core.py",
+        '            raw_pace: float | str = _env("PACE", "1.0")',
+        '            raw_pace: float | str = "1.0"',
+        ["Pace.test_the_environment_can_set_it"],
+    ),
+    # -- window_title, the wrapper bar's text ---------------------------------
+    (
+        "the web take's window title ignores the take's own answer",
+        "web.py",
+        '        return self._window_title or urlparse(self.base_url).netloc or "app"',
+        '        return urlparse(self.base_url).netloc or "app"',
+        ["WindowTitle.test_an_explicit_window_title_wins_on_both_media"],
+    ),
+    (
+        "the web take stops titling itself after the app it demos",
+        "web.py",
+        'urlparse(self.base_url).netloc or "app"',
+        '"app"',
+        ["WindowTitle.test_a_web_take_opens_titled_for_the_app_it_demos"],
+    ),
+    (
+        "the terminal take's window title ignores the take's own answer",
+        "terminal.py",
+        "        return self._window_title or self._terminal_title",
+        "        return self._terminal_title",
+        ["WindowTitle.test_an_explicit_window_title_wins_on_both_media"],
+    ),
+    (
+        "DEMO_VIDEO_WINDOW_TITLE in the environment is ignored",
+        "core.py",
+        '        self._window_title = window_title or _env("WINDOW_TITLE")',
+        "        self._window_title = window_title",
+        ["WindowTitle.test_the_environment_sets_it"],
+    ),
+    # -- intro, the opt-in opening title card ---------------------------------
+    (
+        "an intro the take asked for is never raised",
+        "web.py",
+        "        if not self._intro:\n            return",
+        "        if True:\n            return",
+        ["Intro.test_an_intro_is_raised_over_the_wrapper_and_paced"],
+    ),
+    (
+        "the intro hold stops scaling with pace",
+        "web.py",
+        "        clip = self._prepare_line(self._intro, self._intro_clip)\n"
+        "        self._start_line(clip)\n"
+        "        hold = INTRO_HOLD_S * self._pace",
+        "        clip = self._prepare_line(self._intro, self._intro_clip)\n"
+        "        self._start_line(clip)\n"
+        "        hold = INTRO_HOLD_S",
+        ["Intro.test_pace_scales_the_intro_hold"],
+    ),
+    (
+        "a voiced intro never starts a line",
+        "web.py",
+        "        clip = self._prepare_line(self._intro, self._intro_clip)\n        self._start_line(clip)",
+        "        clip = None",
+        ["Intro.test_a_voiced_intro_holds_the_card_for_the_whole_line"],
+    ),
+    (
+        "the intro card drops while its line is still being spoken",
+        "web.py",
+        "        clip = self._prepare_line(self._intro, self._intro_clip)\n"
+        "        self._start_line(clip)\n"
+        "        hold = INTRO_HOLD_S * self._pace\n"
+        "        remaining = self._line_end - time.monotonic()\n"
+        "        self._idle(max(hold, remaining))",
+        "        clip = self._prepare_line(self._intro, self._intro_clip)\n"
+        "        self._start_line(clip)\n"
+        "        hold = INTRO_HOLD_S * self._pace\n"
+        "        remaining = self._line_end - time.monotonic()\n"
+        "        self._idle(hold)",
+        ["Intro.test_a_voiced_intro_holds_the_card_for_the_whole_line"],
+    ),
+    (
+        "DEMO_VIDEO_INTRO in the environment is ignored",
+        "core.py",
+        '        self._intro = (intro or _env("INTRO") or "").strip() or None',
+        '        self._intro = (intro or "").strip() or None',
+        ["Intro.test_the_environment_can_set_it"],
+    ),
+    (
+        "a take that opened on an intro never writes it to the timeline",
+        "core.py",
+        '        if self._intro:\n            doc["intro"] = self._intro',
+        "        if False:\n            pass",
+        ["Intro.test_a_take_that_opened_on_one_says_so_in_its_timeline"],
+    ),
+    (
+        "the terminal medium silently accepts an intro it will never raise",
+        "terminal.py",
+        "        if intro is not None:",
+        "        if False:",
+        ["Intro.test_the_terminal_medium_refuses_it_and_names_its_own_card"],
+    ),
+    (
+        "card lines are synthesized on the clock again",
+        "core.py",
+        "        self._intro_clip = self._pre_synth(self._intro)\n"
+        "        self._outro_clip = self._pre_synth(self._outro)",
+        "        pass",
+        ["Intro.test_card_lines_are_synthesized_in_the_constructor_off_the_clock"],
+    ),
+    (
+        "a preset clip is ignored and the line synthesizes again",
+        "core.py",
+        "        if preset is not None:\n            clip = preset",
+        "        if False:\n            pass",
+        [
+            "Intro.test_a_preset_line_is_used_not_synthesized_again",
+            "Intro."
+            "test_a_voiced_intro_starts_its_line_off_the_preset_no_synth_on_the_clock",
+        ],
+    ),
+    (
+        "the voiced intro re-synthesizes its line instead of using the preset",
+        "web.py",
+        "        clip = self._prepare_line(self._intro, self._intro_clip)",
+        "        clip = self._prepare_line(self._intro)",
+        [
+            "Intro."
+            "test_a_voiced_intro_starts_its_line_off_the_preset_no_synth_on_the_clock"
+        ],
+    ),
+    # -- narration serialization under a backward clock step ------------------
+    (
+        "the corrected placements stop being serialized",
+        "narration.py",
+        "        if durations is not None and at < prev_end:",
+        "        if False:",
+        [
+            "MixSerialization."
+            "test_a_line_that_would_start_inside_its_predecessor_starts_at_its_end"
+        ],
+    ),
+    (
+        "a held line stops saying it was held",
+        "narration.py",
+        '        if held:\n            line["held"] = held',
+        "        if False:\n            pass",
+        [
+            "MixSerialization."
+            "test_a_line_that_would_start_inside_its_predecessor_starts_at_its_end"
+        ],
+    ),
+    (
+        "the mix stops handing the clips' durations to the plan",
+        "core.py",
+        "                    [media_duration(clip) for _, clip in self._lines],",
+        "                    None,",
+        [
+            "NarrationMix."
+            "test_two_lines_a_step_would_overlap_are_serialized_in_the_real_mix"
+        ],
+    ),
+    # -- voice stability, loudness, crossfade, zoom, outro --------------------
+    (
+        "the cache key stops carrying the voice stability",
+        "narration.py",
+        "joined = TTS_KEY_SEP.join(\n"
+        '        (voice_id, model_id, text, f"stability={stability:.2f}")\n'
+        "    )",
+        "joined = TTS_KEY_SEP.join((voice_id, model_id, text))",
+        ["VoiceSettings.test_stability_is_part_of_the_cache_key"],
+    ),
+    (
+        "DEMO_VIDEO_SPEECH_STABILITY in the environment is ignored",
+        "core.py",
+        "            raw_stability: float | str = _env(\n"
+        '                "SPEECH_STABILITY", str(DEFAULT_STABILITY)\n'
+        "            )",
+        "            speech_stability = str(DEFAULT_STABILITY)",
+        ["VoiceSettings.test_the_recorder_pins_one_and_the_environment_can_set_it"],
+    ),
+    (
+        "a stability outside 0..1 is accepted",
+        "core.py",
+        "        if not 0.0 < speech_stability <= 1.0:",
+        "        if False:",
+        ["VoiceSettings.test_out_of_range_and_non_numbers_are_refused_at_construction"],
+    ),
+    (
+        "synthesis requests drop the pinned stability",
+        "core.py",
+        "                stability=self._speech_stability,",
+        "                stability=0.5,",
+        ["VoiceSettings.test_synthesis_requests_carry_the_pinned_stability"],
+    ),
+    (
+        "the volume filter stops reaching the mix",
+        "core.py",
+        '                    + (f"volume={gain:.2f}dB," if abs(gain) >= 0.1 else "")',
+        '                    + ""',
+        ["NarrationMix.test_every_clip_is_gained_to_the_one_loudness_target"],
+    ),
+    (
+        "a gained clip stops saying it was gained",
+        "core.py",
+        '                        line["gain_db"] = gain',
+        "                        pass",
+        ["NarrationMix.test_every_clip_is_gained_to_the_one_loudness_target"],
+    ),
+    (
+        "the second caption layer disappears",
+        "chrome.py",
+        '  <div id="__chrome_band"><div id="__demo_caption"></div><div id="__demo_caption2"></div></div>',
+        '  <div id="__chrome_band"><div id="__demo_caption"></div></div>',
+        ["CaptionCrossfade.test_two_stacked_layers_exist_and_share_the_caption_style"],
+    ),
+    # -- the camera: post-production push-ins ---------------------------------
+    (
+        "the push-in stops easing in, it snaps to full zoom",
+        "camera.py",
+        '    u = f"clip({expr},0,1)"\n    return f"{u}*{u}*(3-2*{u})"',
+        '    return "1.0"',
+        [
+            "CameraMove.test_the_push_eases_in_and_back",
+            "CameraMove.test_a_real_encode_pushes_and_pulls",
+        ],
+    ),
+    (
+        "the camera centres on the frame, not the element",
+        "camera.py",
+        '        xs.append(f"{weight}*clip({cx:.1f}-iw/(2*zoom),0,iw-iw/zoom)")',
+        '        xs.append(f"{weight}*clip(iw/2-iw/(2*zoom),0,iw-iw/zoom)")',
+        ["CameraMove.test_the_camera_centres_on_the_element_not_the_frame"],
+    ),
+    (
+        "the PTS normalize is dropped and zoompan re-stamps a VFR stream",
+        "camera.py",
+        '    return (\n        f"fps={fps},"',
+        '    return (\n        f""',
+        ["CameraMove.test_one_zoompan_carrying_the_event_at_the_output_size"],
+    ),
+    (
+        "the camera filter is never built",
+        "camera.py",
+        "    if not events:\n        return None",
+        "    if False:\n        return None",
+        ["CameraMove.test_no_events_build_no_chain"],
+    ),
+    (
+        "a spotlight left open never closes its camera event",
+        "core.py",
+        "        self._camera_close()",
+        "        pass",
+        ["CameraMove.test_a_spotlight_left_open_closes_with_the_take"],
+    ),
+    (
+        "closing a camera event appends nothing",
+        "core.py",
+        "        if self._camera_open is None:\n            return",
+        "        if True:\n            return",
+        ["CameraMove.test_camera_events_open_and_close_and_land_on_the_timeline"],
+    ),
+    (
+        "a take with camera moves never writes them to the timeline",
+        "core.py",
+        '        if self._camera:\n            doc["camera"] = [dict(event) for event in self._camera]',
+        "        if False:\n            pass",
+        ["CameraMove.test_camera_events_open_and_close_and_land_on_the_timeline"],
+    ),
+    (
+        "the spotlight stops handing its element's rect to the camera",
+        "web.py",
+        "        if rect:\n            self._camera_raise(rect)",
+        "        if rect:\n            pass",
+        ["CameraMove.test_spotlight_opens_a_camera_event_over_the_element"],
+    ),
+    (
+        "the spotlight's clear stops closing the camera event",
+        "web.py",
+        "        self._camera_close(time.monotonic() - self._t0)",
+        "        pass",
+        ["CameraMove.test_spotlight_opens_a_camera_event_over_the_element"],
+    ),
+    (
+        "a move's start stops being corrected onto the video clock",
+        "core.py",
+        '            moved["t_start"] = round(place(event["t_start"]).at, 3)',
+        '            moved["t_start"] = event["t_start"]',
+        ["CameraMove.test_the_moves_ride_the_same_clock_correction_as_the_voice"],
+    ),
+    (
+        "a move's end stops being corrected onto the video clock",
+        "core.py",
+        '            moved["t_end"] = round(place(event["t_end"]).at, 3)',
+        '            moved["t_end"] = event["t_end"]',
+        ["CameraMove.test_the_moves_ride_the_same_clock_correction_as_the_voice"],
+    ),
+    (
+        "an interval a step swallowed is rendered anyway",
+        "core.py",
+        '            if moved["t_end"] > moved["t_start"]:\n                corrected.append(moved)',
+        "            corrected.append(moved)",
+        ["CameraMove.test_an_interval_a_step_swallowed_whole_is_dropped"],
+    ),
+    (
+        "an outro the take asked for is never raised",
+        "web.py",
+        "        if not self._outro:\n            return",
+        "        if True:\n            return",
+        ["Outro.test_an_outro_is_raised_voiced_and_left_up"],
+    ),
+    (
+        "the cursor dot survives onto the outro frame",
+        "web.py",
+        "        self.page.evaluate(\n"
+        '            "id => { const c = document.getElementById(id);"\n'
+        "            \" if (c) c.style.display = 'none'; }\",\n"
+        "            CURSOR_ID,\n"
+        "        )",
+        "        pass",
+        ["Outro.test_the_cursor_dot_leaves_with_the_take"],
+    ),
+    (
+        "a raised outro stops claiming it happened",
+        "web.py",
+        "        self._outro_up = True",
+        "        pass",
+        ["Outro.test_a_take_that_ended_on_one_says_so_in_its_timeline"],
+    ),
+    (
+        "a take that ended on an outro never writes it to the timeline",
+        "core.py",
+        '        if self._outro_up:\n            doc["outro"] = self._outro',
+        "        if False:\n            pass",
+        ["Outro.test_a_take_that_ended_on_one_says_so_in_its_timeline"],
+    ),
+    (
+        "the overlay probe stops waiving the outro card",
+        "core.py",
+        "                ids = [i for i in ids if i != INTERLUDE_ID]",
+        "                pass",
+        ["Outro.test_the_probe_waives_the_outro_card_and_nothing_else"],
+    ),
+    (
+        "the terminal medium silently accepts an outro it will never raise",
+        "terminal.py",
+        "        if outro is not None:",
+        "        if False:",
+        ["Outro.test_the_terminal_medium_refuses_it_and_names_its_own_ending"],
     ),
 ]
 

--- a/tests/unit
+++ b/tests/unit
@@ -7063,84 +7063,11 @@ class CameraMove(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.chain([self.event(t_end=1.0)])
 
-    def test_a_real_encode_pushes_and_pulls(self):
-        # A static source — a white box on black — so every difference
-        # between two frames is the camera's, never the app's. The frame
-        # before the push and the held frame must differ (finite PSNR);
-        # identical frames would mean the chain parsed and moved nothing,
-        # which is exactly what the DOM zoom this replaces did.
-        tmp = tempfile.TemporaryDirectory()
-        self.addCleanup(tmp.cleanup)
-        work = Path(tmp.name)
-        chain = camera_filter(
-            [{"t_start": 1.0, "t_end": 3.0, "rect": [130, 50, 60, 80]}],
-            src_w=640,
-            src_h=360,
-            out_w=320,
-            out_h=180,
-        )
-        mp4 = work / "cam.mp4"
-        subprocess.run(
-            [
-                "ffmpeg",
-                "-y",
-                "-loglevel",
-                "error",
-                "-f",
-                "lavfi",
-                "-i",
-                "color=c=black:size=640x360:rate=25:duration=4,"
-                "drawbox=x=260:y=100:w=120:h=160:color=white:t=fill",
-                "-filter_complex",
-                chain,
-                "-c:v",
-                "libx264",
-                "-pix_fmt",
-                "yuv420p",
-                str(mp4),
-            ],
-            check=True,
-        )
-        before, held = work / "a.png", work / "b.png"
-        for name, at in ((before, "0.2"), (held, "2.0")):
-            subprocess.run(
-                [
-                    "ffmpeg",
-                    "-y",
-                    "-loglevel",
-                    "error",
-                    "-ss",
-                    at,
-                    "-i",
-                    str(mp4),
-                    "-frames:v",
-                    "1",
-                    str(name),
-                ],
-                check=True,
-            )
-        psnr = subprocess.run(
-            [
-                "ffmpeg",
-                "-i",
-                str(before),
-                "-i",
-                str(held),
-                "-filter_complex",
-                "psnr",
-                "-f",
-                "null",
-                "-",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
-        ).stderr
-        found = re.search(r"average:(\S+)", psnr)
-        self.assertIsNotNone(found, f"no PSNR in ffmpeg output: {psnr[-400:]}")
-        self.assertNotIn(
-            "inf", found.group(1), "the camera did not move: frames identical"
-        )
+    # What a real encode does with that chain — does the picture actually
+    # move — is not here: it needs ffmpeg, and this suite's `dependencies = []`
+    # is the point of the file (issue #139). It is graded in `tests/smoke`'s
+    # spotlight arm instead, by `check_camera_push`, on a take that has both a
+    # camera event and window chrome for the push to move.
 
     def test_a_spotlight_left_open_closes_with_the_take(self):
         src = inspect.getsource(_DemoBase.__exit__)
@@ -7204,6 +7131,13 @@ class CameraMove(unittest.TestCase):
         # The verb wiring, browser-free: the rect the page returns opens an
         # event, and the next clear — the next spotlight's or an explicit
         # one — is what ends it.
+        #
+        # The rect comes back in the **app's** coordinates and the event is
+        # in the recorded frame's, so the slot's offset is added on the way
+        # in. Reading it in the page instead put the push 156 px from the
+        # element: the app frame is cross-origin to the wrapper, and
+        # `window.frameElement` is null across that boundary
+        # (`WebRecorder._frame_rect`).
         rec = recorder(self, page=DrawingPage())
         rec._t0 = time.monotonic() - 5.0
         rec._target = lambda: rec.page  # type: ignore[method-assign]
@@ -7217,12 +7151,18 @@ class CameraMove(unittest.TestCase):
             first = _First()
 
         rec.page.locator = lambda _sel: _Locator()  # type: ignore[method-assign]
+        rec._geom = chrome_geometry(1280, 720)
         rec.spotlight("#box")
         self.assertIsNone(
             rec._camera[0] if rec._camera else None,
             "an open event is not yet a move",
         )
-        self.assertEqual(rec._camera_open["rect"], [10, 20, 30, 40])
+        self.assertEqual(
+            rec._camera_open["rect"],
+            [10 + rec._geom["appx"], 20 + rec._geom["appy"], 30, 40],
+            "the event is at the element's app coordinates, not the frame's "
+            "— the wrapper slot's offset was not added",
+        )
         # Real time between raise and clear: both ends round to 3 decimals,
         # and a sub-millisecond take would be a degenerate event by the same
         # rule the recorder itself applies.
@@ -17983,10 +17923,7 @@ INJECTIONS = [
         "camera.py",
         '    u = f"clip({expr},0,1)"\n    return f"{u}*{u}*(3-2*{u})"',
         '    return "1.0"',
-        [
-            "CameraMove.test_the_push_eases_in_and_back",
-            "CameraMove.test_a_real_encode_pushes_and_pulls",
-        ],
+        ["CameraMove.test_the_push_eases_in_and_back"],
     ),
     (
         "the camera centres on the frame, not the element",
@@ -18033,8 +17970,15 @@ INJECTIONS = [
     (
         "the spotlight stops handing its element's rect to the camera",
         "web.py",
-        "        if rect:\n            self._camera_raise(rect)",
+        "        if rect:\n            self._camera_raise(self._frame_rect(rect))",
         "        if rect:\n            pass",
+        ["CameraMove.test_spotlight_opens_a_camera_event_over_the_element"],
+    ),
+    (
+        "the camera event keeps the app's coordinates instead of the frame's",
+        "web.py",
+        "            self._camera_raise(self._frame_rect(rect))",
+        "            self._camera_raise(rect)",
         ["CameraMove.test_spotlight_opens_a_camera_event_over_the_element"],
     ),
     (


### PR DESCRIPTION
Seven changes to what a take looks and sounds like. None changes what the app on screen does; every move is added where motion lives (the encode) or to a hold the recorder computes for itself.

## What changed

**Camera** (`helpers/demo_recording/camera.py`, new). Each `spotlight()` interval becomes an eased 1.3x push-in on the *composited* frame, rendered after the take by `zoompan`. It replaces a live DOM zoom of 1.06 centred on the element - which moved nothing a viewer could see, while shifting and clipping the layout around it. The geometry is published as `timeline.json`'s `camera` key, so a move can be re-rendered or audited without the take. Rendered from 1x footage: #395 records why supersampling is not reachable from Playwright's `record_video`, and what the two honest paths past it cost.

**`pace`** (`Recorder(pace=...)`, `DEMO_VIDEO_PACE`). Scales every hold the recorder *computes* - caption read time, the defaults of `hold()`, `interlude()`, `criterion()` - so one storyboard serves an executive skimming a PR and a dev pausing to inspect. A duration the storyboard writes itself (`pause(2)`, `hold(min_s=...)`) is never scaled. A take off the default records its `pace`.

**`intro` / `outro` cards**, both opt-in. The intro sits over the wrapper until the first `goto()`; the outro is the take's deliberate last frame. Voiced when narration is on, synthesized in the constructor so no TTS call sits on the capture clock. `TerminalRecorder` refuses both and names its own equivalents.

**`window_title`.** The wrapper's title bar - the app's host on a web take, `terminal_title` on a terminal one.

**Caption crossfade.** Two stacked layers in the chrome document; the old line fades out as the new one fades in. A text-to-text change used to swap instantly under a steady opacity, which read as a pop between otherwise smooth takes.

**One voice.** Voice `stability` is pinned at 0.75 on every synthesis request *and in the cache key*. Unpinned, per-sentence pacing measured **2.1 to 3.3 words/s** across one take's five clips, which a listener reads as some lines being sped up. Every clip is separately gained to one loudness target, measured per clip with `volumedetect`; the correction lands in `timeline.json` as `gain_db`. Tempo is untouched end to end.

**The mix refuses to speak twice at once.** A backward host clock step compresses the video but not the clip, so corrected onsets could land inside the previous line. Re-measured at **1.6 s of double-talk after a -1.65 s step** - against the 0.4 s an earlier measurement had accepted as the price of sync. A line that would start inside its predecessor now starts at its predecessor's end and carries `held`; it trails its caption by that much rather than overlapping. `timeline.md` names held lines beside the clock correction.

`SKILL.md` also tells a session to read - and, failing that, write - `<project root>/.demo-video/context.md`: how the app runs, how to seed it, which selectors it uses. Re-deriving that is the heaviest part of a first demo.

## The assertion that graded the camera, and the defect it found

The camera shipped in the first commit with no assertion that watched a real encode move real pixels - the one it had needed ffmpeg and sat in `tests/unit`, whose `dependencies = []` is the point of that file (#139), so CI's browser-free job went red on a missing binary.

The reading moved to where ffmpeg and a recording both exist: **`check_camera_push`, in `tests/smoke`'s spotlight arm** (`--polish-only`, on every push under `--cheap`). It reads the strip of window chrome *above* the app rect - the one region of the frame the page cannot reach, which is the whole difference between this camera and the DOM zoom it replaced. Three statements, each broken by its own mistake: the strip is **still** in the quiet before the event, has **moved** at the held zoom, and is **back** once the event ends. Plus two no pixel can make: one event per spotlight interval, aimed at the element the storyboard lit.

**The last one failed on the first take, and it was right.** The event was centred **156 px from the element**. `window.__demoSpotlight` added the wrapper's offset by reading `window.frameElement`, which is null when the app frame is cross-origin to the wrapper - which it is whenever the demo is not served from the recorder's own origin. The push was rendered over the wrong part of the screen on every take of a real app. The offset is now added in Python from the recorder's own geometry (`WebRecorder._frame_rect`), the same mapping `tests/_pixels.to_video_rect` applies from the other side, and a `tests/unit` injection pins it.

A host that steps its wall clock mid-push is not a camera defect - the recorder corrects the event onto the video's clock and the video really does hold fewer seconds of the move. That case is printed, not failed.

Also repaired here: **nine `tests/smoke-inject` entries** whose search strings this branch moved (the caption crossfade, the narration mix's new gain term, the overlay probe's outro waiver). Two changed shape - the overlay probe's call now sits under a guard, so "reports an overlay on every take" has to break the guard, or it can only ever fire on a take that already had one up.

## Evidence

| Check | Result |
|---|---|
| `tests/unit` | 659 pass |
| `tests/unit --fault-inject` | 419 injections caught |
| `tests/ci-unit` | 196 pass |
| `tests/smoke-inject --self-test` | 78 entries match the tree, README's 7 figures agree, every guard held |
| `tests/smoke --polish-only` | **PASSED** |
| `tests/smoke-inject --only camera` | both new entries caught |
| `tests/pixel` | **7 checks, 0 failing** |
| `tests/lint`, `tests/typecheck` | clean |

The camera check, clean and under each injection:

```
smoke: spotlight camera pushed in and back (chrome strip moved 26.34 mean luma
       at the held zoom, 0.07 in the quiet before it, 0.45 once it pulled back)

PASS  break: the camera renders a push that moves nothing  [29s]
      caught: the chrome strip above the app moved 0.03 mean luma between the
      frame before the event and the held zoom, under the 8.0 bar
PASS  break: the camera pushes in and never pulls back  [29s]
      caught: the chrome strip is still 26.14 mean luma from where it was,
      0.4s after the event ended and over the 1.5 bar
```

`tests/pixel` lines, in full:

```
terminal/opening-card: ok - frame 0 luma 24.0 over (138, 109, 921, 76) (cover <= 60), no bare frame (max 28.3), terminal revealed from 1.75s (bar 1.0s, stddev floor 1.2)
web/stills-match: ok - 2 still(s) held against the paced take: 01-criterion.png inf dB, 02-spotlight.png inf dB (bar 40 dB)
web/card-vs-window: ok - card 3 off (24, 24, 37) (bar 6) and 1 off the window body (bar 5) over 2 instants; card-down control 218 off
web/cursor-parked: ok - disc centre (591.0, 401.1) vs park (590.5, 401.0), off (+0.5, +0.1)px (bar 3.0), 248 accent px
web/cursor-absence: ok - 12 frames before beat 13 probed, worst frame 0 accent px in the 16x16px origin crop (bar 0)
```

## Stated limits

- **`tests/smoke` did not record its timing arms on this host.** It refuses before recording because the wall clock stepped -1247 ms during its 40 s probe (#370) - a property of this WSL box, not of the change. Every clock-safe subset was run and passes: `--narration-only`, `--polish-only`, `--content-only`, `--overlay-only`, `--wrapper-only`, `--evidence-only`. The two it blocks (`--web-only`, `--terminal-only`) grade a beat log against a video, which is what a stepping clock corrupts. CI runs them.
- **The camera push renders from 1x footage**, so the pushed crop is softer than the static frames around it for the half second of the ease. Measured, not assumed; #395 holds the analysis and the two ways out.
- **`NARRATION_STABILITY` in `tests/smoke` is hand-copied** from `DEFAULT_STABILITY`, like the voice and model constants beside it, and goes stale the same way if the default moves.
- **`check_camera_push` reads one interval on one fixture.** It grades that a push happened, was aimed at the element, and came back - not how far it pushed or how it eased. The envelope's shape is `tests/unit`'s (`CameraMove`), from the filter string.
- **Not in this branch:** `examples/ticket-queue/.demo-video/context.md` and the two `examples/ticket-queue/demos/` takes recorded while building this are still untracked locally. This PR is scoped to the skill and the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDGqaYG6DYzwHQZcTs6G55
