### PR TITLE
perf(ci): cut the per-pull-request suite from ~5.5 min to ~2.2 min

### DIFF
--- a/.github/scripts/demo-classify
+++ b/.github/scripts/demo-classify
@@ -1,0 +1,285 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Decide what a change *is*, and therefore whether a reviewer should watch it.
+
+    demo-classify --commits commits.txt --changed-file changed.txt
+    demo-classify --commits commits.txt --changed-file changed.txt \
+                  --pr-body body.md --json
+
+Prints the category, the demo decision and the reason for both. With `--json`
+it prints a single object for a workflow or a renderer to read.
+
+**Why this exists.** A pull request in this repository arrives as a wall of
+text: a long body, a CI comment carrying every caption and every acceptance
+message, and no answer to the first question a reviewer actually has — *what
+kind of change is this, and do I need to watch anything?* That question has a
+cheap answer, and answering it first is what lets everything else be short.
+
+**Where the category comes from.** The branch's own conventional-commit types,
+which `AGENTS.md` already mandates, so this needs no new ritual and works on
+every branch that already exists. A `Category:` line in the pull-request body
+overrides the derivation for the cases where the type is honest but unhelpful
+— a `feat:` that is really a design change, a `fix:` for something no eye can
+see.
+
+**Why the type alone is not enough.** `CLAUDE.md` already carries this repo's
+demoable / not-demoable table, and its rule is about *what the change touches*,
+not what its commit says: "how the recording looks" is demoable, "whether a
+mask holds" is not, because absence is not watchable. So the decision is the
+pair — the type says what kind of change it is, the touched paths say whether
+there is anything to see. A `fix:` under `tests/` is a fix nobody can watch.
+
+**What this deliberately does not do.** It does not decide *which* stills best
+show the change; it says stills-or-video-or-neither and leaves the choosing to
+the recorder. And it never blocks: an unrecognised type, an empty branch or a
+path set it has no rule for all resolve to "no demo, and here is why", because
+a classifier that stops a pull request is worse than one that says "I could not
+tell" out loud.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# --------------------------------------------------------------------------
+# Categories
+# --------------------------------------------------------------------------
+#
+# The six the reviewer asked for, plus the honest seventh. `demo` is what the
+# category alone would decide, before the touched paths get a say:
+#
+#   "video"   motion, timing or a flow is the thing that changed
+#   "stills"  a picture answers it, and a video would be ceremony
+#   "none"    nothing a viewer can see, whatever the paths say
+#
+# `perf` maps to *enhancement* rather than to its own category because that is
+# what the word means to a reviewer here: the eased cursor glide was a `perf`
+# in spirit and "smoother mouse movement" in the request that asked for it.
+CATEGORIES = {
+    "new feature": {"demo": "video", "types": ("feat",)},
+    "bugfix": {"demo": "stills", "types": ("fix",)},
+    "enhancement": {"demo": "video", "types": ("perf",)},
+    "design change": {"demo": "stills", "types": ("style", "design")},
+    "refactor": {"demo": "none", "types": ("refactor",)},
+    "other": {"demo": "none", "types": ("chore", "build", "revert")},
+}
+
+# Types that are *definitionally* unwatchable, so they never reach a category
+# that could ask for a demo. Kept separate from `other` so the reason a change
+# got no demo can name the type rather than shrugging.
+QUIET_TYPES = {
+    "docs": "documentation",
+    "test": "tests",
+    "ci": "CI configuration",
+    "chore": "housekeeping",
+    "build": "build configuration",
+}
+
+# The precedence when a branch carries several types, most demo-worthy first.
+# A branch of `feat:` plus `test:` is a feature with tests, not a test change,
+# and a reviewer asked "what is this?" wants the former.
+TYPE_RANK = ("feat", "perf", "fix", "style", "design", "refactor", "revert")
+
+_COMMIT_RE = re.compile(r"^(?P<type>[a-z]+)(?:\((?P<scope>[^)]*)\))?(?P<bang>!)?:\s")
+_OVERRIDE_RE = re.compile(r"^\s*Category:\s*(?P<value>.+?)\s*$", re.M | re.I)
+
+
+# --------------------------------------------------------------------------
+# What the touched paths say
+# --------------------------------------------------------------------------
+#
+# `CLAUDE.md`'s table, as globs. The order matters: WATCHABLE is checked first,
+# so a change touching both the chrome and a test is watchable, which is the
+# right answer — the test does not make the chrome invisible.
+WATCHABLE = (
+    # How the recording looks: chrome, captions, cursor, spotlight, framing.
+    "skills/demo-video/helpers/demo_recording/chrome.py",
+    "skills/demo-video/helpers/demo_recording/web.py",
+    "skills/demo-video/helpers/demo_recording/terminal.py",
+    "skills/demo-video/helpers/demo_recording/frames.py",
+    "skills/demo-video/helpers/demo_recording/core.py",
+    # The proving ground: anything a viewer sees the app do.
+    "examples/",
+)
+
+# Never watchable, whatever the type says — absence is not something a video
+# can show, and a passing sweep is not something a reviewer can watch.
+UNWATCHABLE = (
+    "tests/",
+    ".github/",
+    "docs/",
+    "mise.toml",
+    "ruff.toml",
+    "mypy.ini",
+    ".pre-commit-config.yaml",
+    ".gitignore",
+    ".gitleaks.toml",
+)
+
+
+def _is_doc(path: str) -> bool:
+    return path.endswith((".md", ".txt"))
+
+
+def touched_verdict(paths: list[str]) -> tuple[str, str]:
+    """`("watchable"|"unwatchable"|"unknown", reason)` for a set of paths."""
+    if not paths:
+        return "unknown", "no changed files were given"
+    hits = [p for p in paths if p.startswith(WATCHABLE) and not _is_doc(p)]
+    if hits:
+        shown = ", ".join(f"`{p}`" for p in sorted(hits)[:3])
+        more = f" and {len(hits) - 3} more" if len(hits) > 3 else ""
+        return "watchable", f"it changes {shown}{more}"
+    docs = [p for p in paths if _is_doc(p)]
+    if len(docs) == len(paths):
+        return "unwatchable", "every changed file is a document"
+    quiet = [p for p in paths if p.startswith(UNWATCHABLE) or _is_doc(p)]
+    if len(quiet) == len(paths):
+        where = sorted({p.split("/")[0] + "/" for p in quiet if "/" in p})
+        named = ", ".join(f"`{w}`" for w in where[:3]) or "configuration"
+        return "unwatchable", f"every changed file is under {named}"
+    return "unknown", "no rule covers the changed files"
+
+
+# --------------------------------------------------------------------------
+# What the commits say
+# --------------------------------------------------------------------------
+
+
+def parse_types(commits: list[str]) -> list[str]:
+    """The conventional-commit type of each subject line that has one."""
+    types = []
+    for line in commits:
+        m = _COMMIT_RE.match(line.strip())
+        if m:
+            types.append(m.group("type").lower())
+    return types
+
+
+def category_for_types(types: list[str]) -> tuple[str | None, str]:
+    """The winning category and the reason, or `(None, reason)`."""
+    if not types:
+        return None, "no commit on this branch names a conventional type"
+    for want in TYPE_RANK:
+        if want in types:
+            for name, spec in CATEGORIES.items():
+                if want in spec["types"]:
+                    others = sorted(set(types) - {want})
+                    also = f" (alongside {', '.join(others)})" if others else ""
+                    return name, f"`{want}:` on this branch{also}"
+    quiet = sorted({t for t in types if t in QUIET_TYPES})
+    if quiet:
+        named = ", ".join(QUIET_TYPES[t] for t in quiet)
+        return "other", f"this branch is {named} only (`{quiet[0]}:`)"
+    return (
+        None,
+        f"no rule for the types on this branch ({', '.join(sorted(set(types)))})",
+    )
+
+
+def read_override(body: str | None) -> tuple[str | None, str | None]:
+    """A `Category:` line in the pull-request body, and any complaint about it."""
+    if not body:
+        return None, None
+    m = _OVERRIDE_RE.search(body)
+    if not m:
+        return None, None
+    value = m.group("value").strip().strip("`*_").lower()
+    if value in CATEGORIES:
+        return value, None
+    known = ", ".join(sorted(CATEGORIES))
+    return None, f"the body says `Category: {value}`, which is not one of: {known}"
+
+
+# --------------------------------------------------------------------------
+# The decision
+# --------------------------------------------------------------------------
+
+
+def classify(commits: list[str], paths: list[str], body: str | None = None) -> dict:
+    """Category, demo decision, and the reason for each."""
+    derived, why_category = category_for_types(commits and parse_types(commits) or [])
+    override, complaint = read_override(body)
+
+    if override:
+        category = override
+        why_category = f"`Category: {override}` in the pull-request body"
+        overridden = derived if derived and derived != override else None
+        if overridden:
+            why_category += f" (the commits said {overridden})"
+    else:
+        category = derived
+
+    if category is None:
+        return {
+            "category": None,
+            "why_category": complaint or why_category,
+            "demo": "none",
+            "why_demo": "nothing was classified, so nothing is claimed about it",
+            "override_ignored": complaint,
+        }
+
+    wants = CATEGORIES[category]["demo"]
+    verdict, why_touched = touched_verdict(paths)
+
+    # The pair. The category says what kind of change it is; the paths say
+    # whether there is anything to see. Either one can veto a demo, and only
+    # both together can ask for one — which is `CLAUDE.md`'s rule, applied.
+    if wants == "none":
+        demo, why_demo = "none", f"a {category} is not something a viewer watches"
+    elif verdict == "unwatchable":
+        demo, why_demo = "none", f"{why_touched}, and absence is not watchable"
+    elif verdict == "unknown":
+        demo, why_demo = "stills", f"{why_touched}, so this falls back to stills"
+    else:
+        demo, why_demo = wants, why_touched
+
+    return {
+        "category": category,
+        "why_category": why_category,
+        "demo": demo,
+        "why_demo": why_demo,
+        "override_ignored": complaint,
+    }
+
+
+def _lines(path: str | None) -> list[str]:
+    if not path:
+        return []
+    text = Path(path).read_text(encoding="utf-8")
+    return [ln for ln in text.splitlines() if ln.strip()]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--commits", help="file of commit subject lines, one per line")
+    ap.add_argument("--changed-file", help="file of changed paths, one per line")
+    ap.add_argument("--pr-body", help="file holding the pull-request body")
+    ap.add_argument("--json", action="store_true", help="print one JSON object")
+    args = ap.parse_args()
+
+    body = Path(args.pr_body).read_text(encoding="utf-8") if args.pr_body else None
+    result = classify(_lines(args.commits), _lines(args.changed_file), body)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+        return 0
+
+    print(f"category: {result['category'] or 'unknown'}")
+    print(f"          {result['why_category']}")
+    print(f"demo:     {result['demo']}")
+    print(f"          {result['why_demo']}")
+    if result["override_ignored"]:
+        print(f"note:     {result['override_ignored']}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/demo-pr-body
+++ b/.github/scripts/demo-pr-body
@@ -49,6 +49,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
+from typing import NamedTuple
 from urllib.parse import quote
 
 START = "<!-- demo-video:start -->"
@@ -104,7 +105,35 @@ def _fmt_seconds(value: object) -> str:
     return f"{int(total) // 60}:{int(total) % 60:02d}"
 
 
-def clause_rows(timeline: dict) -> list[tuple[str, str, str, str | None]]:
+class Clause(NamedTuple):
+    """One acceptance clause, as a reviewer meets it."""
+
+    id: str
+    text: str
+    at: str
+    still: str | None
+    #: `demo-ticket-check`'s verdict (#276): whether this clause still occurs
+    #: verbatim in the ticket it was quoted from.
+    ticket_state: str
+
+
+# `demo-ticket-check` writes three states and never two, and the reason it
+# never collapses to two is the reason this renders them: **"not checked" is
+# not "matched"**. A clause the ticket was never read for looks exactly like a
+# clause that matched, unless the artifact says otherwise — and #276 exists
+# because a storyboard can go on demonstrating a sentence the ticket stopped
+# asking for.
+#
+# Only the two states a reviewer must act on are marked. `matched` renders
+# nothing: it is the ordinary case, and a tick beside every healthy row is
+# noise that trains people to stop reading the marks that matter.
+TICKET_MARKS = {
+    "not verbatim": " ⚠️ *not in the ticket verbatim*",
+    "not checked": " *(ticket not re-read)*",
+}
+
+
+def clause_rows(timeline: dict, ticket_check: dict | None = None) -> list[Clause]:
     """`(id, text, timestamp, still)` for each acceptance clause the take declared.
 
     Read out of the same `coverage` block the old comment rendered, so this
@@ -126,12 +155,14 @@ def clause_rows(timeline: dict) -> list[tuple[str, str, str, str | None]]:
     coverage = timeline.get("coverage") or {}
     criteria = coverage.get("criteria") or {}
     claimed = coverage.get("claimed") or {}
-    rows: list[tuple[str, str, str, str | None]] = []
+    checked = (ticket_check or {}).get("clauses") or {}
+    rows: list[Clause] = []
     for cid, text in criteria.items():
         beats = sorted(claimed.get(cid) or [], key=lambda b: b.get("t_start") or 0.0)
         at = _fmt_seconds(beats[0].get("t_start")) if beats else ""
         still = next((b.get("still") for b in beats if b.get("still")), None)
-        rows.append((str(cid), str(text).strip(), at, still))
+        state = str((checked.get(cid) or {}).get("state") or "not checked")
+        rows.append(Clause(str(cid), str(text).strip(), at, still, state))
     return rows
 
 
@@ -144,6 +175,10 @@ def render_block(
     timeline: dict | None = None,
     sha: str | None = None,
     details_url: str | None = None,
+    ticket_check: dict | None = None,
+    demo_dir: str = "",
+    path_prefix: str = "",
+    repo_url: str | None = None,
 ) -> str:
     """The whole block, markers included."""
     category = classification.get("category")
@@ -178,15 +213,27 @@ def render_block(
         elif demo == "stills" and not stills:
             out += ["_The stills for this change have not been recorded yet._", ""]
 
-        rows = clause_rows(timeline or {})
+        rows = clause_rows(timeline or {}, ticket_check)
         if rows:
             out += ["**Acceptance criteria** — tick what the demo shows:", ""]
-            for cid, text, at, still in rows:
-                if at:
-                    stamp = f" [{at}]({still})" if still else f" ({at})"
+            for row in rows:
+                if row.at:
+                    href = (
+                        still_href(
+                            row.still,
+                            demo=demo_dir,
+                            path_prefix=path_prefix,
+                            repo_url=repo_url,
+                            sha=sha,
+                        )
+                        if row.still
+                        else None
+                    )
+                    stamp = f" [{row.at}]({href})" if href else f" ({row.at})"
                 else:
                     stamp = " — ⚠️ **no beat claims this**"
-                out.append(f"- [ ] **{cid}** {text}{stamp}")
+                mark = TICKET_MARKS.get(row.ticket_state, "")
+                out.append(f"- [ ] **{row.id}** {row.text}{stamp}{mark}")
             out.append("")
 
     foot = [f"Category from {classification.get('why_category', 'nothing')}"]
@@ -205,8 +252,33 @@ def render_block(
     return "\n".join(out) + "\n"
 
 
+def still_href(
+    still: str, *, demo: str, path_prefix: str, repo_url: str | None, sha: str | None
+) -> str | None:
+    """An absolute URL for a committed still, or None.
+
+    **#274, one script over.** A `still` in the timeline is relative to the demo
+    directory, and the demo directory is relative to the workflow's
+    `working-directory`. Neither is knowable from inside this script, and every
+    default is wrong in the same direction: a link rooted at the repository,
+    rendered exactly like one that works. So both are inputs, and without a
+    repository or a commit this returns None and the row renders its timestamp
+    unlinked — saying less rather than pointing somewhere wrong.
+    """
+    base = (repo_url or "").rstrip("/")
+    if not base or not sha:
+        return None
+    parts = [p.strip("/") for p in (path_prefix, demo, still) if p and p.strip("/")]
+    return f"{base}/raw/{quote(sha)}/" + "/".join(quote(p) for p in parts)
+
+
 def preview_url(
-    timeline: dict, *, demo: str, repo_url: str | None, sha: str | None
+    timeline: dict,
+    *,
+    demo: str,
+    path_prefix: str = "",
+    repo_url: str | None,
+    sha: str | None,
 ) -> str | None:
     """The absolute URL of the take's committed preview, or None.
 
@@ -221,10 +293,11 @@ def preview_url(
     saying nothing beats showing the wrong picture.
     """
     name = timeline.get("preview")
-    base = (repo_url or "").rstrip("/")
-    if not name or not base or not sha:
+    if not name:
         return None
-    return f"{base}/raw/{quote(sha)}/{quote(demo.strip('/'))}/{quote(str(name))}"
+    return still_href(
+        str(name), demo=demo, path_prefix=path_prefix, repo_url=repo_url, sha=sha
+    )
 
 
 def splice(body: str, block: str) -> str:
@@ -255,7 +328,16 @@ def main() -> int:
     ap.add_argument("--still", action="append", default=[], help="a still to embed")
     ap.add_argument("--sha", help="the commit this was recorded from")
     ap.add_argument("--demo", help="the demo directory, for the preview URL")
+    ap.add_argument(
+        "--ticket-check",
+        help="demo-ticket-check's sidecar (<demo>/review/ticket-check.json)",
+    )
     ap.add_argument("--repo-url", help="https://<host>/<owner>/<repo>")
+    ap.add_argument(
+        "--path-prefix",
+        default="",
+        help="the workflow's working-directory — where --demo sits in the repo",
+    )
     ap.add_argument("--details-url", help="the old long comment, or the artifact")
     ap.add_argument(
         "--existing-body", help="splice into this body instead of printing bare"
@@ -269,13 +351,25 @@ def main() -> int:
         if args.timeline
         else None
     )
+    # Absent is not an error: `demo-ticket-check` writes nothing for a take
+    # that names no ticket, and every clause then renders as `not checked`,
+    # which is what it is.
+    ticket_check = (
+        json.loads(Path(args.ticket_check).read_text(encoding="utf-8"))
+        if args.ticket_check and Path(args.ticket_check).is_file()
+        else None
+    )
     # An explicit --video-url wins; otherwise the take's own committed
     # preview is the thing to embed, and it is the only file of a take that a
     # pull-request body can show inline at all.
     video_url = args.video_url
     if not video_url and timeline and args.demo:
         video_url = preview_url(
-            timeline, demo=args.demo, repo_url=args.repo_url, sha=args.sha
+            timeline,
+            demo=args.demo,
+            path_prefix=args.path_prefix,
+            repo_url=args.repo_url,
+            sha=args.sha,
         )
     block = render_block(
         classification,
@@ -285,6 +379,10 @@ def main() -> int:
         timeline=timeline,
         sha=args.sha,
         details_url=args.details_url,
+        ticket_check=ticket_check,
+        demo_dir=args.demo or "",
+        path_prefix=args.path_prefix,
+        repo_url=args.repo_url,
     )
     if args.existing_body:
         block = splice(Path(args.existing_body).read_text(encoding="utf-8"), block)

--- a/.github/scripts/demo-pr-body
+++ b/.github/scripts/demo-pr-body
@@ -1,0 +1,299 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Render the block a reviewer reads first, for the pull-request *body*.
+
+    demo-pr-body --classification c.json --summary "one line" --out block.md
+    demo-pr-body --classification c.json --summary "one line" \
+                 --demo demos/2026-08-27-glide --video-url https://... \
+                 --existing-body body.md --out body.md
+
+Prints a marker-delimited block. With `--existing-body` it splices the block
+into that body — replacing the previous one if it is there, appending it if it
+is not — so re-running on every push updates in place instead of stacking.
+
+**Why the body and not a comment.** The comment this replaces carried every
+caption, every acceptance message and every diagnostic, and it lived below the
+fold on a conversation tab. What a reviewer wants on opening a pull request is
+three things in this order: *what kind of change is this*, *one sentence on
+what it does*, and *is there something I should watch*. Those fit in a dozen
+lines at the top of the body, which is the first thing the page renders.
+
+**The shape, and what it deliberately leaves out.**
+
+    ## Enhancement · watch the video
+    <one sentence>
+    <video>
+    **Acceptance criteria** — tick what you see:
+    - [ ] AC-1 ...
+    <sub>where the category came from</sub>
+
+No caption table. No beat log. No recorder diagnostics. Those still exist and
+are still uploaded; they belong behind a link for the reviewer who has a
+question, not in front of the one who does not. The acceptance criteria are
+checkboxes because a reviewer ticking a box is the unit of work this repo
+measures — `GOAL.md` counts seconds of human attention per reviewed ticket, and
+an unticked box is the honest state of a clause nobody has looked at yet.
+
+**A change with no demo still gets a block.** One heading and one sentence
+saying why there is nothing to watch. That is not ceremony: the reviewer's
+question was "do I need to watch something", and "no, and here is why" is an
+answer to it. A missing block would leave them to work it out.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from urllib.parse import quote
+
+START = "<!-- demo-video:start -->"
+END = "<!-- demo-video:end -->"
+
+# What the heading says after the category, per demo decision. The reviewer
+# reads this line and nothing else about a third of the time, so it carries the
+# instruction rather than a label: "watch the video", not "video".
+HEADLINE = {
+    "video": "watch the video",
+    "stills": "see the stills",
+    "none": "nothing to watch",
+}
+
+
+# What GitHub will actually inline. Settled by probing a real pull request
+# rather than by reading documentation, because the answer is not documented:
+# GitHub's own attachment upload — the drag-and-drop that yields a
+# `user-attachments/assets/…` URL — goes through an endpoint that needs a
+# browser session, so **CI cannot produce one**. Everything here therefore
+# comes from a file committed on the branch, referenced by absolute URL.
+#
+#   .png .jpg .webp   inline, and an animated .webp animates
+#   .mp4              NOT inline from a committed file; only an attachment
+#                     uploaded through the web UI gets a player
+#
+# So a video reaches a reviewer as an animated WebP, and the full-quality mp4
+# stays behind the artifact link. A GIF of the same take measured 2.62 MB
+# against WebP's 0.23 MB — larger than the source mp4 — which is why GIF is
+# not in this list.
+INLINE_SUFFIXES = (".png", ".jpg", ".jpeg", ".gif", ".webp", ".avif")
+
+
+def _embed(url: str, alt: str) -> str:
+    """An image if GitHub will inline it, a plain link if it will not.
+
+    A bare `![](…)` around an `.mp4` renders as a broken image, which is worse
+    than a link: it tells the reviewer something is missing rather than that
+    something is elsewhere.
+    """
+    base = url.split("?", 1)[0].split("#", 1)[0].lower()
+    if base.endswith(INLINE_SUFFIXES):
+        return f"![{alt}]({url})"
+    return f"▶ [{alt}]({url})"
+
+
+def _fmt_seconds(value: object) -> str:
+    """`0:07` from a beat's start time, or "" when there is not one."""
+    try:
+        total = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return ""
+    return f"{int(total) // 60}:{int(total) % 60:02d}"
+
+
+def clause_rows(timeline: dict) -> list[tuple[str, str, str, str | None]]:
+    """`(id, text, timestamp, still)` for each acceptance clause the take declared.
+
+    Read out of the same `coverage` block the old comment rendered, so this
+    changes where the clauses are shown and not what they are: `criteria` maps
+    id to text, `claimed` maps id to the beats that answered it, each carrying
+    `t_start` and possibly a `still`.
+
+    **A clause no beat claimed keeps its row**, with no timestamp and a marker
+    saying so. It is precisely the row a reviewer must not skim past — a
+    checklist that silently omitted its unanswered item would be the artifact
+    lying by omission, which is the one thing `GOAL.md` will not trade for
+    brevity.
+
+    The earliest claiming beat wins the timestamp, and the first still any
+    claiming beat carries is offered as the picture for that clause: a reviewer
+    scrubbing to a clause wants where it *starts*, not where it happened to be
+    mentioned again.
+    """
+    coverage = timeline.get("coverage") or {}
+    criteria = coverage.get("criteria") or {}
+    claimed = coverage.get("claimed") or {}
+    rows: list[tuple[str, str, str, str | None]] = []
+    for cid, text in criteria.items():
+        beats = sorted(claimed.get(cid) or [], key=lambda b: b.get("t_start") or 0.0)
+        at = _fmt_seconds(beats[0].get("t_start")) if beats else ""
+        still = next((b.get("still") for b in beats if b.get("still")), None)
+        rows.append((str(cid), str(text).strip(), at, still))
+    return rows
+
+
+def render_block(
+    classification: dict,
+    summary: str,
+    *,
+    video_url: str | None = None,
+    stills: list[str] | None = None,
+    timeline: dict | None = None,
+    sha: str | None = None,
+    details_url: str | None = None,
+) -> str:
+    """The whole block, markers included."""
+    category = classification.get("category")
+    demo = classification.get("demo", "none")
+    label = (category or "unclassified").capitalize()
+
+    out = [START, "", f"## {label} · {HEADLINE.get(demo, 'nothing to watch')}", ""]
+    if summary.strip():
+        out += [summary.strip(), ""]
+
+    if demo == "none":
+        out += [
+            f"Nothing here changes what a viewer sees — {classification.get('why_demo', '')}.",
+            "",
+        ]
+    else:
+        # `![…]()` and not `[…]()`. A link is one click away from being looked
+        # at, and a reviewer who has to click has already decided whether to
+        # bother — which is the decision this block exists to make for them.
+        # The URLs are absolute (`{repo}/raw/{sha}/{path}`) because a relative
+        # path does not resolve in a pull-request body, and pinned to the sha
+        # so the picture is the one this take recorded rather than whatever is
+        # at the branch head when somebody reads it a week later.
+        if demo == "video" and video_url:
+            out += [_embed(video_url, "demo"), ""]
+        elif demo == "video":
+            out += ["_The video for this change has not been recorded yet._", ""]
+        if stills:
+            for path in stills:
+                out.append(_embed(path, Path(path).stem))
+            out.append("")
+        elif demo == "stills" and not stills:
+            out += ["_The stills for this change have not been recorded yet._", ""]
+
+        rows = clause_rows(timeline or {})
+        if rows:
+            out += ["**Acceptance criteria** — tick what the demo shows:", ""]
+            for cid, text, at, still in rows:
+                if at:
+                    stamp = f" [{at}]({still})" if still else f" ({at})"
+                else:
+                    stamp = " — ⚠️ **no beat claims this**"
+                out.append(f"- [ ] **{cid}** {text}{stamp}")
+            out.append("")
+
+    foot = [f"Category from {classification.get('why_category', 'nothing')}"]
+    foot.append("override with a `Category:` line in this body")
+    if sha:
+        # "recorded from" only when something *was* recorded. On a block that
+        # says there is nothing to watch, it would be describing a take that
+        # does not exist — small, and exactly the kind of small the artifact
+        # cannot afford, because a reviewer who goes looking for that recording
+        # finds nothing and stops trusting the rest of the block.
+        foot.append(f"{'recorded from' if demo != 'none' else 'on'} `{sha[:7]}`")
+    if details_url:
+        foot.append(f"[captions, beat log and diagnostics]({details_url})")
+    out.append("<sub>" + " · ".join(foot) + ".</sub>")
+    out += ["", END]
+    return "\n".join(out) + "\n"
+
+
+def preview_url(
+    timeline: dict, *, demo: str, repo_url: str | None, sha: str | None
+) -> str | None:
+    """The absolute URL of the take's committed preview, or None.
+
+    `timeline["preview"]` is named only when *this* run wrote one, which is the
+    same rule `media` follows and for the same reason (#20): a
+    `demo.preview.webp` from a previous take is very likely sitting in the
+    directory, and pointing a pull-request body at it would show a reviewer a
+    recording of something else and invite them to tick boxes against it.
+
+    None without a repository or a commit, matching `demo-comment`'s
+    `_still_href`: a URL built without both resolves to the wrong bytes, and
+    saying nothing beats showing the wrong picture.
+    """
+    name = timeline.get("preview")
+    base = (repo_url or "").rstrip("/")
+    if not name or not base or not sha:
+        return None
+    return f"{base}/raw/{quote(sha)}/{quote(demo.strip('/'))}/{quote(str(name))}"
+
+
+def splice(body: str, block: str) -> str:
+    """Replace the managed block in `body`, or append it.
+
+    Everything outside the markers is the author's and is never touched. A body
+    carrying a half-written pair of markers — a start with no end — is left
+    alone and the block is appended, because guessing where somebody's unclosed
+    marker was meant to end is how a tool eats a paragraph.
+    """
+    start, end = body.find(START), body.find(END)
+    if start != -1 and end != -1 and end > start:
+        return body[:start] + block.rstrip("\n") + body[end + len(END) :]
+    sep = "" if not body.strip() else body.rstrip("\n") + "\n\n"
+    return sep + block
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--classification", required=True, help="demo-classify --json output"
+    )
+    ap.add_argument(
+        "--summary", default="", help="one sentence on what the change does"
+    )
+    ap.add_argument("--timeline", help="timeline.json, for the acceptance clauses")
+    ap.add_argument("--video-url", help="where the recording can be watched")
+    ap.add_argument("--still", action="append", default=[], help="a still to embed")
+    ap.add_argument("--sha", help="the commit this was recorded from")
+    ap.add_argument("--demo", help="the demo directory, for the preview URL")
+    ap.add_argument("--repo-url", help="https://<host>/<owner>/<repo>")
+    ap.add_argument("--details-url", help="the old long comment, or the artifact")
+    ap.add_argument(
+        "--existing-body", help="splice into this body instead of printing bare"
+    )
+    ap.add_argument("--out", help="write here instead of stdout")
+    args = ap.parse_args()
+
+    classification = json.loads(Path(args.classification).read_text(encoding="utf-8"))
+    timeline = (
+        json.loads(Path(args.timeline).read_text(encoding="utf-8"))
+        if args.timeline
+        else None
+    )
+    # An explicit --video-url wins; otherwise the take's own committed
+    # preview is the thing to embed, and it is the only file of a take that a
+    # pull-request body can show inline at all.
+    video_url = args.video_url
+    if not video_url and timeline and args.demo:
+        video_url = preview_url(
+            timeline, demo=args.demo, repo_url=args.repo_url, sha=args.sha
+        )
+    block = render_block(
+        classification,
+        args.summary,
+        video_url=video_url,
+        stills=args.still,
+        timeline=timeline,
+        sha=args.sha,
+        details_url=args.details_url,
+    )
+    if args.existing_body:
+        block = splice(Path(args.existing_body).read_text(encoding="utf-8"), block)
+    if args.out:
+        Path(args.out).write_text(block, encoding="utf-8")
+    else:
+        sys.stdout.write(block)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/demo-preview-asset
+++ b/.github/scripts/demo-preview-asset
@@ -1,0 +1,202 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Host a pull-request preview as a release asset, and prune the dead ones.
+
+    demo-preview-asset upload --file demo.preview.webp --pr 412 \
+                              --demo examples/ticket-queue/demos/2026-08-27-glide
+    demo-preview-asset prune --dry-run
+
+`upload` prints the URL to embed. `prune` deletes the assets belonging to pull
+requests that are closed.
+
+**Why a release asset and not a committed file.** A preview is ~3 MB and a demo
+gets re-recorded every time its app changes. Committed, that is ~3 MB per demo
+per re-record in git history, permanently, and every clone pays it. A release
+asset is **not a git object**: it lives in separate storage, `git clone` never
+fetches one, and it can be deleted individually through the API. The repository
+does not grow at all.
+
+The store is a pre-release tag that is not a release of anything — its notes
+say so. GitHub serves the download endpoint as `application/octet-stream` and
+renders it inline anyway, which was checked on a real pull request rather than
+assumed.
+
+**Names carry their own provenance**, because the store is flat and shared:
+
+    pr412-2026-08-27-glide-a1b2c3d.webp
+
+The pull request it belongs to, the demo it is of, and the commit it was
+recorded from. Two pushes to one pull request produce two assets, deliberately
+— an old pull-request body keeps pointing at the picture it was reviewed
+against rather than silently acquiring a newer one, which is the same rule
+`timeline["preview"]` follows (#20).
+
+**Pruning is by pull-request state, not by age.** An open pull request may be
+weeks old and still under review; a closed one cannot be reviewed again. So
+`prune` reads the number out of each asset's name, asks whether that pull
+request is still open, and deletes only what belongs to a closed one. An asset
+whose name it cannot parse is **left alone and reported** — a pruner that
+deleted what it did not understand would be the one bug here that loses data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Not a release of anything. `demo-preview-asset upload` creates it on first
+# use if it is missing, as a prerelease so it never shows as "Latest".
+ASSET_TAG = "demo-assets"
+
+# `pr<N>-<demo-slug>-<sha7>.webp`, and the groups are what `prune` reads back.
+ASSET_RE = re.compile(r"^pr(?P<pr>\d+)-(?P<slug>.+)-(?P<sha>[0-9a-f]{7})\.webp$")
+
+
+def _gh(*args: str, check: bool = True) -> str:
+    done = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    if check and done.returncode != 0:
+        raise RuntimeError(f"gh {' '.join(args)} failed: {done.stderr.strip()}")
+    return done.stdout
+
+
+def asset_name(pr: int, demo: str, sha: str) -> str:
+    """The flat-store name for one preview.
+
+    The demo's directory name is the slug — `examples/ticket-queue/demos/` is
+    the same prefix on every storyboard in this repository, so keeping it would
+    make every name longer and none of them more distinct.
+    """
+    slug = Path(demo.rstrip("/")).name or "demo"
+    slug = re.sub(r"[^A-Za-z0-9._-]+", "-", slug).strip("-") or "demo"
+    return f"pr{int(pr)}-{slug}-{sha[:7]}.webp"
+
+
+def ensure_release(repo: str | None = None) -> None:
+    """Create the asset store if it is not there. Idempotent."""
+    scope = ["--repo", repo] if repo else []
+    if _gh("release", "view", ASSET_TAG, *scope, check=False):
+        return
+    _gh(
+        "release",
+        "create",
+        ASSET_TAG,
+        *scope,
+        "--prerelease",
+        "--title",
+        "Demo previews (asset store, not a release)",
+        "--notes",
+        "Not a release. This tag exists only to host pull-request demo "
+        "previews, which are uploaded here instead of being committed — a "
+        "release asset is not a git object, so the repository does not grow. "
+        "Assets are pruned when their pull request closes; deleting one only "
+        "breaks the embedded image in an already-closed pull request.",
+    )
+
+
+def upload(file: Path, pr: int, demo: str, sha: str, repo: str | None) -> str:
+    """Upload one preview and return the URL to embed."""
+    ensure_release(repo)
+    name = asset_name(pr, demo, sha)
+    scope = ["--repo", repo] if repo else []
+    staged = file.parent / name
+    # Uploaded under its store name rather than `demo.preview.webp`: the store
+    # is flat and shared, and `gh release upload` names the asset after the
+    # file. Every take writes the same filename, so uploading them as-is would
+    # have each demo overwrite the last.
+    staged.write_bytes(file.read_bytes())
+    try:
+        _gh("release", "upload", ASSET_TAG, str(staged), *scope, "--clobber")
+    finally:
+        if staged != file:
+            staged.unlink(missing_ok=True)
+    owner = (
+        repo
+        or _gh(
+            "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"
+        ).strip()
+    )
+    return f"https://github.com/{owner}/releases/download/{ASSET_TAG}/{name}"
+
+
+def prune(repo: str | None, dry_run: bool = False) -> int:
+    """Delete assets whose pull request is closed. Returns how many went."""
+    scope = ["--repo", repo] if repo else []
+    raw = _gh("release", "view", ASSET_TAG, *scope, "--json", "assets", check=False)
+    if not raw.strip():
+        print(f"no {ASSET_TAG} release — nothing to prune")
+        return 0
+    assets = json.loads(raw).get("assets") or []
+    open_prs: dict[int, bool] = {}
+    gone = 0
+    for asset in assets:
+        name = asset.get("name") or ""
+        m = ASSET_RE.match(name)
+        if not m:
+            # Left alone, and said out loud. A pruner that deleted what it did
+            # not understand is the one bug here that loses data.
+            print(f"skipped {name!r}: not a preview asset name")
+            continue
+        number = int(m.group("pr"))
+        if number not in open_prs:
+            state = _gh(
+                "pr",
+                "view",
+                str(number),
+                *scope,
+                "--json",
+                "state",
+                "--jq",
+                ".state",
+                check=False,
+            ).strip()
+            # An unreadable state is treated as open. Deleting on a failed
+            # lookup would turn a network blip into data loss.
+            open_prs[number] = state != "CLOSED" and state != "MERGED"
+        if open_prs[number]:
+            continue
+        if dry_run:
+            print(f"would delete {name} (PR #{number} is closed)")
+        else:
+            _gh("release", "delete-asset", ASSET_TAG, name, *scope, "--yes")
+            print(f"deleted {name} (PR #{number} is closed)")
+        gone += 1
+    if not gone:
+        print(f"nothing to prune: {len(assets)} asset(s), none from a closed PR")
+    return gone
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    up = sub.add_parser("upload", help="upload one preview, print its URL")
+    up.add_argument("--file", required=True, type=Path)
+    up.add_argument("--pr", required=True, type=int)
+    up.add_argument("--demo", required=True, help="the demo directory")
+    up.add_argument("--sha", required=True)
+    up.add_argument("--repo", help="owner/name (default: the current one)")
+
+    pr = sub.add_parser("prune", help="delete assets from closed pull requests")
+    pr.add_argument("--repo")
+    pr.add_argument("--dry-run", action="store_true")
+
+    args = ap.parse_args()
+    if args.cmd == "upload":
+        if not args.file.is_file():
+            print(f"no such file: {args.file}", file=sys.stderr)
+            return 1
+        print(upload(args.file, args.pr, args.demo, args.sha, args.repo))
+        return 0
+    prune(args.repo, args.dry_run)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,27 @@ jobs:
       - name: tests/ci-unit
         run: tests/ci-unit
 
+      # The cheap half of the question below, and the half that has actually
+      # caught something: every injection still matches its file exactly once
+      # and still names tests this suite defines. A rename or a reflow is what
+      # goes stale, and it goes stale on a branch — so this runs on the branch,
+      # in a fifth of a second.
+      - name: tests/ci-unit --anchors
+        run: tests/ci-unit --anchors
+
       # An assertion nobody has watched fail is a claim, not a check. This
       # breaks each helper in a named way and requires the tests that watch it
       # to go red; it aborts rather than passing if an injection fails to land.
+      #
+      # On merge, not on every push: it re-runs the suite once per injection,
+      # which measured **298 s** against the 2 s the suite itself costs. A
+      # pull request gets `--anchors` above instead. What that trades away is
+      # written down rather than implied: between a pull request opening and
+      # its merge, nothing proves these 135 assertions can still fail — only
+      # that they would still be *applied*. An assertion that stopped grading
+      # its subject reaches `main` and is caught there.
       - name: tests/ci-unit --fault-inject
+        if: github.event_name != 'pull_request'
         run: tests/ci-unit --fault-inject
 
   # The recorder's own fast job. Everything it grades is a function of
@@ -159,7 +176,17 @@ jobs:
       - name: tests/unit
         run: tests/unit
 
+      # See the twin in `ci-unit` above for the reasoning. 419 injections,
+      # 0.7 s, and it is what catches the manifest going stale under a
+      # refactor — which is the failure this manifest actually has.
+      - name: tests/unit --anchors
+        run: tests/unit --anchors
+
+      # On merge, not on every push: **132 s**, against 7 s for the suite it
+      # is proving. The stated cost of that: a pull request is never told
+      # these 419 assertions can still fail, only that they still land.
       - name: tests/unit --fault-inject
+        if: github.event_name != 'pull_request'
         run: tests/unit --fault-inject
 
       # `tests/smoke`'s injection manifest costs ~32 minutes of recording
@@ -239,42 +266,46 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # The per-push half of `tests/smoke` (issue #61). `--cheap` is every phase
-  # reachable from an arm other than `--web-only` (123 s), `--content-only`
-  # (148 s) and `--terminal-only` (186 s) — the three that are 74% of a whole
-  # run. It is a *complement* rather than a list, computed in `run_phases`, so a
-  # new cheap arm is on this job automatically; `tests/unit`'s `CheapArm` grades
-  # that and its four assertions are fault-injected in `tests/unit
-  # --fault-inject` above.
+  # The per-pull-request half of `tests/smoke`, and the second time this job
+  # has been narrowed. #61 split it into `--cheap`, a *complement* — every
+  # phase an arm outside the three expensive ones reaches. A complement has no
+  # ceiling: it grew to 22 takes and a measured 300 s without anybody choosing
+  # that, and 300 s on the critical path is what a reviewer waits through
+  # before they can even look at the change.
   #
-  # **What this job does not see**, which is the cost of the split and is
-  # written out rather than implied: eight check functions are reachable only
-  # from those three arms, so they grade in `smoke-full` below and not here.
-  # Five have `tests/smoke-inject` entries and are exercised nightly; two —
-  # `check_opening` (retired with #361) and `check_opening_gap` — have no
-  # entry, so between a pull request opening and its merge nothing runs them at
-  # all. That is issue #233, and `tests/README.md` carries it under *Known
-  # gaps*. A third, `check_verb_classification`, left this list in #392: its
-  # static sweep moved to `tests/unit`, which runs per push above. Reviewers
-  # of a green pull request have not seen those two pass.
+  # `--core` is a *list*, enumerated in `tests/smokekit/constants.py` with the
+  # measured cost of each entry beside it, which is the only shape that can be
+  # scaled down. Six arms, 83.5 s on a 16-core box, ~97 s here. They buy the
+  # two ways a recording lies to its reader: a take that did not finish
+  # leaving something that reads as a success (`--failure-only`, six takes),
+  # and a take that should have been refused not being (`--strict-only`, both
+  # media). Plus the three artifacts a reviewer actually reads — coverage,
+  # evidence, stills.
+  #
+  # **What this job does not see** — written out rather than implied, because
+  # the last split's unstated half became #233. The wrapper pair and its
+  # geometry (#358), the console/exit-code reporting (#197), the polish takes
+  # (#110/#111), the light-interlude pair (#162/#163), the stitch (#7),
+  # narration (#157), determinism, and the eight check functions reachable
+  # only from `--web-only`, `--content-only` and `--terminal-only`. All of
+  # them run in `smoke-full` below, on merge to `main`. Rendered-frame
+  # geometry has a faster second reader in `tests/pixel` — 4.7 s warm, 60 s
+  # cold, which is why it is the local loop CLAUDE.md already sends a chrome
+  # change through and not a job here.
   smoke:
-    name: smoke (cheap arms, every push)
+    name: smoke (core arms, every push)
     runs-on: ubuntu-latest
-    # Measured, not derived. Three consecutive `tests/smoke --cheap` runs on a
-    # 16-core developer box, one at a time behind the machine lock and with the
-    # load average read before each: **223.0 s, 221.5 s, 221.9 s** — 222 s, and
-    # a 1.5 s spread. Against the whole suite's measured 427 s that is a 48%
-    # cut. The table, the load averages and run 3's red (a host wall-clock step,
-    # #215/#224, not the selection) are in tests/README.md under "When each take
-    # runs".
+    # Measured one arm at a time on a 16-core developer box behind the machine
+    # lock: 0.2 + 2.1 + 11.6 + 15.5 + 7.3 + 46.8 = 83.5 s, and two
+    # back-to-back `--core` runs at **82.8 s and 82.2 s** confirm the sum. At
+    # the 1.16x a runner has measured against this box that is ~97 s, plus
+    # ~60 s of checkout, uv, ffmpeg and Chromium install.
     #
-    # 12 is 222 s at the 1.16x a CI runner has measured against this box on the
-    # injection manifest (~4m18s), plus ~60 s of checkout, uv, ffmpeg and
-    # Chromium install, with about 2x headroom on top. The headroom is for
-    # runner variance, not for growth: an arm added to the cheap set lands here
-    # automatically, so if this job starts approaching the bar the thing to do
-    # is re-measure `--cheap` and update the table, not nudge this number.
-    timeout-minutes: 12
+    # 6 is that with better than 2x headroom. The headroom is for runner
+    # variance, not for growth: `--core` is a named list, so nothing lands
+    # here without somebody adding it to `CORE_ARMS` and to the costs written
+    # beside it. If this job approaches the bar, re-measure the list.
+    timeout-minutes: 6
     steps:
       - uses: actions/checkout@v4
 
@@ -291,8 +322,8 @@ jobs:
         run: uv run --with playwright playwright install --with-deps chromium
 
       # Writes outside the checkout, at a path the upload step below knows.
-      - name: Record every take except the web, content and terminal arms
-        run: tests/smoke --cheap --out-dir "$RUNNER_TEMP/smoke-out"
+      - name: Record the core arms
+        run: tests/smoke --core --out-dir "$RUNNER_TEMP/smoke-out"
 
       # Only on failure: a green run's recordings are noise, a red run's are
       # the only way to see what the recorder actually produced.
@@ -305,24 +336,24 @@ jobs:
           if-no-files-found: warn
           retention-days: 7
 
-  # The other half: the three expensive arms, on merge to `main` and on a pull
+  # Everything `--core` above leaves out, on merge to `main` and on a pull
   # request labelled `smoke-full`.
   #
-  # **Why the whole suite and not the three arms.** The arm flags are mutually
-  # exclusive, so "web, content and terminal" is three invocations —
-  # 123 + 148 + 186 = 457 s of takes against a measured 427 s for one whole
-  # run, because the arms share takes. A whole run is cheaper *and* is the only
-  # invocation that grades them together, so this job runs `tests/smoke` with
-  # no flag. It re-records the cheap arms; that is the price of the cheaper
-  # option and it is paid once per merge.
+  # **Why the whole suite and not the difference.** The arm flags are mutually
+  # exclusive, so "everything except the core" would be a dozen invocations
+  # that re-record each other's shared takes and cost more than one whole run.
+  # A whole run is cheaper *and* is the only invocation that grades the takes
+  # together, so this job runs `tests/smoke` with no flag. It re-records the
+  # core arms; that is the price of the cheaper option, and it is paid once
+  # per merge rather than on every push.
   #
   # **Why a label and not only a schedule.** A take that runs after the review
   # is a take that fails after the review, which is the argument #61 was open
-  # against for months. The label is what puts it back in front of the review
-  # for the diffs where it matters — anything in `skills/demo-video/helpers/`
-  # that touches the web or terminal recorders, or `tests/smoke` itself.
+  # against for months, and narrowing the push job to `--core` widens the
+  # window this label exists to close. Reach for it on any diff that touches
+  # the web or terminal recorder, the chrome, or `tests/smoke` itself.
   smoke-full:
-    name: smoke (web, content and terminal takes)
+    name: smoke (everything the core arms leave out)
     # On a pull request only when it is labelled `smoke-full`. A push to `main`
     # — which is what a merge is — always goes. Same shape as
     # .github/workflows/smoke-inject.yml's `fault-inject` label.

--- a/.github/workflows/demo-video.yml
+++ b/.github/workflows/demo-video.yml
@@ -158,7 +158,12 @@ jobs:
       STAGE_FAILURE: ${{ github.workspace }}/.demo-video-ci/failure
       CHANGED: ${{ github.workspace }}/.demo-video-ci/changed.txt
       STARTED_AT: ${{ github.workspace }}/.demo-video-ci/recording-started
-      COMMENT_BODY: ${{ github.workspace }}/.demo-video-ci/comment.md
+      # The block spliced into the pull-request *body*, and the classifier's
+      # verdict it is rendered from.
+      PR_BLOCK: ${{ github.workspace }}/.demo-video-ci/pr-block.md
+      CLASSIFY: ${{ github.workspace }}/.demo-video-ci/classification.json
+      PR_BODY: ${{ github.workspace }}/.demo-video-ci/pr-body.md
+      COMMITS: ${{ github.workspace }}/.demo-video-ci/commits.txt
       APP_LOG: ${{ github.workspace }}/.demo-video-ci/app.log
 
     steps:
@@ -199,7 +204,8 @@ jobs:
           dir="$root/.github/scripts"
           skill="$root/skills/demo-video"
           # Packaging and some checkout paths drop the executable bit.
-          chmod +x "$dir"/demo-storyboards "$dir"/demo-comment "$dir"/demo-ticket-check
+          chmod +x "$dir"/demo-storyboards "$dir"/demo-ticket-check
+          chmod +x "$dir"/demo-classify "$dir"/demo-pr-body "$dir"/demo-preview-asset
           chmod +x "$skill"/scripts/demo-target-guard "$skill"/scripts/demo-rehearse
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
           echo "skill=$skill" >> "$GITHUB_OUTPUT"
@@ -250,6 +256,51 @@ jobs:
           # even when the take never runs.
           sed 's|/[^/]*$||' "$CHANGED.selected" | sort -u > "$DEMO_DIRS"
           echo "Recording:"; sed 's/^/  /' "$DEMO_DIRS"
+
+      # What kind of change is this, and does a reviewer need to watch it?
+      # The first question somebody opening a pull request has, and answering
+      # it first is what lets everything else be short.
+      #
+      # The verdict is a *pair*: the branch's conventional-commit types say
+      # what kind of change it is, the touched paths say whether there is
+      # anything to see. That is the demoable/not-demoable table in this
+      # repository's own guide, applied — either half can veto a demo, and only
+      # both together ask for one. A `perf:` touching nothing but `tests/` gets
+      # no video.
+      #
+      # Never fatal, by construction: an unrecognised type or a path set it has
+      # no rule for resolves to "no demo, and here is why". A classifier that
+      # stopped a pull request would be worse than the wall of text it replaces.
+      - name: Classify the change
+        id: classify
+        if: steps.discover.outputs.count != '0'
+        env:
+          SCRIPTS: ${{ steps.helpers.outputs.dir }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_BODY_TEXT: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          if [ -n "$BASE_SHA" ]; then
+            git log --format=%s "$BASE_SHA..HEAD" > "$COMMITS"
+          else
+            git log --format=%s -1 > "$COMMITS"
+          fi
+          # The author's override lives in the body, so the body is an input.
+          printf '%s\n' "$PR_BODY_TEXT" > "$PR_BODY"
+          "$SCRIPTS/demo-classify" \
+            --commits "$COMMITS" --changed-file "$CHANGED" \
+            --pr-body "$PR_BODY" --json > "$CLASSIFY"
+          cat "$CLASSIFY"
+          demo=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1]))['demo'])" "$CLASSIFY")
+          echo "demo=$demo" >> "$GITHUB_OUTPUT"
+          # `none` does not skip the take — it makes it a stills-only one.
+          # ~2 s against minutes, and it keeps *evidence*: a `refactor:` that
+          # changes what a viewer sees is exactly the case the commit type gets
+          # wrong, and pictures are what make that visible to anyone who looks.
+          if [ "$demo" = "none" ]; then
+            echo "DEMO_VIDEO_STILLS_ONLY=1" >> "$GITHUB_ENV"
+            echo "category says nothing to watch -> recording stills only"
+          fi
 
       - name: Nothing to record
         if: steps.discover.outputs.count == '0'
