### PR TITLE
demo-video polish: eased cursor glide, overlay captions, azure + 1080p + near-full-bleed defaults, quality presets

### DIFF
--- a/examples/ticket-queue/web/styles.css
+++ b/examples/ticket-queue/web/styles.css
@@ -273,6 +273,23 @@ h1 {
   overflow-wrap: anywhere;
 }
 
+/* One line however narrow the pane: the address ellipsizes rather than
+   breaking a character before its end, and the Copy button's title carries
+   the full value. */
+.requester {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.requester-email {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .copy-email {
   margin-left: 6px;
   font-size: 12px;
@@ -306,12 +323,6 @@ details pre {
   margin-top: 14px;
 }
 
-button.primary {
-  background: var(--accent);
-  border-color: var(--accent);
-  color: #fff;
-}
-
 .detail-actions button,
 .modal-actions button {
   font: inherit;
@@ -321,6 +332,15 @@ button.primary {
   border: 1px solid var(--line);
   background: var(--paper);
   cursor: pointer;
+}
+
+/* After the generic action-button rule: both selectors weigh (0,1,1), so
+   source order is what keeps the primary button orange instead of
+   white-on-white. */
+button.primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: #fff;
 }
 
 .modal {

--- a/skills/demo-video/SKILL.md
+++ b/skills/demo-video/SKILL.md
@@ -66,7 +66,8 @@ and is **Unix-only** because it uses a PTY.
 Both record into the **same framed window on a soft pastel background** (rounded
 window, title bar, traffic lights): one recorder-owned chrome whose content slot
 holds the web app in an iframe at true pixel size, or the terminal's xterm.js
-screen, with the caption in a reserved band **below** the app rect. The page is
+screen, with the caption a floating pill riding the app rect's bottom edge
+(`caption_overlay=False` restores the reserved band below the app). The page is
 the finished picture — one encode per take, and `shot()` stills match the video.
 `rec.page` is the framed page; `rec.app` is the app's document. Two edges:
 an app answering `X-Frame-Options`/CSP `frame-ancestors` refuses the take
@@ -233,7 +234,7 @@ three it is not the variable lowercased, so do not infer it:
 | `DEMO_VIDEO_OUT_DIR` | `out_dir` — where demo files land | — (required one way or the other) |
 | `DEMO_VIDEO_BASE_URL` | `base_url` — app under demo. Classified before the browser opens; a public host is refused | `http://localhost:8000` |
 | `DEMO_VIDEO_ALLOW_PRIVATE` | `allow_private` — permit a private/internal target (`1`/`0`). There is no equivalent for a public one | off |
-| `DEMO_VIDEO_ACCENT_RGB` | `accent_rgb` — cursor/spotlight color, `"235,110,20"` | orange |
+| `DEMO_VIDEO_ACCENT_RGB` | `accent_rgb` — cursor/spotlight color, `"0,127,255"` | azure |
 | `DEMO_VIDEO_PACE` | `pace` — multiplier over the holds the recorder computes (caption read time; the defaults of `hold()`, `interlude()`, `criterion()`). Durations the storyboard writes itself are never touched. See **Pacing and perception** | `1.0` |
 | `DEMO_VIDEO_WINDOW_TITLE` | `window_title` — the wrapper window's title bar. Web default: the app's host; terminal default: `terminal_title` | — |
 | `DEMO_VIDEO_INTRO` | `intro` — opt-in opening title card over the wrapper (web takes), taken down by the first `goto()`. Held ~2.8 s (scaled by `pace`), or the whole spoken line when narration is on. Terminal takes already have this as `TerminalRecorder(interlude=…)` | off |
@@ -241,8 +242,10 @@ three it is not the variable lowercased, so do not infer it:
 | `DEMO_VIDEO_TERMINAL_PROMPT` | `terminal_prompt` — prompt string: web card, and `TerminalRecorder`'s shell PS1 | `$ ` (web card); `❯ ` (`TerminalRecorder`) |
 | `DEMO_VIDEO_TERMINAL_SHELL` | `shell` — shell `TerminalRecorder` launches | `/bin/bash` |
 | `DEMO_VIDEO_TERMINAL_FONT_SIZE` | `font_size` — `TerminalRecorder` font px | `15` |
-| `DEMO_VIDEO_VIEWPORT` | `viewport` — recording size, `"1280x720"` | 1280×720 |
-| `DEMO_VIDEO_WINDOW_SCALE` | `window_scale` — framed-window size relative to the viewport: a fraction of it for width/height, in `(0, 1]`. A single float or `"width,height"` | 0.80 width; 2/3 height |
+| `DEMO_VIDEO_VIEWPORT` | `viewport` — recording size, `"1920x1080"` | 1920×1080 (`quick` preset: 1280×720) |
+| `DEMO_VIDEO_WINDOW_SCALE` | `window_scale` — framed-window size relative to the viewport: a fraction of it for width/height, in `(0, 1]`. A single float or `"width,height"` | 0.95 width; 0.9 height (0.85 with the reserved band — the taller default plus the band cannot fit a viewport) |
+| `DEMO_VIDEO_CAPTION_OVERLAY` | `caption_overlay` — caption as a floating pill over the app's bottom edge (`1`), or a reserved band below the app rect (`0`). **Known limit of the overlay:** a camera push-in crops the frame around the spotlit element and can shave the pill — fade it (`caption("")`) before spotlighting, or turn the band back on | **on** |
+| `DEMO_VIDEO_PRESET` | `preset` — quality preset, `"high"` or `"quick"`; see **Quality presets** below | `high` |
 | `DEMO_VIDEO_DETERMINISTIC` | `deterministic` — freeze the page clock and flatten motion (`1`/`0`) — **read [reference/determinism.md](reference/determinism.md) first** | **off** |
 | `DEMO_VIDEO_CLOCK` | `clock` — the instant the page's clock is frozen at, when it is (ISO 8601) | `2025-01-01T09:00:00Z` |
 | `DEMO_VIDEO_TIMEZONE` | `timezone_id` — browser timezone, always applied | `UTC` |
@@ -264,6 +267,22 @@ parameters with **no** env var are per-storyboard by nature: `segment`,
 `criteria` and `ticket` on both recorders, plus `TerminalRecorder`'s
 `interlude`, `interlude_hold` and `type_delay_ms`.
 
+### Quality presets
+
+`preset` picks a named bundle of defaults so a take can say what it is for
+instead of tuning knobs — explicit parameters and `DEMO_VIDEO_*` env vars
+still win over whatever the preset says:
+
+- **`high`** (the default) — the settings table above exactly: 1080p,
+  narration on when a key is present, `pace` 1.0. For finished demos and
+  anything shared with others. "Make a high quality demo of X" means this,
+  which means it means the plain defaults.
+- **`quick`** — 720p, `pace` 0.6, narration off (no TTS round trips, so it
+  is also the fast and free one). For a cheap watchable proof: a code-review
+  demonstration, an issue comment, "a quick demo proving B".
+
+`Recorder(out_dir, preset="quick")` or `DEMO_VIDEO_PRESET=quick`.
+
 ## Recorder API (storyboard verbs)
 
 `Recorder(out_dir, base_url=..., segment=None, strict=False, ...)` as a context
@@ -278,7 +297,7 @@ exception, or a non-zero exit. Both are
 |---|---|
 | `goto(path)` | Navigate (relative to base_url); waits for networkidle, but gives up after 10 s for apps that poll |
 | `pause(s)` / `shot(name)` | Hold the frame / capture `images/<name>.png` |
-| `caption(text)` | Narrator line in the caption band below the app; `""` clears. Both media draw it in the same band, which is the recorder's own document — so the line survives full page loads and SPA routing alike, and `caption_lost` cannot fire at all any more. A line taller than the two-line band is shaved at the band's edges and recorded as a `caption_clipped` issue: shorten it, or split it over two captions |
+| `caption(text)` | Narrator line in the caption pill over the app's bottom edge (a reserved band below the app with `caption_overlay=False`); `""` clears. Both media draw it in the recorder's own document — so the line survives full page loads and SPA routing alike, and `caption_lost` cannot fire at all any more. A line taller than the two-line zone is shaved at its edges and recorded as a `caption_clipped` issue: shorten it, or split it over two captions. With the overlay pill, fade the line (`caption("")`) before a `spotlight()` — the camera push-in crops the frame and can shave a pill riding the bottom edge |
 | `caption(text, ac="AC-3")` / `shot(name, ac="AC-3")` | Tag this beat with the acceptance criterion it is there to demonstrate. Needs `Recorder(criteria={...})`; a tag naming an undeclared criterion is refused. Add `shows="unmet"` to point the claim the other way — this beat is evidence the clause is **not** met, which is the case worth the most to a reviewer. It needs an `ac=`, and it is still the author's assertion: nothing read the ticket. See [reference/review.md](reference/review.md). |
 | `criterion("AC-3")` | Raise a card carrying **AC-3's own declared sentence**, read out of `criteria={...}` rather than retyped — so the viewer meets the clause and then watches it happen. The beat claims AC-3 and nothing else; the beats after it are untagged. Held to reading speed, and cleared by `interlude("")` like any card. |
 | `hold(min_s=1.5)` | Keep the current frame up until the current caption's narration finishes (min `min_s`). Use after a spotlight/action so the emphasis rides the whole spoken line instead of flashing. See **Pacing and perception** below. |
@@ -446,7 +465,7 @@ terminal demo takes, and the gotchas — pagers, echo, prompts that never return
     commit only after the real take).
 3. **Caption every beat.** A fresh caption before each thing the viewer
    should understand, `caption("")` to end clean. The caption lives in the
-   recorder's own band and survives every navigation — full loads and SPA
+   recorder's own document and survives every navigation — full loads and SPA
    routing alike — so a line left up across one reads as narrating the next
    view too: `caption("")` before the click that navigates, fresh caption
    after. Rules (each earned in a fresh-eyes review round):

--- a/skills/demo-video/helpers/demo_recording/chrome.py
+++ b/skills/demo-video/helpers/demo_recording/chrome.py
@@ -95,6 +95,11 @@ HOLD_Z = 2147483644
 CARD_LAYER_Z = 2147483645
 
 
+# How far the overlay caption pill's zone keeps off the slot's bottom edge,
+# when the caption renders as an overlay (see `caption_overlay` below).
+CAPTION_OVERLAY_INSET_PX = 14
+
+
 def chrome_geometry(
     width: int,
     height: int,
@@ -104,6 +109,7 @@ def chrome_geometry(
     band: int = CAPTION_BAND_PX,
     width_scale: float = 0.80,
     height_scale: float = 2 / 3,
+    caption_overlay: bool = False,
 ) -> dict:
     """Where the window, the content slot and the caption band sit.
 
@@ -114,13 +120,20 @@ def chrome_geometry(
     construction — the property `tests/unit` asserts on this function and
     `tests/smoke` asserts on the pixels.
 
+    `caption_overlay=True` trades that invariant away deliberately (#403
+    prototype): the band contributes nothing to the window's height and the
+    caption renders as a floating pill *over* the slot's bottom edge, the way
+    a video player subtitles. The band keys then describe the overlay zone —
+    inside the app rect — and "the app never shares a pixel with the caption"
+    no longer holds.
+
     The `app*`/`win*` keys deliberately match `Recorder._frame_geometry`'s,
     so `_content_rect` and every geometry consumer reads one shape.
     """
     appw = int(width * width_scale) & ~1
     apph = int(height * height_scale) & ~1
     winw = appw + 2 * pad
-    winh = bar + pad + apph + band + pad
+    winh = bar + pad + apph + (0 if caption_overlay else band) + pad
     winx = (width - winw) // 2
     winy = (height - winh) // 2
     if winx < 0 or winy < 0:
@@ -129,10 +142,14 @@ def chrome_geometry(
             f"window would be {winw}x{winh}. Use a viewport of at least "
             f"{winw}x{winh}."
         )
+    bandy = winy + bar + pad + apph
+    if caption_overlay:
+        bandy -= band + CAPTION_OVERLAY_INSET_PX
     return {
         "pad": pad,
         "bar": bar,
         "band": band,
+        "overlay": caption_overlay,
         "appw": appw,
         "apph": apph,
         "winw": winw,
@@ -142,7 +159,7 @@ def chrome_geometry(
         "appx": winx + pad,
         "appy": winy + bar + pad,
         "bandx": winx + pad,
-        "bandy": winy + bar + pad + apph,
+        "bandy": bandy,
         "bandw": appw,
         "bandh": band,
     }
@@ -188,7 +205,8 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
     width: __APPW__px; height: __APPH__px; }
   #__chrome_band { position: absolute; left: __PAD__px; top: __BANDTOP__px;
     width: __APPW__px; height: __BAND__px; overflow: hidden;
-    display: flex; align-items: center; justify-content: center; }
+    display: flex; align-items: center; justify-content: center;
+    pointer-events: none; }
   /* Two stacked caption layers crossfade: `__demoCaption` fades the old
      line out while the new one fades in, so a caption-to-caption change is
      a transition instead of a pop. The layers sit on top of each other in
@@ -309,8 +327,18 @@ _CHROME_HTML = """<!doctype html><meta charset="utf-8"><title>__TITLE__</title>
     const el = document.getElementById('__chrome_hold');
     if (el) el.style.opacity = '0';
   };
-  window.__demoChromeCursor = (x, y) => {
+  window.__demoChromeCursor = (x, y, ms) => {
+    // ms > 0: the browser eases the dot to (x, y) over that long —
+    // cubic-bezier(.33,1,.68,1) is easeOutCubic, the deceleration a hand
+    // makes landing on a target. The recorder paces the real pointer along
+    // the same curve (web._glide), so dot and pointer land together. ms
+    // absent or 0 keeps the old contract: the dot is exactly where this
+    // call puts it, instantly.
     const dot = document.getElementById('__demo_cursor');
+    const glide = ms ? ms + 'ms' : '0s';
+    dot.style.transition = 'width .1s, height .1s, '
+      + 'left ' + glide + ' cubic-bezier(.33,1,.68,1), '
+      + 'top ' + glide + ' cubic-bezier(.33,1,.68,1)';
     dot.style.left = x + 'px';
     dot.style.top = y + 'px';
   };
@@ -346,7 +374,9 @@ def chrome_html(
     `#__chrome_slot`.
     """
     slot_top = geom["bar"] + geom["pad"]
-    band_top = slot_top + geom["apph"]
+    # Window-local position of the caption zone: below the slot normally,
+    # riding over its bottom edge when the geometry says overlay.
+    band_top = geom["bandy"] - geom["winy"]
     replacements = {
         "__TITLE__": title,
         "__BG__": background,

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -678,6 +678,21 @@ def _env_flag(name: str) -> bool | None:
     return value.lower() in ("1", "true", "yes", "on")
 
 
+# Quality presets (#403): a named bundle of *defaults*, so a storyboard (or
+# the agent writing one) can say what the take is for instead of tuning five
+# knobs. "high" is the registered defaults — a polished take fit for sharing —
+# and deliberately empty: high quality IS the default, and a key added here
+# would fork it from the documented settings table. "quick" is the cheap
+# proof for a code review or an issue comment: smaller frame, brisker holds,
+# no narration (which is also what makes it free and fast — no TTS round
+# trips). Resolution stays explicit parameter > DEMO_VIDEO_* env var > preset
+# > built-in default, so a preset never overrides something the take said.
+PRESETS: dict[str, dict] = {
+    "high": {},
+    "quick": {"viewport": "1280x720", "pace": 0.6, "speech": False},
+}
+
+
 def _verb_target(fn: Callable) -> Callable[[tuple, dict], str | None]:
     """Build the default beat-target extractor for one storyboard verb.
 
@@ -900,6 +915,14 @@ class _DemoBase:
         # larger/smaller app rect within the wrapper window. Accepts a single
         # float (applied to both width and height) or a tuple of (width_scale, height_scale).
         window_scale: float | tuple[float, float] | None = None,
+        # Caption as a floating pill over the app's bottom edge, instead of
+        # the reserved band below it (#403). Trades the "app never shares a
+        # pixel with the caption" invariant for schoko-style framing.
+        caption_overlay: bool | None = None,
+        # Quality preset (#403): "high" (the defaults) or "quick" — see
+        # PRESETS. A preset replaces built-in defaults only; explicit
+        # parameters and DEMO_VIDEO_* env vars still win.
+        preset: str | None = None,
         # Last, and kept last. `tests/unit`'s "a way to permit a public host
         # appears as a constructor argument" injection anchors on this line
         # followed by the closing paren, and a parameter added after it makes
@@ -966,8 +989,19 @@ class _DemoBase:
         if stills_only is None:
             stills_only = _env_flag("STILLS_ONLY")
         self.stills_only = False if stills_only is None else bool(stills_only)
+        # The preset resolves before every setting it can default, and its
+        # name is validated here so a typo fails the take at construction
+        # rather than silently recording at "high".
+        preset_name = (preset or _env("PRESET") or "high").strip().lower()
+        if preset_name not in PRESETS:
+            raise RuntimeError(
+                f"DEMO_VIDEO_PRESET must be one of {sorted(PRESETS)}, "
+                f"got {preset_name!r}"
+            )
+        self.preset = preset_name
+        preset_defaults = PRESETS[preset_name]
         if accent_rgb is None:
-            raw = _env("ACCENT_RGB", "235,110,20")
+            raw = _env("ACCENT_RGB", "0,127,255")
             parts = [p.strip() for p in raw.split(",")]
             if len(parts) != 3 or not all(p.isdigit() for p in parts):
                 raise RuntimeError(
@@ -991,7 +1025,7 @@ class _DemoBase:
         self._terminal_title = terminal_title or _env("TERMINAL_TITLE", "terminal")
         self._terminal_prompt = terminal_prompt or _env("TERMINAL_PROMPT", "$ ")
         if viewport is None:
-            raw = _env("VIEWPORT", "1280x720")
+            raw = _env("VIEWPORT", preset_defaults.get("viewport", "1920x1080"))
             w, sep, h = raw.lower().partition("x")
             if not (sep and w.strip().isdigit() and h.strip().isdigit()):
                 raise RuntimeError(
@@ -999,16 +1033,39 @@ class _DemoBase:
                 )
             viewport = (int(w), int(h))
         self._size = {"width": viewport[0], "height": viewport[1]}
+        # Overlay caption (#403): explicit parameter > DEMO_VIDEO_CAPTION_OVERLAY
+        # > on. Known limit, accepted when this became the default: the camera
+        # push-in crops the composited frame around the spotlit element, and a
+        # pill riding the app's bottom edge can be shaved by that crop — a
+        # storyboard that spotlights while a caption is up should fade the
+        # pill first (caption("")), or set caption_overlay=False to get the
+        # reserved band back. Resolved before window_scale, because the scale
+        # *default* depends on it.
+        if caption_overlay is None:
+            caption_overlay = _env_flag("CAPTION_OVERLAY")
+        self._caption_overlay = True if caption_overlay is None else bool(
+            caption_overlay
+        )
         # Window scale override (issue #397). Allows consumers to request a
         # larger/smaller app rect within the wrapper window. Resolved from
         # explicit parameter > DEMO_VIDEO_WINDOW_SCALE env var > built-in default.
         if window_scale is None:
             raw_scale = _env("WINDOW_SCALE")
+        elif isinstance(window_scale, (tuple, list)):
+            # str() on a tuple would render "(0.95, 0.66)" and the float()
+            # below would choke on "(0.95" — the bug the status-filter-exec
+            # take's record.py worked around by passing a string.
+            raw_scale = ",".join(str(part) for part in window_scale)
         else:
             raw_scale = str(window_scale)
         if raw_scale is None:
-            width_scale = 0.80
-            height_scale = 2 / 3
+            width_scale = 0.95
+            # The default height is coupled to the caption mode: 0.9 fills
+            # the frame when nothing else needs vertical room, but with the
+            # reserved band back on, bar + pads + a 0.9 slot + the band
+            # overflow any viewport (chrome_geometry would refuse the take).
+            # 0.85 is the largest even fit at 1920x1080 with the band.
+            height_scale = 0.9 if self._caption_overlay else 0.85
         else:
             parts = [p.strip() for p in raw_scale.split(",")]
             if len(parts) == 1:
@@ -1035,7 +1092,9 @@ class _DemoBase:
         # stills_only zeroes pacing entirely, so rehearsal speed does not
         # depend on whatever a take sets here.
         if pace is None:
-            raw_pace: float | str = _env("PACE", "1.0")
+            raw_pace: float | str = _env(
+                "PACE", str(preset_defaults.get("pace", 1.0))
+            )
         else:
             raw_pace = pace
         try:
@@ -1066,6 +1125,8 @@ class _DemoBase:
         api_key = os.environ.get("ELEVENLABS_API_KEY", "")
         if speech is None:
             speech = _env_flag("SPEECH")
+        if speech is None:
+            speech = preset_defaults.get("speech")
         if speech is True and not api_key:
             raise RuntimeError("speech is forced on but ELEVENLABS_API_KEY is not set")
         if speech is True and self.stills_only:

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -291,6 +291,8 @@ class TerminalRecorder(_DemoBase):
         outro: str | None = None,
         window_title: str | None = None,
         window_scale: float | tuple[float, float] | None = None,
+        caption_overlay: bool | None = None,
+        preset: str | None = None,
         allow_private: bool | None = None,
         type_delay_ms: int = 45,
         interlude: str | None = None,
@@ -299,6 +301,13 @@ class TerminalRecorder(_DemoBase):
         # A branded, distinctive default prompt so wait_for_prompt's marker
         # is unlikely to collide with command output.
         prompt = terminal_prompt or _env("TERMINAL_PROMPT") or "❯ "
+        # This medium defaults to the reserved band even though the base
+        # defaults to the overlay pill (#403): a shell keeps its prompt on
+        # the bottom rows, exactly where the pill rides, so the overlay
+        # would sit on the one line a terminal take is usually about. An
+        # explicit parameter or DEMO_VIDEO_CAPTION_OVERLAY still wins.
+        if caption_overlay is None and _env("CAPTION_OVERLAY") is None:
+            caption_overlay = False
         # This medium's opening card is `interlude=`, raised before capture
         # and cleared by its own hold. An `intro=` accepted and ignored here
         # would be a setting that does nothing, so it is refused with the way
@@ -341,6 +350,8 @@ class TerminalRecorder(_DemoBase):
             outro=outro,
             window_title=window_title,
             window_scale=window_scale,
+            caption_overlay=caption_overlay,
+            preset=preset,
         )
         self._shell = shell or _env("TERMINAL_SHELL") or "/bin/bash"
         fs = font_size
@@ -389,6 +400,7 @@ class TerminalRecorder(_DemoBase):
                     self._size["height"],
                     width_scale=self._window_scale[0],
                     height_scale=self._window_scale[1],
+                    caption_overlay=self._caption_overlay,
                 ),
                 window_body=TERM_WINDOW_BODY,
             )
@@ -410,6 +422,7 @@ class TerminalRecorder(_DemoBase):
             self._size["height"],
             width_scale=self._window_scale[0],
             height_scale=self._window_scale[1],
+            caption_overlay=self._caption_overlay,
         )
         self.page.set_content(
             chrome_html(

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -32,6 +32,7 @@ to survive the downscale. #355 records why in-page framing replaced it and
 
 from __future__ import annotations
 
+import math
 import re
 import time
 from collections.abc import Iterator
@@ -490,6 +491,8 @@ class Recorder(_DemoBase):
         outro: str | None = None,
         window_title: str | None = None,
         window_scale: float | tuple[float, float] | None = None,
+        caption_overlay: bool | None = None,
+        preset: str | None = None,
         allow_private: bool | None = None,
     ) -> None:
         super().__init__(
@@ -518,6 +521,8 @@ class Recorder(_DemoBase):
             outro=outro,
             window_title=window_title,
             window_scale=window_scale,
+            caption_overlay=caption_overlay,
+            preset=preset,
         )
         self.base_url = (base_url or _env("BASE_URL", "http://localhost:8000")).rstrip(
             "/"
@@ -621,6 +626,7 @@ class Recorder(_DemoBase):
                     self._size["height"],
                     width_scale=width_scale,
                     height_scale=height_scale,
+                    caption_overlay=self._caption_overlay,
                 ),
                 window_body=WEB_WINDOW_BODY,
             )
@@ -698,6 +704,7 @@ class Recorder(_DemoBase):
             self._size["height"],
             width_scale=width_scale,
             height_scale=height_scale,
+            caption_overlay=self._caption_overlay,
         )
         self.page.set_content(
             chrome_html(
@@ -1147,18 +1154,28 @@ class Recorder(_DemoBase):
             "h": int(rect["h"]),
         }
 
-    def _glide(self, x: float, y: float, steps: int) -> None:
+    def _glide(self, x: float, y: float, fast: bool = False) -> None:
         """Move the pointer to page coordinates `(x, y)`, dot included.
 
         The dot lives in the wrapper document, and no wrapper listener can
         hear a move whose target is inside the iframe — the browser delivers
-        it to the iframe's document — so the recorder drives the dot itself,
-        one explicit update per pointer step. The dot is exactly where the
-        pointer was commanded to be, by construction, which is also what
-        makes the #186/#202 class (a dot placed by an event the storyboard
-        never sent) unreachable here: nothing listens, so nothing synthetic
-        can move it. The stated cost: raw `rec.page.mouse` work moves the
-        pointer and not the dot.
+        it to the iframe's document — so the recorder drives the dot itself.
+        One call commands the dot to the target and the browser eases it
+        there over a duration set by the travel distance (#403): the
+        compositor paints the dot's easeOutCubic in every frame, which is
+        what the old per-step scheme could not do — its 30 CDP round-trips
+        completed in ~250 ms of wall time, so the encode held ~6 frames of
+        constant-velocity motion and a hard stop. The dot still moves only
+        when the storyboard says so — a CSS transition toward a commanded
+        target is commanded motion — so the #186/#202 class (a dot placed by
+        an event the storyboard never sent) stays unreachable: nothing
+        listens, so nothing synthetic can move it. The stated cost is
+        unchanged: raw `rec.page.mouse` work moves the pointer and not the
+        dot.
+
+        The real pointer is paced along the same easing curve while the dot
+        animates, so hover states track the visible motion and both land
+        together. `fast=True` halves the duration — `click_fast`'s ask.
 
         Coordinates are wrapper-page coordinates — Playwright's
         `bounding_box()` answers relative to the main frame's viewport even
@@ -1166,11 +1183,23 @@ class Recorder(_DemoBase):
         every box the verbs read.
         """
         sx, sy = self._cursor_at
-        for i in range(1, steps + 1):
-            xi = sx + (x - sx) * i / steps
-            yi = sy + (y - sy) * i / steps
-            self.page.mouse.move(xi, yi)
-            self.page.evaluate("([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi])
+        dist = math.hypot(x - sx, y - sy)
+        # ~800 px/s reads as a hand, not a dart; clamped so a short hop is
+        # not instant and a corner-to-corner run does not stall the story.
+        ms = min(max(dist / 800.0 * 1000.0, 280.0), 1000.0)
+        if fast:
+            ms /= 2
+        self.page.evaluate(
+            "([x, y, ms]) => window.__demoChromeCursor(x, y, ms)", [x, y, ms]
+        )
+        t0 = time.monotonic()
+        while True:
+            t = min((time.monotonic() - t0) * 1000.0 / ms, 1.0)
+            p = 1 - (1 - t) ** 3  # easeOutCubic — the dot's cubic-bezier(.33,1,.68,1)
+            self.page.mouse.move(sx + (x - sx) * p, sy + (y - sy) * p)
+            if t >= 1.0:
+                break
+            time.sleep(0.016)
         self._cursor_at = (x, y)
 
     def _cursor_pressed(self, down: bool) -> None:
@@ -1184,7 +1213,7 @@ class Recorder(_DemoBase):
         box = self._target().locator(selector).first.bounding_box()
         if box is None:
             raise RuntimeError(f"no visible element for {selector!r}")
-        self._glide(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2, steps=30)
+        self._glide(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
 
     @_beat_verb("click")
     def click(self, selector: str) -> None:
@@ -1211,7 +1240,7 @@ class Recorder(_DemoBase):
                     raise RuntimeError(f"no visible element for {selector!r}")
                 time.sleep(0.1)
         x, y = box["x"] + box["width"] / 2, box["y"] + box["height"] / 2
-        self._glide(x, y, steps=15)
+        self._glide(x, y, fast=True)
         self.pause(0.3)
         self._cursor_pressed(True)
         try:

--- a/tests/pixel
+++ b/tests/pixel
@@ -245,19 +245,20 @@ MIN_CARD_STRETCH_S = 1.0
 MIN_CARD_DOWN_S = 1.0
 
 # The recorder's default accent — core.py's DEMO_VIDEO_ACCENT_RGB fallback,
-# "235,110,20". scrub_env() strips the knob before recording, so the default
-# is what painted every cached frame.
-ACCENT_RGB = (235, 110, 20)
+# "0,127,255" (azure, #403). scrub_env() strips the knob before recording,
+# so the default is what painted every cached frame.
+ACCENT_RGB = (0, 127, 255)
 
 # What counts as a pixel of the cursor dot. Channel *gaps* rather than a
 # distance to ACCENT_RGB, because the dot is drawn at two alphas (.45 fill,
 # .95 border, chrome.py's #__demo_cursor rule) over whatever the page has
-# there: the blends range (122,66,25)–(246,175,149) across dark and white
-# grounds, all of them ≥ 95 red-over-blue and ≥ 56 red-over-green, while
-# the fixture's paper (245,246,249), the window body (24,24,37) and the
-# terminal card (28,26,23) are all ≤ 5 on at least one gap.
-ACCENT_R_MINUS_B = 60
-ACCENT_R_MINUS_G = 40
+# there: the blends range (13,70,135)–(135,192,252) across dark and white
+# grounds, all of them ≥ 117 blue-over-red and ≥ 60 blue-over-green, while
+# the fixture's paper (245,246,249), the window body (24,24,37), the
+# terminal card (28,26,23) and the fixture's slate ink-soft (91,100,120)
+# are all ≤ 29 blue-over-red.
+ACCENT_B_MINUS_R = 60
+ACCENT_B_MINUS_G = 40
 
 # How far the disc's measured centre may sit from the park, in video pixels.
 # The healthy reading is ~1 px (centroid over a review frame downscaled 0.8,
@@ -303,11 +304,14 @@ MIN_ABSENCE_FRAMES = 2
 # of pixels away. 50 px keeps an order of magnitude between them without
 # forgiving a real drift.
 SPOTLIGHT_POSITION_TOLERANCE_PX = 50.0
-# Fewer accent pixels than this within the app rect is not a ring: the
-# fixture node's ring reads well over a thousand pixels in a review frame
-# (measured on the take this bar was set from). A recorder that stopped
-# drawing the ring must fail here rather than pass an absence as a match.
-SPOTLIGHT_MIN_RING_PX = 400
+# Fewer accent pixels than this within the app rect is not a ring. The bar
+# was 400 when takes recorded at 1280x720 (the ring read well over a
+# thousand pixels); the 1080p default (#403) downscales review frames by
+# 1024/1920 instead of 1024/1280, and the healthy azure ring measures ~306
+# px in that geometry. 150 keeps half the healthy reading between a ring
+# and an absence (which reads ~0): a recorder that stopped drawing the ring
+# must fail here rather than pass an absence as a match.
+SPOTLIGHT_MIN_RING_PX = 150
 
 HEADER = (
     "pixel: no suite lock - this loop reads colour and geometry off cached "
@@ -452,14 +456,13 @@ def record_web(out_dir: Path, base_url: str) -> dict:
         rec.spotlight()
         rec.caption("The pointer has not moved yet.")
         # -- first pointer verb of the take: the park ------------------------
-        # Parked on #search, and the choice is load-bearing: the dot is drawn
-        # in the accent colour at .45/.95 alpha, and #refresh IS the accent
-        # colour (the fixture themes itself to the recorder's default), so a
-        # dot parked there is pixel-invisible — measured on a real take, the
-        # "accent disc" a probe finds over #refresh is the button itself,
-        # 1306 pixels whose centroid agrees with the park whether or not any
-        # dot was drawn. Over #search's white field the only accent pixels
-        # near the park are the dot's own.
+        # Parked on #search. The choice was load-bearing while the fixture's
+        # own #refresh button shared the recorder's old orange accent — a dot
+        # parked there was pixel-invisible, and the "accent disc" a probe
+        # found was the button itself (1306 pixels agreeing with the park
+        # whether or not any dot was drawn). The azure default (#403) ended
+        # that collision, but the park stays on #search: a neutral ground
+        # under the dot is what makes the probe's count the dot's own.
         rec.move_to("#search")
         rec.hold()
         rec.caption("")
@@ -710,8 +713,8 @@ def longest_run(flags: list[bool]) -> tuple[int, int] | None:
 
 
 def accent_like(r: int, g: int, b: int) -> bool:
-    """Whether one pixel could be the cursor dot. See ACCENT_R_MINUS_B."""
-    return (r - b) >= ACCENT_R_MINUS_B and (r - g) >= ACCENT_R_MINUS_G
+    """Whether one pixel could be the cursor dot. See ACCENT_B_MINUS_R."""
+    return (b - r) >= ACCENT_B_MINUS_R and (b - g) >= ACCENT_B_MINUS_G
 
 
 def accent_centroid(w: int, h: int, raw: bytes) -> tuple[float, float, int] | None:

--- a/tests/smokekit/support.py
+++ b/tests/smokekit/support.py
@@ -110,6 +110,18 @@ def scrub_env() -> None:
     for name in [k for k in os.environ if k.startswith("DEMO_VIDEO_")]:
         del os.environ[name]
     os.environ.pop("ELEVENLABS_API_KEY", None)
+    # Pin the geometry every bar in this suite was measured in — 720p, the
+    # 0.80x2/3 window, the reserved caption band. The recorder's defaults
+    # moved to 1080p / 0.95x0.9 / overlay pill (#403), and under those two
+    # premises silently invert: the near-full-bleed window puts the band
+    # outside a camera push-in's crop (so the band sweep finds the caption
+    # a beat late), and WRAPPER_LONG_CAPTION wraps to two lines in a
+    # 1824px band and legitimately stops clipping. This suite grades
+    # recorder *mechanics*, not the defaults; the default geometry's pixels
+    # are graded by tests/pixel, whose cached takes record at the defaults.
+    os.environ["DEMO_VIDEO_VIEWPORT"] = "1280x720"
+    os.environ["DEMO_VIDEO_WINDOW_SCALE"] = "0.80,0.66666667"
+    os.environ["DEMO_VIDEO_CAPTION_OVERLAY"] = "0"
 
 
 def fresh_take_dir(out_root: Path, name: str) -> Path:

--- a/tests/unit
+++ b/tests/unit
@@ -13352,13 +13352,13 @@ INJECTIONS = [
         ["PixelChecks.test_longest_run_finds_the_longest_stretch_not_the_first"],
     ),
     (
-        # The accent predicate drops its red-over-green gap, so any warm
+        # The accent predicate drops its blue-over-green gap, so any cool
         # surface reads as the cursor dot and both cursor checks grade the
         # page instead of the pointer.
-        "the accent predicate takes any red-over-blue surface as the dot",
+        "the accent predicate takes any blue-over-red surface as the dot",
         "tests/pixel",
-        "    return (r - b) >= ACCENT_R_MINUS_B and (r - g) >= ACCENT_R_MINUS_G",
-        "    return (r - b) >= ACCENT_R_MINUS_B",
+        "    return (b - r) >= ACCENT_B_MINUS_R and (b - g) >= ACCENT_B_MINUS_G",
+        "    return (b - r) >= ACCENT_B_MINUS_R",
         ["PixelChecks.test_accent_like_matches_the_dot_blends_and_not_the_chrome"],
     ),
     (
@@ -16106,9 +16106,11 @@ INJECTIONS = [
         # browser-free half of the same drive.
         "the glide moves the pointer and never the dot",
         "web.py",
-        '            self.page.evaluate("([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi])',
-        "            pass  # the dot is never told",
-        ["CursorDrive.test_the_dot_rides_every_pointer_step_and_ends_at_the_target"],
+        """        self.page.evaluate(
+            "([x, y, ms]) => window.__demoChromeCursor(x, y, ms)", [x, y, ms]
+        )""",
+        "        pass  # the dot is never told",
+        ["CursorDrive.test_the_dot_is_commanded_once_to_the_target_with_a_duration"],
     ),
     (
         # The dot commanded somewhere the pointer is not — #202's class with
@@ -16116,9 +16118,13 @@ INJECTIONS = [
         # so an offset here is the one way left for them to disagree.
         "the dot is commanded off the pointer's own path",
         "web.py",
-        '            self.page.evaluate("([x, y]) => window.__demoChromeCursor(x, y)", [xi, yi])',
-        '            self.page.evaluate("([x, y]) => window.__demoChromeCursor(x, y)", [xi + 30, yi])',
-        ["CursorDrive.test_the_dot_rides_every_pointer_step_and_ends_at_the_target"],
+        """        self.page.evaluate(
+            "([x, y, ms]) => window.__demoChromeCursor(x, y, ms)", [x, y, ms]
+        )""",
+        """        self.page.evaluate(
+            "([x, y, ms]) => window.__demoChromeCursor(x, y, ms)", [x + 30, y, ms]
+        )""",
+        ["CursorDrive.test_the_dot_is_commanded_once_to_the_target_with_a_duration"],
     ),
     (
         # The seed forgotten: every glide sweeps in from the origin, which is
@@ -16872,6 +16878,7 @@ INJECTIONS = [
         '                    self._size["height"],\n'
         "                    width_scale=self._window_scale[0],\n"
         "                    height_scale=self._window_scale[1],\n"
+        "                    caption_overlay=self._caption_overlay,\n"
         "                ),\n"
         "                window_body=TERM_WINDOW_BODY,\n"
         "            )\n"
@@ -16899,6 +16906,7 @@ INJECTIONS = [
         '                    self._size["height"],\n'
         "                    width_scale=self._window_scale[0],\n"
         "                    height_scale=self._window_scale[1],\n"
+        "                    caption_overlay=self._caption_overlay,\n"
         "                ),\n"
         "                window_body=TERM_WINDOW_BODY,",
         "                chrome_geometry(\n"
@@ -16906,6 +16914,7 @@ INJECTIONS = [
         '                    self._size["height"],\n'
         "                    width_scale=self._window_scale[0],\n"
         "                    height_scale=self._window_scale[1],\n"
+        "                    caption_overlay=self._caption_overlay,\n"
         "                ),\n"
         '                window_body="#1c1a17",',
         [
@@ -17541,8 +17550,8 @@ INJECTIONS = [
         # what keeps the arithmetic half honest without a browser.
         "the caption band is raised into the app rect it must sit below",
         "chrome.py",
-        '        "bandy": winy + bar + pad + apph,',
-        '        "bandy": winy + bar + pad + apph - band // 2,',
+        "    bandy = winy + bar + pad + apph",
+        "    bandy = winy + bar + pad + apph - band // 2",
         [
             "WrapperChrome.test_the_caption_band_and_the_app_rect_share_no_pixels",
             "WrapperChrome.test_the_band_sits_directly_below_the_slot_inside_the_window",
@@ -17793,7 +17802,9 @@ INJECTIONS = [
     (
         "DEMO_VIDEO_PACE in the environment is ignored",
         "core.py",
-        '            raw_pace: float | str = _env("PACE", "1.0")',
+        """            raw_pace: float | str = _env(
+                "PACE", str(preset_defaults.get("pace", 1.0))
+            )""",
         '            raw_pace: float | str = "1.0"',
         ["Pace.test_the_environment_can_set_it"],
     ),

--- a/tests/unit
+++ b/tests/unit
@@ -3722,19 +3722,24 @@ class PixelChecks(unittest.TestCase):
 
     def test_accent_like_matches_the_dot_blends_and_not_the_chrome(self):
         px = self.px
-        # The dot's own colours: full accent, the .45 fill over white and
-        # over a dark ground — the range the policy comment states.
-        for dot in [(235, 110, 20), (246, 175, 149), (122, 66, 25)]:
+        # The dot's own colours: full azure accent (#403), the .45 fill over
+        # white and over a dark ground — the range the policy comment states.
+        for dot in [(0, 127, 255), (135, 192, 252), (13, 70, 135)]:
             self.assertTrue(px.accent_like(*dot), f"{dot} is the dot")
         # What the probes actually sweep past: the fixture's paper, both
-        # cards, white — and a pale yellow that is red-over-blue but not
-        # red-over-green, which a predicate reduced to one gap would take.
+        # cards, white, the slate ink-soft — and a cyan that is
+        # blue-over-red but not blue-over-green, which a predicate reduced
+        # to one gap would take. The recorder's old orange accent is here
+        # too: the fixture's #refresh still wears it, and it must not read
+        # as the dot any more.
         for ground in [
             (245, 246, 249),
             (24, 23, 38),
             (28, 26, 23),
             (255, 255, 255),
-            (230, 220, 120),
+            (91, 100, 120),
+            (120, 220, 230),
+            (235, 110, 20),
         ]:
             self.assertFalse(px.accent_like(*ground), f"{ground} is not the dot")
 
@@ -3746,7 +3751,7 @@ class PixelChecks(unittest.TestCase):
             raw[i : i + 3] = (245, 246, 249)  # the fixture's paper
         for y in range(4, 7):  # a 3x3 accent block centred on (5, 5)
             for x in range(4, 7):
-                raw[(y * w + x) * 3 : (y * w + x) * 3 + 3] = (235, 110, 20)
+                raw[(y * w + x) * 3 : (y * w + x) * 3 + 3] = (0, 127, 255)
         found = px.accent_centroid(w, h, bytes(raw))
         self.assertIsNotNone(found)
         cx, cy, count = found
@@ -7276,7 +7281,13 @@ class TerminalChrome(unittest.TestCase):
         from demo_recording.terminal import _TERM_THEME, TERM_WINDOW_BODY
 
         self.assertEqual(TERM_WINDOW_BODY, _TERM_THEME["background"])
-        geom = chrome_geometry(1280, 720)
+        # The terminal recorder's own registered defaults, not
+        # chrome_geometry's function defaults — the two diverged when #403
+        # registered the near-full-bleed framing, and this test is about the
+        # hold sitting on whatever rect the take actually uses. This medium
+        # keeps the reserved band (a pill would ride the prompt line), and
+        # the band couples the height default down to 0.85.
+        geom = chrome_geometry(1920, 1080, width_scale=0.95, height_scale=0.85)
         hold = self.hold_scripts()[0]
         self.assertIn(TERM_WINDOW_BODY, hold)
         self.assertIn(f"left: {geom['appx']}px", hold)
@@ -7410,30 +7421,38 @@ class CursorDrive(unittest.TestCase):
                 self.squeezed.append("up")
             return None
 
-    def glided(self, *to, steps):
+    def glided(self, *to):
         page = self.PointerPage()
         rec = recorder(self, page=page)
         for target in to:
-            rec._glide(*target, steps=steps)
+            rec._glide(*target)
         return rec, page
 
-    def test_the_dot_rides_every_pointer_step_and_ends_at_the_target(self):
-        # One dot command per pointer step, at the same coordinate — the dot
-        # cannot trail the pointer or jump ahead of it, because the recorder
-        # is the only writer of both.
-        rec, page = self.glided((60, 640), steps=4)
-        self.assertEqual(len(page.pointer), 4)
-        self.assertEqual(page.dot, page.pointer)
-        self.assertEqual(page.dot[-1], (60.0, 640.0))
+    def test_the_dot_is_commanded_once_to_the_target_with_a_duration(self):
+        # One dot command per glide, at the exact target, with a positive
+        # duration for the browser to ease over (#403) — and the pointer's
+        # last step is the same coordinate, so dot and pointer land together.
+        rec, page = self.glided((60, 640))
+        self.assertEqual(len(page.dot), 1)
+        x, y, ms = page.dot[0]
+        self.assertEqual((x, y), (60.0, 640.0))
+        self.assertGreater(ms, 0)
+        self.assertEqual(page.pointer[-1], (60.0, 640.0))
         self.assertEqual(rec._cursor_at, (60.0, 640.0))
 
     def test_a_second_glide_starts_from_the_last_commanded_position(self):
         # `_cursor_at` is the seed: a glide that forgot it would sweep in
         # from the origin on every move, which is motion the storyboard
-        # never asked for.
-        rec, page = self.glided((60.0, 640.0), (100.0, 640.0), steps=2)
-        self.assertEqual(page.dot[-2], (80.0, 640.0))
-        self.assertEqual(page.dot[-1], (100.0, 640.0))
+        # never asked for. Every pointer step of the second glide stays on
+        # the segment between the two targets.
+        rec, page = self.glided((60.0, 640.0), (100.0, 640.0))
+        first_end = page.pointer.index((60.0, 640.0))
+        for x, y in page.pointer[first_end + 1 :]:
+            self.assertGreaterEqual(x, 60.0)
+            self.assertLessEqual(x, 100.0)
+            self.assertEqual(y, 640.0)
+        self.assertEqual(page.dot[-1][:2], (100.0, 640.0))
+        self.assertEqual(rec._cursor_at, (100.0, 640.0))
 
     def test_nothing_but_a_glide_moves_the_dot(self):
         # The structural end of the #186 class: with no glide commanded, no


### PR DESCRIPTION
Fixes #403 (design record with the frame-by-frame comparison that motivated this).

## What a viewer gets

- **Eased cursor glide** - the wrapper dot is commanded once per move with a distance-derived duration (~800 px/s, clamped 280-1000ms) and the browser eases it (easeOutCubic) in the compositor, so motion lands in every encoded frame; the real pointer is paced along the same curve so hover states track the dot. Measured on the committed-on-disk look-test take: per-frame displacement decelerates 35 -> 30 -> 10 -> 6 px into the target with no frame gaps, where the old linear walk showed ~6 frames of constant velocity and a hard stop.
- **Overlay pill caption** (default; `caption_overlay=False` keeps the reserved band). The terminal medium defaults to the band - a pill would ride the shell's bottom-anchored prompt line.
- **Registered defaults**: azure accent `0,127,255` (dot and spotlight ring share it), 1080p, `window_scale (0.95, 0.9)` - height coupled to the caption mode (`0.85` with the band, which otherwise cannot fit any viewport).
- **Quality presets**: `preset="high"` (an empty bundle - the defaults) and `"quick"` (720p, pace 0.6, speech off). Precedence: parameter > env > preset > built-in.
- **Bug fix**: `window_scale` now takes a real tuple (`str(tuple)` used to feed `"(0.95,"` into `float()`; the status-filter-exec storyboard carries the workaround note).

Demoable by watching: `examples/ticket-queue/demos/2026-08-26-glide-tour/demo.mp4` (25s, 1080p, all-default settings, ElevenLabs "George") and `.../2026-08-26-look-test/demo.mp4` - both on disk, not committed, per the demos convention.

## Acceptance criterion

The registered defaults produce, on the ticket-queue example, a take whose cursor motion is compositor-eased (motion in every frame, decelerating landing), whose caption floats over the app, and whose window nearly fills a 1080p frame - verified by watching the glide-tour take and by the frame measurements above.

## tests/pixel

```
terminal/opening-card: ok - frame 0 luma 24.5 over (66, 110, 1641, 155) (cover <= 60), no bare frame (max 26.3)
web/stills-match: ok - 3 still(s) held against the paced take: inf dB, inf dB, inf dB (bar 40 dB)
web/card-vs-window: ok - card 3 off (24, 24, 37) (bar 6) and 2 off the window body (bar 5)
web/cursor-parked: ok - disc centre (911.1, 382.8) vs park (910.5, 383.0), off (+0.6, +0.2)px (bar 3.0), 112 accent px
web/cursor-absence: ok - worst frame 0 accent px in the origin crop (bar 0)
web/spotlight-position: ok - ring off (+22.5, +11.6)px, 306 px (bar 50.0px)
pixel: 8 checks, 0 failing
```

Cache re-recorded at the new defaults (`tests/pixel record --force`). Frames changed on purpose everywhere (color, size, framing); before/after review stills are in the two demo take folders' `frames/` on disk.

## Harness recalibrations (each with its measurement)

- `tests/pixel` accent model re-derived for azure: blue-over-red/green channel gaps; the healthy blends span (13,70,135)-(135,192,252); the fixture's orange `#refresh` must now NOT match, which retires the old park-collision caveat. Watched fail before recalibration: `web/cursor-parked: FAIL - 0 accent pixels at the park`.
- Spotlight ring floor 400 -> 150: 1080p review frames downscale 1024/1920 (was 1024/1280); the healthy ring measures ~306 px. Watched fail before: `web/spotlight-position: FAIL ... 306 accent pixels ... (floor 400)`.
- `tests/smoke` `scrub_env()` now pins the suite to the geometry its bars were measured in (720p, 0.80x2/3, band). Under the new defaults two premises silently invert - a camera push-in crops the band out of a near-full-bleed frame (the band sweep finds the caption a beat late), and `WRAPPER_LONG_CAPTION` wraps to two lines in a 1824px band and legitimately stops clipping. Watched both fail before the pin; wrapper arm PASSED after.

## Assertion evidence (seen failing for the stated reason)

Rewritten `CursorDrive` test, injection = dot commanded with `ms=0`:
```
FAIL: test_the_dot_is_commanded_once_to_the_target_with_a_duration
AssertionError: 0 not greater than 0
```
Azure `accent_like` tests, injection = predicate reverted to red-gaps:
```
FAIL: test_accent_like_matches_the_dot_blends_and_not_the_chrome
AssertionError: False is not true : (0, 127, 255) is the dot
FAIL: test_accent_centroid_is_the_planted_disc_centre
AssertionError: unexpectedly None
```
Both injections undone; tree green after.

## Local runs

`mise run check` green; `tests/pixel` 8/8; `tests/smoke --wrapper-only --overlay-only --content-only --stills-only` all PASSED. The full smoke suite **refused to run on this WSL2 host** - its clock probe measured two ~1.6s backward steps in 40s and the timing arms would read host skew as recorder defects (#370). CI's runner is the verdict for those arms.

## Stated limits

- The post-production camera push-in crops the composited frame, so an overlay pill riding the bottom edge can be shaved during a `spotlight()`. Accepted in review; the remedy is storyboard-level (`caption("")` before the spotlight, or `caption_overlay=False`) and is documented in SKILL.md at the setting, at the verb, and in core.py.
- The overlay default retires #355's "the app never shares a pixel with the caption" for overlay takes; the band contract keeps its smoke gate via the suite-wide geometry pin.
- Smoke grades band mode only; the overlay default's pixels are graded by tests/pixel plus the on-disk demo takes. A future smoke arm for overlay geometry would close that gap; not filed as an issue - it neither makes a demo lie nor blocks the next phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)