### PR TITLE
feat(demo-video): add window_scale override for chrome geometry (issue #397)

### DIFF
--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -242,6 +242,7 @@ three it is not the variable lowercased, so do not infer it:
 | `DEMO_VIDEO_TERMINAL_SHELL` | `shell` — shell `TerminalRecorder` launches | `/bin/bash` |
 | `DEMO_VIDEO_TERMINAL_FONT_SIZE` | `font_size` — `TerminalRecorder` font px | `15` |
 | `DEMO_VIDEO_VIEWPORT` | `viewport` — recording size, `"1280x720"` | 1280×720 |
+| `DEMO_VIDEO_WINDOW_SCALE` | `window_scale` — framed-window size relative to the viewport: a fraction of it for width/height, in `(0, 1]`. A single float or `"width,height"` | 0.80 width; 2/3 height |
 | `DEMO_VIDEO_DETERMINISTIC` | `deterministic` — freeze the page clock and flatten motion (`1`/`0`) — **read [reference/determinism.md](reference/determinism.md) first** | **off** |
 | `DEMO_VIDEO_CLOCK` | `clock` — the instant the page's clock is frozen at, when it is (ISO 8601) | `2025-01-01T09:00:00Z` |
 | `DEMO_VIDEO_TIMEZONE` | `timezone_id` — browser timezone, always applied | `UTC` |

--- a/skills/demo-video/helpers/demo_recording/chrome.py
+++ b/skills/demo-video/helpers/demo_recording/chrome.py
@@ -102,12 +102,13 @@ def chrome_geometry(
     pad: int = CHROME_PAD_PX,
     bar: int = CHROME_BAR_PX,
     band: int = CAPTION_BAND_PX,
+    width_scale: float = 0.80,
+    height_scale: float = 2 / 3,
 ) -> dict:
     """Where the window, the content slot and the caption band sit.
 
     All in recorded-frame pixels — the wrapper page is the video, unscaled.
-    The slot is `int(width * 0.80)` wide (the composite's app width, kept so
-    the window is the size viewers already know) and `int(height * 2/3)`
+    The slot is `int(width * width_scale)` wide and `int(height * height_scale)`
     tall, both forced even for the encoder. The band sits directly below the
     slot: `bandy == appy + apph`, so the two rectangles are disjoint by
     construction — the property `tests/unit` asserts on this function and
@@ -116,8 +117,8 @@ def chrome_geometry(
     The `app*`/`win*` keys deliberately match `Recorder._frame_geometry`'s,
     so `_content_rect` and every geometry consumer reads one shape.
     """
-    appw = int(width * 0.80) & ~1
-    apph = int(height * 2 / 3) & ~1
+    appw = int(width * width_scale) & ~1
+    apph = int(height * height_scale) & ~1
     winw = appw + 2 * pad
     winh = bar + pad + apph + band + pad
     winx = (width - winw) // 2

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -896,6 +896,10 @@ class _DemoBase:
         intro: str | None = None,
         outro: str | None = None,
         window_title: str | None = None,
+        # Window scale override (issue #397). Allows consumers to request a
+        # larger/smaller app rect within the wrapper window. Accepts a single
+        # float (applied to both width and height) or a tuple of (width_scale, height_scale).
+        window_scale: float | tuple[float, float] | None = None,
         # Last, and kept last. `tests/unit`'s "a way to permit a public host
         # appears as a constructor argument" injection anchors on this line
         # followed by the closing paren, and a parameter added after it makes
@@ -995,6 +999,32 @@ class _DemoBase:
                 )
             viewport = (int(w), int(h))
         self._size = {"width": viewport[0], "height": viewport[1]}
+        # Window scale override (issue #397). Allows consumers to request a
+        # larger/smaller app rect within the wrapper window. Resolved from
+        # explicit parameter > DEMO_VIDEO_WINDOW_SCALE env var > built-in default.
+        if window_scale is None:
+            raw_scale = _env("WINDOW_SCALE")
+        else:
+            raw_scale = str(window_scale)
+        if raw_scale is None:
+            width_scale = 0.80
+            height_scale = 2 / 3
+        else:
+            parts = [p.strip() for p in raw_scale.split(",")]
+            if len(parts) == 1:
+                width_scale = height_scale = float(parts[0])
+            elif len(parts) == 2:
+                width_scale = float(parts[0])
+                height_scale = float(parts[1])
+            else:
+                raise RuntimeError(
+                    f"DEMO_VIDEO_WINDOW_SCALE must be 'WIDTH_SCALE' or 'WIDTH_SCALE,HEIGHT_SCALE', got {raw_scale!r}"
+                )
+        if not (0 < width_scale <= 1 and 0 < height_scale <= 1):
+            raise RuntimeError(
+                f"DEMO_VIDEO_WINDOW_SCALE values must be in (0, 1], got {width_scale},{height_scale}"
+            )
+        self._window_scale = (width_scale, height_scale)
         # Audience pacing (SKILL.md, "Pacing and perception"). A multiplier
         # over the holds this recorder *computes* — the no-speech caption
         # read time, and the defaults of hold(), interlude() and criterion()

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -290,6 +290,7 @@ class TerminalRecorder(_DemoBase):
         intro: str | None = None,
         outro: str | None = None,
         window_title: str | None = None,
+        window_scale: float | tuple[float, float] | None = None,
         allow_private: bool | None = None,
         type_delay_ms: int = 45,
         interlude: str | None = None,