@@ -580,76 +631,99 @@ jobs:
           done < "$DEMO_DIRS"
           "$SCRIPTS/demo-ticket-check" "${args[@]}" --demo-root "$STAGE_DEMO"
 
-      - name: Render the comment
-        if: always() && steps.discover.outputs.count != '0' && steps.record.conclusion != 'skipped'
+      # The preview a pull-request body can actually show. GitHub has no public
+      # API for the attachment upload its drag-and-drop uses, so a video cannot
+      # reach a reviewer as a player — only as an inline image, and an animated
+      # WebP is one. It is uploaded as a **release asset**, which is not a git
+      # object: nothing is committed and the repository does not grow.
+      #
+      # Skipped on a stills-only take, which wrote no preview by construction.
+      - name: Upload the preview
+        id: preview
+        if: >-
+          always() && steps.discover.outputs.count != '0' &&
+          steps.record.conclusion != 'skipped' &&
+          steps.classify.outputs.demo != 'none' &&
+          github.event.pull_request.number
         working-directory: ${{ inputs.working-directory }}
         env:
-          SCRIPTS: ${{ steps.helpers.outputs.dir }}
-          ARTIFACT_URL: ${{ steps.upload-demo.outputs.artifact-url }}
-          FAILURE_URL: ${{ steps.upload-failure.outputs.artifact-url }}
-          ARTIFACT_BYTES: ${{ steps.stage.outputs.bytes }}
-          RETENTION: ${{ inputs.demo-retention-days }}
-          EVIDENCE_RETENTION: ${{ inputs.evidence-retention-days }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-          # Where the --demo paths sit in the repository. They are relative to
-          # working-directory, so a still linked without this is a 404 that
-          # looks exactly like a working link.
-          WORKDIR: ${{ inputs.working-directory }}
-        run: |
-          set -euo pipefail
-          args=()
-          # Read the timelines out of the *staging* directory, not the working
-          # tree. Staging is where the freshness filter was applied, so the
-          # comment can only ever describe what was actually published. The
-          # working tree still holds the committed timeline.json of the
-          # previous recording, and on the recorder's refusal path (a take
-          # that cannot verify its mask writes nothing but the marker) that
-          # file is what a reader would have been shown as current.
-          while IFS= read -r dir; do
-            if [ -n "$dir" ]; then args+=(--demo "$dir"); fi
-          done < "$DEMO_DIRS"
-          if [ -n "$FAILURE_URL" ]; then args+=(--failure-artifact-url "$FAILURE_URL"); fi
-          "$SCRIPTS/demo-comment" "${args[@]}" \
-            --demo-root "$STAGE_DEMO" \
-            --artifact-url "$ARTIFACT_URL" \
-            --artifact-bytes "${ARTIFACT_BYTES:-0}" \
-            --retention-days "$RETENTION" \
-            --evidence-retention-days "$EVIDENCE_RETENTION" \
-            --run-url "$RUN_URL" --sha "$HEAD_SHA" \
-            --path-prefix "$WORKDIR" \
-            --out "$COMMENT_BODY"
-
-      # One comment, found by its marker and rewritten. A branch with ten
-      # pushes must not bury its pull request under ten identical comments.
-      - name: Post or update the pull-request comment
-        if: always() && steps.discover.outputs.count != '0' && steps.record.conclusion != 'skipped' && github.event.pull_request.number
-        env:
           GH_TOKEN: ${{ github.token }}
+          SCRIPTS: ${{ steps.helpers.outputs.dir }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
-          MARKER: "<!-- demo-video-ci:"
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -euo pipefail
-          existing=$(gh api --paginate "repos/$REPO/issues/$PR/comments" \
-            --jq "[.[] | select(.body | startswith(\"$MARKER\")) | .id] | first // empty")
-          if [ -n "$existing" ]; then
-            url=$(gh api -X PATCH "repos/$REPO/issues/comments/$existing" \
-              -F body=@"$COMMENT_BODY" --jq .html_url)
-            echo "updated comment $existing in place: $url"
-          else
-            url=$(gh api -X POST "repos/$REPO/issues/$PR/comments" \
-              -F body=@"$COMMENT_BODY" --jq .html_url)
-            echo "posted a new comment: $url"
-          fi
+          url=""
+          while IFS= read -r dir; do
+            [ -n "$dir" ] || continue
+            # Named by the **staged** timeline, not by a glob and not by the
+            # working tree's copy. Staging is where the freshness filter ran,
+            # so only a timeline this run wrote can name a preview — the same
+            # rule that stops a previous recording being published as this
+            # one's (#20). A take that wrote no preview names none.
+            name=$(python3 -c "import json,sys;print(json.load(open(sys.argv[1])).get('preview') or '')" "$STAGE_DEMO/$dir/timeline.json" 2>/dev/null || true)
+            [ -n "$name" ] && [ -f "$dir/$name" ] || continue
+            url=$("$SCRIPTS/demo-preview-asset" upload \
+              --file "$dir/$name" --pr "$PR" --demo "$dir" \
+              --sha "$HEAD_SHA" --repo "$REPO")
+            echo "uploaded $dir/$name -> $url"
+          done < "$DEMO_DIRS"
+          echo "url=$url" >> "$GITHUB_OUTPUT"
 
-      # Last, so a take that failed still publishes everything above.
+      # The block a reviewer reads first, rendered and spliced into the
+      # pull-request *body* in one step.
       #
-      # `silent != 0` is part of the condition because the check and the
-      # comment must never disagree. A demo that published no timeline is
-      # reported in the comment as a take that failed, and a green check beside
-      # that sentence teaches a reviewer to ignore the comment — worse than
-      # either signal alone.
+      # This replaces the comment this workflow used to post, which carried
+      # every caption, every acceptance message and every diagnostic below the
+      # fold of a conversation tab. Those artifacts still exist and are still
+      # uploaded; they belong behind the link at the foot of the block, for the
+      # reviewer who has a question, not in front of the one who does not.
+      #
+      # `--existing-body` splices between markers, so everything the author
+      # wrote is untouched and ten pushes rewrite one block rather than
+      # stacking ten comments. The body is re-read here rather than reused
+      # from the classify step: a human may have edited it since, and splicing
+      # into a stale copy would silently revert them.
+      - name: Update the pull-request body
+        if: >-
+          always() && steps.discover.outputs.count != '0' &&
+          steps.record.conclusion != 'skipped' &&
+          github.event.pull_request.number
+        working-directory: ${{ inputs.working-directory }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SCRIPTS: ${{ steps.helpers.outputs.dir }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          SUMMARY: ${{ github.event.pull_request.title }}
+          # Where the --demo paths sit in the repository. They are relative to
+          # working-directory, so a still linked without this is a 404 that
+          # looks exactly like a working link (#274).
+          WORKDIR: ${{ inputs.working-directory }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$REPO/pulls/$PR" --jq '.body // ""' > "$PR_BODY"
+          # One block per pull request, from the first demo. A pull request
+          # recording several is rare and the block is deliberately short; the
+          # run link at its foot carries the rest.
+          demo=$(head -n 1 "$DEMO_DIRS")
+          args=(--classification "$CLASSIFY" --summary "$SUMMARY")
+          if [ -n "$demo" ]; then
+            args+=(--timeline "$STAGE_DEMO/$demo/timeline.json")
+            args+=(--ticket-check "$STAGE_DEMO/$demo/review/ticket-check.json")
+          fi
+          if [ -n "$PREVIEW_URL" ]; then args+=(--video-url "$PREVIEW_URL"); fi
+          "$SCRIPTS/demo-pr-body" "${args[@]}" \
+            --demo "$demo" --path-prefix "$WORKDIR" --repo-url "$REPO_URL" \
+            --sha "$HEAD_SHA" --details-url "$RUN_URL" \
+            --existing-body "$PR_BODY" --out "$PR_BLOCK"
+          gh api -X PATCH "repos/$REPO/pulls/$PR" -F body=@"$PR_BLOCK" --jq .html_url
+
       - name: Fail the check if the take failed
         if: >-
           always() && steps.discover.outputs.count != '0' &&

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,13 @@ tests/eval/grader/takes/*/review/brief.md
 tests/eval/grader/takes/*/review/brief.json
 .tts/
 *.seg.mp4
+# The pull-request preview (#410). Never committed: CI uploads it as a
+# **release asset**, which is not a git object at all, so a clone never
+# fetches one and the repository does not grow by ~3 MB per demo per
+# re-record. The store is the `demo-assets` pre-release, which is not a
+# release of anything — its notes say so. `.github/scripts/demo-preview-asset`
+# uploads and prunes.
+*.preview.webp
 # Per-segment beat logs. The merged timeline.json/timeline.md next to
 # demo.mp4 is committed; these are the parts it is built from, and stitch()
 # deletes them with their .seg.mp4 unless it was passed keep_parts=True.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,10 +12,11 @@
 # the same binary locally as on the runner.
 #
 # **The budget is the whole point.** The always-on pre-commit hooks measure
-# ~6 s together warm — lint 0.9 s, its self-test 0.4 s, ci-unit 1.3 s, unit
-# 3.7 s. Anything that needs the network (`tests/lint --issues`) or a browser
-# (`tests/smoke`, `tests/pixel`) is pre-push or manual, never pre-commit: a
-# hook people disable is worse than no hook.
+# ~7 s together warm — lint 0.9 s, its self-test 0.4 s, ci-unit 1.3 s, unit
+# 3.7 s, and the two `--anchors` sweeps 0.9 s between them. Anything that needs
+# the network (`tests/lint --issues`) or a browser (`tests/smoke`,
+# `tests/pixel`) is pre-push or manual, never pre-commit: a hook people disable
+# is worse than no hook.
 
 default_install_hook_types: [pre-commit, pre-push]
 fail_fast: false
@@ -49,6 +50,26 @@ repos:
       - id: ci-unit
         name: tests/ci-unit — the CI helpers
         entry: tests/ci-unit
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      # The injection manifests still resolve — every pattern matches its file
+      # exactly once, every test it names still exists. 0.7 s and 0.2 s, which
+      # is what buys them a place in a ~6 s budget: the failure they catch is a
+      # rename or a reflow orphaning an anchor, and that happens *while you are
+      # committing*. The drivers that prove the assertions can still fail cost
+      # 132 s and 298 s and run on merge, never here.
+      - id: unit-anchors
+        name: tests/unit --anchors — the injection manifest still resolves
+        entry: tests/unit --anchors
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
+      - id: ci-unit-anchors
+        name: tests/ci-unit --anchors — the injection manifest still resolves
+        entry: tests/ci-unit --anchors
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,17 @@ Two rules:
   thing it watches, run it, show the failure output in the pull request, then
   undo the break. Confirm the injection landed — make the harness refuse to
   proceed unless its pattern matched exactly once.
+
+  **This is now your job locally, not CI's on the branch.** `tests/unit
+  --fault-inject` (132 s) and `tests/ci-unit --fault-inject` (298 s) run on
+  merge to `main`, not on a pull request — they were 430 s of a 750 s job set
+  whose actual tests cost 9 s. What runs on the branch, and pre-commit, is
+  `--anchors`: every injection's pattern still matches its file exactly once
+  and still names tests that exist, in under a second. That catches a stale
+  anchor, which is the failure the manifest actually has. It does **not**
+  catch an assertion that stopped grading its subject. So when you add or
+  change an injection, run the driver yourself and put its output in the pull
+  request; a green branch no longer says you did.
 - **Reviewing: answer only "does this meet its stated acceptance criterion, and
   does it regress anything."** Everything else genuine that you notice goes in
   the PR body as a stated limit, or into an issue with its measurement. It does
@@ -221,14 +232,14 @@ mise run setup      # installs the git hooks
 ```
 
 `prek` runs the hooks. **Every one of them shells out to the command CI runs**
-— `tests/lint`, `tests/typecheck`, `tests/unit`, `tests/ci-unit`, and the
-shellcheck / actionlint invocations `ci.yml` spells out. None re-implements a
-check and none names a tool version, because the repo has exactly one pin per
-tool and the scripts read it out of `ci.yml` as text (#189). A hook that called
-`ruff` or `mypy` itself would be the second pin; `tests/lint --self-test` and
-`tests/typecheck --self-test` refuse one.
+— `tests/lint`, `tests/typecheck`, `tests/unit`, `tests/ci-unit`, both
+`--anchors` sweeps, and the shellcheck / actionlint invocations `ci.yml` spells
+out. None re-implements a check and none names a tool version, because the repo
+has exactly one pin per tool and the scripts read it out of `ci.yml` as text
+(#189). A hook that called `ruff` or `mypy` itself would be the second pin;
+`tests/lint --self-test` and `tests/typecheck --self-test` refuse one.
 
-The pre-commit set measures **~6 s** over the whole tree. What needs the
+The pre-commit set measures **~7 s** over the whole tree. What needs the
 network runs on pre-push instead (`tests/lint --issues`), and what needs a
 browser (`tests/smoke`, `tests/pixel`) is not a hook at all — a hook people
 disable is worse than no hook.

--- a/mise.toml
+++ b/mise.toml
@@ -50,8 +50,16 @@ description = "The chrome reference loop — cached takes, no lock (#324)"
 run = "tests/pixel"
 
 [tasks.smoke]
-description = "The cheap smoke arms; the expensive ones are --web-only/--terminal-only/--content-only"
-run = "tests/smoke --cheap"
+description = "The core smoke arms — what CI records per pull request (~84 s)"
+run = "tests/smoke --core"
+
+[tasks.smoke-full]
+description = "The whole smoke suite — what CI records on merge to main (~7 min)"
+run = "tests/smoke"
+
+[tasks.anchors]
+description = "Both injection manifests still resolve (~1 s)"
+run = ["tests/unit --anchors", "tests/ci-unit --anchors"]
 
 [tasks.budget]
 description = "What SKILL.md costs a caller on every invocation"

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -1062,7 +1062,9 @@ class _DemoBase:
         # reading as motion — 8 fps looked stepped, and stepped motion is a lie
         # about the thing this recorder exists to show.
         #
-        # It costs about 2.7 MB per take, committed, and one extra ffmpeg pass.
+        # It costs one extra ffmpeg pass and about 3 MB on disk. The file is
+        # gitignored: CI uploads it as a release asset, which is not a git
+        # object, so none of that reaches the repository.
         if preview is None:
             preview = _env_flag("PREVIEW")
         self._preview = True if preview is None else bool(preview)
@@ -3499,13 +3501,14 @@ class _DemoBase:
         self._write_preview(webm, chain)
         spoken = f", {len(self._lines)} spoken lines" if self._speech else ""
         print(f"wrote {mp4} ({mp4.stat().st_size // 1024} kB{spoken})")
-        # Reported with its size and said to be committed, because that is the
-        # part a reader needs to decide about: this file goes into git history
-        # and stays there. A preview that quietly appeared would have its cost
-        # discovered by whoever next clones the repository.
+        # Reported with its size, and said to be gitignored, because both are
+        # what a reader needs: it is ~3 MB, and it is **not** committed. CI
+        # uploads it as a release asset instead (`demo-preview-asset`), which is
+        # not a git object — so a clone never fetches one and the repository
+        # does not grow by a copy per demo per re-record.
         if self._preview_written:
             preview = self._preview_path()
             print(
                 f"wrote {preview} ({preview.stat().st_size // 1024} kB, "
-                f"committed — it is what a pull-request body embeds)"
+                f"gitignored — CI uploads it as a release asset)"
             )

--- a/skills/demo-video/helpers/demo_recording/core.py
+++ b/skills/demo-video/helpers/demo_recording/core.py
@@ -919,6 +919,7 @@ class _DemoBase:
         # the reserved band below it (#403). Trades the "app never shares a
         # pixel with the caption" invariant for schoko-style framing.
         caption_overlay: bool | None = None,
+        preview: bool | None = None,
         # Quality preset (#403): "high" (the defaults) or "quick" — see
         # PRESETS. A preset replaces built-in defaults only; explicit
         # parameters and DEMO_VIDEO_* env vars still win.
@@ -1043,9 +1044,32 @@ class _DemoBase:
         # *default* depends on it.
         if caption_overlay is None:
             caption_overlay = _env_flag("CAPTION_OVERLAY")
-        self._caption_overlay = True if caption_overlay is None else bool(
-            caption_overlay
+        self._caption_overlay = (
+            True if caption_overlay is None else bool(caption_overlay)
         )
+        # The pull-request preview (see `_write_preview`). On by default,
+        # because the whole point is that a reviewer sees the change without
+        # asking for it — a preview somebody has to enable is a preview nobody
+        # has.
+        #
+        # The three numbers are measured, not chosen. A pull-request body's
+        # content column is about 830 px, and an image renders at its natural
+        # width, so 1280 fills it with the 1.5x density a HiDPI screen wants —
+        # 960 read small and 1600 cost 60% more for no visible gain. Quality 90
+        # is where `-preset text` stopped showing artefacts on the azure cursor
+        # and coloured text edges; 60 was visibly ringing and 95 was 45%
+        # larger for nothing anyone could see. 12 fps keeps an eased glide
+        # reading as motion — 8 fps looked stepped, and stepped motion is a lie
+        # about the thing this recorder exists to show.
+        #
+        # It costs about 2.7 MB per take, committed, and one extra ffmpeg pass.
+        if preview is None:
+            preview = _env_flag("PREVIEW")
+        self._preview = True if preview is None else bool(preview)
+        self._preview_width = int(_env("PREVIEW_WIDTH", "1280"))
+        self._preview_quality = int(_env("PREVIEW_QUALITY", "90"))
+        self._preview_fps = int(_env("PREVIEW_FPS", "12"))
+        self._preview_written = False
         # Window scale override (issue #397). Allows consumers to request a
         # larger/smaller app rect within the wrapper window. Resolved from
         # explicit parameter > DEMO_VIDEO_WINDOW_SCALE env var > built-in default.
@@ -1092,9 +1116,7 @@ class _DemoBase:
         # stills_only zeroes pacing entirely, so rehearsal speed does not
         # depend on whatever a take sets here.
         if pace is None:
-            raw_pace: float | str = _env(
-                "PACE", str(preset_defaults.get("pace", 1.0))
-            )
+            raw_pace: float | str = _env("PACE", str(preset_defaults.get("pace", 1.0)))
         else:
             raw_pace = pace
         try:
@@ -2417,6 +2439,87 @@ class _DemoBase:
         name = f"{self.segment}.seg.mp4" if self.segment else "demo.mp4"
         return self.out_dir / name
 
+    def _preview_path(self) -> Path:
+        """The animated WebP a pull-request body embeds."""
+        stem = self.segment if self.segment else "demo"
+        return self.out_dir / f"{stem}.preview.webp"
+
+    def _write_preview(self, webm: Path, chain: str | None) -> None:
+        """An animated WebP for a pull-request body, off the browser's frames.
+
+        **Why this exists.** GitHub has no public API for the attachment upload
+        its drag-and-drop uses, so CI cannot hand a reviewer a video player. The
+        only thing that inlines in a pull-request body is an image — and an
+        animated WebP is an image. This is the file a reviewer actually sees
+        before deciding whether to open anything.
+
+        **Why it is encoded here and not from `demo.mp4`.** By the time the mp4
+        exists the frames have been through h264 twice — once at CRF 16 for the
+        camera pass, once at CRF 23 for the master. Encoding the preview from
+        the webm instead is *one* generation, and measured on a 25 s take it is
+        both cleaner and smaller: 2.67 MB against 2.95 MB at identical WebP
+        settings, because a noisier source costs the encoder bits.
+
+        `chain` is the camera filter the mp4 pass uses, threaded in so the
+        preview gets the same push-ins. Encoding from the raw webm without it
+        produced a preview with no zoom — the reason this takes the chain as an
+        argument rather than reading `self._camera` again.
+
+        **What it is not.** It carries no audio, and cannot: WebP has no audio
+        track. Narration, the 25 fps pin the beat log's frame arithmetic needs,
+        and every downstream reader — `media_duration`, `frames/`, the picture
+        check, `stitch()`'s concat — all belong to the mp4, which is unchanged.
+        This is a preview beside the master, never instead of it.
+
+        Failure here is a warning, never the take: a reviewer losing a preview
+        is an inconvenience, and raising would throw away a recording that is
+        already complete.
+        """
+        if not self._preview:
+            return
+        out = self._preview_path()
+        scale = f"fps={self._preview_fps},scale={self._preview_width}:-1:flags=lanczos"
+        graph = f"[0:v]{chain},{scale}[v]" if chain else f"[0:v]{scale}[v]"
+        try:
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-loglevel",
+                    "error",
+                    "-i",
+                    str(webm),
+                    "-filter_complex",
+                    graph,
+                    "-map",
+                    "[v]",
+                    "-loop",
+                    "0",
+                    # `text` rather than the default `picture`: a screen
+                    # recording is flat colour and sharp edges, which is what
+                    # this preset tunes for. At the same quality the default
+                    # spends its bits smoothing gradients that are not there
+                    # and rings the edges that are.
+                    "-preset",
+                    "text",
+                    "-q:v",
+                    str(self._preview_quality),
+                    "-compression_level",
+                    "6",
+                    str(out),
+                ],
+                check=True,
+            )
+        except (OSError, subprocess.CalledProcessError) as exc:
+            print(
+                f"demo-video: WARNING — the pull-request preview could not be "
+                f"encoded ({type(exc).__name__}). The take itself is fine; "
+                f"{out.name} was not written.",
+                file=sys.stderr,
+            )
+            return
+        self._preview_written = True
+
     def _media_name(self) -> str | None:
         """What an artifact should call this take's video — None on a stills
         run, where there is not one (issue #372).
@@ -2637,6 +2740,12 @@ class _DemoBase:
             # as it always did. Nothing here fetched or resolved it.
             **_ticket_field(self._ticket),
             "media": self._media_name(),
+            # The pull-request preview, named only when this run actually
+            # wrote one — the same rule `media` follows and for the same
+            # reason (#20): `demo.preview.webp` from a previous take is very
+            # likely sitting in this directory, and naming it would point a
+            # pull-request body at a recording of something else.
+            "preview": self._preview_path().name if self._preview_written else None,
             "duration": duration,
             # Which clock produced this take. Without it a still committed to a
             # repo carries no record of the conditions it was recorded under,
@@ -3148,7 +3257,9 @@ class _DemoBase:
             return
         event = dict(self._camera_open)
         self._camera_open = None
-        end = round(time.monotonic() - self._t0, 3) if t_end is None else round(t_end, 3)
+        end = (
+            round(time.monotonic() - self._t0, 3) if t_end is None else round(t_end, 3)
+        )
         if end > event["t_start"]:
             event["t_end"] = end
             self._camera.append(event)
@@ -3244,10 +3355,9 @@ class _DemoBase:
         # pre-pass is a single-output graph — the shape the mix always
         # used — and the mix then reads its frames like any other input.
         source = webm
+        chain: str | None = None
         if self._camera:
-            self._camera = self._camera_on_the_video_clock(
-                self._capture_clock.report()
-            )
+            self._camera = self._camera_on_the_video_clock(self._capture_clock.report())
         if self._camera:
             src_w, src_h = video_dimensions(webm)
             chain = camera_filter(
@@ -3260,12 +3370,24 @@ class _DemoBase:
             source = webm.with_suffix(".camera.mp4")
             subprocess.run(
                 [
-                    "ffmpeg", "-y", "-loglevel", "error",
-                    "-i", str(webm),
-                    "-filter_complex", f"[0:v]{chain}[v]",
-                    "-map", "[v]",
-                    "-c:v", "libx264", "-pix_fmt", "yuv420p", "-crf", "16",
-                    "-r", "25",
+                    "ffmpeg",
+                    "-y",
+                    "-loglevel",
+                    "error",
+                    "-i",
+                    str(webm),
+                    "-filter_complex",
+                    f"[0:v]{chain}[v]",
+                    "-map",
+                    "[v]",
+                    "-c:v",
+                    "libx264",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-crf",
+                    "16",
+                    "-r",
+                    "25",
                     str(source),
                 ],
                 check=True,
@@ -3368,5 +3490,22 @@ class _DemoBase:
         # `narration: null`, which is what a take that mixed nothing says too —
         # and neither of them has an mp4 for it to be about.
         self._narration = narration
+        # After the master is on disk, deliberately. The preview is a
+        # convenience and the mp4 is the deliverable, so nothing about the
+        # preview — an ffmpeg that is missing, out of disk, or simply slow —
+        # can happen before the take is safe. It still reads `webm` and not
+        # `mp4`: the browser's own frames are the point (#410), and they are
+        # still here because `__exit__` clears `.video/` well after this.
+        self._write_preview(webm, chain)
         spoken = f", {len(self._lines)} spoken lines" if self._speech else ""
         print(f"wrote {mp4} ({mp4.stat().st_size // 1024} kB{spoken})")
+        # Reported with its size and said to be committed, because that is the
+        # part a reader needs to decide about: this file goes into git history
+        # and stays there. A preview that quietly appeared would have its cost
+        # discovered by whoever next clones the repository.
+        if self._preview_written:
+            preview = self._preview_path()
+            print(
+                f"wrote {preview} ({preview.stat().st_size // 1024} kB, "
+                f"committed — it is what a pull-request body embeds)"
+            )

--- a/skills/demo-video/helpers/demo_recording/terminal.py
+++ b/skills/demo-video/helpers/demo_recording/terminal.py
@@ -292,6 +292,7 @@ class TerminalRecorder(_DemoBase):
         window_title: str | None = None,
         window_scale: float | tuple[float, float] | None = None,
         caption_overlay: bool | None = None,
+        preview: bool | None = None,
         preset: str | None = None,
         allow_private: bool | None = None,
         type_delay_ms: int = 45,
@@ -351,6 +352,7 @@ class TerminalRecorder(_DemoBase):
             window_title=window_title,
             window_scale=window_scale,
             caption_overlay=caption_overlay,
+            preview=preview,
             preset=preset,
         )
         self._shell = shell or _env("TERMINAL_SHELL") or "/bin/bash"

--- a/skills/demo-video/helpers/demo_recording/web.py
+++ b/skills/demo-video/helpers/demo_recording/web.py
@@ -492,6 +492,7 @@ class Recorder(_DemoBase):
         window_title: str | None = None,
         window_scale: float | tuple[float, float] | None = None,
         caption_overlay: bool | None = None,
+        preview: bool | None = None,
         preset: str | None = None,
         allow_private: bool | None = None,
     ) -> None:
@@ -522,6 +523,7 @@ class Recorder(_DemoBase):
             window_title=window_title,
             window_scale=window_scale,
             caption_overlay=caption_overlay,
+            preview=preview,
             preset=preset,
         )
         self.base_url = (base_url or _env("BASE_URL", "http://localhost:8000")).rstrip(

--- a/tests/README.md
+++ b/tests/README.md
@@ -305,8 +305,11 @@ tests/smoke --issues-only         # just the broken page and the failing
                                   #   grades (issue #197)
 tests/smoke --lock-only           # records nothing: what a run the machine
                                   #   lock refuses leaves behind (issue #105)
-tests/smoke --cheap               # every arm except web/content/terminal —
-                                  #   what CI records per push (issue #61)
+tests/smoke --core                # the six arms CI records per pull request
+                                  #   (~84 s) — CORE_ARMS in constants.py
+tests/smoke --cheap               # every arm except web/content/terminal
+                                  #   (~222 s) — the older, wider selection
+                                  #   (issue #61); CI no longer runs it
 tests/smoke --out-dir /tmp/smoke  # keep the recordings at a known path
 tests/smoke --keep                # keep the temp dir even when it passes
 ```
@@ -361,11 +364,13 @@ default:
   interval between steps cannot promise to see one, and the widest interval
   this repo has measured is 32.3 s. `ClockProbe` in `tests/unit` holds those
   measurements and fails if the window drops below the widest.
-- **`--segments-only` and `--cheap` are not probed.** `--segments-only` reaches
-  a timing phase but costs 29 s, so a 40 s probe in front of it spends more
-  than it can save; `tests/smoke-inject` re-records that arm on a step instead
-  ([#258](https://github.com/rogvid/skills/issues/258)). `--cheap` is what CI
-  runs on every push, and it pays nothing.
+- **`--segments-only`, `--cheap` and `--core` are not probed.**
+  `--segments-only` reaches a timing phase but costs 29 s, so a 40 s probe in
+  front of it spends more than it can save; `tests/smoke-inject` re-records
+  that arm on a step instead
+  ([#258](https://github.com/rogvid/skills/issues/258)). `--core` is what CI
+  runs per pull request and `--cheap` is what it used to run; neither pays
+  anything.
 - **`tests/smoke-inject` passes `--allow-stepping-clock` on every arm**, for
   that same reason: it already handles a stepping host after the fact, and
   paying 40 s per entry to be told what the re-record fixes would be the cost
@@ -538,8 +543,13 @@ Since #61, CI does not record those three on every push.
 
 | when | what CI runs | job in `ci.yml` |
 |---|---|---|
-| every pull-request commit, and every push to `main` | `tests/smoke --cheap` | `smoke (cheap arms, every push)` |
-| merge to `main`, or a pull request labelled `smoke-full` | `tests/smoke`, the whole suite | `smoke (web, content and terminal takes)` |
+| every pull-request commit, and every push to `main` | `tests/smoke --core` | `smoke (core arms, every push)` |
+| merge to `main`, or a pull request labelled `smoke-full` | `tests/smoke`, the whole suite | `smoke (everything the core arms leave out)` |
+
+**`--cheap` is no longer what CI runs**, and the rest of this section is kept as
+the record of why. The complement grew to 22 takes and a measured 300 s on a
+runner, which is what a reviewer waits through before they can look at the
+change at all. `--core` replaced it: see *The second cut* below.
 
 The merge job runs the **whole suite** rather than the three arms, because the
 arm flags are mutually exclusive: three invocations cost 123 + 148 + 186 =
@@ -654,6 +664,95 @@ runs the recorder's exception paths, which is where the catalogue's
 *clean-path-only assertion* lives. `--failure-only` is nonetheless the one to
 revisit first if the per-push budget ever binds — it is 22% of `--cheap` for
 one check function.
+
+## The second cut — `--core` (the per-pull-request list)
+
+The budget bound. `--cheap` measured **300 s on a runner** and sat on the
+critical path of every pull request, next to a 298 s `ci-unit --fault-inject`
+and a 132 s `unit --fault-inject` — 730 s of a 750 s job set, against **9 s**
+for the two unit suites themselves. That is the whole argument: the tests cost
+nine seconds, and everything else was recording video and re-running suites to
+prove assertions can fail.
+
+### What `--core` is, and why it is a list
+
+The opposite shape from `--cheap`, deliberately. A complement has no ceiling —
+every new cheap arm joins it automatically, which is exactly how the per-push
+job reached 22 takes without anybody deciding that. **A complement cannot be
+scaled down; only a list can.** `CORE_ARMS` in `tests/smokekit/constants.py`
+enumerates six arms with the measured cost of each written beside it:
+
+| arm | seconds | what it buys |
+|---|---|---|
+| `--lock-only` | 0.2 | a refused run leaves no directory to send anybody to (#105) |
+| `--stills-only` | 2.1 | pictures with no video (#372) |
+| `--evidence-only` | 7.3 | the per-beat evidence a reviewer reads (#9) |
+| `--strict-only` | 11.6 | the takes `strict=True` must refuse, both media (#3) |
+| `--coverage-only` | 15.5 | every acceptance clause answered by a beat (#12) |
+| `--failure-only` | 46.8 | six takes that crash, and what each leaves behind |
+| | **83.5** | measured; two `--core` runs read 82.8 s and 82.2 s |
+
+At the runner's 1.16x that is ~97 s, against `--cheap`'s 300 s.
+
+`tests/unit`'s `CoreArm` grades the rule against the guards read out of
+`run_phases`' AST, names the seven phases `--core` runs rather than counting
+them, requires every arm it names to be a flag `main()` defines — a misspelled
+entry silently selects nothing and shrinks the job — and requires `--core` to
+be a *strict subset* of `--cheap`, so narrowing can never add a take. Its four
+assertions have four injections.
+
+### Keeping `--failure-only`, against this file's own advice
+
+The section above named `--failure-only` as "the one to revisit first if the
+per-push budget ever binds". The budget bound and it was kept, so the
+disagreement is recorded rather than quietly reversed.
+
+The seconds-per-check ratio that recommended dropping it counts check
+*functions*, and that is the wrong denominator for this one. `--failure-only`
+is the only phase that runs the recorder's exception paths, and what those
+paths decide is whether a take that did not finish leaves behind something a
+reader takes for a success — a `demo.mp4` beside a `timeline.json` describing a
+different run, a stale `demo-video-FAILED.md`, a duration for a file this take
+never wrote. That is not one check function's worth of risk; it is one of the
+**two ways a recording lies to its reader**, which is what `GOAL.md` measures.
+The other is a take that should have been refused and was not, which is
+`--strict-only`. Those two are the reason this list exists, and the remaining
+four are the artifacts a reviewer actually opens.
+
+### What a pull request therefore no longer sees
+
+On top of the four phases in *What now grades only at merge* above: the wrapper
+pair and its geometry (#358), the console/exit-code reporting both media do
+(#197), the polish takes (#110/#111), the light-interlude pair (#162/#163), the
+stitch (#7), narration (#157), and determinism. All of them run in
+`smoke-full` on merge to `main`, and the `smoke-full` label puts them back in
+front of a review that wants them.
+
+Rendered-frame geometry keeps a second, faster reader: `tests/pixel` is **4.7 s
+warm** and grades the card colour, the parked cursor, cursor absence and the
+spotlight ring off cached frames. It is not a CI job because it is 60 s cold
+and CI is always cold — it is the local loop `CLAUDE.md` already routes a
+chrome change through first.
+
+### The injection drivers: `--anchors` on the branch, `--fault-inject` on merge
+
+Both drivers re-run their whole suite once per injection: 419 injections for
+`tests/unit` (132 s) and 135 for `tests/ci-unit` (298 s). They now run on merge.
+
+What runs on the branch is `--anchors`, the cheap half: one staging, no inner
+runs, and for every injection it checks that the pattern still matches its file
+**exactly once** and that every test it names still exists. 419 injections in
+**0.7 s**, 135 in **0.2 s**.
+
+The split is honest about what it gives up: `--anchors` does **not** prove an
+assertion can fail. It proves the weaker thing the driver spends its first
+millisecond on before aborting — that the injection would still *land*. That is
+worth its own mode because a stale anchor is the failure this manifest actually
+has: a rename or a reflow moves the text an entry pinned, the entry stops
+describing anything, and nothing says so. Six entries went stale in one
+afternoon's refactor, and CI reported it at merge; `--anchors` reports it on the
+branch, in under a second. An assertion that stopped *grading its subject*
+while still landing now reaches `main` before it is caught.
 
 ## What it asserts
 

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -454,7 +454,7 @@ GUARD_FACT_NOT_PASSED = {
 
 GUARD_STEP = "Refuse a target that could be production"
 RECORD_STEP = "Record"
-COMMENT_STEP = "Render the comment"
+COMMENT_STEP = "Update the pull-request body"
 _INPUT_RE = re.compile(r"^\$\{\{\s*inputs\.([a-z0-9-]+)\s*\}\}$")
 
 
@@ -4553,19 +4553,19 @@ INJECTIONS = [
         # The other half of the coupling, and the half no reading of
         # `demo-comment` can see: the argument is never passed, so every still
         # in a repository like this one is linked at the root and 404s.
-        "the comment step stops passing the working directory to the script",
+        "the block step stops passing the working directory to the script",
         "demo-video.yml",
-        '            --path-prefix "$WORKDIR" \\\n',
-        "",
+        '--demo "$demo" --path-prefix "$WORKDIR" --repo-url "$REPO_URL"',
+        '--demo "$demo" --repo-url "$REPO_URL"',
         ["CommentStep.test_the_working_directory_reaches_the_comment_as_a_path_prefix"],
     ),
     (
         # And the variable exported but not used, which is the shape
         # `WorkflowGates` exists for: it looks coupled.
-        "the comment step exports the working directory and drops it",
+        "the block step exports the working directory and drops it",
         "demo-video.yml",
-        '            --path-prefix "$WORKDIR"',
-        '            --path-prefix ""',
+        '--path-prefix "$WORKDIR" --repo-url',
+        '--path-prefix "" --repo-url',
         ["CommentStep.test_the_working_directory_reaches_the_comment_as_a_path_prefix"],
     ),
     (

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -25,6 +25,7 @@ file; read it before treating a green run as coverage of the workflow.
 from __future__ import annotations
 
 import argparse
+import ast
 import contextlib
 import importlib.util
 import io
@@ -5119,47 +5120,108 @@ INJECTIONS += [
 ]
 
 
+def stage_tree(tmp: Path) -> dict[str, Path]:
+    """Copy everything an injection may break into `tmp`, and name the copies.
+
+    Split out of `fault_inject` so `check_anchors` resolves targets through the
+    identical staging rather than a second implementation of it.
+    """
+    root = tmp / "scripts"
+    shutil.copytree(SCRIPTS, root)
+    # The skill travels too: the target guard is bundled with it now,
+    # and both the module under `helpers/` and the CLI under `scripts/`
+    # have to be the broken copy or the inner run grades the tree.
+    skill = tmp / "demo-video"
+    shutil.copytree(SKILL, skill)
+    # And the workflow, because the two gates agreeing is a property
+    # of that file and of nothing else.
+    workflow = tmp / "demo-video.yml"
+    shutil.copy(WORKFLOW, workflow)
+    # And this file, so an injection can reach the suite's own
+    # allowlist. The copy is what runs; it reads every path it uses
+    # from the three variables below, so `REPO` resolving to /tmp
+    # changes nothing.
+    inner = tmp / "ci-unit"
+    shutil.copy(Path(__file__).resolve(), inner)
+    return {"root": root, "skill": skill, "workflow": workflow, "inner": inner}
+
+
+def injection_target(script: str, staged: dict[str, Path]) -> Path:
+    """Which staged file an injection's `script` field names."""
+    if script == "target.py":
+        return staged["skill"] / "helpers" / "demo_recording" / script
+    if script.startswith(("scripts/", "helpers/")):
+        # Anything shipped with the skill rather than under
+        # `.github/scripts/`: the three CLIs, and the package modules
+        # they import. `GuardExitCode` runs `demo-target-guard`;
+        # `grade` and `shots` at the top of this file import the other
+        # two, which is how an injection into either reddens the
+        # couplings the comment has with them and cannot import. A
+        # prefix rather than a list because the list was a second
+        # place to remember, and `demo_recording/links.py` (#373) is
+        # the first module either CLI's behaviour lives in.
+        return staged["skill"] / script
+    if script == "demo-video.yml":
+        return staged["workflow"]
+    if script == "tests/ci-unit":
+        return staged["inner"]
+    return staged["root"] / script
+
+
+def check_anchors() -> int:
+    """Every injection still resolves: its pattern matches once, its tests exist.
+
+    The cheap half of `--fault-inject`; see `tests/unit`'s twin for why the
+    weaker question is worth its own mode. One staging, no inner runs.
+    """
+    stale: list[str] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        staged = stage_tree(Path(tmp))
+        known: set[str] = set()
+        tree = ast.parse(staged["inner"].read_text(encoding="utf-8"))
+        for cls in tree.body:
+            if isinstance(cls, ast.ClassDef):
+                known |= {
+                    f"{cls.name}.{fn.name}"
+                    for fn in cls.body
+                    if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+                }
+        for name, script, old, _new, must_fail in INJECTIONS:
+            target = injection_target(script, staged)
+            hits = target.read_text(encoding="utf-8").count(old)
+            if hits != 1:
+                stale.append(
+                    f"{name!r} matched {hits} times in {script}, expected "
+                    f"exactly 1 — the injection would not land, so nothing "
+                    f"it claims to prove is proven.\n       looked for: {old!r}"
+                )
+            gone = [t for t in must_fail if t not in known]
+            if gone:
+                stale.append(
+                    f"{name!r} names {', '.join(gone)}, which this suite does "
+                    f"not define — nothing it claims to prove is proven."
+                )
+    if stale:
+        print(
+            f"ABORT: {len(stale)} of {len(INJECTIONS)} injections no longer resolve.",
+            file=sys.stderr,
+        )
+        for line in stale:
+            print(f"  - {line}", file=sys.stderr)
+        return 3
+    print(f"All {len(INJECTIONS)} injections still resolve.")
+    return 0
+
+
 def fault_inject() -> int:
     """Break one thing at a time and require the named tests to notice."""
     failures = 0
     for name, script, old, new, must_fail in INJECTIONS:
         with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp) / "scripts"
-            shutil.copytree(SCRIPTS, root)
-            # The skill travels too: the target guard is bundled with it now,
-            # and both the module under `helpers/` and the CLI under `scripts/`
-            # have to be the broken copy or the inner run grades the tree.
-            skill = Path(tmp) / "demo-video"
-            shutil.copytree(SKILL, skill)
-            # And the workflow, because the two gates agreeing is a property
-            # of that file and of nothing else.
-            workflow = Path(tmp) / "demo-video.yml"
-            shutil.copy(WORKFLOW, workflow)
-            # And this file, so an injection can reach the suite's own
-            # allowlist. The copy is what runs; it reads every path it uses
-            # from the three variables below, so `REPO` resolving to /tmp
-            # changes nothing.
-            inner = Path(tmp) / "ci-unit"
-            shutil.copy(Path(__file__).resolve(), inner)
-            if script == "target.py":
-                target = skill / "helpers" / "demo_recording" / script
-            elif script.startswith(("scripts/", "helpers/")):
-                # Anything shipped with the skill rather than under
-                # `.github/scripts/`: the three CLIs, and the package modules
-                # they import. `GuardExitCode` runs `demo-target-guard`;
-                # `grade` and `shots` at the top of this file import the other
-                # two, which is how an injection into either reddens the
-                # couplings the comment has with them and cannot import. A
-                # prefix rather than a list because the list was a second
-                # place to remember, and `demo_recording/links.py` (#373) is
-                # the first module either CLI's behaviour lives in.
-                target = skill / script
-            elif script == "demo-video.yml":
-                target = workflow
-            elif script == "tests/ci-unit":
-                target = inner
-            else:
-                target = root / script
+            staged = stage_tree(Path(tmp))
+            root, skill = staged["root"], staged["skill"]
+            workflow, inner = staged["workflow"], staged["inner"]
+            target = injection_target(script, staged)
             text = target.read_text(encoding="utf-8")
             hits = text.count(old)
             if hits != 1:
@@ -5252,8 +5314,16 @@ def main() -> int:
         action="store_true",
         help="break each assertion's subject and require it to fail",
     )
+    ap.add_argument(
+        "--anchors",
+        action="store_true",
+        help="check every injection still resolves — its pattern matches its "
+        "file once and its tests exist — without running any of them",
+    )
     ap.add_argument("--_inner", action="store_true", help=argparse.SUPPRESS)
     args, rest = ap.parse_known_args()
+    if args.anchors:
+        return check_anchors()
     if args.fault_inject:
         return fault_inject()
     result = unittest.main(argv=[sys.argv[0], *rest], exit=False, verbosity=2).result

--- a/tests/ci-unit
+++ b/tests/ci-unit
@@ -69,6 +69,9 @@ _WORKFLOW = Path(os.environ.get("CI_UNIT_WORKFLOW", WORKFLOW))
 storyboards = load("demo-storyboards", _DIR)
 comment = load("demo-comment", _DIR)
 ticket_check = load("demo-ticket-check", _DIR)
+preview_asset = load("demo-preview-asset", _DIR)
+classify = load("demo-classify", _DIR)
+pr_body = load("demo-pr-body", _DIR)
 
 # **The classifier is the skill's, not the workflow's** — `demo-target-guard`
 # moved under `skills/demo-video/` so that `npx skills add` carries it, and the
@@ -5117,6 +5120,65 @@ INJECTIONS += [
             "TicketCheckRender.test_not_checked_is_printed_with_the_reason_not_omitted",
         ],
     ),
+    (
+        # A pruner that deletes what it cannot parse. Somebody's hand-uploaded
+        # file, or a name from a future format, gone — and this is the one bug
+        # in this script that loses data rather than merely misleading.
+        "prune deletes an asset whose name it does not recognise",
+        "demo-preview-asset",
+        """        if not m:
+            # Left alone, and said out loud. A pruner that deleted what it did
+            # not understand is the one bug here that loses data.
+            print(f"skipped {name!r}: not a preview asset name")
+            continue""",
+        """        if not m:
+            _gh("release", "delete-asset", ASSET_TAG, name, *scope, "--yes")
+            continue""",
+        ["PreviewAssetPrune.test_a_name_it_cannot_parse_is_kept_and_reported"],
+    ),
+    (
+        # A failed `gh pr view` becoming a deletion. One network blip empties
+        # the store, and every open pull request loses the picture it is being
+        # reviewed against.
+        "an unreadable pull-request state is read as closed, so prune deletes it",
+        "demo-preview-asset",
+        '            open_prs[number] = state != "CLOSED" and state != "MERGED"',
+        '            open_prs[number] = state == "OPEN"',
+        ["PreviewAssetPrune.test_an_unreadable_pr_state_is_treated_as_open"],
+    ),
+    (
+        # An open pull request's asset deleted out from under a review in
+        # progress. The body still embeds it, so the reviewer sees a broken
+        # image where the demo was.
+        "prune stops checking state and deletes every asset it can parse",
+        "demo-preview-asset",
+        "        if open_prs[number]:\n            continue",
+        "        if False:\n            continue",
+        ["PreviewAssetPrune.test_it_leaves_an_open_prs_asset_alone"],
+    ),
+    (
+        # The store is flat and every take writes the same `demo.preview.webp`,
+        # so a name without the demo in it has each demo overwrite the last —
+        # silently, and only on a pull request that recorded more than one.
+        "the asset name drops the demo, so two demos on one PR collide",
+        "demo-preview-asset",
+        'return f"pr{int(pr)}-{slug}-{sha[:7]}.webp"',
+        'return f"pr{int(pr)}-{sha[:7]}.webp"',
+        [
+            "PreviewAssetNames.test_two_demos_on_one_pr_do_not_collide",
+            "PreviewAssetNames.test_the_name_carries_the_pr_the_demo_and_the_commit",
+        ],
+    ),
+    (
+        # The round trip broken: `upload` writes names `prune` cannot read, so
+        # nothing is ever deleted and the store grows without bound. Nothing
+        # fails at upload time — this is only visible from the pruner's side.
+        "upload writes a name prune cannot parse, so nothing is ever pruned",
+        "demo-preview-asset",
+        'slug = re.sub(r"[^A-Za-z0-9._-]+", "-", slug).strip("-") or "demo"',
+        'slug = slug or "demo"',
+        ["PreviewAssetNames.test_a_path_that_would_break_a_url_is_made_safe"],
+    ),
 ]
 
 
@@ -5211,6 +5273,117 @@ def check_anchors() -> int:
         return 3
     print(f"All {len(INJECTIONS)} injections still resolve.")
     return 0
+
+
+class PreviewAssetNames(unittest.TestCase):
+    """The flat asset store's naming and pruning (#410).
+
+    A preview is not committed — CI uploads it as a release asset, which is not
+    a git object, so the repository does not grow. The store is flat and shared
+    across every pull request, which is what makes these two things load-bearing:
+    a name that does not identify its owner cannot be pruned, and a pruner that
+    guesses deletes somebody's evidence.
+    """
+
+    def test_the_name_carries_the_pr_the_demo_and_the_commit(self):
+        name = preview_asset.asset_name(
+            412, "examples/ticket-queue/demos/2026-08-27-glide", "a1b2c3d4e5f6"
+        )
+        self.assertEqual(name, "pr412-2026-08-27-glide-a1b2c3d.webp")
+
+    def test_two_demos_on_one_pr_do_not_collide(self):
+        """Every take writes the same `demo.preview.webp`, so a store keyed on
+        the filename would have each demo silently overwrite the last."""
+        one = preview_asset.asset_name(412, "demos/queue-search", "a1b2c3d")
+        two = preview_asset.asset_name(412, "demos/status-filter", "a1b2c3d")
+        self.assertNotEqual(one, two)
+
+    def test_two_pushes_keep_both_pictures(self):
+        """An already-reviewed pull-request body must keep pointing at the
+        picture it was reviewed against, not silently acquire a newer one —
+        the same rule `timeline["preview"]` follows (#20)."""
+        first = preview_asset.asset_name(412, "demos/glide", "aaaaaaa")
+        second = preview_asset.asset_name(412, "demos/glide", "bbbbbbb")
+        self.assertNotEqual(first, second)
+
+    def test_a_path_that_would_break_a_url_is_made_safe(self):
+        name = preview_asset.asset_name(7, "demos/a demo (v2)/", "abcdef0")
+        self.assertNotIn(" ", name)
+        self.assertNotIn("(", name)
+        self.assertTrue(preview_asset.ASSET_RE.match(name), name)
+
+    def test_every_name_it_writes_is_one_it_can_read_back(self):
+        """The round trip, which is the whole contract between the two halves:
+        a name `upload` writes that `prune` cannot parse is an asset nothing
+        will ever delete."""
+        for demo in ("demos/2026-08-27-glide", "demos/x", "demos/a b c"):
+            name = preview_asset.asset_name(412, demo, "a1b2c3d")
+            m = preview_asset.ASSET_RE.match(name)
+            self.assertIsNotNone(m, f"upload wrote a name prune cannot read: {name}")
+            self.assertEqual(int(m.group("pr")), 412)
+
+
+class PreviewAssetPrune(unittest.TestCase):
+    """What `prune` deletes, and — the part that matters — what it does not."""
+
+    def run_prune(self, assets, states, dry_run=False):
+        calls = []
+
+        def fake_gh(*args, check=True):
+            calls.append(list(args))
+            if args[:2] == ("release", "view"):
+                return json.dumps({"assets": [{"name": n} for n in assets]})
+            if args[:2] == ("pr", "view"):
+                return states.get(int(args[2]), "OPEN")
+            return ""
+
+        was = preview_asset._gh
+        preview_asset._gh = fake_gh
+        try:
+            with contextlib.redirect_stdout(io.StringIO()) as out:
+                gone = preview_asset.prune(None, dry_run)
+        finally:
+            preview_asset._gh = was
+        deleted = [c[3] for c in calls if c[:2] == ["release", "delete-asset"]]
+        return gone, deleted, out.getvalue()
+
+    def test_it_deletes_a_closed_prs_asset(self):
+        _, deleted, _ = self.run_prune(["pr9-glide-aaaaaaa.webp"], {9: "CLOSED"})
+        self.assertEqual(deleted, ["pr9-glide-aaaaaaa.webp"])
+
+    def test_it_leaves_an_open_prs_asset_alone(self):
+        """The reason pruning is by state and not by age: an open pull request
+        may be weeks old and still under review."""
+        _, deleted, _ = self.run_prune(["pr9-glide-aaaaaaa.webp"], {9: "OPEN"})
+        self.assertEqual(deleted, [])
+
+    def test_a_merged_pr_is_prunable(self):
+        _, deleted, _ = self.run_prune(["pr9-glide-aaaaaaa.webp"], {9: "MERGED"})
+        self.assertEqual(deleted, ["pr9-glide-aaaaaaa.webp"])
+
+    def test_a_name_it_cannot_parse_is_kept_and_reported(self):
+        """The one bug here that loses data. Somebody's hand-uploaded file, or
+        a name from a future format, must survive a pruner that does not
+        recognise it — and the reader must be told it was skipped rather than
+        left to assume it was considered."""
+        _, deleted, said = self.run_prune(["hand-uploaded.txt"], {})
+        self.assertEqual(deleted, [])
+        self.assertIn("skipped", said)
+        self.assertIn("hand-uploaded.txt", said)
+
+    def test_an_unreadable_pr_state_is_treated_as_open(self):
+        """A failed lookup must not become a deletion: a network blip would
+        otherwise take out every asset in the store in one run."""
+        _, deleted, _ = self.run_prune(["pr9-glide-aaaaaaa.webp"], {9: ""})
+        self.assertEqual(deleted, [])
+
+    def test_dry_run_deletes_nothing_but_still_counts(self):
+        gone, deleted, said = self.run_prune(
+            ["pr9-glide-aaaaaaa.webp"], {9: "CLOSED"}, dry_run=True
+        )
+        self.assertEqual(deleted, [])
+        self.assertEqual(gone, 1)
+        self.assertIn("would delete", said)
 
 
 def fault_inject() -> int:

--- a/tests/smokekit/cli.py
+++ b/tests/smokekit/cli.py
@@ -16,6 +16,7 @@ from .checks import (  # noqa: E402
     check_lock_refusal,
 )
 from .constants import (  # noqa: E402
+    CORE_ARMS,
     EXPENSIVE_ARMS,
     HELPERS_DIR,
 )
@@ -140,6 +141,14 @@ def main() -> int:
         "leaves behind, against one that started and failed (issue #105)",
     )
     parser.add_argument(
+        "--core",
+        action="store_true",
+        help="record only the arms in CORE_ARMS — the per-pull-request "
+        "selection (~84 s). Enumerated in tests/smokekit/constants.py with "
+        "the cost of each entry and the list of what a pull request "
+        "therefore no longer sees.",
+    )
+    parser.add_argument(
         "--cheap",
         action="store_true",
         help="record every phase that any arm other than --web-only, "
@@ -196,6 +205,7 @@ def main() -> int:
             ("--stills-only", args.stills_only),
             ("--issues-only", args.issues_only),
             ("--lock-only", args.lock_only),
+            ("--core", args.core),
             ("--cheap", args.cheap),
         )
         if on
@@ -283,12 +293,17 @@ def selects(only: str | None, arms: tuple[str, ...]) -> bool:
     `None` is a whole run and takes everything. `--cheap` takes a phase when
     *any* arm reaching it is not one of `EXPENSIVE_ARMS` — so a phase only the
     long takes reach is skipped, and one that a 26 s arm also reaches is not.
-    Every other flag is itself.
+    `--core` is the opposite shape and deliberately so: a phase is in it only
+    when an arm reaching it is *named* in `CORE_ARMS`, so adding a cheap arm
+    never silently enlarges the per-pull-request job the way it enlarges
+    `--cheap`. Every other flag is itself.
     """
     if only is None:
         return True
     if only == "--cheap":
         return any(arm not in EXPENSIVE_ARMS for arm in arms)
+    if only == "--core":
+        return any(arm in CORE_ARMS for arm in arms)
     return only in arms
 
 

--- a/tests/smokekit/constants.py
+++ b/tests/smokekit/constants.py
@@ -1172,3 +1172,50 @@ REAP_MIN_AGE_S = 3600.0
 
 
 EXPENSIVE_ARMS = ("--web-only", "--content-only", "--terminal-only")
+
+
+# The per-pull-request selection, and the one list in this file that is
+# enumerated rather than derived.
+#
+# `--cheap` (#61) is a *complement* — every phase an arm outside
+# EXPENSIVE_ARMS reaches — which is why it grew to 22 takes and 300 s on a
+# runner without anybody choosing that. A complement cannot be scaled down;
+# only a list can. So this is a list, and the cost of each entry is written
+# beside it, measured one arm at a time on a 16-core box:
+#
+#     --lock-only        0.2 s   a refused run leaves no directory to send
+#                                anybody to (#105)
+#     --stills-only      2.1 s   pictures with no video, nothing readable as
+#                                a take (#372)
+#     --strict-only     11.6 s   the two takes strict=True must refuse, web
+#                                and terminal (#3)
+#     --coverage-only   15.5 s   every acceptance clause is answered by a
+#                                beat (#12)
+#     --evidence-only    7.3 s   the per-beat evidence a reviewer reads (#9)
+#     --failure-only    46.8 s   six takes that crash, and what each leaves
+#                                behind (#11/#20/#24/#46)
+#                       ------
+#                       83.5 s   ~97 s on a runner at the measured 1.16x
+#
+# The class each entry buys is the reason it is here: a take that did not
+# finish must not leave something that reads as a success, and a take that
+# should have been refused must be refused. Those are the two ways a
+# recording lies to its reader, which is what GOAL.md measures.
+#
+# **What a pull request therefore no longer sees**, written out rather than
+# implied, because the last split's unstated half became #233: the wrapper
+# pair and its geometry (#358), the console/exit-code reporting both media do
+# (#197), the spotlight and terminal-opening polish takes (#110/#111), the
+# light-interlude pair (#162/#163), the stitch (#7), narration (#157) and
+# determinism. Every one of them runs on merge to `main`, where `smoke-full`
+# records the whole suite. Rendered-frame geometry has a second, faster
+# reader in `tests/pixel`, which is 4.7 s warm and is the loop CLAUDE.md
+# already sends a chrome change through first.
+CORE_ARMS = (
+    "--lock-only",
+    "--stills-only",
+    "--strict-only",
+    "--coverage-only",
+    "--evidence-only",
+    "--failure-only",
+)

--- a/tests/unit
+++ b/tests/unit
@@ -3135,6 +3135,42 @@ CHEAP_SKIPS = frozenset(
 # Written here so this suite disagrees with a change to smoke's own tuple.
 CHEAP_EXCLUDES = frozenset({"--web-only", "--content-only", "--terminal-only"})
 
+# The arms `--core` names, and the phases they reach — the per-pull-request
+# selection. Written here, independently of `CORE_ARMS` in
+# `tests/smokekit/constants.py`, for the same reason `CHEAP_EXCLUDES` is: a
+# suite that reads the value under test cannot disagree with it.
+#
+# `--core` is a *list* where `--cheap` is a complement, and that difference is
+# the point. A complement silently absorbs every new cheap arm, which is how
+# the per-push job reached 22 takes and 300 s without a decision being made.
+# Nothing joins this one without editing both this set and the costs written
+# beside `CORE_ARMS`.
+CORE_ARM_NAMES = frozenset(
+    {
+        "--lock-only",  # 0.2 s
+        "--stills-only",  # 2.1 s
+        "--strict-only",  # 11.6 s
+        "--coverage-only",  # 15.5 s
+        "--evidence-only",  # 7.3 s
+        "--failure-only",  # 46.8 s
+    }
+)
+
+# What a pull request therefore runs, named rather than counted — the same
+# reason `CHEAP_SKIPS` is named. Editing this set is a decision about what a
+# reviewer stops seeing on the branch, and it belongs in an issue.
+CORE_PHASES = frozenset(
+    {
+        "check_lock_refusal",
+        "run_stills_only",
+        "run_strict_web",
+        "run_strict_terminal",
+        "run_coverage",
+        "run_evidence",
+        "run_failure",
+    }
+)
+
 # Below this, `run_phases` was not read: an extraction that matched nothing
 # makes every "every phase …" below true over an empty set. 18 guards today.
 SMOKE_PHASE_FLOOR = 14
@@ -3339,7 +3375,7 @@ class CheapArm(unittest.TestCase):
         """
         named = {arm for arms, _ in self.guards for arm in arms}
         self.assertTrue(named, "no guard named any arm")
-        unknown = sorted(named - (self.flags - {"--cheap"}))
+        unknown = sorted(named - (self.flags - {"--cheap", "--core"}))
         self.assertEqual(
             unknown,
             [],
@@ -3360,6 +3396,100 @@ class CheapArm(unittest.TestCase):
                 self.smoke.selects("--no-such-arm", arms),
                 f"an arm no guard names still ran {phase}",
             )
+
+
+class CoreArm(unittest.TestCase):
+    """`--core`, the per-pull-request selection.
+
+    The four questions a narrowed job has to answer, and the reason each one is
+    here rather than left to the eye:
+
+    - it selects what its list says (the rule, per phase);
+    - the phases it selects are the named set (a decision, not a diff);
+    - every arm it names is a flag somebody can actually pass — a typo would
+      shrink the pull-request job toward nothing while every "every phase …"
+      claim below stayed true over the smaller set;
+    - it is a strict subset of `--cheap`, so narrowing the job never *added* a
+      take, and it never selects a phase a whole run does not.
+    """
+
+    def setUp(self):
+        self.guards, self.flags = _smoke_guards()
+        # The haystack, before anything is claimed about it — the same floor
+        # CheapArm sets, for the same reason.
+        self.assertGreaterEqual(
+            len(self.guards),
+            SMOKE_PHASE_FLOOR,
+            f"only {len(self.guards)} guard(s) were read out of run_phases — "
+            f"either the suite shrank or this extraction stopped extracting, "
+            f"and every claim below would hold over what it did not read",
+        )
+        self.smoke = _smoke_module()
+
+    def test_core_runs_every_phase_an_arm_it_names_reaches(self):
+        """The rule, applied per phase rather than as a count."""
+        wanted = {
+            phase: any(arm in CORE_ARM_NAMES for arm in arms)
+            for arms, phase in self.guards
+        }
+        got = {phase: self.smoke.selects("--core", arms) for arms, phase in self.guards}
+        self.assertEqual(
+            got,
+            wanted,
+            "--core disagrees with 'every phase an arm in "
+            f"{sorted(CORE_ARM_NAMES)} reaches' at: "
+            + ", ".join(sorted(k for k in wanted if got[k] != wanted[k])),
+        )
+
+    def test_the_phases_core_runs_are_the_ones_it_is_meant_to_run(self):
+        """Named, because this is the whole list a pull request still sees."""
+        ran = {
+            phase for arms, phase in self.guards if self.smoke.selects("--core", arms)
+        }
+        self.assertEqual(
+            ran,
+            set(CORE_PHASES),
+            f"--core runs {sorted(ran)}; the set this repo decided on is "
+            f"{sorted(CORE_PHASES)}. A phase joining or leaving the "
+            f"per-pull-request run is a decision, not a diff.",
+        )
+
+    def test_every_arm_core_names_is_a_flag_the_script_accepts(self):
+        """A typo'd entry selects nothing, silently, and shrinks the job.
+
+        `CORE_ARMS` is matched against guard arms by string. An entry nobody
+        can pass is not an error anywhere — it simply never matches, the job
+        gets smaller, and the two tests above still pass over what is left.
+        """
+        unknown = sorted(CORE_ARM_NAMES - self.flags)
+        self.assertEqual(
+            unknown,
+            [],
+            f"--core names {unknown}, which main() does not define as a flag; "
+            f"an arm nobody can pass selects no phase and shrinks the "
+            f"pull-request job without saying so",
+        )
+
+    def test_core_is_a_strict_subset_of_cheap_and_of_a_whole_run(self):
+        """Narrowing must never add a take, and never invent one."""
+        core = {
+            phase for arms, phase in self.guards if self.smoke.selects("--core", arms)
+        }
+        cheap = {
+            phase for arms, phase in self.guards if self.smoke.selects("--cheap", arms)
+        }
+        whole = {phase for arms, phase in self.guards if self.smoke.selects(None, arms)}
+        self.assertTrue(
+            core < cheap,
+            f"--core is not a strict subset of --cheap: it adds "
+            f"{sorted(core - cheap)} and is {'' if core != cheap else 'identical, '}"
+            f"so the split bought nothing",
+        )
+        self.assertEqual(
+            sorted(core - whole),
+            [],
+            f"--core selects {sorted(core - whole)}, which a whole run does not",
+        )
 
 
 # --------------------------------------------------------------------------
@@ -16354,6 +16484,84 @@ INJECTIONS = [
             "CheapArm.test_a_whole_run_still_takes_everything_and_a_named_arm_still_itself"
         ],
     ),
