### PR TITLE
PROBE: host previews without committing them (delete after picking)

### DIFF
--- a/.probe/README.md
+++ b/.probe/README.md
@@ -1,0 +1,1 @@
+throwaway


### PR DESCRIPTION
You asked why we commit the WebP at all. Fair — I went straight from "there is no attachment API" to "commit it" without checking what sits in between. Three candidates.

---

### 1 — release asset, uploaded with `gh release upload` · serves `application/octet-stream`

![release asset](https://github.com/rogvid/skills/releases/download/demo-assets/pr999-glide.webp)

---

### 2 — release asset re-uploaded with an explicit `Content-Type: image/webp` · **still** serves `application/octet-stream`

![release asset typed](https://github.com/rogvid/skills/releases/download/demo-assets/pr999-glide-typed.webp)

---

### 3 — orphan branch `demo-previews`, raw URL · serves `image/webp`

![orphan branch](https://github.com/rogvid/skills/raw/demo-previews/glide.webp)

---

## What I measured

    orphan raw      status=200  type=image/webp
    release asset   status=200  type=application/octet-stream

The release API *accepts* `image/webp` and reports it back — but the
`releases/download/…` endpoint forces `application/octet-stream` regardless,
because it is a download endpoint. GitHub's image proxy will almost certainly
refuse that, so I expect 1 and 2 to be broken images. **Please confirm.** If
they render, they win outright: release assets are not git objects at all.

## If only 3 renders, that is still the answer

An orphan branch shares no history with `main`, so **no preview ever enters
`main`'s tree or history**. Force-pushing it replaces the set, which makes old
previews unreachable and eventually collectable — so the repository holds
roughly *one current set* rather than one blob per demo per re-record, forever.

Honest about the remaining cost: those blobs are still in the repository's
object store, so a full `git clone` fetches them. It is **bounded instead of
unbounded**, not free.

The genuinely free variant is a **separate repository** (`rogvid/skills-previews`)
— `main` never carries a byte, raw URLs render identically. The cost is a second
repository to create and keep permissions on.

## What I would do

Whichever of 3 or a separate repo you prefer, and **rip the committing out
either way** — `demo.preview.webp` stops being a tracked file and becomes
something CI uploads. That deletes the "~3 MB per demo, forever" limit I flagged
on the last change, which was the right thing to be unhappy about.

<sub>Cleanup either way: the `demo-assets` pre-release, this branch, and the `demo-previews` branch are all throwaway and I will delete whichever we do not use.</sub>