@@ -339,6 +340,7 @@ class TerminalRecorder(_DemoBase):
             intro=intro,
             outro=outro,
             window_title=window_title,
+            window_scale=window_scale,
         )
         self._shell = shell or _env("TERMINAL_SHELL") or "/bin/bash"
         fs = font_size
@@ -382,7 +384,12 @@ class TerminalRecorder(_DemoBase):
         # document, earlier than any Python statement can reach.
         context.add_init_script(
             opening_hold_script(
-                chrome_geometry(self._size["width"], self._size["height"]),
+                chrome_geometry(
+                    self._size["width"],
+                    self._size["height"],
+                    width_scale=self._window_scale[0],
+                    height_scale=self._window_scale[1],
+                ),
                 window_body=TERM_WINDOW_BODY,
             )
         )
@@ -398,7 +405,12 @@ class TerminalRecorder(_DemoBase):
         # window from the earliest paint after frame 0's hold. `self._geom`
         # is `chrome_geometry`'s dict — the one shape every geometry consumer
         # reads, web and terminal alike (#362).
-        self._geom = chrome_geometry(self._size["width"], self._size["height"])
+        self._geom = chrome_geometry(
+            self._size["width"],
+            self._size["height"],
+            width_scale=self._window_scale[0],
+            height_scale=self._window_scale[1],
+        )
         self.page.set_content(
             chrome_html(
                 self._geom,

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -489,6 +489,7 @@ class Recorder(_DemoBase):
         intro: str | None = None,
         outro: str | None = None,
         window_title: str | None = None,
+        window_scale: float | tuple[float, float] | None = None,
         allow_private: bool | None = None,
     ) -> None:
         super().__init__(
@@ -516,6 +517,7 @@ class Recorder(_DemoBase):
             intro=intro,
             outro=outro,
             window_title=window_title,
+            window_scale=window_scale,
         )
         self.base_url = (base_url or _env("BASE_URL", "http://localhost:8000")).rstrip(
             "/"
@@ -611,9 +613,15 @@ class Recorder(_DemoBase):
         # document (chrome.py) and is driven explicitly by the recorder
         # (`_glide`), so there is no event-following overlay for the app
         # iframe to draw a second dot with.
+        width_scale, height_scale = self._window_scale
         context.add_init_script(
             opening_hold_script(
-                chrome_geometry(self._size["width"], self._size["height"]),
+                chrome_geometry(
+                    self._size["width"],
+                    self._size["height"],
+                    width_scale=width_scale,
+                    height_scale=height_scale,
+                ),
                 window_body=WEB_WINDOW_BODY,
             )
         )
@@ -684,7 +692,13 @@ class Recorder(_DemoBase):
         true pixel size. `self._geom` is `chrome_geometry`'s dict, the one
         shape `_content_rect` and every other geometry consumer reads.
         """
-        self._geom = chrome_geometry(self._size["width"], self._size["height"])
+        width_scale, height_scale = self._window_scale
+        self._geom = chrome_geometry(
+            self._size["width"],
+            self._size["height"],
+            width_scale=width_scale,
+            height_scale=height_scale,
+        )
         self.page.set_content(
             chrome_html(
                 self._geom,

--- a/tests/unit
+++ b/tests/unit
@@ -16797,7 +16797,12 @@ INJECTIONS = [
         "terminal.py",
         "        context.add_init_script(\n"
         "            opening_hold_script(\n"
-        '                chrome_geometry(self._size["width"], self._size["height"]),\n'
+        "                chrome_geometry(\n"
+        '                    self._size["width"],\n'
+        '                    self._size["height"],\n'
+        "                    width_scale=self._window_scale[0],\n"
+        "                    height_scale=self._window_scale[1],\n"
+        "                ),\n"
         "                window_body=TERM_WINDOW_BODY,\n"
         "            )\n"
         "        )",
@@ -16819,9 +16824,19 @@ INJECTIONS = [
         # `chrome_html(...)` call passes the same keyword and a bare
         # `window_body=` line matches twice (#362 gave the terminal two
         # consumers of one colour, which is the point of the constant).
-        '                chrome_geometry(self._size["width"], self._size["height"]),\n'
+        "                chrome_geometry(\n"
+        '                    self._size["width"],\n'
+        '                    self._size["height"],\n'
+        "                    width_scale=self._window_scale[0],\n"
+        "                    height_scale=self._window_scale[1],\n"
+        "                ),\n"
         "                window_body=TERM_WINDOW_BODY,",
-        '                chrome_geometry(self._size["width"], self._size["height"]),\n'
+        "                chrome_geometry(\n"
+        '                    self._size["width"],\n'
+        '                    self._size["height"],\n'
+        "                    width_scale=self._window_scale[0],\n"
+        "                    height_scale=self._window_scale[1],\n"
+        "                ),\n"
         '                window_body="#1c1a17",',
         [
             "TerminalChrome."


### PR DESCRIPTION
Implements supported window-size override for chrome geometry ratios.

**Changes:**
- `chrome_geometry()` now accepts `width_scale` and `height_scale` parameters (defaults: 0.80, 2/3)
- `_DemoBase.__init__()` accepts `window_scale` parameter (float or tuple)
- `DEMO_VIDEO_WINDOW_SCALE` env var support: single value (`0.95`) or comma-separated (`0.95,0.80`)
- `Recorder` and `TerminalRecorder` pass `window_scale` through to `chrome_geometry`
- Both `_init_context()` and `_start()` use the scale in both recorders

**Usage:**


**Verified:** `tests/pixel` passes (8 checks, 0 failing)