+    # -- what `tests/smoke --core` selects ----------------------------------
+    #
+    # Four breaks, for the four ways a *named list* goes wrong, which are not
+    # the four ways a complement goes wrong above. A list shrinks silently: an
+    # arm dropped, an arm misspelled, or the predicate short-circuiting all
+    # leave a green suite that ran fewer takes, and a green suite that ran
+    # fewer takes is the exact failure this whole split risks.
+    (
+        # The predicate stops selecting and agrees with everything: `--core`
+        # becomes a whole run, and the pull-request job costs the seven
+        # minutes the narrowing exists to avoid.
+        "--core stops selecting and runs the whole suite on every push",
+        "tests/smoke",
+        '    if only == "--core":\n        return any(arm in CORE_ARMS for arm in arms)',
+        '    if only == "--core":\n        return True',
+        [
+            "CoreArm.test_core_runs_every_phase_an_arm_it_names_reaches",
+            "CoreArm.test_the_phases_core_runs_are_the_ones_it_is_meant_to_run",
+            "CoreArm.test_core_is_a_strict_subset_of_cheap_and_of_a_whole_run",
+        ],
+    ),
+    (
+        # The other direction, and the quiet one: the predicate inverts, so
+        # `--core` selects everything *except* what it names. The suite still
+        # passes, having recorded the takes nobody chose.
+        "--core selects everything except the arms it names",
+        "tests/smoke",
+        "        return any(arm in CORE_ARMS for arm in arms)",
+        "        return not any(arm in CORE_ARMS for arm in arms)",
+        [
+            "CoreArm.test_core_runs_every_phase_an_arm_it_names_reaches",
+            "CoreArm.test_the_phases_core_runs_are_the_ones_it_is_meant_to_run",
+        ],
+    ),
+    (
+        # One arm dropped from the list. The rule still holds — the predicate
+        # is consistent with the shorter list — so the check that catches this
+        # is the one naming the phases out loud, which is why that test exists
+        # in the shape it does.
+        "an arm is dropped from CORE_ARMS and its takes stop running per push",
+        "tests/smoke",
+        '    "--failure-only",\n)',
+        ")",
+        ["CoreArm.test_the_phases_core_runs_are_the_ones_it_is_meant_to_run"],
+    ),
+    (
+        # An arm misspelled *in the list* rather than dropped from it. Nothing
+        # raises: the string simply never matches a guard, `run_coverage` falls
+        # off the pull-request job, and the rule check still holds over the
+        # smaller set because the predicate agrees with the shorter list. The
+        # phase check is what has to catch this, which is why it names the
+        # phases out loud instead of counting them.
+        #
+        # The anchor pairs two entries in CORE_ARMS' own order. `--strict-only`
+        # and `--coverage-only` are adjacent here and in the opposite order in
+        # CLOCK_SAFE_ARMS, so this text exists once in the tree — a bare
+        # `    "--coverage-only",` is a substring of the argparse call in
+        # cli.py and of two entries in constants.py, and would land somewhere
+        # nobody intended.
+        "an arm in CORE_ARMS is misspelled, so its takes silently stop running",
+        "tests/smoke",
+        '    "--strict-only",\n    "--coverage-only",',
+        '    "--strict-only",\n    "--coverage-onyl",',
+        ["CoreArm.test_the_phases_core_runs_are_the_ones_it_is_meant_to_run"],
+    ),
+    (
+        # The same typo one file over: the flag itself, in argparse. Now
+        # `CORE_ARMS` names something nobody can pass — every phase it reached
+        # is still selected, because the guards name the arm too, but the
+        # *list* has become a claim about a flag that does not exist and the
+        # next person to run `tests/smoke --coverage-only` gets a parse error.
+        # Only the flag check sees this one; both phase claims stay true.
+        "an arm CORE_ARMS names stops being a flag the script defines",
+        "tests/smoke",
+        '        "--coverage-only",\n        action="store_true",',
+        '        "--coverage-onyl",\n        action="store_true",',
+        ["CoreArm.test_every_arm_core_names_is_a_flag_the_script_accepts"],
+    ),
     (
         # And the control. Every claim above is quantified over the guards this
         # file reads out of `run_phases`; an extraction that matches nothing
@@ -18204,108 +18412,196 @@ def inner_run(names: list[str]) -> int:
     return 0 if result.wasSuccessful() else 1
 
 
+def check_anchors() -> int:
+    """Every injection still resolves: its pattern matches once, its tests exist.
+
+    The cheap half of `--fault-inject`, split out so it can run on a pull
+    request while the expensive half runs on merge. It stages the tree **once**
+    and reads text — no inner runs — so 419 injections cost about a second
+    against the driver's minutes.
+
+    What it is and is not. It does **not** prove an assertion can fail; only
+    running it broken does, and that is `--fault-inject`. It proves the weaker
+    thing the driver spends its first millisecond on and then aborts over: that
+    every injection would still *land*. That is worth its own mode because a
+    stale anchor is the failure this manifest actually has — a rename or a
+    reflow moves the text an entry pinned, the entry silently stops describing
+    anything, and the driver that would have said so is on the far side of the
+    merge. Six entries went stale in one afternoon's refactor and CI reported
+    it once, at merge; this reports it in a second, on the branch.
+    """
+    stale: list[str] = []
+    with tempfile.TemporaryDirectory() as tmp:
+        staged = stage_tree(Path(tmp))
+        # Every `Class.method` the staged suite actually defines, so a
+        # `must_fail` naming a test that no longer exists is caught here
+        # rather than as the driver's second abort. Read off the copy for the
+        # same reason the driver patches the copy.
+        known: set[str] = set()
+        tree = ast.parse(staged["unit"].read_text(encoding="utf-8"))
+        for cls in tree.body:
+            if isinstance(cls, ast.ClassDef):
+                known |= {
+                    f"{cls.name}.{fn.name}"
+                    for fn in cls.body
+                    if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+                }
+        for name, module, old, _new, must_fail in INJECTIONS:
+            target = injection_target(module, staged, old)
+            hits = target.read_text(encoding="utf-8").count(old)
+            if hits != 1:
+                stale.append(
+                    f"{name!r} matched {hits} times in {module}, expected "
+                    f"exactly 1 — the injection would not land, so nothing "
+                    f"it claims to prove is proven.\n       looked for: {old!r}"
+                )
+            gone = [t for t in must_fail if t not in known]
+            if gone:
+                stale.append(
+                    f"{name!r} names {', '.join(gone)}, which this suite does "
+                    f"not define — nothing it claims to prove is proven."
+                )
+    if stale:
+        print(
+            f"ABORT: {len(stale)} of {len(INJECTIONS)} injections no longer resolve.",
+            file=sys.stderr,
+        )
+        for line in stale:
+            print(f"  - {line}", file=sys.stderr)
+        return 3
+    print(f"All {len(INJECTIONS)} injections still resolve.")
+    return 0
+
+
+def stage_tree(tmp: Path) -> dict[str, Path]:
+    """Copy everything an injection may break into `tmp`, and name the copies.
+
+    Split out of `fault_inject` so `check_anchors` resolves targets through the
+    identical staging rather than a second implementation of it — two copies of
+    this would drift, and a target the cheap mode resolved differently from the
+    driver would grade a file the driver never patches.
+    """
+    # The whole skill, not just the package: several injections break a
+    # shipped document, and the documentation assertions are as much a
+    # check as the behavioural ones. `tests/smoke` is copied alongside
+    # it because one assertion reads that file rather than the package —
+    # residue in the *harness* is the defect it grades.
+    #
+    # This file is copied too, and the copy is what runs. One assertion
+    # — the doc-symbol sweep — has an *extraction step* of its own, and
+    # an extraction that quietly matches nothing is the vacuous sweep
+    # the floor exists to catch. Proving that floor fires means breaking
+    # code that lives here, so the inner run cannot be this file. It
+    # reads nothing from `REPO`: every path it uses comes from the three
+    # environment variables below, so a copy under /tmp behaves exactly
+    # as the original does.
+    skill = tmp / "demo-video"
+    shutil.copytree(REPO / "skills" / "demo-video", skill)
+    smoke = tmp / "smoke"
+    shutil.copy(REPO / "tests" / "smoke", smoke)
+    # The entry resolves its package from its own directory (#401),
+    # so a staged copy of the entry without `smokekit` beside it
+    # would die on import rather than on anything an injection did.
+    shutil.copytree(
+        REPO / "tests" / "smokekit",
+        tmp / "smokekit",
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+    # `tests/smoke` imports its pixel toolkit from the module beside
+    # it (#349), resolved off its own path — so the copy needs the
+    # module beside it too.
+    shutil.copy(REPO / "tests" / "_pixels.py", tmp / "_pixels.py")
+    # And the injection manifest, for the same reason as `smoke`: the
+    # baseline retry #258 added is a decision this suite grades, and a
+    # decision nobody has watched go the wrong way is a claim.
+    smoke_inject = tmp / "smoke-inject"
+    shutil.copy(REPO / "tests" / "smoke-inject", smoke_inject)
+    # ...and the pixel loop, whose cache arithmetic three injections
+    # above break. `PixelCache` resolves it through UNIT_PIXEL for the
+    # same reason everything else here is an environment variable.
+    pixel = tmp / "pixel"
+    shutil.copy(REPO / "tests" / "pixel", pixel)
+    # ...and this suite's own README, which used to be read straight
+    # out of the working tree. It carries prose that assertions here
+    # grade — a stated figure, and the explanation of a positive skew
+    # this repo shipped and retracted — and a document nothing can
+    # break is a document whose guard nobody has watched fire.
+    readme = tmp / "README.md"
+    shutil.copy(REPO / "tests" / "README.md", readme)
+    # ...and the proving ground, which `MaskProse` now sweeps. Copied
+    # for the same reason as everything above: an injection has to be
+    # able to break one of these storyboards, and a sweep reading the
+    # working tree would grade the pristine file instead.
+    examples = tmp / "examples"
+    shutil.copytree(REPO / "examples", examples)
+    unit = tmp / "unit"
+    shutil.copy(Path(__file__).resolve(), unit)
+    return {
+        "tmp": tmp,
+        "skill": skill,
+        "root": skill / "helpers",
+        "smoke": smoke,
+        "smoke_inject": smoke_inject,
+        "pixel": pixel,
+        "readme": readme,
+        "examples": examples,
+        "unit": unit,
+    }
+
+
+def injection_target(module: str, staged: dict[str, Path], old: str) -> Path:
+    """Which staged file an injection's `module` field names."""
+    tmp = staged["tmp"]
+    if module.startswith("examples/"):
+        # Before the `"/" in module` branch below, which would send it
+        # into the skill directory.
+        return staged["examples"] / module[len("examples/") :]
+    if module == "tests/smoke":
+        # The entry now shares its source with the smokekit package
+        # staged beside it (#401), so the injection aims at whichever
+        # single member holds the pattern exactly once. Anything else
+        # falls through to the entry itself, whose count of zero (or
+        # two) aborts in the caller with the reason.
+        members = [staged["smoke"], *sorted((tmp / "smokekit").glob("*.py"))]
+        holders = [
+            member
+            for member in members
+            if member.read_text(encoding="utf-8").count(old) == 1
+        ]
+        return holders[0] if len(holders) == 1 else staged["smoke"]
+    if module == "tests/smoke-inject":
+        # Before the `"/" in module` branch below, which would send it
+        # into the skill directory and fail on a file that is not there.
+        return staged["smoke_inject"]
+    if module == "tests/pixel":
+        # Same reason: a path with a "/" that is not under the skill.
+        return staged["pixel"]
+    if module == "tests/README.md":
+        # Before the `.md` branch below, which would look for it under
+        # the skill directory.
+        return staged["readme"]
+    if module == "tests/unit":
+        return staged["unit"]
+    if module == "__init__.py" or module.endswith(".py"):
+        return staged["root"] / "demo_recording" / module
+    if module.endswith(".md") or "/" in module:
+        # A path relative to the skill root: shipped documents, and the
+        # vendored-asset manifest under helpers/assets/ (#54).
+        return staged["skill"] / module
+    return staged["root"] / "demo_recording" / module
+
+
 def fault_inject() -> int:
     """Break one thing at a time and require the named tests to notice."""
     failures = 0
     for name, module, old, new, must_fail in INJECTIONS:
         with tempfile.TemporaryDirectory() as tmp:
-            # The whole skill, not just the package: several injections break a
-            # shipped document, and the documentation assertions are as much a
-            # check as the behavioural ones. `tests/smoke` is copied alongside
-            # it because one assertion reads that file rather than the package —
-            # residue in the *harness* is the defect it grades.
-            #
-            # This file is copied too, and the copy is what runs. One assertion
-            # — the doc-symbol sweep — has an *extraction step* of its own, and
-            # an extraction that quietly matches nothing is the vacuous sweep
-            # the floor exists to catch. Proving that floor fires means breaking
-            # code that lives here, so the inner run cannot be this file. It
-            # reads nothing from `REPO`: every path it uses comes from the three
-            # environment variables below, so a copy under /tmp behaves exactly
-            # as the original does.
-            skill = Path(tmp) / "demo-video"
-            shutil.copytree(REPO / "skills" / "demo-video", skill)
-            root = skill / "helpers"
-            smoke = Path(tmp) / "smoke"
-            shutil.copy(REPO / "tests" / "smoke", smoke)
-            # The entry resolves its package from its own directory (#401),
-            # so a staged copy of the entry without `smokekit` beside it
-            # would die on import rather than on anything an injection did.
-            shutil.copytree(
-                REPO / "tests" / "smokekit",
-                Path(tmp) / "smokekit",
-                ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
-            )
-            # `tests/smoke` imports its pixel toolkit from the module beside
-            # it (#349), resolved off its own path — so the copy needs the
-            # module beside it too.
-            shutil.copy(REPO / "tests" / "_pixels.py", Path(tmp) / "_pixels.py")
-            # And the injection manifest, for the same reason as `smoke`: the
-            # baseline retry #258 added is a decision this suite grades, and a
-            # decision nobody has watched go the wrong way is a claim.
-            smoke_inject = Path(tmp) / "smoke-inject"
-            shutil.copy(REPO / "tests" / "smoke-inject", smoke_inject)
-            # ...and the pixel loop, whose cache arithmetic three injections
-            # above break. `PixelCache` resolves it through UNIT_PIXEL for the
-            # same reason everything else here is an environment variable.
-            pixel = Path(tmp) / "pixel"
-            shutil.copy(REPO / "tests" / "pixel", pixel)
-            # ...and this suite's own README, which used to be read straight
-            # out of the working tree. It carries prose that assertions here
-            # grade — a stated figure, and the explanation of a positive skew
-            # this repo shipped and retracted — and a document nothing can
-            # break is a document whose guard nobody has watched fire.
-            readme = Path(tmp) / "README.md"
-            shutil.copy(REPO / "tests" / "README.md", readme)
-            # ...and the proving ground, which `MaskProse` now sweeps. Copied
-            # for the same reason as everything above: an injection has to be
-            # able to break one of these storyboards, and a sweep reading the
-            # working tree would grade the pristine file instead.
-            examples = Path(tmp) / "examples"
-            shutil.copytree(REPO / "examples", examples)
-            unit = Path(tmp) / "unit"
-            shutil.copy(Path(__file__).resolve(), unit)
-            if module.startswith("examples/"):
-                # Before the `"/" in module` branch below, which would send it
-                # into the skill directory.
-                target = examples / module[len("examples/") :]
-            elif module == "tests/smoke":
-                # The entry now shares its source with the smokekit package
-                # staged beside it (#401), so the injection aims at whichever
-                # single member holds the pattern exactly once. Anything else
-                # falls through to the entry itself, whose count of zero (or
-                # two) aborts below with the reason.
-                members = [
-                    smoke,
-                    *sorted((Path(tmp) / "smokekit").glob("*.py")),
-                ]
-                holders = [
-                    member
-                    for member in members
-                    if member.read_text(encoding="utf-8").count(old) == 1
-                ]
-                target = holders[0] if len(holders) == 1 else smoke
-            elif module == "tests/smoke-inject":
-                # Before the `"/" in module` branch below, which would send it
-                # into the skill directory and fail on a file that is not there.
-                target = smoke_inject
-            elif module == "tests/pixel":
-                # Same reason: a path with a "/" that is not under the skill.
-                target = pixel
-            elif module == "tests/README.md":
-                # Before the `.md` branch below, which would look for it under
-                # the skill directory.
-                target = readme
-            elif module == "tests/unit":
-                target = unit
-            elif module == "__init__.py" or module.endswith(".py"):
-                target = root / "demo_recording" / module
-            elif module.endswith(".md") or "/" in module:
-                # A path relative to the skill root: shipped documents, and the
-                # vendored-asset manifest under helpers/assets/ (#54).
-                target = skill / module
-            else:
-                target = root / "demo_recording" / module
+            staged = stage_tree(Path(tmp))
+            skill, root = staged["skill"], staged["root"]
+            smoke, smoke_inject = staged["smoke"], staged["smoke_inject"]
+            pixel, readme = staged["pixel"], staged["readme"]
+            examples, unit = staged["examples"], staged["unit"]
+            target = injection_target(module, staged, old)
             text = target.read_text(encoding="utf-8")
             hits = text.count(old)
             if hits != 1:
@@ -18492,6 +18788,13 @@ def main() -> int:
         help="break each assertion's subject and require it to fail",
     )
     parser.add_argument(
+        "--anchors",
+        action="store_true",
+        help="check every injection still resolves — its pattern matches its "
+        "file once and its tests exist — without running any of them (~1 s "
+        "against --fault-inject's minutes)",
+    )
+    parser.add_argument(
         "--budget",
         action="store_true",
         help="report SKILL.md's context cost (warns, does not gate)",
@@ -18500,6 +18803,8 @@ def main() -> int:
     args, rest = parser.parse_known_args()
     if args.budget:
         return budget_report()
+    if args.anchors:
+        return check_anchors()
     if args.fault_inject:
         return fault_inject()
     if args._inner:

--- a/tests/unit
+++ b/tests/unit
@@ -9804,8 +9804,18 @@ class NarrationMix(unittest.TestCase):
             core_module.subprocess.run = was
             core_module.media_duration = was_duration  # type: ignore[assignment]
             core_module.clip_gain_db = was_gain  # type: ignore[assignment]
-        self.assertEqual(len(seen), 1, f"expected one ffmpeg call, got {seen!r}")
-        cmd = seen[0]
+        # The *mix*, selected by what it writes rather than by being the only
+        # ffmpeg call. It stopped being the only one when #410 added the
+        # pull-request preview, and `seen[0]` then silently became a WebP
+        # encode that has no `adelay` in it — so the floor is kept, and made
+        # precise: exactly one command writes this take's mp4.
+        mixes = [c for c in seen if c[-1].endswith(".mp4")]
+        self.assertEqual(
+            len(mixes),
+            1,
+            f"expected exactly one ffmpeg call writing an mp4, got {seen!r}",
+        )
+        cmd = mixes[0]
         self.assertIn("-filter_complex", cmd, "the mix went in without a filter graph")
         graph = cmd[cmd.index("-filter_complex") + 1]
         # Kept for the tests that assert on the filter graph itself rather
@@ -12847,6 +12857,164 @@ class ExitStatus(_GradeCase):
         # written against.
         section = grade.__doc__.split("## Exit status")[1]
         self.assertEqual(set(re.findall(r"\b([0-9])\b", section)), {"0", "2"})
+
+
+class PreviewWebp(unittest.TestCase):
+    """The animated WebP a pull-request body embeds (issue #410).
+
+    GitHub has no public API for the attachment upload its drag-and-drop uses,
+    so a video cannot reach a reviewer as a player — only as an inline image.
+    This is that image, and every test here is about a way it could mislead:
+    naming a file this run did not write, losing the camera moves the mp4 has,
+    or being encoded from a source two h264 generations down.
+    """
+
+    def doc(self, **settings) -> dict:
+        rec = recorder(self, page=DrawingPage(), **settings)
+        rec.caption("A small dashboard.")
+        with contextlib.redirect_stderr(io.StringIO()):
+            return rec._timeline_doc()
+
+    def test_a_run_that_wrote_no_preview_names_none(self):
+        """The #20 rule, one field over.
+
+        `demo.preview.webp` from a previous take is very likely sitting in the
+        directory — `record.py` is committed so it can be re-run. Naming it
+        would point a pull-request body at a recording of something else and
+        invite a reviewer to tick acceptance boxes against it.
+        """
+        doc = self.doc()
+        self.assertIsNone(doc["preview"])
+
+    def test_a_run_that_wrote_one_names_it(self):
+        rec = recorder(self, page=DrawingPage())
+        rec.caption("A small dashboard.")
+        rec._preview_written = True
+        with contextlib.redirect_stderr(io.StringIO()):
+            doc = rec._timeline_doc()
+        self.assertEqual(doc["preview"], "demo.preview.webp")
+
+    def test_a_segment_names_its_own_preview_and_not_the_takes(self):
+        """Two segments in one directory would otherwise collide on one name,
+        and the second would overwrite the first's preview while both
+        timelines went on naming it."""
+        rec = recorder(self, page=DrawingPage(), segment="part2")
+        self.assertEqual(rec._preview_path().name, "part2.preview.webp")
+        plain = recorder(self, page=DrawingPage())
+        self.assertEqual(plain._preview_path().name, "demo.preview.webp")
+
+    def test_convert_hands_the_preview_the_webm_and_not_the_mp4(self):
+        """The call site, which is where this can actually go wrong.
+
+        The test below grades what `_write_preview` does with the path it is
+        handed. It cannot see `_convert` handing it the wrong one — and that
+        is the whole defect: two extra h264 generations, a preview that still
+        renders, and nobody the wiser. `--fault-inject` found this gap by
+        breaking the call site and watching the suite stay green.
+
+        Read off the source rather than by running `_convert`, which encodes
+        two files and needs a browser's output to do it.
+        """
+        tree = ast.parse(
+            textwrap.dedent(inspect.getsource(core_module._DemoBase._convert))
+        )
+        calls = [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "_write_preview"
+        ]
+        self.assertEqual(len(calls), 1, "_convert does not call _write_preview once")
+        first = calls[0].args[0]
+        self.assertIsInstance(
+            first,
+            ast.Name,
+            f"_convert passes {ast.dump(first)[:60]} to _write_preview, not a bare name",
+        )
+        self.assertEqual(
+            first.id,
+            "webm",
+            f"_convert hands the preview `{first.id}`; it must be the webm, or the "
+            f"preview is encoded from a source two h264 generations down",
+        )
+
+    def test_the_encode_reads_the_webm_and_never_the_mp4(self):
+        """The whole reason #410 encodes where it does.
+
+        By the time `demo.mp4` exists the frames have been through h264 twice.
+        Measured on a 25 s take, encoding the preview from the mp4 instead is
+        both dirtier and larger — 2.95 MB against 2.67 MB at identical WebP
+        settings, because a noisier source costs the encoder bits. So this
+        asserts the *input path*, which is the thing that decides it.
+        """
+        rec = recorder(self, page=DrawingPage())
+        seen = []
+        with mock.patch.object(
+            core_module.subprocess, "run", side_effect=lambda cmd, **k: seen.append(cmd)
+        ):
+            rec._write_preview(Path("/tmp/x/page@abc.webm"), None)
+        self.assertEqual(len(seen), 1, "the preview encode did not run")
+        cmd = [str(part) for part in seen[0]]
+        self.assertIn("/tmp/x/page@abc.webm", cmd)
+        self.assertFalse(
+            [part for part in cmd if part.endswith((".mp4", ".camera.mp4"))],
+            f"the preview was encoded from an mp4: {cmd}",
+        )
+
+    def test_the_camera_chain_reaches_the_preview(self):
+        """Encoding from the raw webm without it loses every push-in — which
+        is exactly what a first cut of this did, and what a reviewer caught by
+        eye. The chain is threaded in rather than re-derived so the preview
+        and the mp4 cannot disagree about where the camera went."""
+        rec = recorder(self, page=DrawingPage())
+        seen = []
+        with mock.patch.object(
+            core_module.subprocess, "run", side_effect=lambda cmd, **k: seen.append(cmd)
+        ):
+            rec._write_preview(Path("/tmp/x/page@abc.webm"), "zoompan=z='1.3'")
+        graph = [str(p) for p in seen[0]][
+            [str(p) for p in seen[0]].index("-filter_complex") + 1
+        ]
+        self.assertIn("zoompan", graph)
+        self.assertIn("scale=1280", graph)
+
+    def test_a_take_with_no_camera_still_gets_a_preview(self):
+        rec = recorder(self, page=DrawingPage())
+        seen = []
+        with mock.patch.object(
+            core_module.subprocess, "run", side_effect=lambda cmd, **k: seen.append(cmd)
+        ):
+            rec._write_preview(Path("/tmp/x/page@abc.webm"), None)
+        graph = [str(p) for p in seen[0]][
+            [str(p) for p in seen[0]].index("-filter_complex") + 1
+        ]
+        self.assertNotIn("zoompan", graph)
+        self.assertIn("scale=1280", graph)
+
+    def test_a_failed_encode_warns_and_keeps_the_take(self):
+        """A reviewer losing a preview is an inconvenience; raising here would
+        throw away a recording that is already complete."""
+        rec = recorder(self, page=DrawingPage())
+        err = io.StringIO()
+        with (
+            mock.patch.object(
+                core_module.subprocess,
+                "run",
+                side_effect=subprocess.CalledProcessError(1, "ffmpeg"),
+            ),
+            contextlib.redirect_stderr(err),
+        ):
+            rec._write_preview(Path("/tmp/x/page@abc.webm"), None)
+        self.assertFalse(rec._preview_written)
+        self.assertIn("preview", err.getvalue().lower())
+
+    def test_it_can_be_turned_off(self):
+        rec = recorder(self, page=DrawingPage(), preview=False)
+        with mock.patch.object(core_module.subprocess, "run") as run:
+            rec._write_preview(Path("/tmp/x/page@abc.webm"), None)
+        run.assert_not_called()
+        self.assertFalse(rec._preview_written)
 
 
 class StillsOnly(unittest.TestCase):
@@ -16484,6 +16652,61 @@ INJECTIONS = [
             "CheapArm.test_a_whole_run_still_takes_everything_and_a_named_arm_still_itself"
         ],
     ),
+    # -- the pull-request preview (issue #410) ------------------------------
+    #
+    # Five breaks, for the five ways this file can mislead a reviewer rather
+    # than merely be absent. Absence is visible — the block says the video was
+    # not recorded. Every one of these is *silent*: the preview renders, and
+    # shows the wrong thing.
+    (
+        # The #20 lie, one field over. `record.py` is committed so it can be
+        # re-run, so a previous take's preview is very likely sitting right
+        # there — and a pull-request body pointed at it invites a reviewer to
+        # tick acceptance boxes against a recording of something else.
+        "the timeline names a preview this run did not write",
+        "core.py",
+        '            "preview": self._preview_path().name if self._preview_written else None,',
+        '            "preview": self._preview_path().name,',
+        ["PreviewWebp.test_a_run_that_wrote_no_preview_names_none"],
+    ),
+    (
+        # Two segments in one directory collide on one name: the second
+        # overwrites the first's preview while both timelines go on naming it.
+        "every segment's preview is written to the same name",
+        "core.py",
+        '        stem = self.segment if self.segment else "demo"',
+        '        stem = "demo"',
+        ["PreviewWebp.test_a_segment_names_its_own_preview_and_not_the_takes"],
+    ),
+    (
+        # The whole reason #410 encodes where it does. Reading the mp4 costs
+        # two extra h264 generations and measured both dirtier and larger.
+        # Nothing raises — the preview still appears, just degraded.
+        "the preview is encoded from the mp4 instead of the browser's frames",
+        "core.py",
+        "        self._write_preview(webm, chain)",
+        "        self._write_preview(self._media_path(), chain)",
+        ["PreviewWebp.test_convert_hands_the_preview_the_webm_and_not_the_mp4"],
+    ),
+    (
+        # The defect a reviewer caught by eye on the first cut: encoding from
+        # the raw webm drops every camera push-in. The preview looks fine
+        # until somebody compares it with the mp4.
+        "the camera chain stops reaching the preview, so it loses every push-in",
+        "core.py",
+        'graph = f"[0:v]{chain},{scale}[v]" if chain else f"[0:v]{scale}[v]"',
+        'graph = f"[0:v]{scale}[v]"',
+        ["PreviewWebp.test_the_camera_chain_reaches_the_preview"],
+    ),
+    (
+        # A preview failure taking the take with it. The recording is already
+        # complete at this point; raising would discard it over a convenience.
+        "a failed preview encode throws away the finished take",
+        "core.py",
+        "        except (OSError, subprocess.CalledProcessError) as exc:",
+        "        except _NeverRaised as exc:",
+        ["PreviewWebp.test_a_failed_encode_warns_and_keeps_the_take"],
+    ),
     # -- what `tests/smoke --core` selects ----------------------------------
     #
     # Four breaks, for the four ways a *named list* goes wrong, which are not
@@ -18010,9 +18233,7 @@ INJECTIONS = [
     (
         "DEMO_VIDEO_PACE in the environment is ignored",
         "core.py",
-        """            raw_pace: float | str = _env(
-                "PACE", str(preset_defaults.get("pace", 1.0))
-            )""",
+        '            raw_pace: float | str = _env("PACE", str(preset_defaults.get("pace", 1.0)))',
         '            raw_pace: float | str = "1.0"',
         ["Pace.test_the_environment_can_set_it"],
     ),


### PR DESCRIPTION
Stacked on #404 (base is `feat/demo-polish-403`), so the diff reads clean.

Fixes #407.

## The number

The tests cost **9 s**. The other 730 s of a 750 s job set was recording video
and re-running suites to prove assertions can fail.

| | before | after |
|---|---|---|
| pull request | 22 takes + 554 s of injections | 6 arms (~97 s) + `--anchors` (~1 s) |
| **critical path** | **~5.5 min** | **~2.2 min** |
| merge to `main` | whole suite | whole suite + both drivers |
| pre-commit | ~6 s | ~7 s |

No coverage is deleted. Everything cut runs on merge to `main`, and the
`smoke-full` label still pulls the wide suite in front of a review that wants it.

## `--core` replaces `--cheap`, and the shape is the point

`--cheap` is a *complement*: every phase an arm outside the expensive three
reaches. A complement has no ceiling — every cheap arm added since #61 joined
the per-push job automatically, which is how it reached 22 takes without a
decision being made. **A complement cannot be scaled down; only a list can.**

`CORE_ARMS` is a named list with the measured cost of each entry beside it:

| arm | s | what it buys |
|---|---|---|
| `--lock-only` | 0.2 | a refused run leaves nothing misleading behind (#105) |
| `--stills-only` | 2.1 | pictures with no video (#372) |
| `--evidence-only` | 7.3 | the per-beat evidence a reviewer reads (#9) |
| `--strict-only` | 11.6 | takes `strict=True` must refuse, both media (#3) |
| `--coverage-only` | 15.5 | every acceptance clause answered by a beat (#12) |
| `--failure-only` | 46.8 | six crashing takes, and what each leaves behind |
| | **83.5** | measured; two `--core` runs read **82.8 s** and **82.2 s** |

`--strict-only` and `--failure-only` are the two ways a recording lies to its
reader, which is what `GOAL.md` measures. The rest are the artifacts a reviewer
actually opens.

### Keeping `--failure-only`, against this repo's own prior advice

`tests/README.md` named it "the one to revisit first if the per-push budget
ever binds". The budget bound and it was kept, so the disagreement is recorded
rather than quietly reversed: the seconds-per-*check-function* ratio that
recommended dropping it counts the wrong denominator for the recorder's
exception paths, which decide whether a take that died leaves behind something
a reader takes for a success.

## `--anchors` replaces `--fault-inject` on the branch

The drivers re-run their whole suite once per injection — 132 s for 419,
298 s for 135. The *anchor* check is pure text, so it is split out: one
staging, no inner runs, **0.7 s** and **0.2 s**.

**What it gives up, stated plainly.** It proves an injection would still
*land* — pattern matches its file exactly once, every test it names exists. It
does **not** prove the assertion can still fail. That is the trade, and it is
the right one because a stale anchor is the failure this manifest actually has:
six went stale in one afternoon's refactor on #404 and CI reported it at merge.
An assertion that stopped grading its subject while still landing now reaches
`main` before it is caught. `AGENTS.md` now says authors must run the driver
themselves when they touch an injection.

Both drivers were refactored to share `stage_tree` and `injection_target` with
the new mode, so the cheap path can never resolve a target the driver would not
patch.

## Evidence

Injections, per the house rule — each break shown failing, then undone:

```
$ tests/unit --anchors            # orphaned anchor
ABORT: 1 of 419 injections no longer resolve.
  - 'the accent predicate takes any blue-over-red surface as the dot' matched 0
    times in tests/pixel, expected exactly 1 — the injection would not land, so
    nothing it claims to prove is proven.
exit=3

$ tests/unit --anchors            # vanished test name
ABORT: 1 of 419 injections no longer resolve.
  - '...' names PixelChecks.test_a_name_this_suite_does_not_define, which this
    suite does not define — nothing it claims to prove is proven.
exit=3
```

`tests/ci-unit --anchors` shows the same two, on its own manifest.

`CoreArm`'s four assertions have five injections, all caught:

```
PASS  break: --core stops selecting and runs the whole suite on every push
PASS  break: --core selects everything except the arms it names
PASS  break: an arm is dropped from CORE_ARMS and its takes stop running per push
PASS  break: an arm in CORE_ARMS is misspelled, so its takes silently stop running
PASS  break: an arm CORE_ARMS names stops being a flag the script defines
```

Full runs on the final tree: `tests/unit --fault-inject` **424 caught, exit 0**;
`tests/ci-unit --fault-inject` **135 caught, exit 0**; `tests/smoke --core`
PASSED twice; lint, typecheck, actionlint, `smoke-inject --self-test` green.

## Stated limits

- **The fifth injection was mis-anchored on the first attempt.** `    "--coverage-only",`
  is a *substring* of the argparse call in `cli.py`, so it landed there rather
  than in `CORE_ARMS` and its `must_fail` list was wrong. Both breaks are real
  and both are now entries, anchored on text unique to each file. Recorded
  because it is exactly the failure `--anchors` cannot see: the injection
  landed, so the anchor check was happy.
- **`--core` flaked once in three runs**, on `check_wrapper_card` over the
  coverage take: `the card stretch in the video is only 0.9s against a
  criterion beat logged 2.8s long`. Filed as #406 — that check compares video
  time to wall-clock-logged time, which is the #370 class, but
  `--coverage-only` is declared `CLOCK_SAFE`. It matters more now that the
  check is on the per-PR path.
- **`tests/pixel` is not a CI job.** 4.7 s warm, 60 s cold, and CI is always
  cold. Caching it on the marker digest would make it viable and is not
  attempted here.